### PR TITLE
Add GET /rest/repositories API call.

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -87,6 +87,7 @@ func startGUI(cfg config.GUIConfiguration, assetDir string, m *model.Model) erro
 	router.Get("/rest/connections", restGetConnections)
 	router.Get("/rest/config", restGetConfig)
 	router.Get("/rest/config/sync", restGetConfigInSync)
+	router.Get("/rest/config/repository_ids", restGetRepositoryIDs)
 	router.Get("/rest/system", restGetSystem)
 	router.Get("/rest/errors", restGetErrors)
 	router.Get("/rest/discovery", restGetDiscovery)
@@ -310,6 +311,10 @@ func getQR(w http.ResponseWriter, params martini.Params) {
 
 	w.Header().Set("Content-Type", "image/png")
 	w.Write(code.PNG())
+}
+
+func restGetRepositoryIDs(w http.ResponseWriter) {
+	json.NewEncoder(w).Encode(cfg.RepositoryIDs())
 }
 
 func basic(username string, passhash string) http.HandlerFunc {

--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,14 @@ func (r *RepositoryConfiguration) NodeIDs() []string {
 	return r.nodeIDs
 }
 
+func (c *Configuration) RepositoryIDs() []string {
+	var repositoryIDs = []string{}
+	for _, repo := range c.Repositories {
+		repositoryIDs = append(repositoryIDs, repo.ID)
+	}
+	return repositoryIDs
+}
+
 type NodeConfiguration struct {
 	NodeID    string   `xml:"id,attr"`
 	Name      string   `xml:"name,attr,omitempty"`


### PR DESCRIPTION
This allows calling GET /rest/model for existing repos without reading them
from config.xml.

This makes the API for other interfaces cleaner, easier to use.

Example:
$ curl http://localhost:8080/rest/repository_ids
["default","documents"]
