### PR TITLE
Support multiple scan query strings at the same time

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -685,8 +685,8 @@ func restPostScan(m *model.Model, w http.ResponseWriter, r *http.Request) {
 	qs := r.URL.Query()
 	folder := qs.Get("folder")
 	if folder != "" {
-		sub := qs.Get("sub")
-		err := m.ScanFolderSub(folder, sub)
+		subs := qs["sub"]
+		err := m.ScanFolderSubs(folder, subs)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 		}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1102,13 +1102,16 @@ func (m *Model) ScanFolders() map[string]error {
 }
 
 func (m *Model) ScanFolder(folder string) error {
-	return m.ScanFolderSub(folder, "")
+	return m.ScanFolderSubs(folder, nil)
 }
 
-func (m *Model) ScanFolderSub(folder, sub string) error {
-	sub = osutil.NativeFilename(sub)
-	if p := filepath.Clean(filepath.Join(folder, sub)); !strings.HasPrefix(p, folder) {
-		return errors.New("invalid subpath")
+func (m *Model) ScanFolderSubs(folder string, subs []string) error {
+	for i, sub := range subs {
+		sub = osutil.NativeFilename(sub)
+		if p := filepath.Clean(filepath.Join(folder, sub)); !strings.HasPrefix(p, folder) {
+			return errors.New("invalid subpath")
+		}
+		subs[i] = sub
 	}
 
 	m.fmut.Lock()
@@ -1129,19 +1132,30 @@ func (m *Model) ScanFolderSub(folder, sub string) error {
 
 	// Required to make sure that we start indexing at a directory we're already
 	// aware off.
-	for sub != "" {
-		if _, ok = fs.Get(protocol.LocalDeviceID, sub); ok {
-			break
+	var unifySubs []string
+nextSub:
+	for _, sub := range subs {
+		for sub != "" {
+			if _, ok = fs.Get(protocol.LocalDeviceID, sub); ok {
+				break
+			}
+			sub = filepath.Dir(sub)
+			if sub == "." || sub == string(filepath.Separator) {
+				sub = ""
+			}
 		}
-		sub = filepath.Dir(sub)
-		if sub == "." || sub == string(filepath.Separator) {
-			sub = ""
+		for _, us := range unifySubs {
+			if strings.HasPrefix(sub, us) {
+				continue nextSub
+			}
 		}
+		unifySubs = append(unifySubs, sub)
 	}
+	subs = unifySubs
 
 	w := &scanner.Walker{
 		Dir:           folderCfg.Path,
-		Sub:           sub,
+		Subs:          subs,
 		Matcher:       ignores,
 		BlockSize:     protocol.BlockSize,
 		TempNamer:     defTempNamer,
@@ -1184,10 +1198,17 @@ func (m *Model) ScanFolderSub(folder, sub string) error {
 	seenPrefix := false
 	fs.WithHaveTruncated(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
 		f := fi.(db.FileInfoTruncated)
-		if !strings.HasPrefix(f.Name, sub) {
-			// Return true so that we keep iterating, until we get to the part
-			// of the tree we are interested in. Then return false so we stop
-			// iterating when we've passed the end of the subtree.
+		hasPrefix := len(subs) == 0
+		for _, sub := range subs {
+			if strings.HasPrefix(f.Name, sub) {
+				hasPrefix = true
+				break
+			}
+		}
+		// Return true so that we keep iterating, until we get to the part
+		// of the tree we are interested in. Then return false so we stop
+		// iterating when we've passed the end of the subtree.
+		if !hasPrefix {
 			return !seenPrefix
 		}
 

--- a/internal/scanner/walk_test.go
+++ b/internal/scanner/walk_test.go
@@ -60,7 +60,7 @@ func TestWalkSub(t *testing.T) {
 
 	w := Walker{
 		Dir:       "testdata",
-		Sub:       "dir2",
+		Subs:      []string{"dir2"},
 		BlockSize: 128 * 1024,
 		Matcher:   ignores,
 	}


### PR DESCRIPTION
Related to https://github.com/syncthing/syncthing-inotify/commit/b886866fd7c1a605fb58c186a36e63786a10eef7
- (Partially) fixes renames for inotify clients
- Improves scanning performance when many files change at the same time (i.e. when scan requires are initiated by external clients)

Note: it was mentioned that this might need a lock before exchanging the updated index to other clients, but I'm not sure where to put it. The current patch should be a regression without this lock so that's why I invoke the PR already.