### PR TITLE
Cache ignore file matches

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,7 @@ type OptionsConfiguration struct {
 	RestartOnWakeup      bool     `xml:"restartOnWakeup" default:"true"`
 	AutoUpgradeIntervalH int      `xml:"autoUpgradeIntervalH" default:"12"` // 0 for off
 	KeepTemporariesH     int      `xml:"keepTemporariesH" default:"24"`     // 0 for off
+	CacheIgnoredFiles    bool     `xml:"cacheIgnoredFiles" default:"true"`
 
 	Deprecated_RescanIntervalS int    `xml:"rescanIntervalS,omitempty" json:"-"`
 	Deprecated_UREnabled       bool   `xml:"urEnabled,omitempty" json:"-"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -50,6 +50,7 @@ func TestDefaultValues(t *testing.T) {
 		RestartOnWakeup:      true,
 		AutoUpgradeIntervalH: 12,
 		KeepTemporariesH:     24,
+		CacheIgnoredFiles:    true,
 	}
 
 	cfg := New(device1)
@@ -138,6 +139,7 @@ func TestOverriddenValues(t *testing.T) {
 		RestartOnWakeup:      false,
 		AutoUpgradeIntervalH: 24,
 		KeepTemporariesH:     48,
+		CacheIgnoredFiles:    false,
 	}
 
 	cfg, err := Load("testdata/overridenvalues.xml", device1)

--- a/internal/config/testdata/overridenvalues.xml
+++ b/internal/config/testdata/overridenvalues.xml
@@ -18,5 +18,6 @@
         <restartOnWakeup>false</restartOnWakeup>
         <autoUpgradeIntervalH>24</autoUpgradeIntervalH>
         <keepTemporariesH>48</keepTemporariesH>
+        <cacheIgnoredFiles>false</cacheIgnoredFiles>
     </options>
 </configuration>

--- a/internal/ignore/ignore.go
+++ b/internal/ignore/ignore.go
@@ -23,31 +23,94 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/syncthing/syncthing/internal/fnmatch"
 )
+
+var caches = make(map[string]MatcherCache)
 
 type Pattern struct {
 	match   *regexp.Regexp
 	include bool
 }
 
-type Patterns []Pattern
+type Matcher struct {
+	patterns   []Pattern
+	oldMatches map[string]bool
 
-func Load(file string) (Patterns, error) {
-	seen := make(map[string]bool)
-	return loadIgnoreFile(file, seen)
+	newMatches map[string]bool
+	mut        sync.Mutex
 }
 
-func Parse(r io.Reader, file string) (Patterns, error) {
+type MatcherCache struct {
+	patterns []Pattern
+	matches  *map[string]bool
+}
+
+func Load(file string, cache bool) (*Matcher, error) {
+	seen := make(map[string]bool)
+	matcher, err := loadIgnoreFile(file, seen)
+	if !cache || err != nil {
+		return matcher, err
+	}
+
+	// Get the current cache object for the given file
+	cached, ok := caches[file]
+	if !ok || !patternsEqual(cached.patterns, matcher.patterns) {
+		// Nothing in cache or a cache mismatch, create a new cache which will
+		// store matches for the given set of patterns.
+		// Initialize oldMatches to indicate that we are interested in
+		// caching.
+		matcher.oldMatches = make(map[string]bool)
+		matcher.newMatches = make(map[string]bool)
+		caches[file] = MatcherCache{
+			patterns: matcher.patterns,
+			matches:  &matcher.newMatches,
+		}
+		return matcher, nil
+	}
+
+	// Patterns haven't changed, so we can reuse the old matches, create a new
+	// matches map and update the pointer. (This prevents matches map from
+	// growing indefinately, as we only cache whatever we've matched in the last
+	// iteration, rather than through runtime history)
+	matcher.oldMatches = *cached.matches
+	matcher.newMatches = make(map[string]bool)
+	cached.matches = &matcher.newMatches
+	caches[file] = cached
+	return matcher, nil
+}
+
+func Parse(r io.Reader, file string) (*Matcher, error) {
 	seen := map[string]bool{
 		file: true,
 	}
 	return parseIgnoreFile(r, file, seen)
 }
 
-func (l Patterns) Match(file string) bool {
-	for _, pattern := range l {
+func (m *Matcher) Match(file string) (result bool) {
+	if len(m.patterns) == 0 {
+		return false
+	}
+
+	// We have old matches map set, means we should do caching
+	if m.oldMatches != nil {
+		// Capture the result to the new matches regardless of who returns it
+		defer func() {
+			m.mut.Lock()
+			m.newMatches[file] = result
+			m.mut.Unlock()
+		}()
+		// Check perhaps we've seen this file before, and we already know
+		// what the outcome is going to be.
+		result, ok := m.oldMatches[file]
+		if ok {
+			return result
+		}
+	}
+
+	for _, pattern := range m.patterns {
 		if pattern.match.MatchString(file) {
 			return pattern.include
 		}
@@ -55,7 +118,7 @@ func (l Patterns) Match(file string) bool {
 	return false
 }
 
-func loadIgnoreFile(file string, seen map[string]bool) (Patterns, error) {
+func loadIgnoreFile(file string, seen map[string]bool) (*Matcher, error) {
 	if seen[file] {
 		return nil, fmt.Errorf("Multiple include of ignore file %q", file)
 	}
@@ -70,8 +133,8 @@ func loadIgnoreFile(file string, seen map[string]bool) (Patterns, error) {
 	return parseIgnoreFile(fd, file, seen)
 }
 
-func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) (Patterns, error) {
-	var exps Patterns
+func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) (*Matcher, error) {
+	var exps Matcher
 
 	addPattern := func(line string) error {
 		include := true
@@ -86,27 +149,27 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) (Pa
 			if err != nil {
 				return fmt.Errorf("Invalid pattern %q in ignore file", line)
 			}
-			exps = append(exps, Pattern{exp, include})
+			exps.patterns = append(exps.patterns, Pattern{exp, include})
 		} else if strings.HasPrefix(line, "**/") {
 			// Add the pattern as is, and without **/ so it matches in current dir
 			exp, err := fnmatch.Convert(line, fnmatch.FNM_PATHNAME)
 			if err != nil {
 				return fmt.Errorf("Invalid pattern %q in ignore file", line)
 			}
-			exps = append(exps, Pattern{exp, include})
+			exps.patterns = append(exps.patterns, Pattern{exp, include})
 
 			exp, err = fnmatch.Convert(line[3:], fnmatch.FNM_PATHNAME)
 			if err != nil {
 				return fmt.Errorf("Invalid pattern %q in ignore file", line)
 			}
-			exps = append(exps, Pattern{exp, include})
+			exps.patterns = append(exps.patterns, Pattern{exp, include})
 		} else if strings.HasPrefix(line, "#include ") {
 			includeFile := filepath.Join(filepath.Dir(currentFile), line[len("#include "):])
 			includes, err := loadIgnoreFile(includeFile, seen)
 			if err != nil {
 				return err
 			} else {
-				exps = append(exps, includes...)
+				exps.patterns = append(exps.patterns, includes.patterns...)
 			}
 		} else {
 			// Path name or pattern, add it so it matches files both in
@@ -115,13 +178,13 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) (Pa
 			if err != nil {
 				return fmt.Errorf("Invalid pattern %q in ignore file", line)
 			}
-			exps = append(exps, Pattern{exp, include})
+			exps.patterns = append(exps.patterns, Pattern{exp, include})
 
 			exp, err = fnmatch.Convert("**/"+line, fnmatch.FNM_PATHNAME)
 			if err != nil {
 				return fmt.Errorf("Invalid pattern %q in ignore file", line)
 			}
-			exps = append(exps, Pattern{exp, include})
+			exps.patterns = append(exps.patterns, Pattern{exp, include})
 		}
 		return nil
 	}
@@ -155,5 +218,17 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) (Pa
 		}
 	}
 
-	return exps, nil
+	return &exps, nil
+}
+
+func patternsEqual(a, b []Pattern) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].include != b[i].include || a[i].match.String() != b[i].match.String() {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -390,7 +390,7 @@ func TestIgnores(t *testing.T) {
 	}
 
 	db, _ := leveldb.Open(storage.NewMemStorage(), nil)
-	m := NewModel(nil, "device", "syncthing", "dev", db)
+	m := NewModel(config.Wrap("", config.Configuration{}), "device", "syncthing", "dev", db)
 	m.AddFolder(config.FolderConfiguration{ID: "default", Path: "testdata"})
 
 	expected := []string{

--- a/internal/scanner/walk.go
+++ b/internal/scanner/walk.go
@@ -36,7 +36,7 @@ type Walker struct {
 	// BlockSize controls the size of the block used when hashing.
 	BlockSize int
 	// List of patterns to ignore
-	Ignores ignore.Patterns
+	Ignores *ignore.Matcher
 	// If TempNamer is not nil, it is used to ignore tempory files when walking.
 	TempNamer TempNamer
 	// If CurrentFiler is not nil, it is queried for the current file before rescanning.

--- a/internal/scanner/walk_test.go
+++ b/internal/scanner/walk_test.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func TestWalkSub(t *testing.T) {
-	ignores, err := ignore.Load("testdata/.stignore")
+	ignores, err := ignore.Load("testdata/.stignore", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -93,7 +93,7 @@ func TestWalkSub(t *testing.T) {
 }
 
 func TestWalk(t *testing.T) {
-	ignores, err := ignore.Load("testdata/.stignore")
+	ignores, err := ignore.Load("testdata/.stignore", false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A bit of a pointless thing for desktops, but it seemed like an interesting challenge.
I bet ARM people will benefit.

```
BenchmarkMatch     50000         35664 ns/op
BenchmarkMatchCached    20000000           111 ns/op
```
