### PR TITLE
Check existing nodes before adding from introducer (Fixes #745)

### DIFF
--- a/model/model.go
+++ b/model/model.go
@@ -475,7 +475,7 @@ func (m *Model) ClusterConfig(nodeID protocol.NodeID, cm protocol.ClusterConfigM
 				var id protocol.NodeID
 				copy(id[:], node.ID)
 
-				if _, ok := m.nodeRepos[id]; !ok {
+				if _, ok := m.nodeRepos[id]; !ok && m.cfg.GetNodeConfiguration(id) == nil {
 					// The node is currently unknown. Add it to the config.
 
 					l.Infof("Adding node %v to config (vouched for by introducer %v)", id, nodeID)


### PR DESCRIPTION
Sorry about the last one ;( 

We still add nodes to the repositories where the "introducer" think they should be. I think this is okay.
