### PR TITLE
Don't use Go 1.4 range syntax in queue_test.go

### DIFF
--- a/internal/model/queue_test.go
+++ b/internal/model/queue_test.go
@@ -191,7 +191,7 @@ func BenchmarkJobQueuePushPopDone10k(b *testing.B) {
 		for _, f := range files {
 			q.Push(f.Name)
 		}
-		for range files {
+		for _ = range files {
 			n, _ := q.Pop()
 			q.Done(n)
 		}


### PR DESCRIPTION
I'm trying to update the syncthing package for NixOS, but the tests are failing because of one instance of Go 1.4 syntax:

    internal/model/queue_test.go:194:7: expected operand, found 'range'
    internal/model/queue_test.go:200:3: expected '{', found 'EOF'

This changes it to valid 1.3 syntax.

Another option would be to just change this page to say that Go 1.4 is now required, but that would make things hard for people, since Fedora, Ubuntu and NixOS all come with Go 1.3 right now.