### PR TITLE
Revisit -no-console option for Windows

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -188,6 +188,7 @@ var (
 	doUpgrade         bool
 	doUpgradeCheck    bool
 	noBrowser         bool
+	noConsole         bool
 	generateDir       string
 	logFile           string
 	noRestart         = os.Getenv("STNORESTART") != ""
@@ -214,6 +215,9 @@ func main() {
 
 		logFile = filepath.Join(defConfDir, "syncthing.log")
 		flag.StringVar(&logFile, "logfile", logFile, "Log file name (blank for stdout)")
+
+		// We also add an option to hide the console window
+		flag.BoolVar(&noConsole, "no-console", false, "Hide console window")
 	}
 
 	flag.StringVar(&generateDir, "generate", "", "Generate key and config in specified dir, then exit")
@@ -231,6 +235,10 @@ func main() {
 
 	flag.Usage = usageFor(flag.CommandLine, usage, fmt.Sprintf(extraUsage, defConfDir))
 	flag.Parse()
+
+	if noConsole {
+		osutil.HideConsole()
+	}
 
 	if confDir == "" {
 		// Not set as default above because the string can be really long.

--- a/internal/osutil/hidden_unix.go
+++ b/internal/osutil/hidden_unix.go
@@ -24,3 +24,5 @@ func HideFile(path string) error {
 func ShowFile(path string) error {
 	return nil
 }
+
+func HideConsole() {}

--- a/internal/osutil/hidden_windows.go
+++ b/internal/osutil/hidden_windows.go
@@ -48,3 +48,14 @@ func ShowFile(path string) error {
 	attrs &^= syscall.FILE_ATTRIBUTE_HIDDEN
 	return syscall.SetFileAttributes(p, attrs)
 }
+
+func HideConsole() {
+	getConsoleWindow := syscall.NewLazyDLL("kernel32.dll").NewProc("GetConsoleWindow")
+	showWindow := syscall.NewLazyDLL("user32.dll").NewProc("ShowWindow")
+	if getConsoleWindow.Find() == nil && showWindow.Find() == nil {
+		hwnd, _, _ := getConsoleWindow.Call()
+		if hwnd != 0 {
+			showWindow.Call(hwnd, 0)
+		}
+	}
+}


### PR DESCRIPTION
The reason for ShowWindow opose to your FreeConsole is because if you start up
cmd.exe and do syncthing.exe -no-output it actually hides the existing cmd.exe
window oppose to opening a separate window and then hiding it, which keeps the
existing console hanging on syncthing.exe running.

I tried playing around with compiling as GUI, then given the option is not present
allocating a console, and redirecting the std streams to the new console, but that
seems ugly as I'd have to make quite a few calls. But that does get of the initial
flash.
