### PR TITLE
Use separate routine for database updates in puller

### DIFF
--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -1027,17 +1027,14 @@ func sendIndexTo(initial bool, minLocalVer int64, conn protocol.Connection, fold
 	return maxLocalVer, err
 }
 
-func (m *Model) updateLocal(folder string, f protocol.FileInfo) {
-	f.LocalVersion = 0
+func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 	m.fmut.RLock()
-	m.folderFiles[folder].Update(protocol.LocalDeviceID, []protocol.FileInfo{f})
+	m.folderFiles[folder].Update(protocol.LocalDeviceID, fs)
 	m.fmut.RUnlock()
+
 	events.Default.Log(events.LocalIndexUpdated, map[string]interface{}{
 		"folder":   folder,
-		"name":     f.Name,
-		"modified": time.Unix(f.Modified, 0),
-		"flags":    fmt.Sprintf("0%o", f.Flags),
-		"size":     f.Size(),
+		"numFiles": len(fs),
 	})
 }
 

--- a/internal/model/rwfolder_test.go
+++ b/internal/model/rwfolder_test.go
@@ -70,7 +70,7 @@ func TestHandleFile(t *testing.T) {
 	m := NewModel(defaultConfig, protocol.LocalDeviceID, "device", "syncthing", "dev", db)
 	m.AddFolder(defaultFolderConfig)
 	// Update index
-	m.updateLocal("default", existingFile)
+	m.updateLocals("default", []protocol.FileInfo{existingFile})
 
 	p := rwFolder{
 		folder: "default",
@@ -124,7 +124,7 @@ func TestHandleFileWithTemp(t *testing.T) {
 	m := NewModel(defaultConfig, protocol.LocalDeviceID, "device", "syncthing", "dev", db)
 	m.AddFolder(defaultFolderConfig)
 	// Update index
-	m.updateLocal("default", existingFile)
+	m.updateLocals("default", []protocol.FileInfo{existingFile})
 
 	p := rwFolder{
 		folder: "default",
@@ -184,7 +184,7 @@ func TestCopierFinder(t *testing.T) {
 	m := NewModel(defaultConfig, protocol.LocalDeviceID, "device", "syncthing", "dev", db)
 	m.AddFolder(defaultFolderConfig)
 	// Update index
-	m.updateLocal("default", existingFile)
+	m.updateLocals("default", []protocol.FileInfo{existingFile})
 
 	iterFn := func(folder, file string, index int32) bool {
 		return true
@@ -268,7 +268,7 @@ func TestCopierCleanup(t *testing.T) {
 	}
 
 	// Add file to index
-	m.updateLocal("default", file)
+	m.updateLocals("default", []protocol.FileInfo{file})
 
 	if !m.finder.Iterate(blocks[0].Hash, iterFn) {
 		t.Error("Expected block not found")
@@ -277,7 +277,7 @@ func TestCopierCleanup(t *testing.T) {
 	file.Blocks = []protocol.BlockInfo{blocks[1]}
 	file.Version = file.Version.Update(protocol.LocalDeviceID.Short())
 	// Update index (removing old blocks)
-	m.updateLocal("default", file)
+	m.updateLocals("default", []protocol.FileInfo{file})
 
 	if m.finder.Iterate(blocks[0].Hash, iterFn) {
 		t.Error("Unexpected block found")
@@ -290,7 +290,7 @@ func TestCopierCleanup(t *testing.T) {
 	file.Blocks = []protocol.BlockInfo{blocks[0]}
 	file.Version = file.Version.Update(protocol.LocalDeviceID.Short())
 	// Update index (removing old blocks)
-	m.updateLocal("default", file)
+	m.updateLocals("default", []protocol.FileInfo{file})
 
 	if !m.finder.Iterate(blocks[0].Hash, iterFn) {
 		t.Error("Unexpected block found")
@@ -316,7 +316,7 @@ func TestLastResortPulling(t *testing.T) {
 		Modified: 0,
 		Blocks:   []protocol.BlockInfo{blocks[0]},
 	}
-	m.updateLocal("default", file)
+	m.updateLocals("default", []protocol.FileInfo{file})
 
 	// Pretend that we are handling a new file of the same content but
 	// with a different name (causing to copy that particular block)

--- a/test/transfer-bench_test.go
+++ b/test/transfer-bench_test.go
@@ -14,7 +14,15 @@ import (
 	"time"
 )
 
-func TestBenchmarkTransfer(t *testing.T) {
+func TestBenchmarkTransferManyFiles(t *testing.T) {
+	benchmarkTransfer(t, 50000, 15)
+}
+
+func TestBenchmarkTransferLargeFiles(t *testing.T) {
+	benchmarkTransfer(t, 200, 24)
+}
+
+func benchmarkTransfer(t *testing.T, files, sizeExp int) {
 	log.Println("Cleaning...")
 	err := removeAll("s1", "s2", "h1/index*", "h2/index*")
 	if err != nil {
@@ -22,7 +30,7 @@ func TestBenchmarkTransfer(t *testing.T) {
 	}
 
 	log.Println("Generating files...")
-	err = generateFiles("s1", 10000, 22, "../LICENSE")
+	err = generateFiles("s1", files, sizeExp, "../LICENSE")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This batches database updates, which is a pretty big win on many small files. I added two benchmark tests, one for many (50.000) small files, one for a few (100) large files. It also changes the `LocalIndexUpdated` event to be per commit, not per file (that was pretty expensive for some reason). We already have the `ItemStarted` and `ItemFinished` events per file.

Pre change:

```
$ go test -v -tags "integration benchmark" -run Benchmark
=== RUN TestBenchmarkTransferManyFiles
2015/04/05 15:35:01 Cleaning...
2015/04/05 15:35:01 Generating files...
2015/04/05 15:35:16 Starting sender...
...
2015/04/05 15:40:13 Verifying...
2015/04/05 15:40:16 Sync took 4m38.013740143s
--- PASS: TestBenchmarkTransferManyFiles (314.54s)
```

Post change:

```
$ go test -v -tags "integration benchmark" -run BenchmarkTransferMany
=== RUN TestBenchmarkTransferManyFiles
2015/04/05 15:42:25 Cleaning...
2015/04/05 15:42:39 Generating files...
2015/04/05 15:42:55 Starting sender...
...
2015/04/05 15:43:44 Verifying...
2015/04/05 15:43:47 Sync took 29.438082339s
--- PASS: TestBenchmarkTransferManyFiles (81.98s)
```

Note that just creating the files on disk in the first place takes 16 seconds, so this is just a factor two in overhead on top of pure disk IO, which I think is pretty good. The LargeFile benchmark is also slightly improved, but no big deal.