### PR TITLE
reformat "folder" and "shared with" table items

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -60,6 +60,7 @@
     }
 
     .table th {
+      white-space:nowrap;
       font-weight: 400;
     }
 


### PR DESCRIPTION
Other solution than https://github.com/calmh/syncthing/pull/300 using white-space:nowrap;

Looks like this:
![syncthing_reformat_column2](https://cloud.githubusercontent.com/assets/71315/3089287/3ba6ff8a-e57d-11e3-832b-d52a0f60b2d7.png)
