### PR TITLE
Close connection if the client is not requesting anything

### DIFF
--- a/cmd/syncthing/tls.go
+++ b/cmd/syncthing/tls.go
@@ -124,6 +124,7 @@ func (l *DowngradingListener) Accept() (net.Conn, error) {
 		return nil, err
 	}
 
+	conn.SetReadDeadline(time.Now().Add(20 * time.Second))
 	br := bufio.NewReader(conn)
 	bs, err := br.Peek(1)
 	if err != nil {


### PR DESCRIPTION
Probably related to https://github.com/syncthing/syncthing/issues/805
Setting the _read_ deadline to two seconds.
