### PR TITLE
vulnerable TLS config!? main.go

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -233,14 +233,14 @@ func main() {
 
 	// The TLS configuration is used for both the listening socket and outgoing
 	// connections.
-
+	// InsecureSkipVerify should be false!?
 	tlsCfg := &tls.Config{
 		Certificates:           []tls.Certificate{cert},
 		NextProtos:             []string{"bep/1.0"},
 		ServerName:             myID,
 		ClientAuth:             tls.RequestClientCert,
 		SessionTicketsDisabled: true,
-		InsecureSkipVerify:     true,
+		InsecureSkipVerify:     false,
 		MinVersion:             tls.VersionTLS12,
 	}
 


### PR DESCRIPTION
InsecureSkipVerify should be false!? if not please explain

// InsecureSkipVerify controls whether a client verifies the
// server's certificate chain and host name.
// If InsecureSkipVerify is true, TLS accepts any certificate
// presented by the server and any host name in that certificate.
// In this mode, TLS is susceptible to man-in-the-middle attacks.
// This should be used only for testing.
InsecureSkipVerify bool

http://golang.org/pkg/crypto/tls/
