### PR TITLE
Use separate db commit routine 

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1041,6 +1041,24 @@ func (m *Model) updateLocal(folder string, f protocol.FileInfo) {
 	})
 }
 
+func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
+	m.fmut.RLock()
+	m.folderFiles[folder].Update(protocol.LocalDeviceID, fs)
+	m.fmut.RUnlock()
+
+	for _, f := range fs {
+		// Maybe we should introduce a new event type here for a bulk of
+		// files...
+		events.Default.Log(events.LocalIndexUpdated, map[string]interface{}{
+			"folder":   folder,
+			"name":     f.Name,
+			"modified": time.Unix(f.Modified, 0),
+			"flags":    fmt.Sprintf("0%o", f.Flags),
+			"size":     f.Size(),
+		})
+	}
+}
+
 func (m *Model) requestGlobal(deviceID protocol.DeviceID, folder, name string, offset int64, size int, hash []byte, flags uint32, options []protocol.Option) ([]byte, error) {
 	m.pmut.RLock()
 	nc, ok := m.protoConn[deviceID]

--- a/internal/model/rwfolder.go
+++ b/internal/model/rwfolder.go
@@ -69,8 +69,9 @@ type rwFolder struct {
 	copiers       int
 	pullers       int
 
-	stop  chan struct{}
-	queue *jobQueue
+	stop      chan struct{}
+	queue     *jobQueue
+	dbUpdates chan protocol.FileInfo
 }
 
 func newRWFolder(m *Model, cfg config.FolderConfiguration) *rwFolder {
@@ -276,6 +277,7 @@ func (p *rwFolder) pullerIteration(ignores *ignore.Matcher) int {
 	copyChan := make(chan copyBlocksState)
 	finisherChan := make(chan *sharedPullerState)
 
+	var updateWg sync.WaitGroup
 	var copyWg sync.WaitGroup
 	var pullWg sync.WaitGroup
 	var doneWg sync.WaitGroup
@@ -283,6 +285,14 @@ func (p *rwFolder) pullerIteration(ignores *ignore.Matcher) int {
 	if debug {
 		l.Debugln(p, "c", p.copiers, "p", p.pullers)
 	}
+
+	p.dbUpdates = make(chan protocol.FileInfo)
+	updateWg.Add(1)
+	go func() {
+		// dbUpdaterRoutine finishes when p.dbUpdates is closed
+		p.dbUpdaterRoutine()
+		updateWg.Done()
+	}()
 
 	for i := 0; i < p.copiers; i++ {
 		copyWg.Add(1)
@@ -453,6 +463,10 @@ nextFile:
 		p.deleteDir(dir)
 	}
 
+	// Wait for db updates to complete
+	close(p.dbUpdates)
+	updateWg.Wait()
+
 	return changed
 }
 
@@ -510,7 +524,7 @@ func (p *rwFolder) handleDir(file protocol.FileInfo) {
 		}
 
 		if err = osutil.InWritableDir(mkdir, realName); err == nil {
-			p.model.updateLocal(p.folder, file)
+			p.dbUpdates <- file
 		} else {
 			l.Infof("Puller (folder %q, dir %q): %v", p.folder, file.Name, err)
 		}
@@ -527,9 +541,9 @@ func (p *rwFolder) handleDir(file protocol.FileInfo) {
 	// It's OK to change mode bits on stuff within non-writable directories.
 
 	if p.ignorePerms {
-		p.model.updateLocal(p.folder, file)
+		p.dbUpdates <- file
 	} else if err := os.Chmod(realName, mode); err == nil {
-		p.model.updateLocal(p.folder, file)
+		p.dbUpdates <- file
 	} else {
 		l.Infof("Puller (folder %q, dir %q): %v", p.folder, file.Name, err)
 	}
@@ -564,7 +578,7 @@ func (p *rwFolder) deleteDir(file protocol.FileInfo) {
 	}
 	err = osutil.InWritableDir(os.Remove, realName)
 	if err == nil || os.IsNotExist(err) {
-		p.model.updateLocal(p.folder, file)
+		p.dbUpdates <- file
 	} else {
 		l.Infof("Puller (folder %q, dir %q): delete: %v", p.folder, file.Name, err)
 	}
@@ -601,7 +615,7 @@ func (p *rwFolder) deleteFile(file protocol.FileInfo) {
 	if err != nil && !os.IsNotExist(err) {
 		l.Infof("Puller (folder %q, file %q): delete: %v", p.folder, file.Name, err)
 	} else {
-		p.model.updateLocal(p.folder, file)
+		p.dbUpdates <- file
 	}
 }
 
@@ -653,7 +667,7 @@ func (p *rwFolder) renameFile(source, target protocol.FileInfo) {
 		// of the source and the creation of the target. Fix-up the metadata,
 		// and update the local index of the target file.
 
-		p.model.updateLocal(p.folder, source)
+		p.dbUpdates <- source
 
 		err = p.shortcutFile(target)
 		if err != nil {
@@ -671,7 +685,7 @@ func (p *rwFolder) renameFile(source, target protocol.FileInfo) {
 			return
 		}
 
-		p.model.updateLocal(p.folder, source)
+		p.dbUpdates <- source
 	}
 }
 
@@ -802,7 +816,7 @@ func (p *rwFolder) shortcutFile(file protocol.FileInfo) (err error) {
 		}
 	}
 
-	p.model.updateLocal(p.folder, file)
+	p.dbUpdates <- file
 	return
 }
 
@@ -810,7 +824,7 @@ func (p *rwFolder) shortcutFile(file protocol.FileInfo) (err error) {
 func (p *rwFolder) shortcutSymlink(file protocol.FileInfo) (err error) {
 	err = symlinks.ChangeType(filepath.Join(p.dir, file.Name), file.Flags)
 	if err == nil {
-		p.model.updateLocal(p.folder, file)
+		p.dbUpdates <- file
 	} else {
 		l.Infof("Puller (folder %q, file %q): symlink shortcut: %v", p.folder, file.Name, err)
 	}
@@ -1048,7 +1062,7 @@ func (p *rwFolder) performFinish(state *sharedPullerState) {
 	}
 
 	// Record the updated file in the index
-	p.model.updateLocal(p.folder, state.file)
+	p.dbUpdates <- state.file
 }
 
 func (p *rwFolder) finisherRoutine(in <-chan *sharedPullerState) {
@@ -1087,6 +1101,46 @@ func (p *rwFolder) BringToFront(filename string) {
 
 func (p *rwFolder) Jobs() ([]string, []string) {
 	return p.queue.Jobs()
+}
+
+// dbUpdaterRoutine aggregates db updates and commits them in batches no
+// larger than 1000 items, and no more delayed than 2 seconds.
+func (p *rwFolder) dbUpdaterRoutine() {
+	const (
+		maxBatchSize = 1000
+		maxBatchTime = 2 * time.Second
+	)
+
+	batch := make([]protocol.FileInfo, 0, maxBatchSize)
+	tick := time.NewTicker(maxBatchTime)
+
+loop:
+	for {
+		select {
+		case file, ok := <-p.dbUpdates:
+			if !ok {
+				break loop
+			}
+
+			file.LocalVersion = 0
+			batch = append(batch, file)
+
+			if len(batch) == maxBatchSize {
+				p.model.updateLocals(p.folder, batch)
+				batch = batch[:0]
+			}
+
+		case <-tick.C:
+			if len(batch) > 0 {
+				p.model.updateLocals(p.folder, batch)
+				batch = batch[:0]
+			}
+		}
+	}
+
+	if len(batch) > 0 {
+		p.model.updateLocals(p.folder, batch)
+	}
 }
 
 func invalidateFolder(cfg *config.Configuration, folderID string, err error) {

--- a/test/transfer-bench_test.go
+++ b/test/transfer-bench_test.go
@@ -14,7 +14,15 @@ import (
 	"time"
 )
 
-func TestBenchmarkTransfer(t *testing.T) {
+func TestBenchmarkTransferManyFiles(t *testing.T) {
+	benchmarkTransfer(t, 50000, 15)
+}
+
+func TestBenchmarkTransferLargeFiles(t *testing.T) {
+	benchmarkTransfer(t, 200, 24)
+}
+
+func benchmarkTransfer(t *testing.T, files, sizeExp int) {
 	log.Println("Cleaning...")
 	err := removeAll("s1", "s2", "h1/index*", "h2/index*")
 	if err != nil {
@@ -22,7 +30,7 @@ func TestBenchmarkTransfer(t *testing.T) {
 	}
 
 	log.Println("Generating files...")
-	err = generateFiles("s1", 10000, 22, "../LICENSE")
+	err = generateFiles("s1", files, sizeExp, "../LICENSE")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This batches database updates, which is a pretty big win on many small files. I added two benchmark tests, one for many (50.000) small files, one for a few (100) large files.

Pre change:

```bash
$ go test -v -tags "integration benchmark" -run Benchmark
=== RUN TestBenchmarkTransferManyFiles
2015/04/05 15:35:01 Cleaning...
2015/04/05 15:35:01 Generating files...
2015/04/05 15:35:16 Starting sender...
...
2015/04/05 15:40:13 Verifying...
2015/04/05 15:40:16 Sync took 4m38.013740143s
--- PASS: TestBenchmarkTransferManyFiles (314.54s)
```

Post change:

```bash
$ go test -v -tags "integration benchmark" -run BenchmarkTransferMany
=== RUN TestBenchmarkTransferManyFiles
2015/04/05 15:42:25 Cleaning...
2015/04/05 15:42:39 Generating files...
2015/04/05 15:42:55 Starting sender...
...
2015/04/05 15:43:44 Verifying...
2015/04/05 15:43:47 Sync took 29.438082339s
--- PASS: TestBenchmarkTransferManyFiles (81.98s)
```

Note that just creating the files on disk in the first place takes 16 seconds, so this is just a factor two in overhead on top of pure disk IO, which I think is pretty good. The LargeFile benchmark is also slightly improved, but no big deal.