### PR TITLE
CSS fix for small screen sizes, e.g. on mobile phones

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -72,6 +72,15 @@ found in the LICENSE file.
     .table td {
       padding-left: 20px !important;
     }
+    
+    @media (max-width:767px){   
+      .table-responsive>.table>tbody>tr>td{
+        /* revert a bootstrap setting e.g.:
+         * for mobile phones to allow linebreaks in long repro folder/shared with
+         * columns. */
+        white-space:normal;
+      }
+    }
   </style>
 </head>
 


### PR DESCRIPTION
see #319

This is needed for e.g. mobile phones

before:

![sync01](https://cloud.githubusercontent.com/assets/71315/3145027/fdbe8a6e-ea2f-11e3-96f1-0d4518eb817c.JPG)

after:

![sync02](https://cloud.githubusercontent.com/assets/71315/3145028/0374e160-ea30-11e3-9e68-7ab2ef7c11a4.JPG)
