### PR TITLE
Update config.go to handle default slices correctly (fixes #76)

### DIFF
--- a/cmd/syncthing/config.go
+++ b/cmd/syncthing/config.go
@@ -57,7 +57,6 @@ func setDefaults(data interface{}, setEmptySlices bool) error {
 		v := tag.Get("default")
 		if len(v) > 0 {
 			if f.Kind().String() == "slice" && f.Len() != 0 {
-				fmt.Println(f.Type(), f.Type().Kind().String(), f.Len())
 				continue
 			}
 


### PR DESCRIPTION
This is a proposition to fix #76, but there is maybe an easier way to do it.
