### PR TITLE
Populate correct defaults

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -335,10 +335,20 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) {
 	sort.Sort(DeviceConfigurationList(cfg.Devices))
 	// Ensure that any loose devices are not present in the wrong places
 	// Ensure that there are no duplicate devices
+	// Ensure that puller settings are sane
 	for i := range cfg.Folders {
 		cfg.Folders[i].Devices = ensureDevicePresent(cfg.Folders[i].Devices, myID)
 		cfg.Folders[i].Devices = ensureExistingDevices(cfg.Folders[i].Devices, existingDevices)
 		cfg.Folders[i].Devices = ensureNoDuplicates(cfg.Folders[i].Devices)
+		if cfg.Folders[i].Copiers == 0 {
+			cfg.Folders[i].Copiers = 1
+		}
+		if cfg.Folders[i].Pullers == 0 {
+			cfg.Folders[i].Pullers = 16
+		}
+		if cfg.Folders[i].Finishers == 0 {
+			cfg.Folders[i].Finishers = 1
+		}
 		sort.Sort(FolderDeviceConfigurationList(cfg.Folders[i].Devices))
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,6 +85,9 @@ func TestDeviceConfig(t *testing.T) {
 				Devices:         []FolderDeviceConfiguration{{DeviceID: device1}, {DeviceID: device4}},
 				ReadOnly:        true,
 				RescanIntervalS: 600,
+				Copiers:         1,
+				Pullers:         16,
+				Finishers:       1,
 			},
 		}
 		expectedDevices := []DeviceConfiguration{

--- a/internal/model/puller.go
+++ b/internal/model/puller.go
@@ -250,6 +250,10 @@ func (p *Puller) pullerIteration(checksum bool) int {
 	var pullWg sync.WaitGroup
 	var doneWg sync.WaitGroup
 
+	if debug {
+		l.Debugln(p, "c", p.copiers, "p", p.pullers, "f", p.finishers)
+	}
+
 	for i := 0; i < p.copiers; i++ {
 		copyWg.Add(1)
 		go func() {


### PR DESCRIPTION
It's a bit sad that it has to be done this way, but I cannot come up with a better way.
It would be nice to have per folder defaults, but that means we either need to copy and modify the XML parser
or do it in some crazy way.

What's even more sad, is that now you have tu provide these default values as part of the `/config` call as otherwise you'll end up in a configuration which doesn't work.

Perhaps I should do just:
`max(p.copiers, 1)`, `max(p.pullers, 16)`, `max(p.finishers, 1)` in the puller? 
