### PR TITLE
use Lstat instead of Stat to prevent errors with symlinks

### DIFF
--- a/internal/versioner/staggered.go
+++ b/internal/versioner/staggered.go
@@ -210,7 +210,7 @@ func (v Staggered) expire(versions []string) {
 	var prevAge int64
 	firstFile := true
 	for _, file := range versions {
-		fi, err := os.Stat(file)
+		fi, err := os.Lstat(file)
 		if err != nil {
 			l.Warnln("versioner:", err)
 			continue


### PR DESCRIPTION
prevents
```
staggered.go:215: WARNING: versioner: stat /home/alex/syncthing-test/instance01/Sync/.stversions/link~20150319-174419.txt: no such file or directory
```
when the version is a symlink