### PR TITLE
Make copiers, pullers and finishers configurable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,9 @@ type FolderConfiguration struct {
 	IgnorePerms     bool                        `xml:"ignorePerms,attr"`
 	Versioning      VersioningConfiguration     `xml:"versioning"`
 	LenientMtimes   bool                        `xml:"lenientMtimes"`
+	Copiers         int                         `xml:"copiers" default:"1"`   // This defines how many files are handled concurrently.
+	Pullers         int                         `xml:"pullers" default:"16"`  // Defines how many blocks are fetched at the same time, possibly between separate copier routines.
+	Finishers       int                         `xml:"finishers" default:"1"` // Most of the time, should be equal to the number of copiers. These are CPU bound due to hashing.
 
 	Invalid string `xml:"-"` // Set at runtime when there is an error, not saved
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -178,6 +178,9 @@ func (m *Model) StartFolderRW(folder string) {
 		model:         m,
 		ignorePerms:   cfg.IgnorePerms,
 		lenientMtimes: cfg.LenientMtimes,
+		copiers:       cfg.Copiers,
+		pullers:       cfg.Pullers,
+		finishers:     cfg.Finishers,
 	}
 	m.folderRunners[folder] = p
 	m.fmut.Unlock()


### PR DESCRIPTION
Compliments #999 as this way you can have multiple files being pulled at a time.

Would benefit from fd caching if you are copying multiple files in one go.
