### PR TITLE
Use ListenMulticastUDP for multicast sockets (potentially fixes #1113)

### DIFF
--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -158,7 +158,7 @@ Mx: %d
 	var results []IGD
 	resultChannel := make(chan IGD, 8)
 
-	socket, err := net.ListenUDP("udp4", &net.UDPAddr{})
+	socket, err := net.ListenMulticastUDP("udp4", nil, &net.UDPAddr{IP: ssdp.IP})
 	if err != nil {
 		l.Infoln(err)
 		return results


### PR DESCRIPTION
UPnP when not glitched by Windows still seems to work.
I assume it shouldn't cause issues on Unix either.
