### PR TITLE
Added ability to send CA chain

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -76,9 +76,14 @@ func startGUI(cfg config.GUIConfiguration, assetDir string, m *model.Model) erro
 	if err != nil {
 		return err
 	}
+
+	CAPool := loadCACert(confDir, "https-")
+
 	tlsCfg := &tls.Config{
 		Certificates: []tls.Certificate{cert},
 		ServerName:   "syncthing",
+		RootCAs: CAPool,
+		ClientCAs: CAPool,
 	}
 
 	rawListener, err := net.Listen("tcp", cfg.Address)

--- a/cmd/syncthing/tls.go
+++ b/cmd/syncthing/tls.go
@@ -26,6 +26,7 @@ import (
 	"encoding/binary"
 	"encoding/pem"
 	"io"
+	"io/ioutil"
 	"math/big"
 	mr "math/rand"
 	"net"
@@ -43,6 +44,22 @@ func loadCert(dir string, prefix string) (tls.Certificate, error) {
 	cf := filepath.Join(dir, prefix+"cert.pem")
 	kf := filepath.Join(dir, prefix+"key.pem")
 	return tls.LoadX509KeyPair(cf, kf)
+}
+
+func loadCACert(dir string, prefix string) (*x509.CertPool) {
+	CAPool := x509.NewCertPool()
+	cf := filepath.Join(dir, prefix+"ca.pem")
+	severCert, err := ioutil.ReadFile(cf)
+
+	if err != nil {
+		l.Infoln("Could not load server CA chain!")
+		return CAPool
+	}
+	ok := CAPool.AppendCertsFromPEM(severCert)
+	if !ok {
+		l.Infoln("Failed to parse PEM data for CA chain")
+	}
+	return CAPool
 }
 
 func certSeed(bs []byte) int64 {


### PR DESCRIPTION
Makes it possible to send the certificate of intermediate CA to the user. Will automatically load the certificates in "https-ca.pem".
This is necessary when using own certificates that are signed by intermediate certificates.

(This is my first time ever using go, and pretty much first git activity, so feedback is appreciated)
