### PR TITLE
Ship test coverage info to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ go:
 install:
    - export PATH=$PATH:$HOME/gopath/bin
    - ./build.sh setup
+   - go get code.google.com/p/go.tools/cmd/cover
+   - go get github.com/mattn/goveralls
 
 script:
-   - ./build.sh test
+   - ./build.sh test-cov
+
+after_success:
+   - goveralls -coverprofile=acc.out -service=travis-ci

--- a/build.sh
+++ b/build.sh
@@ -31,6 +31,25 @@ assets() {
 	godep go run cmd/assets/assets.go gui > auto/gui.files.go
 }
 
+test-cov() {
+   echo "mode: set" > acc.out
+   fail=0
+
+   for dir in $(find . -maxdepth 10 -not -path './.git*' -not -path '*/integration' -not -path '*/_*' -type d);
+   do
+   if ls $dir/*.go &> /dev/null; then
+   godep go test -coverprofile=profile.out $dir || fail=1
+       if [ -f profile.out ]
+       then
+   cat profile.out | grep -v "mode: set" >> acc.out
+         rm profile.out
+       fi
+   fi
+   done
+
+   exit $fail
+}
+
 test() {
 	check
 	godep go test -cpu=1,2,4 ./...
@@ -98,6 +117,10 @@ case "$1" in
 
 	test)
 		test
+		;;
+
+	test-cov)
+		test-cov
 		;;
 
 	tar)


### PR DESCRIPTION
As with the travis-ci patch, you'll need to enable the repo on coveralls.io
