### PR TITLE
events.Subscription.Poll does not seem to require locking

### DIFF
--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -103,7 +103,6 @@ type Subscription struct {
 	mask   EventType
 	id     int
 	events chan Event
-	mutex  sync.Mutex
 }
 
 var Default = NewLogger()
@@ -153,7 +152,6 @@ func (l *Logger) Subscribe(mask EventType) *Subscription {
 		mask:   mask,
 		id:     l.nextID,
 		events: make(chan Event, BufferSize),
-		mutex:  sync.NewMutex(),
 	}
 	l.nextID++
 	l.subs[s.id] = s
@@ -172,9 +170,6 @@ func (l *Logger) Unsubscribe(s *Subscription) {
 }
 
 func (s *Subscription) Poll(timeout time.Duration) (Event, error) {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
 	if debug {
 		dl.Debugln("poll", timeout)
 	}


### PR DESCRIPTION
This is a large source of output from the new lock logging, and it
doesn't seem to accomplish anything useful that I can see. Running
integration with the race detector to make sure...