### PR TITLE
Use chpst instead of djb name setuidgid

### DIFF
--- a/etc/linux-runit/run
+++ b/etc/linux-runit/run
@@ -4,5 +4,5 @@ export USERNAME=jb
 export HOME="/home/$USERNAME"
 export SYNCTHING="$HOME/bin/syncthing"
 
-setuidgid "$USERNAME" "$SYNCTHING" -logflags 0 2>&1 | logger -t syncthing
+chpst -u "$USERNAME" "$SYNCTHING" -logflags 0 2>&1 | logger -t syncthing
 


### PR DESCRIPTION
Some distros (Ubuntu, Debian?) don't link `chpst` to `setuidgid`, as it
could conflict with djb daemontools installation.  If daemontools isn't
going to be referenced in the README, then the example runit config
should reference the runit packaged utility.