### PR TITLE
Fix to for routers that cannot handle many open HTTP-connections

### DIFF
--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -452,6 +452,7 @@ func soapRequest(url, service, function, message string) ([]byte, error) {
 	if err != nil {
 		return resp, err
 	}
+	req.Close = true
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
 	req.Header.Set("User-Agent", "syncthing/1.0")
 	req.Header.Set("SOAPAction", fmt.Sprintf(`"%s#%s"`, service, function))
@@ -467,6 +468,9 @@ func soapRequest(url, service, function, message string) ([]byte, error) {
 
 	r, err := http.DefaultClient.Do(req)
 	if err != nil {
+		if debug {
+			l.Debugln(err)
+		}
 		return resp, err
 	}
 


### PR DESCRIPTION
Some routers do not respond when too many subsequent SOAP-requests are sent directly after eachother and will generate an EOF-error in the call DefaultClient.Do(req). This is the case for instance for Linksys WRT120N. This modification adds a req.Close = True following the description of the problem on http://stackoverflow.com/questions/17714494/golang-http-request-results-in-eof-errors-when-making-multiple-requests-successi