### PR TITLE
Preserve the permission of a newly created directory

### DIFF
--- a/internal/model/rwfolder.go
+++ b/internal/model/rwfolder.go
@@ -489,7 +489,11 @@ func (p *rwFolder) handleDir(file protocol.FileInfo) {
 		// we can pass it to InWritableDir. We use a regular Mkdir and
 		// not MkdirAll because the parent should already exist.
 		mkdir := func(path string) error {
-			return os.Mkdir(path, mode)
+			err = os.Mkdir(path, mode)
+			if err != nil || p.ignorePerms {
+				return err
+			}
+			return os.Chmod(path, mode)
 		}
 
 		if err = osutil.InWritableDir(mkdir, realName); err == nil {


### PR DESCRIPTION
We need an explicit chmod() when creating a new directory.
Otherwise a new directory may be created with a different permission
from the one received from an originating device, because the umask
is applied to the mode given to mkdir().
The incorrect permission is later sent back to the originating device
and the original permission will be lost.