### PR TITLE
[do not merge] API functions for file access

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -597,8 +597,9 @@ func restPostCreateFile(m *model.Model, w http.ResponseWriter, r *http.Request) 
 	var qs = r.URL.Query()
 	var repoId = qs.Get("repo")
 	var repo, repoExists = cfg.RepoMap()[repoId]
-	var path = filepath.Clean(repo.Directory + "/" + qs.Get("path"))
+	var path = qs.Get("path")
 	var isDir = path[len(path)-1] == '/'
+	path = filepath.Clean(repo.Directory + "/" + qs.Get("path"))
 
 	if !repoExists {
 		flushResponse(`{"error": "Repository `+repoId+` does not exist"}`, w)
@@ -607,13 +608,6 @@ func restPostCreateFile(m *model.Model, w http.ResponseWriter, r *http.Request) 
 
 	if !strings.HasPrefix(path, repo.Directory) {
 		flushResponse(`{"error": "Must not create file outside repository"}`, w)
-		return
-	}
-
-	var parent = filepath.Dir(path)
-	var _, statParentError = os.Stat(parent)
-	if !isDir && strings.Contains(path, "/") && statParentError != nil {
-		flushResponse(`{"error": "Parent directory does not exist"}`, w)
 		return
 	}
 

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -602,7 +602,7 @@ func restPostCreateFile(m *model.Model, w http.ResponseWriter, r *http.Request) 
 	var repo, repoExists = cfg.RepoMap()[repoId]
 	var path = qs.Get("path")
 	var isDir = path[len(path)-1] == '/'
-	path = filepath.Clean(repo.Directory + "/" + qs.Get("path"))
+	path = filepath.Clean(filepath.Join(repo.Directory, qs.Get("path")))
 
 	if !repoExists {
 		flushResponse(`{"error": "Repository `+repoId+` does not exist"}`, w)
@@ -635,7 +635,7 @@ func restPostDeleteFile(m *model.Model, w http.ResponseWriter, r *http.Request) 
 	var qs = r.URL.Query()
 	var repoId = qs.Get("repo")
 	var repo, repoExists = cfg.RepoMap()[repoId]
-	var path = filepath.Clean(repo.Directory + "/" + qs.Get("path"))
+	var path = filepath.Clean(filepath.Join(repo.Directory, qs.Get("path")))
 
 	if !repoExists {
 		flushResponse(`{"error": "Repository `+repoId+` does not exist"}`, w)
@@ -663,7 +663,7 @@ func restGetFolderContents(w http.ResponseWriter, r *http.Request) {
 	var qs = r.URL.Query()
 	var repoId = qs.Get("repo")
 	var repo, repoExists = cfg.RepoMap()[repoId]
-	var path = filepath.Clean(repo.Directory + "/" + qs.Get("path"))
+	var path = filepath.Clean(filepath.Join(repo.Directory, qs.Get("path")))
 
 	if !repoExists {
 		flushResponse(`{"error": "Repository `+repoId+` does not exist"}`, w)
@@ -687,7 +687,7 @@ func restGetFolderContents(w http.ResponseWriter, r *http.Request) {
 		if f.IsDir() {
 			mimetype = MIME_TYPE_DIR
 		} else {
-			mimetype = mime.TypeByExtension(filepath.Ext(f.Name()))
+			mimetype = mimeTypeForFile(f.Name())
 		}
 		contents[i] = map[string]string{
 			"name":     f.Name(),


### PR DESCRIPTION
This can be used to implement a web interface like Dropbox has it, so files can be accessed from a device that does not have syncthing installed itself. Personally, I want to implement a [DocumentsProvider](https://developer.android.com/guide/topics/providers/document-provider.html) for Android. The next step (after the Android implementation) would be to get all file data from `Model`, so that files are downloaded on the fly, and local storage is not needed (but I didn't understand the code good enough for that).

**/rest/file/create/**
Creates new file or directory at the given path. To create a directory, pass a trailing '/'. Note that the parent directory must already exist.
(We might also get rid of this and just use `/rest/file/write/`, but I put it in because I was going by the Android API)
`curl -s "http://localhost:8081/rest/file/create?repo=default&path=testfile"`

**/rest/file/delete/**
Deletes the given file. If it is a directory, it has to be empty.
`curl -s "http://localhost:8081/rest/file/delete?repo=default&path=testfile"`

**/rest/file/write/**
Uploads and replaces the file. Must exist.
`curl -s "http://localhost:8081/rest/file/write?repo=default&path=testfile" -H "X-API-Key: xyz" --form "file=@testfile"`

**/rest/file/read/**
Downloads the file. Must exist.
curl -s "http://localhost:8081/rest/file/read?repo=default&path=testfile"

**/rest/file/list**
Lists all directory contents.
```
curl -s "http://localhost:8081/rest/file/list?repo=default"
[ { 
	"mime" : "text/plain; charset=utf-8",
	"modified" : "1411333357",
	"name" : "file.txt",
	"size" : "0"
}]
```

There's lots of duplicate code (mostly error handling), I'll see how I can improve that (open for suggestions).

I'm not quite sure how the CSRF works, it seems that only `POST` requests are protected? (at least that's how it seemed during my debugging)

At the moment, there's no client for this (except for the curls above). You might want to wait until I implement this on Android before merging (I might also have to change stuff for that).

Sorry for this wall of text :D 

Edit: The spećific Android interface is [here](https://developer.android.com/reference/android/provider/DocumentsProvider.html).One difference is that it uses `createDocument(parent, mime, name)`, whereas I only use `path`. Not sure what the best option is here.

Also, I have no idea if the read/write actually works like this on Android, will have to implement and see.