### PR TITLE
Remove nil filenames from database and indexes (fixes #1243)

### DIFF
--- a/internal/db/leveldb.go
+++ b/internal/db/leveldb.go
@@ -586,6 +586,16 @@ func ldbWithAllFolderTruncated(db *leveldb.DB, folder []byte, fn func(device []b
 		if err != nil {
 			panic(err)
 		}
+
+		if f.Name == "" {
+			l.Infoln("Dropping invalid nil filename from database")
+			batch := new(leveldb.Batch)
+			ldbRemoveFromGlobal(db, batch, folder, device, nil)
+			batch.Delete(dbi.Key())
+			db.Write(batch, nil)
+			continue
+		}
+
 		if cont := fn(device, f); !cont {
 			return
 		}


### PR DESCRIPTION
Turns out I actually need this myself, so probably others do as well.