### PR TITLE
Do not warn about failed IPv6 discovery, warn about no discovery

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -989,19 +989,15 @@ func setTCPOptions(conn *net.TCPConn) {
 }
 
 func discovery(extPort int) *discover.Discoverer {
-	disc, err := discover.NewDiscoverer(myID, cfg.Options.ListenAddress, cfg.Options.LocalAnnPort, cfg.Options.LocalAnnMCAddr)
-	if err != nil {
-		l.Warnf("No discovery possible (%v)", err)
-		return nil
-	}
+	disc := discover.NewDiscoverer(myID, cfg.Options.ListenAddress)
 
 	if cfg.Options.LocalAnnEnabled {
-		l.Infoln("Sending local discovery announcements")
-		disc.StartLocal()
+		l.Infoln("Starting local discovery announcements")
+		disc.StartLocal(cfg.Options.LocalAnnPort, cfg.Options.LocalAnnMCAddr)
 	}
 
 	if cfg.Options.GlobalAnnEnabled {
-		l.Infoln("Sending global discovery announcements")
+		l.Infoln("Starting global discovery announcements")
 		disc.StartGlobal(cfg.Options.GlobalAnnServer, uint16(extPort))
 	}
 


### PR DESCRIPTION
Without this patch, announcements for me are not working, due to the returned nil which means the announcement is never started.
