### PR TITLE
Improve OS X launchd configuration

### DIFF
--- a/etc/macosx-launchd/syncthing.plist
+++ b/etc/macosx-launchd/syncthing.plist
@@ -19,12 +19,21 @@
 		</dict>
 
 		<key>KeepAlive</key>
-		<true/>
+		<dict>
+			<key>NetworkState</key>
+			<true/>
+		</dict>
 
 		<key>LowPriorityIO</key>
 		<true/>
 
 		<key>ProcessType</key>
 		<string>Background</string>
+
+		<!-- Optional: store logs to troubleshoot any problems.
+		     Change the path to reflect your user!
+		<key>StandardOutPath</key>
+		<string>/Users/jb/Library/Logs/syncthing.log</string>
+		-->
 	</dict>
 </plist>


### PR DESCRIPTION
This commit introduces two improvements to the OS X-specific launchd
configuration file:

1. Keeps syncthing alive only while there is network connectivity
2. Shows users how to enable logging under this configuration