### PR TITLE
Verify negotiated protocol bep/1.0

### DIFF
--- a/cmd/syncthing/connections.go
+++ b/cmd/syncthing/connections.go
@@ -41,7 +41,14 @@ func listenConnect(myID protocol.DeviceID, m *model.Model, tlsCfg *tls.Config) {
 
 next:
 	for conn := range conns {
-		certs := conn.ConnectionState().PeerCertificates
+		cs := conn.ConnectionState()
+		if !cs.NegotiatedProtocolIsMutual || cs.NegotiatedProtocol != bepProtocolName {
+			l.Infof("Peer %s did not negotiate bep/1.0", conn.RemoteAddr())
+			conn.Close()
+			continue
+		}
+
+		certs := cs.PeerCertificates
 		if cl := len(certs); cl != 1 {
 			l.Infof("Got peer certificate list of length %d != 1 from %s; protocol error", cl, conn.RemoteAddr())
 			conn.Close()

--- a/cmd/syncthing/connections.go
+++ b/cmd/syncthing/connections.go
@@ -42,12 +42,19 @@ func listenConnect(myID protocol.DeviceID, m *model.Model, tlsCfg *tls.Config) {
 next:
 	for conn := range conns {
 		cs := conn.ConnectionState()
+
+		// We should have negotiated the next level protocol "bep/1.0" as part
+		// of the TLS handshake. If we didn't, we're not speaking to another
+		// BEP-speaker so drop the connection.
 		if !cs.NegotiatedProtocolIsMutual || cs.NegotiatedProtocol != bepProtocolName {
 			l.Infof("Peer %s did not negotiate bep/1.0", conn.RemoteAddr())
 			conn.Close()
 			continue
 		}
 
+		// We should have received exactly one certificate from the other
+		// side. If we didn't, they don't have a device ID and we drop the
+		// connection.
 		certs := cs.PeerCertificates
 		if cl := len(certs); cl != 1 {
 			l.Infof("Got peer certificate list of length %d != 1 from %s; protocol error", cl, conn.RemoteAddr())
@@ -57,12 +64,21 @@ next:
 		remoteCert := certs[0]
 		remoteID := protocol.NewDeviceID(remoteCert.Raw)
 
+		// The device ID should not be that of ourselves. It can happen
+		// though, especially in the presense of NAT hairpinning, multiple
+		// clients between the same NAT gateway, and global discovery.
 		if remoteID == myID {
 			l.Infof("Connected to myself (%s) - should not happen", remoteID)
 			conn.Close()
 			continue
 		}
 
+		// We should not already be connected to the other party. TODO: This
+		// could use some better handling. If the old connection is dead but
+		// hasn't timed out yet we may want to drop *that* connection and keep
+		// this one. But in case we are two devices connecting to each other
+		// in parallell we don't want to do that or we end up with no
+		// connections still established...
 		if m.ConnectedTo(remoteID) {
 			l.Infof("Connected to already connected device (%s)", remoteID)
 			conn.Close()

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -72,6 +72,8 @@ const (
 	exitUpgrading          = 4
 )
 
+const bepProtocolName = "bep/1.0"
+
 var l = logger.DefaultLogger
 
 func init() {
@@ -461,7 +463,7 @@ func syncthingMain() {
 
 	tlsCfg := &tls.Config{
 		Certificates:           []tls.Certificate{cert},
-		NextProtos:             []string{"bep/1.0"},
+		NextProtos:             []string{bepProtocolName},
 		ClientAuth:             tls.RequestClientCert,
 		SessionTicketsDisabled: true,
 		InsecureSkipVerify:     true,


### PR DESCRIPTION
We've been doing the `bep/1.0` negotiation as part of the TLS handshake since forever, but not verified the result. Doing this now gains us a somewhat cleaner error ("peer did not negotiate bep/1.0" instead of "connected to $someRandomDeviceID"; "unexpected EOF") when someone inadvertently points their sync connection to the GUI port or the other way around. We might possibly break compatibility with other client implementations, but I think that's OK, if worth highlighting on the forum before release.