### PR TITLE
Print info about gui on start (fixes issue #27)

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,6 +149,7 @@ func main() {
 
 	// GUI
 	if !opts.NoGUI && opts.GUIAddr != "" {
+		infoln("Starting GUI at http://", opts.GUIAddr)
 		startGUI(opts.GUIAddr, m)
 	}
 


### PR DESCRIPTION
Unfortunately untested. I don't have go 1.2.
