### PR TITLE
Return HTTP/500 from /rest/upgrade if STNOUPGRADE is defined

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -571,6 +571,10 @@ func restGetEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func restGetUpgrade(w http.ResponseWriter, r *http.Request) {
+	if noUpgrade {
+		http.Error(w, upgrade.ErrUpgradeUnsupported.Error(), 500)
+		return
+	}
 	rel, err := upgrade.LatestRelease(strings.Contains(Version, "-beta"))
 	if err != nil {
 		http.Error(w, err.Error(), 500)


### PR DESCRIPTION
I had bug report (syncthing/syncthing-gtk#56) recently, from guy that managed to break his Syncthing managed by Syncthing-GTK installation, when he manually upgraded to unsupported Syncthing daemon version. He did it, because he saw that green, friendly-looking button `Upgrade To vXYZ` in WebUI.

That's why that button has to die :)

Ok, now, in all seriousness, this PR disables `Upgrade To...` button in WebUI, but **only** if STNOUPGRADE is specified. As you can see bellow, it does it by adding `enabled` field to `/rest/upgrade` response and adding this field to condition under which button is shown. I believe that it shouldn't break anything else.
And you can protect users from themselves by merging this ;-)