### PR TITLE
Update XDR dependency (fixes #1606)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -19,7 +19,7 @@
 		},
 		{
 			"ImportPath": "github.com/calmh/xdr",
-			"Rev": "bccf335c34c01760bdc89f98c952fcda696e27d2"
+			"Rev": "5f7208e86762911861c94f1849eddbfc0a60cbf0"
 		},
 		{
 			"ImportPath": "github.com/juju/ratelimit",
@@ -31,7 +31,7 @@
 		},
 		{
 			"ImportPath": "github.com/syncthing/protocol",
-			"Rev": "6277c0595c18d42e9db75dfe900463ef093a82d2"
+			"Rev": "3d8a71fdb205fe2401a341a739208bc9d1e79a1b"
 		},
 		{
 			"ImportPath": "github.com/syndtr/goleveldb/leveldb",

--- a/Godeps/_workspace/src/github.com/calmh/xdr/bench_test.go
+++ b/Godeps/_workspace/src/github.com/calmh/xdr/bench_test.go
@@ -67,7 +67,7 @@ func BenchmarkThisEncode(b *testing.B) {
 func BenchmarkThisEncoder(b *testing.B) {
 	w := xdr.NewWriter(ioutil.Discard)
 	for i := 0; i < b.N; i++ {
-		_, err := s.encodeXDR(w)
+		_, err := s.EncodeXDRInto(w)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -108,7 +108,7 @@ func BenchmarkThisDecoder(b *testing.B) {
 	r := xdr.NewReader(rr)
 	var t XDRBenchStruct
 	for i := 0; i < b.N; i++ {
-		err := t.decodeXDR(r)
+		err := t.DecodeXDRFrom(r)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/Godeps/_workspace/src/github.com/calmh/xdr/bench_xdr_test.go
+++ b/Godeps/_workspace/src/github.com/calmh/xdr/bench_xdr_test.go
@@ -26,7 +26,9 @@ XDRBenchStruct Structure:
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |            0x0000             |              I3               |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                             uint8                             |
+/                                                               /
+\                        uint8 Structure                        \
+/                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                         Length of Bs0                         |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
@@ -69,7 +71,7 @@ struct XDRBenchStruct {
 
 func (o XDRBenchStruct) EncodeXDR(w io.Writer) (int, error) {
 	var xw = xdr.NewWriter(w)
-	return o.encodeXDR(xw)
+	return o.EncodeXDRInto(xw)
 }
 
 func (o XDRBenchStruct) MarshalXDR() ([]byte, error) {
@@ -87,11 +89,11 @@ func (o XDRBenchStruct) MustMarshalXDR() []byte {
 func (o XDRBenchStruct) AppendXDR(bs []byte) ([]byte, error) {
 	var aw = xdr.AppendWriter(bs)
 	var xw = xdr.NewWriter(&aw)
-	_, err := o.encodeXDR(xw)
+	_, err := o.EncodeXDRInto(xw)
 	return []byte(aw), err
 }
 
-func (o XDRBenchStruct) encodeXDR(xw *xdr.Writer) (int, error) {
+func (o XDRBenchStruct) EncodeXDRInto(xw *xdr.Writer) (int, error) {
 	xw.WriteUint64(o.I1)
 	xw.WriteUint32(o.I2)
 	xw.WriteUint16(o.I3)
@@ -111,16 +113,16 @@ func (o XDRBenchStruct) encodeXDR(xw *xdr.Writer) (int, error) {
 
 func (o *XDRBenchStruct) DecodeXDR(r io.Reader) error {
 	xr := xdr.NewReader(r)
-	return o.decodeXDR(xr)
+	return o.DecodeXDRFrom(xr)
 }
 
 func (o *XDRBenchStruct) UnmarshalXDR(bs []byte) error {
 	var br = bytes.NewReader(bs)
 	var xr = xdr.NewReader(br)
-	return o.decodeXDR(xr)
+	return o.DecodeXDRFrom(xr)
 }
 
-func (o *XDRBenchStruct) decodeXDR(xr *xdr.Reader) error {
+func (o *XDRBenchStruct) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.I1 = xr.ReadUint64()
 	o.I2 = xr.ReadUint32()
 	o.I3 = xr.ReadUint16()
@@ -155,7 +157,7 @@ struct repeatReader {
 
 func (o repeatReader) EncodeXDR(w io.Writer) (int, error) {
 	var xw = xdr.NewWriter(w)
-	return o.encodeXDR(xw)
+	return o.EncodeXDRInto(xw)
 }
 
 func (o repeatReader) MarshalXDR() ([]byte, error) {
@@ -173,27 +175,27 @@ func (o repeatReader) MustMarshalXDR() []byte {
 func (o repeatReader) AppendXDR(bs []byte) ([]byte, error) {
 	var aw = xdr.AppendWriter(bs)
 	var xw = xdr.NewWriter(&aw)
-	_, err := o.encodeXDR(xw)
+	_, err := o.EncodeXDRInto(xw)
 	return []byte(aw), err
 }
 
-func (o repeatReader) encodeXDR(xw *xdr.Writer) (int, error) {
+func (o repeatReader) EncodeXDRInto(xw *xdr.Writer) (int, error) {
 	xw.WriteBytes(o.data)
 	return xw.Tot(), xw.Error()
 }
 
 func (o *repeatReader) DecodeXDR(r io.Reader) error {
 	xr := xdr.NewReader(r)
-	return o.decodeXDR(xr)
+	return o.DecodeXDRFrom(xr)
 }
 
 func (o *repeatReader) UnmarshalXDR(bs []byte) error {
 	var br = bytes.NewReader(bs)
 	var xr = xdr.NewReader(br)
-	return o.decodeXDR(xr)
+	return o.DecodeXDRFrom(xr)
 }
 
-func (o *repeatReader) decodeXDR(xr *xdr.Reader) error {
+func (o *repeatReader) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.data = xr.ReadBytes()
 	return xr.Error()
 }

--- a/Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go
+++ b/Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go
@@ -143,6 +143,9 @@ func (o *{{.TypeName}}) DecodeXDRFrom(xr *xdr.Reader) error {
 			{{end}}
 		{{else}}
 			_{{$fieldInfo.Name}}Size := int(xr.ReadUint32())
+			if _{{$fieldInfo.Name}}Size < 0 {
+				return xdr.ElementSizeExceeded("{{$fieldInfo.Name}}", _{{$fieldInfo.Name}}Size, {{$fieldInfo.Max}})
+			}
 			{{if ge $fieldInfo.Max 1}}
 				if _{{$fieldInfo.Name}}Size > {{$fieldInfo.Max}} {
 					return xdr.ElementSizeExceeded("{{$fieldInfo.Name}}", _{{$fieldInfo.Name}}Size, {{$fieldInfo.Max}})

--- a/Godeps/_workspace/src/github.com/calmh/xdr/encdec_test.go
+++ b/Godeps/_workspace/src/github.com/calmh/xdr/encdec_test.go
@@ -32,11 +32,11 @@ type TestStruct struct {
 
 type Opaque [32]byte
 
-func (u *Opaque) encodeXDR(w *xdr.Writer) (int, error) {
+func (u *Opaque) EncodeXDRInto(w *xdr.Writer) (int, error) {
 	return w.WriteRaw(u[:])
 }
 
-func (u *Opaque) decodeXDR(r *xdr.Reader) (int, error) {
+func (u *Opaque) DecodeXDRFrom(r *xdr.Reader) (int, error) {
 	return r.ReadRaw(u[:])
 }
 

--- a/Godeps/_workspace/src/github.com/calmh/xdr/reader.go
+++ b/Godeps/_workspace/src/github.com/calmh/xdr/reader.go
@@ -68,7 +68,8 @@ func (r *Reader) ReadBytesMaxInto(max int, dst []byte) []byte {
 	if r.err != nil {
 		return nil
 	}
-	if max > 0 && l > max {
+	if l < 0 || max > 0 && l > max {
+		// l may be negative on 32 bit builds
 		r.err = ElementSizeExceeded("bytes field", l, max)
 		return nil
 	}

--- a/Godeps/_workspace/src/github.com/syncthing/protocol/message_xdr.go
+++ b/Godeps/_workspace/src/github.com/syncthing/protocol/message_xdr.go
@@ -110,12 +110,18 @@ func (o *IndexMessage) UnmarshalXDR(bs []byte) error {
 func (o *IndexMessage) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.Folder = xr.ReadString()
 	_FilesSize := int(xr.ReadUint32())
+	if _FilesSize < 0 {
+		return xdr.ElementSizeExceeded("Files", _FilesSize, 0)
+	}
 	o.Files = make([]FileInfo, _FilesSize)
 	for i := range o.Files {
 		(&o.Files[i]).DecodeXDRFrom(xr)
 	}
 	o.Flags = xr.ReadUint32()
 	_OptionsSize := int(xr.ReadUint32())
+	if _OptionsSize < 0 {
+		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
+	}
 	if _OptionsSize > 64 {
 		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
 	}
@@ -236,6 +242,9 @@ func (o *FileInfo) DecodeXDRFrom(xr *xdr.Reader) error {
 	(&o.Version).DecodeXDRFrom(xr)
 	o.LocalVersion = int64(xr.ReadUint64())
 	_BlocksSize := int(xr.ReadUint32())
+	if _BlocksSize < 0 {
+		return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 0)
+	}
 	o.Blocks = make([]BlockInfo, _BlocksSize)
 	for i := range o.Blocks {
 		(&o.Blocks[i]).DecodeXDRFrom(xr)
@@ -442,6 +451,9 @@ func (o *RequestMessage) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.Hash = xr.ReadBytesMax(64)
 	o.Flags = xr.ReadUint32()
 	_OptionsSize := int(xr.ReadUint32())
+	if _OptionsSize < 0 {
+		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
+	}
 	if _OptionsSize > 64 {
 		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
 	}
@@ -633,11 +645,17 @@ func (o *ClusterConfigMessage) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.ClientName = xr.ReadStringMax(64)
 	o.ClientVersion = xr.ReadStringMax(64)
 	_FoldersSize := int(xr.ReadUint32())
+	if _FoldersSize < 0 {
+		return xdr.ElementSizeExceeded("Folders", _FoldersSize, 0)
+	}
 	o.Folders = make([]Folder, _FoldersSize)
 	for i := range o.Folders {
 		(&o.Folders[i]).DecodeXDRFrom(xr)
 	}
 	_OptionsSize := int(xr.ReadUint32())
+	if _OptionsSize < 0 {
+		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
+	}
 	if _OptionsSize > 64 {
 		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
 	}
@@ -750,12 +768,18 @@ func (o *Folder) UnmarshalXDR(bs []byte) error {
 func (o *Folder) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.ID = xr.ReadStringMax(64)
 	_DevicesSize := int(xr.ReadUint32())
+	if _DevicesSize < 0 {
+		return xdr.ElementSizeExceeded("Devices", _DevicesSize, 0)
+	}
 	o.Devices = make([]Device, _DevicesSize)
 	for i := range o.Devices {
 		(&o.Devices[i]).DecodeXDRFrom(xr)
 	}
 	o.Flags = xr.ReadUint32()
 	_OptionsSize := int(xr.ReadUint32())
+	if _OptionsSize < 0 {
+		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
+	}
 	if _OptionsSize > 64 {
 		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
 	}
@@ -862,6 +886,9 @@ func (o *Device) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.MaxLocalVersion = int64(xr.ReadUint64())
 	o.Flags = xr.ReadUint32()
 	_OptionsSize := int(xr.ReadUint32())
+	if _OptionsSize < 0 {
+		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
+	}
 	if _OptionsSize > 64 {
 		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)
 	}

--- a/internal/db/leveldb_xdr.go
+++ b/internal/db/leveldb_xdr.go
@@ -156,6 +156,9 @@ func (o *versionList) UnmarshalXDR(bs []byte) error {
 
 func (o *versionList) DecodeXDRFrom(xr *xdr.Reader) error {
 	_versionsSize := int(xr.ReadUint32())
+	if _versionsSize < 0 {
+		return xdr.ElementSizeExceeded("versions", _versionsSize, 0)
+	}
 	o.versions = make([]fileVersion, _versionsSize)
 	for i := range o.versions {
 		(&o.versions[i]).DecodeXDRFrom(xr)

--- a/internal/discover/packets_xdr.go
+++ b/internal/discover/packets_xdr.go
@@ -172,6 +172,9 @@ func (o *Announce) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.Magic = xr.ReadUint32()
 	(&o.This).DecodeXDRFrom(xr)
 	_ExtraSize := int(xr.ReadUint32())
+	if _ExtraSize < 0 {
+		return xdr.ElementSizeExceeded("Extra", _ExtraSize, 16)
+	}
 	if _ExtraSize > 16 {
 		return xdr.ElementSizeExceeded("Extra", _ExtraSize, 16)
 	}
@@ -266,6 +269,9 @@ func (o *Device) UnmarshalXDR(bs []byte) error {
 func (o *Device) DecodeXDRFrom(xr *xdr.Reader) error {
 	o.ID = xr.ReadBytesMax(32)
 	_AddressesSize := int(xr.ReadUint32())
+	if _AddressesSize < 0 {
+		return xdr.ElementSizeExceeded("Addresses", _AddressesSize, 16)
+	}
 	if _AddressesSize > 16 {
 		return xdr.ElementSizeExceeded("Addresses", _AddressesSize, 16)
 	}


### PR DESCRIPTION
When reading lengths on the wire we get an uint32 and convert it into an int for `make()` and indexing. This is a problem because sizes larger than 2^31 will become a negative int on 32 bit builds. This can happen when there is a protocol mismatch. This change explicitly checks for sizes less than zero and returns ElementSizeExceeded...

(There's also some unrelated XDR crap because a method changed from private to public and the chart drawing method changed and I forgot to regenerate it...)