### PR TITLE
Fixed invalid nodes in cluster config

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -952,8 +952,10 @@ func (m *Model) clusterConfig(node protocol.NodeID) protocol.ClusterConfigMessag
 		}
 		for _, node := range m.repoNodes[repo] {
 			// TODO: Set read only bit when relevant
+			id_copy := make([]byte, len(node));
+			copy(id_copy, node[:]);
 			cr.Nodes = append(cr.Nodes, protocol.Node{
-				ID:    node[:],
+				ID:    id_copy,
 				Flags: protocol.FlagShareTrusted,
 			})
 		}


### PR DESCRIPTION
As node id wasn’t copied cluster config actually contained id of the last node, i.e. if there was 3 nodes, all of them had id of the last one.

It looked like this:
default
        XXXXXX-XXXXXX-XXXXXX-C2OXXMH-5OUK7US-HSWC467-EQG27WL-UOFW6QF: max 0, flags 1
        XXXXXX-XXXXXX-XXXXXX-C2OXXMH-5OUK7US-HSWC467-EQG27WL-UOFW6QF: max 0, flags 1
        XXXXXX-XXXXXX-XXXXXX-C2OXXMH-5OUK7US-HSWC467-EQG27WL-UOFW6QF: max 0, flags 1
