### PR TITLE
Minor fixes.

### DIFF
--- a/internal/discover/discover.go
+++ b/internal/discover/discover.go
@@ -132,9 +132,9 @@ func (d *Discoverer) ExtAnnounceOK() bool {
 }
 
 func (d *Discoverer) Lookup(device protocol.DeviceID) []string {
-	d.registryLock.Lock()
+	d.registryLock.RLock()
 	cached := d.filterCached(d.registry[device])
-	d.registryLock.Unlock()
+	d.registryLock.RUnlock()
 
 	if len(cached) > 0 {
 		addrs := make([]string, len(cached))

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -25,7 +25,7 @@ import (
 type EventType uint64
 
 const (
-	Ping = 1 << iota
+	Ping EventType = 1 << iota
 	Starting
 	StartupComplete
 	DeviceDiscovered
@@ -39,7 +39,7 @@ const (
 	FolderRejected
 	ConfigSaved
 
-	AllEvents = ^EventType(0)
+	AllEvents = (1 << iota) - 1
 )
 
 func (t EventType) String() string {
@@ -131,7 +131,7 @@ func (l *Logger) Log(t EventType, data interface{}) {
 			select {
 			case s.events <- e:
 			default:
-				//log.Println("Dropping event:", e)
+				// if s.events is not ready, drop the event
 			}
 		}
 	}
@@ -157,7 +157,7 @@ func (l *Logger) Subscribe(mask EventType) *Subscription {
 func (l *Logger) Unsubscribe(s *Subscription) {
 	l.mutex.Lock()
 	if debug {
-		dl.Debugln("unsubsribe")
+		dl.Debugln("unsubscribe")
 	}
 	delete(l.subs, s.id)
 	close(s.events)

--- a/internal/files/set_test.go
+++ b/internal/files/set_test.go
@@ -858,7 +858,8 @@ func TestLongPath(t *testing.T) {
 		t.Fatalf("Incorrect len %d != 1 for global list", l)
 	}
 	if gf[0].Name != local[0].Name {
-		t.Error("Incorrect long filename;\n%q !=\n%q", gf[0].Name, local[0].Name)
+		t.Errorf("Incorrect long filename;\n%q !=\n%q",
+			gf[0].Name, local[0].Name)
 	}
 }
 


### PR DESCRIPTION
- Bug fix - use .Errorf() instead of .Error():
  Before this change, an error message for failed tests in files/set_test.go
  wrongly tried to use format strings in a call to .Error()
- Change event constants to be of type EventType rather than untyped integers.
- Slightly relax the locking for registry cache lookups:
  For read access to Discover.registry we only need to take a read lock.
- Some cosmetic fixes.
