### PR TITLE
Add STNOUPGRADE environment variable to prevents autoupgrades

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -171,6 +171,8 @@ are mostly useful for developers. Use with care.
  STPERFSTATS   Write running performance statistics to perf-$pid.csv. Not
                supported on Windows.
 
+ STNOUPGRADE   Disable automatic upgrades.
+
  GOMAXPROCS    Set the maximum number of CPU cores to use. Defaults to all
                available CPU cores.`
 )
@@ -189,6 +191,7 @@ var (
 	generateDir       string
 	logFile           string
 	noRestart         = os.Getenv("STNORESTART") != ""
+	noUpgrade         = os.Getenv("STNOUPGRADE") != ""
 	guiAddress        = os.Getenv("STGUIADDRESS") // legacy
 	guiAuthentication = os.Getenv("STGUIAUTH")    // legacy
 	guiAPIKey         = os.Getenv("STGUIAPIKEY")  // legacy
@@ -571,7 +574,9 @@ func syncthingMain() {
 	}
 
 	if opts.AutoUpgradeIntervalH > 0 {
-		if IsRelease {
+		if noUpgrade {
+			l.Infof("No automatic upgrades; STNOUPGRADE environment variable defined.")
+		} else if IsRelease {
 			go autoUpgrade()
 		} else {
 			l.Infof("No automatic upgrades; %s is not a relase version.", Version)


### PR DESCRIPTION
So, I finally managed to get Syncthing to compile and, as celebration, I would like to request this simple feature.

I would like STNOUPGRADE environment variable that, if defined, would prevent syncthing from autoupdating even if `autoUpgradeIntervalH` is not set to 0. This may help anyone who is running synthing as service and especially me, as I need Syncthing-GTK to manage upgrading on Windows.
