### PR TITLE
Cleanup blockmap on update (fixes #889)

### DIFF
--- a/internal/files/blockmap.go
+++ b/internal/files/blockmap.go
@@ -90,6 +90,17 @@ func (m *BlockMap) Update(files []protocol.FileInfo) error {
 	return m.db.Write(batch, nil)
 }
 
+// Discard block map state, removing the given files
+func (m *BlockMap) Discard(files []protocol.FileInfo) error {
+	batch := new(leveldb.Batch)
+	for _, file := range files {
+		for _, block := range file.Blocks {
+			batch.Delete(m.blockKey(block.Hash, file.Name))
+		}
+	}
+	return m.db.Write(batch, nil)
+}
+
 // Drop block map, removing all entries related to this block map from the db.
 func (m *BlockMap) Drop() error {
 	batch := new(leveldb.Batch)


### PR DESCRIPTION
Not sure how to deal with the poluted database.

I have two options I guess:
1. Write a migration thing which gets passed a database handle, clearing all data.
2. Hash the block I've read during iteration, and fix it up there (but perhaps also only on last puller iteration before we fail)
