### PR TITLE
Some systemd tweaks

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -1,13 +1,12 @@
 [Unit]
-Description=Syncthing service for %i
+Description=Syncthing - Open Source Continuous File Synchronization for %I
+Documentation=https://github.com/syncthing/syncthing/wiki
 After=network.target
 
 [Service]
 User=%i
-Environment=STARGS=
-EnvironmentFile=-/etc/default/syncthing
 Environment=STNORESTART=yes
-ExecStart=/usr/bin/syncthing ${STARGS}
+ExecStart=/usr/bin/syncthing
 Restart=on-failure
 RestartPreventExitStatus=1
 SuccessExitStatus=2

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -1,15 +1,15 @@
 [Unit]
-Description=Syncthing service
+Description=Syncthing - Open Source Continuous File Synchronization
+Documentation=https://github.com/syncthing/syncthing/wiki
+After=network.target
 
 [Service]
-Environment=STARGS=
-EnvironmentFile=-%h/.config/syncthing/environment
 Environment=STNORESTART=yes
-ExecStart=/usr/bin/syncthing ${STARGS}
+ExecStart=/usr/bin/syncthing
 Restart=on-failure
 RestartPreventExitStatus=1
 SuccessExitStatus=2
 RestartForceExitStatus=3 4
 
 [Install]
-WantedBy=cmdline.target
+WantedBy=default.target


### PR DESCRIPTION
- Removed environment file to keep the service file minimal.
  "systemctl edit syncthing.service" does the job if somebody wants
  to customize the service.
- Changed "cmdline.target" to "default.target" as "cmdline.target"
  does not exist in systemd.special:
  http://www.freedesktop.org/software/systemd/man/systemd.special.html
- Added a missing "After=network.target".