### PR TITLE
bug fix: allow folder names of length 64 in leveldb

### DIFF
--- a/internal/files/leveldb.go
+++ b/internal/files/leveldb.go
@@ -82,23 +82,11 @@ type dbWriter interface {
 	Delete([]byte)
 }
 
-/*
-
-keyTypeDevice (1 byte)
-    folder (64 bytes)
-        device (32 bytes)
-            name (variable size)
-		|
-		scanner.File
-
-keyTypeGlobal (1 byte)
-	folder (64 bytes)
-		name (variable size)
-			|
-			[]fileVersion (sorted)
-
-*/
-
+// deviceKey returns a byte slice encoding the following information:
+//	   keyTypeDevice (1 byte)
+//	   folder (64 bytes)
+//	   device (32 bytes)
+//	   name (variable size)
 func deviceKey(folder, device, file []byte) []byte {
 	k := make([]byte, 1+64+32+len(file))
 	k[0] = keyTypeDevice
@@ -108,24 +96,33 @@ func deviceKey(folder, device, file []byte) []byte {
 	return k
 }
 
+func deviceKeyName(key []byte) []byte {
+	return key[1+64+32:]
+}
+
+func deviceKeyFolder(key []byte) []byte {
+	folder := key[1 : 1+64]
+	izero := bytes.IndexByte(folder, 0)
+	if izero < 0 {
+		return folder
+	}
+	return folder[:izero]
+}
+
+func deviceKeyDevice(key []byte) []byte {
+	return key[1+64 : 1+64+32]
+}
+
+// globalKey returns a byte slice encoding the following information:
+//	   keyTypeGlobal (1 byte)
+//	   folder (64 bytes)
+//	   name (variable size)
 func globalKey(folder, file []byte) []byte {
 	k := make([]byte, 1+64+len(file))
 	k[0] = keyTypeGlobal
 	copy(k[1:], []byte(folder))
 	copy(k[1+64:], []byte(file))
 	return k
-}
-
-func deviceKeyName(key []byte) []byte {
-	return key[1+64+32:]
-}
-func deviceKeyFolder(key []byte) []byte {
-	folder := key[1 : 1+64]
-	izero := bytes.IndexByte(folder, 0)
-	return folder[:izero]
-}
-func deviceKeyDevice(key []byte) []byte {
-	return key[1+64 : 1+64+32]
 }
 
 func globalKeyName(key []byte) []byte {
@@ -135,6 +132,9 @@ func globalKeyName(key []byte) []byte {
 func globalKeyFolder(key []byte) []byte {
 	folder := key[1 : 1+64]
 	izero := bytes.IndexByte(folder, 0)
+	if izero < 0 {
+		return folder
+	}
 	return folder[:izero]
 }
 

--- a/internal/files/leveldb_test.go
+++ b/internal/files/leveldb_test.go
@@ -1,0 +1,43 @@
+package files
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestDeviceKey(t *testing.T) {
+	fld := []byte("folder6789012345678901234567890123456789012345678901234567890123")
+	dev := []byte("device67890123456789012345678901")
+	name := []byte("name")
+
+	key := deviceKey(fld, dev, name)
+
+	fld2 := deviceKeyFolder(key)
+	if bytes.Compare(fld2, fld) != 0 {
+		t.Errorf("wrong folder %q != %q", fld2, fld)
+	}
+	dev2 := deviceKeyDevice(key)
+	if bytes.Compare(dev2, dev) != 0 {
+		t.Errorf("wrong device %q != %q", dev2, dev)
+	}
+	name2 := deviceKeyName(key)
+	if bytes.Compare(name2, name) != 0 {
+		t.Errorf("wrong name %q != %q", name2, name)
+	}
+}
+
+func TestGlobalKey(t *testing.T) {
+	fld := []byte("folder6789012345678901234567890123456789012345678901234567890123")
+	name := []byte("name")
+
+	key := globalKey(fld, name)
+
+	fld2 := globalKeyFolder(key)
+	if bytes.Compare(fld2, fld) != 0 {
+		t.Errorf("wrong folder %q != %q", fld2, fld)
+	}
+	name2 := globalKeyName(key)
+	if bytes.Compare(name2, name) != 0 {
+		t.Errorf("wrong name %q != %q", name2, name)
+	}
+}


### PR DESCRIPTION
The file internal/files/leveldb.go contains code to convert between folder+device+name and byte slices used as database keys.  This code did not work when the folder name was 64 bytes long.  If folder names of length 64 are allowed, something like the attached patch may be useful. (Folder names containing 0 bytes also don't work; I am not sure whether this is a problem.)
