### PR TITLE
Add PrivateTmp to systemd service

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -9,6 +9,7 @@ EnvironmentFile=-/etc/default/syncthing
 Environment=STNORESTART=yes
 ExecStart=/usr/bin/syncthing ${STARGS}
 Restart=on-failure
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -7,6 +7,7 @@ EnvironmentFile=-%h/.config/syncthing/environment
 Environment=STNORESTART=yes
 ExecStart=/usr/bin/syncthing ${STARGS}
 Restart=on-failure
+PrivateTmp=true
 
 [Install]
 WantedBy=cmdline.target


### PR DESCRIPTION
In pull request #1264 the usage of `/tmp` was introduced. So let's add `PrivateTmp=true` to the systemd service files. 

Documentation see here: http://www.freedesktop.org/software/systemd/man/systemd.exec.html#PrivateTmp=