### PR TITLE
"Quick guide to supported patterns" link updated

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -683,7 +683,7 @@
 
           <hr/>
 
-          <p class="small"><span translate>Quick guide to supported patterns</span> (<a href="https://discourse.syncthing.net/t/80" translate>full documentation</a>):</p>
+          <p class="small"><span translate>Quick guide to supported patterns</span> (<a href="https://github.com/syncthing/syncthing/wiki/Ignoring-Files" target="_blank" translate>full documentation</a>):</p>
           <dl class="dl-horizontal dl-narrow small">
             <dt><code>!</code></dt> <dd><span translate>Inversion of the given condition (i.e. do not exclude)</span></dd>
             <dt><code>*</code></dt> <dd><span translate>Single level wildcard (matches within a directory only)</span></dd>


### PR DESCRIPTION
The "Quick guide to supported patterns" link now points to the wiki article and will open in a new page/tab to avoid disrupting the settings page.