### PR TITLE
Small improvements for footer navbar (ref #1154)

### DIFF
--- a/gui/assets/css/overrides.css
+++ b/gui/assets/css/overrides.css
@@ -39,8 +39,8 @@ ul+h5 {
 
 .panel-title {
     position: relative;
-    text-overflow:ellipsis;
-    overflow:hidden;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 identicon {
@@ -204,4 +204,16 @@ table.table-condensed td {
 ul.three-columns li, ul.two-columns li {
     padding-left: 0.5em;
     text-indent: -0.5em;
+}
+
+/** Footer nav on small devices **/
+
+@media (max-width: 767px) {
+    body {
+        padding-bottom: 0;
+    }
+
+    .navbar-fixed-bottom {
+        position: static;
+    }
 }

--- a/gui/index.html
+++ b/gui/index.html
@@ -398,14 +398,14 @@
 
   <!-- Bottom bar -->
 
-  <nav class="navbar navbar-default navbar-fixed-bottom hidden-xs">
+  <nav class="navbar navbar-default navbar-fixed-bottom">
     <div class="container">
       <ul class="nav navbar-nav">
-        <li><a class="navbar-link" href="http://discourse.syncthing.net/"><span translate>Support / Forum</span></a></li>
-        <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/releases"><span translate>Latest Release</span></a></li>
-        <li><a class="navbar-link" href="http://discourse.syncthing.net/category/documentation"><span translate>Documentation</span></a></li>
-        <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/issues"><span translate>Bugs</span></a></li>
-        <li><a class="navbar-link" href="https://github.com/syncthing/syncthing"><span translate>Source Code</span></a></li>
+        <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/wiki"><span class="glyphicon glyphicon-book"></span>&ensp;<span translate>Documentation</span></a></li>
+        <li><a class="navbar-link" href="https://discourse.syncthing.net"><span class="glyphicon glyphicon-question-sign"></span>&ensp;<span translate>Support</span></a></li>
+        <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/releases"><span class="glyphicon glyphicon-info-sign"></span>&ensp;<span translate>Changelog</span></a></li>
+        <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/issues"><span class="glyphicon glyphicon-warning-sign"></span>&ensp;<span translate>Bugs</span></a></li>
+        <li><a class="navbar-link" href="https://github.com/syncthing/syncthing"><span class="glyphicon glyphicon-wrench"></span>&ensp;<span translate>Source Code</span></a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
Small improvements for footer navbar (ref #1154)
- add icons
- link to Syncthing wiki
- show footer navbar on small devices (non-fixed)