### PR TITLE
Reject Index and Request messages with unexpected flags

### DIFF
--- a/internal/protocol/protocol.go
+++ b/internal/protocol/protocol.go
@@ -295,6 +295,11 @@ func (c *rawConnection) readerLoop() (err error) {
 
 		switch msg := msg.(type) {
 		case IndexMessage:
+			if msg.Flags != 0 {
+				// We don't currently support or expect any flags.
+				return fmt.Errorf("protocol error: unknown flags 0x%x in Index(Update) message", msg.Flags)
+			}
+
 			switch hdr.msgType {
 			case messageTypeIndex:
 				if c.state < stateCCRcvd {
@@ -311,6 +316,10 @@ func (c *rawConnection) readerLoop() (err error) {
 			}
 
 		case RequestMessage:
+			if msg.Flags != 0 {
+				// We don't currently support or expect any flags.
+				return fmt.Errorf("protocol error: unknown flags 0x%x in Request message", msg.Flags)
+			}
 			if c.state < stateIdxRcvd {
 				return fmt.Errorf("protocol error: request message in state %d", c.state)
 			}


### PR DESCRIPTION
Also refactors the readerLoop to switch on the type of `msg` directly, as it saves us from type asserting everywhere and we can directly look into the message fields.