### PR TITLE
Fix capitalization in HTTP-header in SOAP request (fixes #1696)

### DIFF
--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -454,7 +454,7 @@ func soapRequest(url, service, function, message string) ([]byte, error) {
 	}
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
 	req.Header.Set("User-Agent", "syncthing/1.0")
-	req.Header["SOAPAction"]=[]string{fmt.Sprintf(`"%s#%s"`, service, function)}  // Enforce capitalization in header-entry for sensitive routers. See issue #1696
+	req.Header["SOAPAction"] = []string{fmt.Sprintf(`"%s#%s"`, service, function)} // Enforce capitalization in header-entry for sensitive routers. See issue #1696
 	req.Header.Set("Connection", "Close")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Pragma", "no-cache")

--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -454,7 +454,7 @@ func soapRequest(url, service, function, message string) ([]byte, error) {
 	}
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
 	req.Header.Set("User-Agent", "syncthing/1.0")
-	req.Header.Set("SOAPAction", fmt.Sprintf(`"%s#%s"`, service, function))
+	req.Header["SOAPAction"]=[]string{fmt.Sprintf(`"%s#%s"`, service, function)}  // Enforce capitalization in header-entry for sensitive routers. See issue #1696
 	req.Header.Set("Connection", "Close")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Pragma", "no-cache")


### PR DESCRIPTION
Some routers are sensitive to the capitalization in  "SOAPAction" in the HTTP-header in SOAP request. See issue #1696. This modification follows the recommendation of preserving caps in HTTP-headers in go described on http://stackoverflow.com/questions/26351716/how-to-keep-key-case-sensitive-in-request-header-using-golang?lq=1 