### PR TITLE
Remove extra byte from the version string (ref #862)

### DIFF
--- a/build.go
+++ b/build.go
@@ -307,6 +307,7 @@ func getVersion() string {
 	if err != nil {
 		return "unknown-dev"
 	}
+	v = v[:len(v)-1]
 	v = versionRe.ReplaceAllFunc(v, func(s []byte) []byte {
 		s[0] = '+'
 		return s


### PR DESCRIPTION
Not sure where the `0xa` comes from.
