### PR TITLE
Fixed many linter errors in gui/app.js

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -524,8 +524,10 @@ func restGetLang(w http.ResponseWriter, r *http.Request) {
 	lang := r.Header.Get("Accept-Language")
 	var langs []string
 	for _, l := range strings.Split(lang, ",") {
-		parts := strings.SplitN(l, ";", 2)
-		langs = append(langs, strings.ToLower(strings.TrimSpace(parts[0])))
+		s := strings.TrimSpace(strings.SplitN(l, ";", 2)[0])
+		if len(s) >= 2 {
+			langs = append(langs, s)
+		}
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	json.NewEncoder(w).Encode(langs)

--- a/gui/app.js
+++ b/gui/app.js
@@ -20,6 +20,26 @@
         });
     });
 
+    syncthing.run(function ($http, $translate) {
+        $http.get(urlbase + "/lang").success(function (langs) {
+            // Find the first language in the list provided by the user's browser
+            // that is a prefix of a language we have available. That is, "en"
+            // sent by the browser will match "en" or "en-US", while "zh-TW" will
+            // match only "zh-TW" and not "zh-CN".
+
+            var i, j;
+            for (i = 0; i < langs.length; i++) {
+                for (j = 0; j < validLangs.length; j++) {
+                    if (validLangs[j].indexOf(langs[i]) === 0) {
+                        $translate.use(validLangs[j]);
+                        return;
+                    }
+                }
+            }
+            $translate.use("en");
+        });
+    });
+
     syncthing.controller('EventCtrl', function ($scope, $http) {
         $scope.lastEvent = null;
         var lastID = 0;
@@ -91,37 +111,6 @@
         $scope.seenError = '';
         $scope.upgradeInfo = {};
         $scope.stats = {};
-
-        $http.get(urlbase + "/lang").success(function (langs) {
-            // Find the first language in the list provided by the user's browser
-            // that is a prefix of a language we have available. That is, "en"
-            // sent by the browser will match "en" or "en-US", while "zh-TW" will
-            // match only "zh-TW" and not "zh-CN".
-
-            var lang, matching, i;
-            for (i = 0; i < langs.length; i++) {
-                lang = langs[i];
-                if (lang.length < 2) {
-                    continue;
-                }
-                matching = validLangs.filter(function (possibleLang) {
-                    // The langs returned by the /rest/langs call will be in lower
-                    // case. We compare to the lowercase version of the language
-                    // code we have as well.
-                    possibleLang = possibleLang.toLowerCase();
-                    if (possibleLang.length > lang.length) {
-                        return possibleLang.indexOf(lang) === 0;
-                    }
-                    return lang.indexOf(possibleLang) === 0;
-                });
-                if (matching.length >= 1) {
-                    $translate.use(matching[0]);
-                    return;
-                }
-            }
-            // Fallback if nothing matched
-            $translate.use("en");
-        });
 
         $(window).bind('beforeunload', function () {
             navigatingAway = true;


### PR DESCRIPTION
gui/app.js had already some jslint settings in it, but it contained very many errors. This fixes most errors, but there are still some, but the remaining errors are more difficult to fix.

Rewrote the user preferred language selector to be more "angular-like".
