### PR TITLE
Make release with correct version in source (fixes #1449)

### DIFF
--- a/build.go
+++ b/build.go
@@ -333,13 +333,15 @@ func clean() {
 }
 
 func ldflags() string {
-	var b bytes.Buffer
+	b := new(bytes.Buffer)
 	b.WriteString("-w")
-	b.WriteString(fmt.Sprintf(" -X main.Version %s", version))
-	b.WriteString(fmt.Sprintf(" -X main.BuildStamp %d", buildStamp()))
-	b.WriteString(fmt.Sprintf(" -X main.BuildUser %s", buildUser()))
-	b.WriteString(fmt.Sprintf(" -X main.BuildHost %s", buildHost()))
-	b.WriteString(fmt.Sprintf(" -X main.BuildEnv %s", buildEnvironment()))
+	if version != "" {
+		fmt.Fprintf(b, " -X main.Version %s", version)
+	}
+	fmt.Fprintf(b, " -X main.BuildStamp %d", buildStamp())
+	fmt.Fprintf(b, " -X main.BuildUser %s", buildUser())
+	fmt.Fprintf(b, " -X main.BuildHost %s", buildHost())
+	fmt.Fprintf(b, " -X main.BuildEnv %s", buildEnvironment())
 	return b.String()
 }
 
@@ -353,7 +355,7 @@ func rmr(paths ...string) {
 func getVersion() string {
 	v, err := runError("git", "describe", "--always", "--dirty")
 	if err != nil {
-		return "unknown-dev"
+		return ""
 	}
 	v = versionRe.ReplaceAllFunc(v, func(s []byte) []byte {
 		s[0] = '+'

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -53,7 +53,6 @@ import (
 )
 
 var (
-	Version     = "unknown-dev"
 	BuildEnv    = "default"
 	BuildStamp  = "0"
 	BuildDate   time.Time

--- a/cmd/syncthing/version.go
+++ b/cmd/syncthing/version.go
@@ -1,0 +1,5 @@
+// This file is auto generated
+
+package main
+
+var Version = "unknown-dev"

--- a/make-release.sh
+++ b/make-release.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+# Check preconditions
+
+version="${1:-}"
+if [[ $version == "" ]] ; then
+	echo Usage:
+	echo " " $0 "[version]"
+	exit 1
+fi
+
+if [[ $version != v*.*.* ]] ; then
+	echo Version has incorrect format
+	exit 1
+fi
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+if [[ $branch != "master" ]] ; then
+	echo Releases can only be made from master branch
+	exit 1
+fi
+
+if [[ -n $(git status -s) ]] ; then
+	echo Releases can only be made from a clean tree
+	exit 1
+fi
+
+# Tag the release
+
+cat > cmd/syncthing/version.go <<EOT
+// This file is auto generated
+
+package main
+
+var Version = "$version"
+EOT
+
+git commit -am "Set version to $version for release"
+
+shouldSign="no"
+if hash gpg >/dev/null 2>&1 ; then
+	if gpg --list-secret-keys release@syncthing.net >/dev/null 2>&1 ; then
+		# We have GPG and the correct key
+		shouldSign="yes"
+	fi
+fi
+
+if [[ $shouldSign == "yes" ]] ; then
+	git tag -a -m "$version" -u release@syncthing.net -s "$version"
+else
+	git tag -a -m "$version" "$version"
+fi
+
+# Start the next dev cycle with a new -dev version number
+
+cat > cmd/syncthing/version.go <<EOT
+// This file is auto generated
+
+package main
+
+var Version = "${version}-dev"
+EOT
+
+git commit -am "Set version to ${version}-dev for development"


### PR DESCRIPTION
This adds the release version to the source so that tarball builds work as expected. It also adds a second commit directly after the release commit to make sure that subsequent tarball / `go get` builds look like dev builds and not the released version. Builds with git available are not affected as the version number then is still based on the git describe.

```
jb@syno:~/src/github.com/syncthing/syncthing (master) $ ./make-release.sh v0.10.27
[master f48c777] Set version to v0.10.27 for release
 1 file changed, 1 insertion(+), 3 deletions(-)

You need a passphrase to unlock the secret key for
user: "Syncthing Release Management <release@syncthing.net>"
2048-bit RSA key, ID D26E6ED000654A3E, created 2014-12-29

[master 55d1982] Set version to v0.10.27-dev for development
 1 file changed, 3 insertions(+), 1 deletion(-)
jb@syno:~/src/github.com/syncthing/syncthing (master) $ git gla -n4
* 55d1982 (HEAD, master) Set version to v0.10.27-dev for development
* f48c777 (tag: v0.10.27) Set version to v0.10.27 for release
* 2aec6d6 Make release with correct version in source (fixes #1449)
* 9c3cee9 (tag: v0.10.26, syncthing/master) Translation update
jb@syno:~/src/github.com/syncthing/syncthing (master) $ 
```
