### PR TITLE
Fix syncthing process reparenting with runit

### DIFF
--- a/etc/linux-runit/README.md
+++ b/etc/linux-runit/README.md
@@ -9,7 +9,8 @@ other platforms also using runit.
     recommended to place it in a directory writeable by the running user
     so that automatic upgrades work.
 
- 3. Copy the edited `run` file to `/etc/service/syncthing/run`.
+ 3. Copy this directory (containing the edited `run` file and `log` folder) to
+    `/etc/service/syncthing`.
 
 Log output is sent to syslogd.
 

--- a/etc/linux-runit/log/run
+++ b/etc/linux-runit/log/run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+exec logger -t syncthing
+

--- a/etc/linux-runit/run
+++ b/etc/linux-runit/run
@@ -4,5 +4,6 @@ export USERNAME=jb
 export HOME="/home/$USERNAME"
 export SYNCTHING="$HOME/bin/syncthing"
 
-chpst -u "$USERNAME" "$SYNCTHING" -logflags 0 2>&1 | logger -t syncthing
+exec 2>&1
+exec chpst -u "$USERNAME" "$SYNCTHING" -logflags 0
 


### PR DESCRIPTION
- Changed call to `chpst` to `exec`
- Moved logging to `log/run` per `runsv` standard

While trying to use syncthing with runit, I noticed that the existing script doesn't behave properly.  The process tree created on start looks like this:

    ├─runsvdir─┬─runsv───runsvdir───runsv
    │          └─runsv───run─┬─logger
    │                        └─syncthing─┬─syncthing───10*[{syncthing}]
    │                                    └─6*[{syncthing}]

Though, when you: `sudo sv down /etc/service/syncthing/` the `TERM` signal isn't propogated or trapped, so syncthing is orphaned and adopted by init (PID 1):

    ├─runsvdir─┬─runsv───runsvdir───runsv
    │          └─runsv
    ├─syncthing─┬─syncthing───10*[{syncthing}]
    │           └─6*[{syncthing}]


    user     22676     1  0 20:05 ?        00:00:00 /home/user/bin/syncthing -logflags 0
    root     22677     1  0 20:05 ?        00:00:00 logger -t syncthing

... and is no longer supervised.

[Most runit scripts will end with an `exec` for this reason](http://smarden.org/runit/runscripts.html).  Though, part of the problem is piping stdout to `logger` *within* the `run` script.  [`runsv` will do this for you when you provide a `log/run` script](http://smarden.org/runit/runsv.8.html).

Fixed process tree:

    ├─runsvdir─┬─runsv─┬─logger
    │          │       └─syncthing─┬─syncthing───10*[{syncthing}]
    │          │                   └─6*[{syncthing}]
    │          └─runsv───runsvdir───runsv

I'm not sure if it's intentional, but `logger` will run as `root` (and would run under `root` in the old script as well).
