### PR TITLE
systemd: Fix error code definitions to prevent failed units

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -8,8 +8,7 @@ User=%i
 Environment=STNORESTART=yes
 ExecStart=/usr/bin/syncthing -no-browser -logflags=0
 Restart=on-failure
-RestartPreventExitStatus=1
-SuccessExitStatus=2
+SuccessExitStatus=2 3 4
 RestartForceExitStatus=3 4
 
 [Install]

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -7,8 +7,7 @@ After=network.target
 Environment=STNORESTART=yes
 ExecStart=/usr/bin/syncthing -no-browser -logflags=0
 Restart=on-failure
-RestartPreventExitStatus=1
-SuccessExitStatus=2
+SuccessExitStatus=2 3 4
 RestartForceExitStatus=3 4
 
 [Install]


### PR DESCRIPTION
The systemd exit code definitions (introduced in c586a17, refs #1324) caused
problems. Per default systemd considers a return code != 0 as failed. So when
you click on "Restart" in the WebUI an error appears:

```
  systemd[953]: syncthing.service: main process exited, code=exited, status=3/NOTIMPLEMENTED
  systemd[953]: Unit syncthing.service entered failed state.
  systemd[953]: syncthing.service failed.
  systemd[953]: syncthing.service holdoff time over, scheduling restart.
  systemd[953]: Started Syncthing - Open Source Continuous File Synchronization.
  systemd[953]: Starting Syncthing - Open Source Continuous File Synchronization...
  syncthing[13222]: [LFKUK] INFO: syncthing v0.10.30 (go1.4.2 linux-amd64 default) builduser@jara 2015-03-29 07:46:44 UTC
```

To fix this error we have to add the "succes codes" 2, 3, 4 to
"SuccessExitStatus":

```
  syncthing[13006]: [LFKUK] INFO: Restarting
  syncthing[13006]: [LFKUK] OK: Exiting
  systemd[953]: syncthing.service holdoff time over, scheduling restart.
  systemd[953]: Started Syncthing - Open Source Continuous File Synchronization.
  systemd[953]: Starting Syncthing - Open Source Continuous File Synchronization...
  syncthing[13031]: [LFKUK] INFO: syncthing v0.10.30 (go1.4.2 linux-amd64 default) builduser@jara 2015-03-29 07:46:44 UTC
```

To make sure that syncthing restarts in case of error, and to make sure
that "Restart=on-failure" actually works, let's remove
"RestartPreventExitStatus=1". Systemd considers this as an error per
default and the restart will be triggered successfully.