### PR TITLE
Send the real hash as part of the config (fixes #681)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -136,7 +136,7 @@ func startGUI(cfg config.GUIConfiguration, assetDir string, m *model.Model) erro
 	handler = withVersionMiddleware(handler)
 
 	// Wrap everything in basic auth, if user/password is set.
-	if len(cfg.User) > 0 {
+	if len(cfg.User) > 0 && len(cfg.Password) > 0 {
 		handler = basicAuthAndSessionMiddleware(cfg, handler)
 	}
 


### PR DESCRIPTION
Fixes the bug where ConfigSaved event sends the config with the real hash,
making it look that the password has changed once the config is next saved
by the UI.

I don't know why we weren't sending the hash in the first place?
