### PR TITLE
Handle long filenames on Windows (fixes #1295)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -670,7 +670,7 @@ func defaultConfig(myName string) config.Configuration {
 	newCfg.Folders = []config.FolderConfiguration{
 		{
 			ID:              "default",
-			Path:            locations[locDefFolder],
+			RawPath:         locations[locDefFolder],
 			RescanIntervalS: 60,
 			Devices:         []config.FolderDeviceConfiguration{{DeviceID: myID}},
 		},

--- a/cmd/syncthing/main_test.go
+++ b/cmd/syncthing/main_test.go
@@ -21,8 +21,8 @@ import (
 
 func TestFolderErrors(t *testing.T) {
 	fcfg := config.FolderConfiguration{
-		ID:   "folder",
-		Path: "testdata/testfolder",
+		ID:      "folder",
+		RawPath: "testdata/testfolder",
 	}
 	cfg := config.Wrap("/tmp/test", config.Configuration{
 		Folders: []config.FolderConfiguration{fcfg},
@@ -62,7 +62,7 @@ func TestFolderErrors(t *testing.T) {
 
 	// Case 2 - new folder, marker created
 
-	fcfg.Path = "testdata/"
+	fcfg.RawPath = "testdata/"
 	cfg = config.Wrap("/tmp/test", config.Configuration{
 		Folders: []config.FolderConfiguration{fcfg},
 	})
@@ -110,7 +110,7 @@ func TestFolderErrors(t *testing.T) {
 	os.Remove("testdata/testfolder/.stfolder")
 	os.Remove("testdata/testfolder/")
 
-	fcfg.Path = "testdata/testfolder"
+	fcfg.RawPath = "testdata/testfolder"
 	cfg = config.Wrap("testdata/subfolder", config.Configuration{
 		Folders: []config.FolderConfiguration{fcfg},
 	})

--- a/internal/config/wrapper.go
+++ b/internal/config/wrapper.go
@@ -159,12 +159,6 @@ func (w *Wrapper) Folders() map[string]FolderConfiguration {
 	if w.folderMap == nil {
 		w.folderMap = make(map[string]FolderConfiguration, len(w.cfg.Folders))
 		for _, fld := range w.cfg.Folders {
-			path, err := osutil.ExpandTilde(fld.Path)
-			if err != nil {
-				l.Warnln("home:", err)
-				continue
-			}
-			fld.Path = path
 			w.folderMap[fld.ID] = fld
 		}
 	}

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -35,8 +35,8 @@ func init() {
 	device2, _ = protocol.DeviceIDFromString("GYRZZQB-IRNPV4Z-T7TC52W-EQYJ3TT-FDQW6MW-DFLMU42-SSSU6EM-FBK2VAY")
 
 	defaultFolderConfig = config.FolderConfiguration{
-		ID:   "default",
-		Path: "testdata",
+		ID:      "default",
+		RawPath: "testdata",
 		Devices: []config.FolderDeviceConfiguration{
 			{
 				DeviceID: device1,
@@ -540,7 +540,7 @@ func TestIgnores(t *testing.T) {
 		t.Error("No error")
 	}
 
-	m.AddFolder(config.FolderConfiguration{ID: "fresh", Path: "XXX"})
+	m.AddFolder(config.FolderConfiguration{ID: "fresh", RawPath: "XXX"})
 	ignores, _, err = m.GetIgnores("fresh")
 	if err != nil {
 		t.Error(err)
@@ -596,7 +596,7 @@ func TestROScanRecovery(t *testing.T) {
 
 	fcfg := config.FolderConfiguration{
 		ID:              "default",
-		Path:            "testdata/rotestfolder",
+		RawPath:         "testdata/rotestfolder",
 		RescanIntervalS: 1,
 	}
 	cfg := config.Wrap("/tmp/test", config.Configuration{
@@ -608,7 +608,7 @@ func TestROScanRecovery(t *testing.T) {
 		},
 	})
 
-	os.RemoveAll(fcfg.Path)
+	os.RemoveAll(fcfg.RawPath)
 
 	m := NewModel(cfg, protocol.LocalDeviceID, "device", "syncthing", "dev", ldb)
 
@@ -633,14 +633,14 @@ func TestROScanRecovery(t *testing.T) {
 		return
 	}
 
-	os.Mkdir(fcfg.Path, 0700)
+	os.Mkdir(fcfg.RawPath, 0700)
 
 	if err := waitFor("Folder marker missing"); err != nil {
 		t.Error(err)
 		return
 	}
 
-	fd, err := os.Create(filepath.Join(fcfg.Path, ".stfolder"))
+	fd, err := os.Create(filepath.Join(fcfg.RawPath, ".stfolder"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -652,14 +652,14 @@ func TestROScanRecovery(t *testing.T) {
 		return
 	}
 
-	os.Remove(filepath.Join(fcfg.Path, ".stfolder"))
+	os.Remove(filepath.Join(fcfg.RawPath, ".stfolder"))
 
 	if err := waitFor("Folder marker missing"); err != nil {
 		t.Error(err)
 		return
 	}
 
-	os.Remove(fcfg.Path)
+	os.Remove(fcfg.RawPath)
 
 	if err := waitFor("Folder path missing"); err != nil {
 		t.Error(err)
@@ -676,7 +676,7 @@ func TestRWScanRecovery(t *testing.T) {
 
 	fcfg := config.FolderConfiguration{
 		ID:              "default",
-		Path:            "testdata/rwtestfolder",
+		RawPath:         "testdata/rwtestfolder",
 		RescanIntervalS: 1,
 	}
 	cfg := config.Wrap("/tmp/test", config.Configuration{
@@ -688,7 +688,7 @@ func TestRWScanRecovery(t *testing.T) {
 		},
 	})
 
-	os.RemoveAll(fcfg.Path)
+	os.RemoveAll(fcfg.RawPath)
 
 	m := NewModel(cfg, protocol.LocalDeviceID, "device", "syncthing", "dev", ldb)
 
@@ -713,14 +713,14 @@ func TestRWScanRecovery(t *testing.T) {
 		return
 	}
 
-	os.Mkdir(fcfg.Path, 0700)
+	os.Mkdir(fcfg.RawPath, 0700)
 
 	if err := waitFor("Folder marker missing"); err != nil {
 		t.Error(err)
 		return
 	}
 
-	fd, err := os.Create(filepath.Join(fcfg.Path, ".stfolder"))
+	fd, err := os.Create(filepath.Join(fcfg.RawPath, ".stfolder"))
 	if err != nil {
 		t.Error(err)
 		return
@@ -732,14 +732,14 @@ func TestRWScanRecovery(t *testing.T) {
 		return
 	}
 
-	os.Remove(filepath.Join(fcfg.Path, ".stfolder"))
+	os.Remove(filepath.Join(fcfg.RawPath, ".stfolder"))
 
 	if err := waitFor("Folder marker missing"); err != nil {
 		t.Error(err)
 		return
 	}
 
-	os.Remove(fcfg.Path)
+	os.Remove(fcfg.RawPath)
 
 	if err := waitFor("Folder path missing"); err != nil {
 		t.Error(err)

--- a/internal/model/rwfolder.go
+++ b/internal/model/rwfolder.go
@@ -82,7 +82,7 @@ func newRWFolder(m *Model, cfg config.FolderConfiguration) *rwFolder {
 		progressEmitter: m.progressEmitter,
 
 		folder:        cfg.ID,
-		dir:           cfg.Path,
+		dir:           cfg.Path(),
 		scanIntv:      time.Duration(cfg.RescanIntervalS) * time.Second,
 		ignorePerms:   cfg.IgnorePerms,
 		lenientMtimes: cfg.LenientMtimes,
@@ -852,7 +852,7 @@ func (p *rwFolder) copierRoutine(in <-chan copyBlocksState, pullChan chan<- pull
 		folderRoots := make(map[string]string)
 		p.model.fmut.RLock()
 		for folder, cfg := range p.model.folderCfgs {
-			folderRoots[folder] = cfg.Path
+			folderRoots[folder] = cfg.Path()
 		}
 		p.model.fmut.RUnlock()
 


### PR DESCRIPTION
There are many approaches to this... This one works on the assumption that it's safest for most of the code if the change is done as early as possible, i.e. at config loading time, lest we forget some critical  place where a conversion might need to be done. And it also assumes that we should not put the `\\?\` in the config or show it to the user in the GUI, as they may be scared and confused by it. If we think most Windows users are fine with `\\?\` being visible then we can just add it at config loading and not do the dance with RawPath/Path...

I've tested that this starts on Windows and seems to hash files while mentioning paths starting with `\\?\` in the debug output... Some more Windows testing would be nice.
