### PR TITLE
Automatically run tests against travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: go
+
+go:
+   - 1.2
+   - tip
+
+install:
+   - export PATH=$PATH:$HOME/gopath/bin
+   - ./build.sh setup
+
+script:
+   - ./build.sh test


### PR DESCRIPTION
This runs tests on travis against go 1.2 and the pending 1.3.  Note that to see this in action you'll need to go to https://travis-ci.org/profile and enable
the syncthing repo.  I couldn't actually ensure that it works because the repo
gets checked out as `github.com/$user/syncthing`, so everything exploded for
me.
