### PR TITLE
Fixes #326 : information were hidden when a repository has a long path

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -85,6 +85,14 @@
         white-space: normal;
       }
     }
+
+    .table-condensed td {
+      max-width: 300px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
   </style>
 </head>
 


### PR DESCRIPTION
Also related to https://github.com/syncthing/syncthing/issues/425 and https://github.com/syncthing/syncthing/issues/309
This doesn't try to fix the other problem of the path being too long in the title.
