### PR TITLE
Check existing nodes before adding from introducer (Fixes #745)

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -475,7 +475,15 @@ func (m *Model) ClusterConfig(nodeID protocol.NodeID, cm protocol.ClusterConfigM
 				var id protocol.NodeID
 				copy(id[:], node.ID)
 
-				if _, ok := m.nodeRepos[id]; !ok {
+				//Skip adding existing nodes to configuration
+				existingNode := false
+				for _, en := range m.cfg.Nodes {
+					if en.NodeID == id {
+						existingNode = true
+					}
+				}
+
+				if _, ok := m.nodeRepos[id]; !ok && !existingNode {
 					// The node is currently unknown. Add it to the config.
 
 					l.Infof("Adding node %v to config (vouched for by introducer %v)", id, nodeID)


### PR DESCRIPTION
Fixes #785 

We still add nodes to repositories where the "introducer" thinks they should be.
