### PR TITLE
Fix documentation link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ latest info on Transifex.
 
 Every contribution is welcome. If you want to contribute but are unsure
 where to start, any open issues are fair game! Be prepared for a
-[certain amount of review](https://discourse.syncthing.net/t/733); it's
-all in the name of quality. :) Following the points below will make this
+[certain amount of review](https://github.com/syncthing/syncthing/wiki/FAQ#why-are-you-being-so-hard-on-my-pull-request);
+it's all in the name of quality. :) Following the points below will make this
 a smoother process.
 
 Individuals making significant and valuable contributions are given
@@ -105,8 +105,8 @@ add yourself as a separate commit in your first pull request.
 
 ## Building
 
-[See the documentation](http://discourse.syncthing.net/t/44) on how to
-get started with a build environment.
+[See the documentation](https://github.com/syncthing/syncthing/wiki/Building)
+on how to get started with a build environment.
 
 ## Branches
 
@@ -133,7 +133,7 @@ Yes please!
 
 ## Documentation
 
-[Over here!](http://discourse.syncthing.net/category/documentation)
+[Over here!](https://github.com/syncthing/syncthing/wiki)
 
 ## License
 


### PR DESCRIPTION
Link in contributing.md points to the old discourse link rather than the github wiki.