### PR TITLE
systemd: Set -logflags to 0, provide -no-browser flag

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 User=%i
 Environment=STNORESTART=yes
-ExecStart=/usr/bin/syncthing
+ExecStart=/usr/bin/syncthing -no-browser -logflags=0
 Restart=on-failure
 RestartPreventExitStatus=1
 SuccessExitStatus=2

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Environment=STNORESTART=yes
-ExecStart=/usr/bin/syncthing
+ExecStart=/usr/bin/syncthing -no-browser -logflags=0
 Restart=on-failure
 RestartPreventExitStatus=1
 SuccessExitStatus=2


### PR DESCRIPTION
Syncthing should not try to start a browser when invoked by systemd.
Furthermore we do not need any timestamps in the journal as systemd
already handles this for us.