### PR TITLE
Fix isTempName to work on Windows (fixes #80)

### DIFF
--- a/cmd/syncthing/walk.go
+++ b/cmd/syncthing/walk.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -39,6 +40,9 @@ func (f File) NewerThan(o File) bool {
 }
 
 func isTempName(name string) bool {
+	if runtime.GOOS == "windows" {
+		name = filepath.ToSlash(name)
+	}
 	return strings.HasPrefix(path.Base(name), ".syncthing.")
 }
 


### PR DESCRIPTION
`path.Base()` is for slash-separated paths, whereas Windows uses "\" to separate paths. Just convert the \ to / and it works.
