### PR TITLE
Make sure we build the lowest ARM/386 version

### DIFF
--- a/build.go
+++ b/build.go
@@ -277,6 +277,15 @@ func listFiles(dir string) []string {
 func setBuildEnv() {
 	os.Setenv("GOOS", goos)
 	os.Setenv("GOARCH", goarch)
+	if goarch == "arm" {
+		if len(os.Getenv("GOARM")) == 0 {
+			os.Setenv("GOARM", "5")
+		}
+	} else if goarch == "386" {
+		if len(os.Getenv("GO386")) == 0 {
+			os.Setenv("GO386", "387")
+		}
+	}
 	wd, err := os.Getwd()
 	if err != nil {
 		log.Println("Warning: can't determine current dir:", err)


### PR DESCRIPTION
[This old commit message](https://github.com/syncthing/syncthing/commit/961a87b743b63c6042ad64404c8c308180cdef32) was incorrect when building outside the docker image. This PR makes sure we build the ARMv5 and 386-387 version.
This issue was discovered by @tnm- in the android repo: https://github.com/syncthing/syncthing-android/issues/333
