### PR TITLE
Renames should be handled efficiently (fixes #3)

### DIFF
--- a/internal/osutil/osutil.go
+++ b/internal/osutil/osutil.go
@@ -17,6 +17,7 @@
 package osutil
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -80,4 +81,24 @@ func InWritableDir(fn func(string) error, path string) error {
 	}
 
 	return fn(path)
+}
+
+func Copy(from, to string) error {
+	src, err := os.Open(from)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.Create(to)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(dst, src)
+	if err != nil {
+		dst.Close()
+		return err
+	}
+	return dst.Close()
 }

--- a/internal/scanner/blocks.go
+++ b/internal/scanner/blocks.go
@@ -129,3 +129,15 @@ func Verify(r io.Reader, blocksize int, blocks []protocol.BlockInfo) error {
 
 	return nil
 }
+
+func BlocksEqual(src, dst []protocol.BlockInfo) bool {
+	if len(src) != len(dst) {
+		return false
+	}
+	for i := range src {
+		if !bytes.Equal(src[i].Hash, dst[i].Hash) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Attempt one.

Alternative version would be to check just for the files we are removing, which would get rid of the `WithHave`.

Ideally I'd like this global block cache thing come true, and have even better stuff happen automagically in `handleFile`.

Not sure if the `if len(file.Blocks) > 0` checks are necessary (probably not?), but just playing it safe.
