### PR TITLE
Implement memorySize() for NetBSD

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Piotr Bejda <piotrb10@gmail.com>
 Ryan Sullivan <kayoticsully@gmail.com>
 Stefan Tatschner <stefan@sevenbyte.org>
 Tim Abell <tim@timwise.co.uk>
+Tobias Nygren <tnn@nygren.pp.se>
 Tomas Cerveny <kozec@kozec.com>
 Tully Robinson <tully@tojr.org>
 Veeti Paananen <veeti.paananen@rojekti.fi>

--- a/cmd/syncthing/memsize_netbsd.go
+++ b/cmd/syncthing/memsize_netbsd.go
@@ -1,0 +1,40 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func memorySize() (int64, error) {
+	cmd := exec.Command("/sbin/sysctl", "hw.physmem64")
+	out, err := cmd.Output()
+	if err != nil {
+		return 0, err
+	}
+	fs := strings.Fields(string(out))
+	if len(fs) != 3 {
+		return 0, errors.New("sysctl parse error")
+	}
+	bytes, err := strconv.ParseInt(fs[2], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return bytes, nil
+}


### PR DESCRIPTION
Here is memorySize() to make syncthing work on NetBSD. Based on Darwin implementation.