### PR TITLE
Use a socket per interface for v6 multicast (fixes #1563)

### DIFF
--- a/internal/beacon/broadcast.go
+++ b/internal/beacon/broadcast.go
@@ -16,7 +16,7 @@ type Broadcast struct {
 }
 
 func NewBroadcast(port int) (*Broadcast, error) {
-	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: port})
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/beacon/multicast.go
+++ b/internal/beacon/multicast.go
@@ -11,22 +11,28 @@ import "net"
 type Multicast struct {
 	conn   *net.UDPConn
 	addr   *net.UDPAddr
+	intf   *net.Interface
 	inbox  chan []byte
 	outbox chan recv
 }
 
-func NewMulticast(addr string) (*Multicast, error) {
-	gaddr, err := net.ResolveUDPAddr("udp", addr)
+func NewMulticast(addr, ifname string) (*Multicast, error) {
+	gaddr, err := net.ResolveUDPAddr("udp6", addr)
 	if err != nil {
 		return nil, err
 	}
-	conn, err := net.ListenMulticastUDP("udp", nil, gaddr)
+	intf, err := net.InterfaceByName(ifname)
+	if err != nil {
+		return nil, err
+	}
+	conn, err := net.ListenMulticastUDP("udp6", intf, gaddr)
 	if err != nil {
 		return nil, err
 	}
 	b := &Multicast{
 		conn:   conn,
 		addr:   gaddr,
+		intf:   intf,
 		inbox:  make(chan []byte),
 		outbox: make(chan recv, 16),
 	}
@@ -47,27 +53,14 @@ func (b *Multicast) Recv() ([]byte, net.Addr) {
 }
 
 func (b *Multicast) writer() {
+	addr := *b.addr
+	addr.Zone = b.intf.Name
 	for bs := range b.inbox {
-		intfs, err := net.Interfaces()
-		if err != nil {
-			if debug {
-				l.Debugln("multicast interfaces:", err)
-			}
-			continue
-		}
-		for _, intf := range intfs {
-			if intf.Flags&net.FlagUp != 0 && intf.Flags&net.FlagMulticast != 0 {
-				addr := *b.addr
-				addr.Zone = intf.Name
-				_, err = b.conn.WriteTo(bs, &addr)
-				if err != nil {
-					if debug {
-						l.Debugln(err, "on write to", addr)
-					}
-				} else if debug {
-					l.Debugf("sent %d bytes to %s", len(bs), addr.String())
-				}
-			}
+		_, err := b.conn.WriteTo(bs, &addr)
+		if err != nil && debug {
+			l.Debugln(err, "on write to", addr)
+		} else if debug {
+			l.Debugf("sent %d bytes to %s", len(bs), addr.String())
 		}
 	}
 }


### PR DESCRIPTION
Moves the interface looping out one level and spins up a multicast beacon per interface.