### PR TITLE
Directly accept GOARM env var for ARM version

### DIFF
--- a/build.go
+++ b/build.go
@@ -75,8 +75,14 @@ func main() {
 	case "386", "amd64", "armv5", "armv6", "armv7":
 		break
 	case "arm":
-		log.Println("Invalid goarch \"arm\". Use one of \"armv5\", \"armv6\", \"armv7\".")
-		log.Fatalln("Note that producing a correct \"armv5\" binary requires a rebuilt stdlib.")
+		switch os.Getenv("GOARM") {
+		case "5", "6", "7":
+			goarch += "v" + os.Getenv("GOARM")
+			break
+		default:
+			log.Println("Invalid goarch \"arm\". Use one of \"armv5\", \"armv6\", \"armv7\".")
+			log.Fatalln("Note that producing a correct \"armv5\" binary requires a rebuilt stdlib.")
+		}
 	default:
 		log.Printf("Unknown goarch %q; proceed with caution!", goarch)
 	}


### PR DESCRIPTION
As GOARCH defaults to 'arm' on arm systems this allows packagers to
specify the arm version by setting the GOARM env var to 5, 6 or 7.

Packagers can then simply put something like this before the build.go call
into the build script. (The same way it is already done for [go itself](https://github.com/archlinuxarm/PKGBUILDs/blob/master/community/go/PKGBUILD#L38)).

``` bash
[ "$CARCH" == 'arm' ] && export GOARM=5
[ "$CARCH" == 'armv6h' ] && export GOARM=6
[ "$CARCH" == 'armv7h' ] && export GOARM=7
```
