### PR TITLE
clearer error message if repro config mismatch

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -279,8 +279,7 @@ func (m *Model) Index(nodeID string, repo string, fs []protocol.FileInfo) {
 	if r, ok := m.repoFiles[repo]; ok {
 		r.Replace(id, files)
 	} else {
-		l.Warnf("Index from %s for unexpected repo %q; verify configuration", nodeID, repo)
-
+                l.Warnf("repo %q doesn't exist on node %s, please add it or change 'shared with' configuration", repo, nodeID)
 	}
 	m.rmut.RUnlock()
 }


### PR DESCRIPTION
Changed this:

> Index from XY for unexpected repo "foobar"; verify configuration

to:

> ERROR: repo "foobar" doesn't exist on node XY, please add it or change 'shared with' configuration

IMHO it's clearer what's to do...

see #330 and #223
