### PR TITLE
Add routine for checking possible standby (fixes #565)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -106,8 +106,8 @@ The following enviroment variables are interpreted by syncthing:
  STGUIADDRESS  Override GUI listen address set in config. Expects protocol type
                followed by hostname or an IP address, followed by a port, such
                as "https://127.0.0.1:8888".
-			
- STGUIAUTH     Override GUI authentication credentials set in config. Expects 
+
+ STGUIAUTH     Override GUI authentication credentials set in config. Expects
                a colon separated username and password, such as "admin:secret".
 
  STGUIAPIKEY   Override GUI API key set in config.
@@ -558,6 +558,8 @@ nextRepo:
 			}
 		}()
 	}
+
+	go standbyMonitor()
 
 	events.Default.Log(events.StartupComplete, nil)
 	go generateEvents()
@@ -1163,4 +1165,16 @@ func overrideGUIConfig(originalCfg config.GUIConfiguration, address, authenticat
 		cfg.APIKey = apikey
 	}
 	return cfg
+}
+
+func standbyMonitor() {
+	now := time.Now()
+	for {
+		time.Sleep(10 * time.Second)
+		if time.Since(now) > 2*time.Minute {
+			l.Infoln("Paused state detected, possibly woke up from standby.")
+			restart()
+		}
+		now = time.Now()
+	}
 }


### PR DESCRIPTION
We can debate about the times, as this whole thing is a bit racey.

Initially had sleep for a minute, allow up to 30 seconds drift. 

Worked like a charm on Windows, though managed to time it quite well two times in a row on Linux for it not to work.

But then having 1 minute sleep with 1 second drift can also give bad results...

Fixes #565
