### PR TITLE
README: fix link to discover.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the future:
    modification time "wins". The correct behavior in the face of
    conflicts is open for discussion.
 
-[discover.go]: (https://github.com/calmh/syncthing/blob/master/discover/discover.go
+[discover.go]: https://github.com/calmh/syncthing/blob/master/discover/discover.go
 
 Security
 --------


### PR DESCRIPTION
Small markdown syntax error fix.
