### PR TITLE
Index reset should generate file conflicts (fixes #1613)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -31,7 +31,7 @@
 		},
 		{
 			"ImportPath": "github.com/syncthing/protocol",
-			"Rev": "3d8a71fdb205fe2401a341a739208bc9d1e79a1b"
+			"Rev": "e7db2648034fb71b051902a02bc25d4468ed492e"
 		},
 		{
 			"ImportPath": "github.com/syndtr/goleveldb/leveldb",

--- a/Godeps/_workspace/src/github.com/syncthing/protocol/vector.go
+++ b/Godeps/_workspace/src/github.com/syncthing/protocol/vector.go
@@ -103,3 +103,13 @@ func (a Vector) Concurrent(b Vector) bool {
 	comp := a.Compare(b)
 	return comp == ConcurrentGreater || comp == ConcurrentLesser
 }
+
+// Counter returns the current value of the given counter ID.
+func (v Vector) Counter(id uint64) uint64 {
+	for _, c := range v {
+		if c.ID == id {
+			return c.Value
+		}
+	}
+	return 0
+}

--- a/Godeps/_workspace/src/github.com/syncthing/protocol/vector_test.go
+++ b/Godeps/_workspace/src/github.com/syncthing/protocol/vector_test.go
@@ -118,5 +118,17 @@ func TestMerge(t *testing.T) {
 			t.Errorf("%d: %+v.Merge(%+v) == %+v (expected %+v)", i, tc.a, tc.b, m, tc.m)
 		}
 	}
+}
 
+func TestCounterValue(t *testing.T) {
+	v0 := Vector{Counter{42, 1}, Counter{64, 5}}
+	if v0.Counter(42) != 1 {
+		t.Error("Counter error, %d != %d", v0.Counter(42), 1)
+	}
+	if v0.Counter(64) != 5 {
+		t.Error("Counter error, %d != %d", v0.Counter(64), 5)
+	}
+	if v0.Counter(72) != 0 {
+		t.Error("Counter error, %d != %d", v0.Counter(72), 0)
+	}
 }

--- a/Godeps/_workspace/src/github.com/thejerf/suture/pre-commit
+++ b/Godeps/_workspace/src/github.com/thejerf/suture/pre-commit
@@ -9,3 +9,4 @@ if [ ! -z "$GOLINTOUT" -o "$?" != 0 ]; then
 fi
 
 go test
+

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -142,7 +142,7 @@ func (m *Model) StartFolderRW(folder string) {
 	if ok {
 		panic("cannot start already running folder " + folder)
 	}
-	p := newRWFolder(m, cfg)
+	p := newRWFolder(m, m.shortID, cfg)
 	m.folderRunners[folder] = p
 	m.fmut.Unlock()
 


### PR DESCRIPTION
This make sure(-ish...) that we come up with a new short ID (used in the version vectors) when the index is removed. This we are in conflict, so non-identical files will go through the conflict handling.