### PR TITLE
Return a blank array instead of null if there are no repositories

### DIFF
--- a/cmd/syncthing/config.go
+++ b/cmd/syncthing/config.go
@@ -171,6 +171,11 @@ func readConfigXML(rd io.Reader, myID string) (Configuration, error) {
 
 	cfg.Options.ListenAddress = uniqueStrings(cfg.Options.ListenAddress)
 
+	// Initialize an empty slice for repositories if the config has none
+	if cfg.Repositories == nil {
+		cfg.Repositories = []RepositoryConfiguration{}
+	}
+
 	// Check for missing, bad or duplicate repository ID:s
 	var seenRepos = map[string]*RepositoryConfiguration{}
 	for i := range cfg.Repositories {


### PR DESCRIPTION
Fixes a bug where it's impossible to add repositories in the web interface if none are defined.

Note: I don't know any Go, I have barely any idea what I'm doing. I guess this could also be fixed in the web interface JS, whatever you think is best.
