### PR TITLE
Fix -reset folder target

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -830,7 +830,7 @@ func resetFolders() {
 	for _, folder := range cfg.Folders() {
 		if _, err := os.Stat(folder.Path); err == nil {
 			base := filepath.Base(folder.Path)
-			dir := filepath.Dir(filepath.Join(folder.Path, ".."))
+			dir := filepath.Dir(folder.Path)
 			l.Infof("Reset: Moving %s -> %s", folder.Path, filepath.Join(dir, base+suffix))
 			os.Rename(folder.Path, filepath.Join(dir, base+suffix))
 		}


### PR DESCRIPTION
When executing syncthing with the -reset flag, an incorrect target directory is used.
Was:
```
20:19:58 INFO: Reset: Moving /home/user/Sync -> /home/Sync.syncthing-reset-1427653198358523653
```
should be:
```
20:19:58 INFO: Reset: Moving /home/user/Sync -> /home/user/Sync.syncthing-reset-1427653198358523653
```