### PR TITLE
Add global announce server on IPv6

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -626,6 +626,8 @@ func uniqueStrings(ss []string) []string {
 		us = append(us, k)
 	}
 
+	sort.Strings(us)
+
 	return us
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,7 +37,7 @@ func init() {
 func TestDefaultValues(t *testing.T) {
 	expected := OptionsConfiguration{
 		ListenAddress:           []string{"0.0.0.0:22000"},
-		GlobalAnnServers:        []string{"udp4://announce.syncthing.net:22026"},
+		GlobalAnnServers:        []string{"udp4://announce.syncthing.net:22026", "udp6://announce-v6.syncthing.net:22026"},
 		GlobalAnnEnabled:        true,
 		LocalAnnEnabled:         true,
 		LocalAnnPort:            21025,

--- a/internal/config/testdata/v8.xml
+++ b/internal/config/testdata/v8.xml
@@ -1,0 +1,12 @@
+<configuration version="8">
+    <folder id="test" path="testdata" ro="true" ignorePerms="false" rescanIntervalS="600">
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+        <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2"></device>
+    </folder>
+    <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR" name="node one" compression="true">
+        <address>a</address>
+    </device>
+    <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2" name="node two" compression="true">
+        <address>b</address>
+    </device>
+</configuration>


### PR DESCRIPTION
This adds a migration for announce-v6.syncthing.net. With this enabled, global discovery will work for IPv6 as well. It has the negative effect of showing a red "1/2" on global announce servers for hosts without IPv6... Should we do something about that?