### PR TITLE
Drop systemd README instruction in favor of the wiki

### DIFF
--- a/etc/linux-systemd/README.md
+++ b/etc/linux-systemd/README.md
@@ -1,27 +1,8 @@
-This directory contains a configuration for running syncthing under the
+# Systemd Configuration
+
+This directory contains configuration files for running syncthing under the
 "systemd" service manager on Linux both under either a systemd system service or
-systemd user service.
+systemd user service. For further documentation take a look at the [systemd
+section][1] on the Github Wiki.
 
- 1. Install systemd.
-
- 2. If you are running this as a system level service:
-
-   1. Create the user you will be running the service as (foo in this example).
-
-   2. Copy the syncthing@.service files to /etc/systemd/system
-
-   3. Enable and start the service
-      systemctl enable syncthing@foo.service
-      systemctl start syncthing@foo.service
-
- 3. If you are running this as a user level service:
-
-   1. Log in as the user you will be running the service as
-
-   2. Copy the syncthing.service files to /etc/systemd/user
-
-   3. Enable and start the service
-      systemctl --user enable syncthing.service
-      systemctl --user start syncthing.service
-
-Log output is sent to the journal.
+[1]: https://github.com/syncthing/syncthing/wiki/Autostart-syncthing#systemd


### PR DESCRIPTION
I have added systemd documentation to the wiki. So the README is kind of obsolete. I also added a pointer to the appropriate [wiki section][1] in the README. There is already some discussion in #1335.

[1]: https://github.com/syncthing/syncthing/wiki/Autostart-syncthing#systemd