### PR TITLE
Get version from RELEASE file if it exists, or guess from directory (fixes #1449)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ coverage.xml
 .DS_Store
 syncthing.md5
 syncthing.exe.md5
+RELEASE

--- a/build.go
+++ b/build.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/md5"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -350,16 +351,66 @@ func rmr(paths ...string) {
 	}
 }
 
-func getVersion() string {
+func getReleaseVersion() (string, error) {
+	fd, err := os.Open("RELEASE")
+	if err != nil {
+		return "", err
+	}
+	defer fd.Close()
+
+	bs, err := ioutil.ReadAll(fd)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(bs)), nil
+}
+
+func getGitVersion() (string, error) {
 	v, err := runError("git", "describe", "--always", "--dirty")
 	if err != nil {
-		return "unknown-dev"
+		return "", err
 	}
 	v = versionRe.ReplaceAllFunc(v, func(s []byte) []byte {
 		s[0] = '+'
 		return s
 	})
-	return string(v)
+	return string(v), nil
+}
+
+func getDirectoryVersion() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	base := filepath.Base(filepath.Clean(wd))
+
+	re := regexp.MustCompile(`syncthing-(v?\d+\.\d+\.\d+)`)
+	parts := re.FindStringSubmatch(base)
+
+	if len(parts) != 2 {
+		return "", errors.New("not a release directory")
+	}
+	if strings.HasPrefix(parts[1], "v") {
+		return parts[1], nil
+	}
+	return "v" + parts[1], nil
+}
+
+func getVersion() string {
+	// First try for a RELEASE file,
+	if ver, err := getReleaseVersion(); err == nil {
+		return ver
+	}
+	// ... then see if we have a Git tag,
+	if ver, err := getGitVersion(); err == nil {
+		return ver
+	}
+	// ... otherwise try to guess from the directory name.
+	if ver, err := getDirectoryVersion(); err == nil {
+		return ver
+	}
+	// This seems to be a dev build.
+	return "unknown-dev"
 }
 
 func buildStamp() int64 {


### PR DESCRIPTION
Another attempt at this. Uses a `RELEASE` file if it exists (we can make our build system create one),a Git tag if one is available, or the directory name (this works for just downloading a release tarball from Github, stepping into it and running ./build.sh).