### PR TITLE
Better handling of wrong config files

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -346,13 +346,20 @@ func syncthingMain() {
 	// Load the configuration file, if it exists.
 	// If it does not, create a template.
 
-	cfg, err = config.Load(cfgFile, myID)
-	if err == nil {
-		myCfg := cfg.Devices()[myID]
-		if myCfg.Name == "" {
-			myName, _ = os.Hostname()
+	if info, err := os.Stat(cfgFile); err == nil {
+		if info.IsDir() {
+			l.Fatalln("config file is a directory!")
+		}
+		cfg, err = config.Load(cfgFile, myID)
+		if err == nil {
+			myCfg := cfg.Devices()[myID]
+			if myCfg.Name == "" {
+				myName, _ = os.Hostname()
+			} else {
+				myName = myCfg.Name
+			}
 		} else {
-			myName = myCfg.Name
+			l.Fatalln("Could not load config file, refusing to replace with empty defaults")
 		}
 	} else {
 		l.Infoln("No config file; starting with empty defaults")


### PR DESCRIPTION
I was editing my config externally and restarted syncthing for it to pick up the config changes. But all it did was report that no config file was found and stomp my modified config with the default one.

The issue was that config.Load() had failed, but not because the file didn't exist, but because the XML was wrong - I had left a boolean field empty.

Anyway, I made it check that the file exists and that it actually is a file before trying Load(). And if Load() fails, I personally think it would be best to not replace a config on disk with the default config, since important data might be lost.

Cheers!
