### PR TITLE
Remove default GC tweak

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -19,7 +19,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"runtime/debug"
 	"runtime/pprof"
 	"strconv"
 	"strings"
@@ -170,7 +169,11 @@ are mostly useful for developers. Use with care.
  STNOUPGRADE     Disable automatic upgrades.
 
  GOMAXPROCS      Set the maximum number of CPU cores to use. Defaults to all
-                 available CPU cores.`
+                 available CPU cores.
+
+ GOGC            Percentage of heap growth at which to trigger GC. Default is
+                 100. Lower numbers keep peak memory usage down, at the price
+                 of CPU usage (ie. performance).`
 )
 
 // Command line and environment options
@@ -367,10 +370,6 @@ func main() {
 
 func syncthingMain() {
 	var err error
-
-	if len(os.Getenv("GOGC")) == 0 {
-		debug.SetGCPercent(25)
-	}
 
 	if len(os.Getenv("GOMAXPROCS")) == 0 {
 		runtime.GOMAXPROCS(runtime.NumCPU())


### PR DESCRIPTION
This reverts the GC behavior to the Go default of triggering GC when the
heap has grown 100% compared to after the previous GC. We were setting
this to 25% to keep memory usage at a minimum, but it has a pretty
severe performance cost (especially when syncing large files) as we keep
triggering GC too often.

This documents the tweak in the `-help` message so users can decide for
themselves, and sticks to whatever the Go runtime developers thinks is
best for the default.