### PR TITLE
Protect GUI HTTPS from some attacks

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -273,7 +273,7 @@ func main() {
 			l.Warnln("Key exists; will not overwrite.")
 			l.Infoln("Device ID:", protocol.NewDeviceID(cert.Certificate[0]))
 		} else {
-			newCertificate(dir, "")
+			newCertificate(dir, "", tlsDefaultCommonName)
 			cert, err = loadCert(dir, "")
 			myID = protocol.NewDeviceID(cert.Certificate[0])
 			if err != nil {
@@ -370,7 +370,7 @@ func syncthingMain() {
 	// Ensure that that we have a certificate and key.
 	cert, err = loadCert(confDir, "")
 	if err != nil {
-		newCertificate(confDir, "")
+		newCertificate(confDir, "", tlsDefaultCommonName)
 		cert, err = loadCert(confDir, "")
 		if err != nil {
 			l.Fatalln("load cert:", err)
@@ -909,7 +909,7 @@ next:
 				// the certificate and used another name.
 				certName := deviceCfg.CertName
 				if certName == "" {
-					certName = "syncthing"
+					certName = tlsDefaultCommonName
 				}
 				err := remoteCert.VerifyHostname(certName)
 				if err != nil {

--- a/cmd/syncthing/tls.go
+++ b/cmd/syncthing/tls.go
@@ -33,8 +33,8 @@ import (
 )
 
 const (
-	tlsRSABits = 3072
-	tlsName    = "syncthing"
+	tlsRSABits           = 3072
+	tlsDefaultCommonName = "syncthing"
 )
 
 func loadCert(dir string, prefix string) (tls.Certificate, error) {
@@ -43,8 +43,8 @@ func loadCert(dir string, prefix string) (tls.Certificate, error) {
 	return tls.LoadX509KeyPair(cf, kf)
 }
 
-func newCertificate(dir string, prefix string) {
-	l.Infoln("Generating RSA key and certificate...")
+func newCertificate(dir, prefix, name string) {
+	l.Infof("Generating RSA key and certificate for %s...", name)
 
 	priv, err := rsa.GenerateKey(rand.Reader, tlsRSABits)
 	if err != nil {
@@ -57,7 +57,7 @@ func newCertificate(dir string, prefix string) {
 	template := x509.Certificate{
 		SerialNumber: new(big.Int).SetInt64(mr.Int63()),
 		Subject: pkix.Name{
-			CommonName: tlsName,
+			CommonName: name,
 		},
 		NotBefore: notBefore,
 		NotAfter:  notAfter,


### PR DESCRIPTION
- Disable SSLv3 against POODLE
- Disable RC4 as a weak cipher
- Set the CommonName to the system host name

This drops compatibility with IE6 and Java 6 - users of those will have to stick to HTTP, which is honestly about as secure anyway on those browsers.

https://nym.se/t/sslreport.pdf
