### PR TITLE
Continue discovery on connect errors (fixes #324)

### DIFF
--- a/discover/discover.go
+++ b/discover/discover.go
@@ -172,16 +172,21 @@ func (d *Discoverer) sendLocalAnnouncements() {
 }
 
 func (d *Discoverer) sendExternalAnnouncements() {
+	// this should go in the Discoverer struct
+	errorRetryIntv := 60 * time.Second
+
 	remote, err := net.ResolveUDPAddr("udp", d.extServer)
-	if err != nil {
-		l.Warnf("Global discovery: %v; no external announcements", err)
-		return
+	for err != nil {
+		l.Warnf("Global discovery: %v; trying again in %v", err, errorRetryIntv)
+		time.Sleep(errorRetryIntv)
+		remote, err = net.ResolveUDPAddr("udp", d.extServer)
 	}
 
 	conn, err := net.ListenUDP("udp", nil)
-	if err != nil {
-		l.Warnf("Global discovery: %v; no external announcements", err)
-		return
+	for err != nil {
+		l.Warnf("Global discovery: %v; trying again in %v", err, errorRetryIntv)
+		time.Sleep(errorRetryIntv)
+		conn, err = net.ListenUDP("udp", nil)
 	}
 
 	var buf []byte
@@ -202,7 +207,7 @@ func (d *Discoverer) sendExternalAnnouncements() {
 			l.Debugf("discover: send announcement -> %v\n%s", remote, hex.Dump(buf))
 		}
 
-		_, err = conn.WriteTo(buf, remote)
+		_, err := conn.WriteTo(buf, remote)
 		if err != nil {
 			if debug {
 				l.Debugln("discover: warning:", err)
@@ -226,7 +231,7 @@ func (d *Discoverer) sendExternalAnnouncements() {
 		if ok {
 			time.Sleep(d.globalBcastIntv)
 		} else {
-			time.Sleep(60 * time.Second)
+			time.Sleep(errorRetryIntv)
 		}
 	}
 }


### PR DESCRIPTION
Continues trying to connect to the discovery server at regular intervals despite failure at initialization time (#324).

Whether or not to retry and the retry interval itself should be specified in the configuration, but this feature is not implemented in this commit.

Additionally, I have not managed to test this change in an isolated way because the version I based it on results in an `element size exceeded` error when reading from all of my remotes. I _can_, however, confirm that it does allow `syncthing` to establish a connection to the global discovery server even when it is not available at initialization time (e.g., when run `@reboot` in `crontab`).
