### PR TITLE
Efficient renames (fixes #1217)

### DIFF
--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -7,7 +7,7 @@
         <lenientMtimes>false</lenientMtimes>
         <copiers>1</copiers>
         <pullers>16</pullers>
-        <finishers>1</finishers>
+        <hashers>0</hashers>
     </folder>
     <folder id="s12" path="s12-2" ro="false" rescanIntervalS="15" ignorePerms="false">
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU"></device>
@@ -16,7 +16,7 @@
         <lenientMtimes>false</lenientMtimes>
         <copiers>1</copiers>
         <pullers>16</pullers>
-        <finishers>1</finishers>
+        <hashers>0</hashers>
     </folder>
     <folder id="s23" path="s23-2" ro="false" rescanIntervalS="15" ignorePerms="false">
         <device id="JMFJCXB-GZDE4BN-OCJE3VF-65GYZNU-AIVJRET-3J6HMRQ-AUQIGJO-FKNHMQU"></device>
@@ -25,7 +25,7 @@
         <lenientMtimes>false</lenientMtimes>
         <copiers>1</copiers>
         <pullers>16</pullers>
-        <finishers>1</finishers>
+        <hashers>0</hashers>
     </folder>
     <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" name="s1" compression="true" introducer="false">
         <address>127.0.0.1:22001</address>

--- a/test/sync_test.go
+++ b/test/sync_test.go
@@ -105,7 +105,7 @@ func testSyncCluster(t *testing.T) {
 	}
 
 	// We'll use this file for appending data without modifying the time stamp.
-	fd, err := os.Create("s1/appendfile")
+	fd, err := os.Create("s1/test-appendfile")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,12 +207,12 @@ func testSyncCluster(t *testing.T) {
 			break
 		}
 
-		// Alter the "appendfile" without changing it's modification time. Sneaky!
-		fi, err := os.Stat("s1/appendfile")
+		// Alter the "test-appendfile" without changing it's modification time. Sneaky!
+		fi, err := os.Stat("s1/test-appendfile")
 		if err != nil {
 			t.Fatal(err)
 		}
-		fd, err := os.OpenFile("s1/appendfile", os.O_APPEND|os.O_WRONLY, 0644)
+		fd, err := os.OpenFile("s1/test-appendfile", os.O_APPEND|os.O_WRONLY, 0644)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -228,7 +228,7 @@ func testSyncCluster(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = os.Chtimes("s1/appendfile", fi.ModTime(), fi.ModTime())
+		err = os.Chtimes("s1/test-appendfile", fi.ModTime(), fi.ModTime())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/test/util.go
+++ b/test/util.go
@@ -116,6 +116,10 @@ func alterFiles(dir string) error {
 			return err
 		}
 
+		if strings.HasPrefix(filepath.Base(path), "test-") {
+			return nil
+		}
+
 		switch filepath.Base(path) {
 		case ".stfolder":
 			return nil
@@ -158,6 +162,17 @@ func alterFiles(dir string) error {
 				return err
 			}
 			err = fd.Close()
+			if err != nil {
+				return err
+			}
+		case r < 0.3 && comps > 1 && (info.Mode().IsRegular() || rand.Float64() < 0.2):
+			rpath := filepath.Dir(path)
+			if rand.Float64() < 0.2 {
+				for move := rand.Intn(comps - 1); move > 0; move-- {
+					rpath = filepath.Join(rpath, "..")
+				}
+			}
+			err = os.Rename(path, filepath.Join(rpath, randomName()))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Just did a basic test renaming folders, seemed to work.

A possible change would be not to take this shortcut if versioning is enabled, and let the file to be assembled from blocks, as the versioned file has to be copied to the archive anyway.