### PR TITLE
Refactor random string stuff and seeding

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -353,7 +353,7 @@ func restPostConfig(m *model.Model, w http.ResponseWriter, r *http.Request) {
 		if curAcc := cfg.Options().URAccepted; newCfg.Options.URAccepted > curAcc {
 			// UR was enabled
 			newCfg.Options.URAccepted = usageReportVersion
-			newCfg.Options.URUniqueID = randomString(6)
+			newCfg.Options.URUniqueID = randomString(8)
 			err := sendUsageReport(m)
 			if err != nil {
 				l.Infoln("Usage report:", err)

--- a/cmd/syncthing/gui_csrf.go
+++ b/cmd/syncthing/gui_csrf.go
@@ -17,8 +17,6 @@ package main
 
 import (
 	"bufio"
-	"crypto/rand"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"os"
@@ -88,7 +86,7 @@ func validCsrfToken(token string) bool {
 }
 
 func newCsrfToken() string {
-	token := randomString(30)
+	token := randomString(32)
 
 	csrfMut.Lock()
 	csrfTokens = append(csrfTokens, token)
@@ -139,14 +137,4 @@ func loadCsrfTokens() {
 	for s.Scan() {
 		csrfTokens = append(csrfTokens, s.Text())
 	}
-}
-
-func randomString(len int) string {
-	bs := make([]byte, len)
-	_, err := rand.Reader.Read(bs)
-	if err != nil {
-		l.Fatalln(err)
-	}
-
-	return base64.StdEncoding.EncodeToString(bs)
 }

--- a/cmd/syncthing/random.go
+++ b/cmd/syncthing/random.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"crypto/md5"
+	cryptoRand "crypto/rand"
+	"encoding/binary"
+	mathRand "math/rand"
+)
+
+// randomCharset contains the characters that can make up a randomString().
+const randomCharset = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+
+// predictableRandom is an RNG that will always have the same sequence. It
+// will be seeded with the device ID during startup, so that the sequence is
+// predictable but varies between instances.
+var predictableRandom = mathRand.New(mathRand.NewSource(42))
+
+func init() {
+	// The default RNG should be seeded with something good.
+	mathRand.Seed(randomInt64())
+}
+
+// randomString returns a string of random characters (taken from
+// randomCharset) of the specified length.
+func randomString(l int) string {
+	bs := make([]byte, l)
+	for i := range bs {
+		bs[i] = randomCharset[mathRand.Intn(len(randomCharset))]
+	}
+	return string(bs)
+}
+
+// randomInt64 returns a strongly random int64, slowly
+func randomInt64() int64 {
+	var bs [8]byte
+	n, err := cryptoRand.Reader.Read(bs[:])
+	if n != 8 || err != nil {
+		panic("randomness failure")
+	}
+	return seedFromBytes(bs[:])
+}
+
+// seedFromBytes calculates a weak 64 bit hash from the given byte slice,
+// suitable for use a predictable random seed.
+func seedFromBytes(bs []byte) int64 {
+	h := md5.New()
+	h.Write(bs)
+	s := h.Sum(nil)
+	// The MD5 hash of the byte slice is 16 bytes long. We interpret it as two
+	// uint64s and XOR them together.
+	return int64(binary.BigEndian.Uint64(s[0:]) ^ binary.BigEndian.Uint64(s[8:]))
+}

--- a/cmd/syncthing/random_test.go
+++ b/cmd/syncthing/random_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import "testing"
+
+func TestPredictableRandom(t *testing.T) {
+	// predictable random sequence is predictable
+	e := 3440579354231278675
+	if v := predictableRandom.Int(); v != e {
+		t.Errorf("Unexpected random value %d != %d", v, e)
+	}
+}
+
+func TestSeedFromBytes(t *testing.T) {
+	// should always return the same seed for the same bytes
+	tcs := []struct {
+		bs []byte
+		v  int64
+	}{
+		{[]byte("hello world"), -3639725434188061933},
+		{[]byte("hello worlx"), -2539100776074091088},
+	}
+
+	for _, tc := range tcs {
+		if v := seedFromBytes(tc.bs); v != tc.v {
+			t.Errorf("Unexpected seed value %d != %d", v, tc.v)
+		}
+	}
+}
+
+func TestRandomString(t *testing.T) {
+	for _, l := range []int{0, 1, 2, 3, 4, 8, 42} {
+		s := randomString(l)
+		if len(s) != l {
+			t.Errorf("Incorrect length %d != %s", len(s), l)
+		}
+	}
+
+	strings := make([]string, 1000)
+	for i := range strings {
+		strings[i] = randomString(8)
+		for j := range strings {
+			if i == j {
+				continue
+			}
+			if strings[i] == strings[j] {
+				t.Errorf("Repeated random string %q", strings[i])
+			}
+		}
+	}
+}
+
+func TestRandomInt64(t *testing.T) {
+	ints := make([]int64, 1000)
+	for i := range ints {
+		ints[i] = randomInt64()
+		for j := range ints {
+			if i == j {
+				continue
+			}
+			if ints[i] == ints[j] {
+				t.Errorf("Repeated random int64 %d", ints[i])
+			}
+		}
+	}
+}

--- a/cmd/syncthing/tls.go
+++ b/cmd/syncthing/tls.go
@@ -19,11 +19,9 @@ import (
 	"bufio"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/binary"
 	"encoding/pem"
 	"io"
 	"math/big"
@@ -43,13 +41,6 @@ func loadCert(dir string, prefix string) (tls.Certificate, error) {
 	cf := filepath.Join(dir, prefix+"cert.pem")
 	kf := filepath.Join(dir, prefix+"key.pem")
 	return tls.LoadX509KeyPair(cf, kf)
-}
-
-func certSeed(bs []byte) int64 {
-	hf := sha256.New()
-	hf.Write(bs)
-	id := hf.Sum(nil)
-	return int64(binary.BigEndian.Uint64(id))
 }
 
 func newCertificate(dir string, prefix string) {


### PR DESCRIPTION
Make sure we have a good random seed on the default RNG, that the
predictable RNG is clearly marked as such, that random strings are
actually the length requested, and that they contain a restricted set of
characters only.
