### PR TITLE
Add option gui-addr for dynamic gui address and port

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -140,7 +140,7 @@ func main() {
 	var generateDir string
 	var noBrowser bool
 	flag.StringVar(&confDir, "home", getDefaultConfDir(), "Set configuration directory")
-	flag.StringVar(&guiAddr, "gui-address", "127.0.0.1:8080", "Overides GUI address and port")
+	flag.StringVar(&guiAddr, "gui-address", "127.0.0.1:8080", "Overrides GUI address and port")
 	flag.BoolVar(&reset, "reset", false, "Prepare to resync from cluster")
 	flag.BoolVar(&showVersion, "version", false, "Show version")
 	flag.BoolVar(&doUpgrade, "upgrade", false, "Perform upgrade")


### PR DESCRIPTION
This PR adds a `-gui-addr` option which allows you to dynamically specify address and port for the GUI interface. The setting defaults to 127.0.0.1:8080 and will only be set the first time syncthing is launched. In other words it does not modify your config.xml after initial launch. This closes #505.
