### PR TITLE
Reduce allocations in blockmap code

### DIFF
--- a/internal/db/blockmap.go
+++ b/internal/db/blockmap.go
@@ -4,170 +4,107 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// Package db provides a set type to track local/remote files with newness
-// checks. We must do a certain amount of normalization in here. We will get
-// fed paths with either native or wire-format separators and encodings
-// depending on who calls us. We transform paths to wire-format (NFC and
-// slashes) on the way to the database, and transform to native format
-// (varying separator and encoding) on the way back out.
 package db
 
 import (
-	"bytes"
-	"encoding/binary"
-	"sort"
-
+	"github.com/Workiva/go-datastructures/trie/ctrie"
 	"github.com/syncthing/protocol"
-	"github.com/syncthing/syncthing/internal/config"
 	"github.com/syncthing/syncthing/internal/osutil"
-	"github.com/syncthing/syncthing/internal/sync"
-
-	"github.com/syndtr/goleveldb/leveldb"
-	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
-var blockFinder *BlockFinder
-
 type BlockMap struct {
-	db     *leveldb.DB
-	folder string
+	trie *ctrie.Ctrie
 }
 
-func NewBlockMap(db *leveldb.DB, folder string) *BlockMap {
+func NewBlockMap() *BlockMap {
 	return &BlockMap{
-		db:     db,
-		folder: folder,
+		trie: ctrie.New(nil),
 	}
 }
 
+type bmEntry struct {
+	name  string
+	index int
+}
+
 // Add files to the block map, ignoring any deleted or invalid files.
-func (m *BlockMap) Add(files []protocol.FileInfo) error {
-	batch := new(leveldb.Batch)
-	buf := make([]byte, 4)
-	folderBytes := []byte(m.folder)
-
-	// We build the key manually in here (instead of calling m.blockKey) to
-	// reduce the allocations and work done per block, since this is a tight
-	// loop running for every block.
-	var key []byte
-
+func (m *BlockMap) Add(files []protocol.FileInfo) {
 	for _, file := range files {
-		keyLen := 1 + 64 + 32 + len(file.Name)
-		if len(key) < keyLen {
-			key = make([]byte, keyLen)
-		}
-
-		key[0] = KeyTypeBlock
-		copy(key[1:], folderBytes)
-		copy(key[1+64+32:], []byte(file.Name))
-
 		if file.IsDirectory() || file.IsDeleted() || file.IsInvalid() {
 			continue
 		}
 
+	nextBlock:
 		for i, block := range file.Blocks {
-			binary.BigEndian.PutUint32(buf, uint32(i))
-			copy(key[1+64:], block.Hash)
-			batch.Put(key[:keyLen], buf)
-
-			if batch.Len() >= 1000 {
-				if err := m.db.Write(batch, nil); err != nil {
-					return err
-				}
-				batch.Reset()
+			val, ok := m.trie.Lookup(block.Hash)
+			if !ok {
+				// New block, add it
+				m.trie.Insert(block.Hash, []bmEntry{{
+					name:  file.Name,
+					index: i,
+				}})
+				continue
 			}
+
+			// Existing block, add to list, if it's not already there.
+			entries := val.([]bmEntry)
+			for _, e := range entries {
+				if e.index == i && e.name == file.Name {
+					// Block is already in the registry
+					continue nextBlock
+				}
+			}
+
+			entries = append(entries, bmEntry{
+				name:  file.Name,
+				index: i,
+			})
+
+			m.trie.Insert(block.Hash, entries)
 		}
 	}
-
-	return m.db.Write(batch, nil)
 }
 
 // Update block map state, removing any deleted or invalid files.
-func (m *BlockMap) Update(files []protocol.FileInfo) error {
-	batch := new(leveldb.Batch)
-	buf := make([]byte, 4)
-	for _, file := range files {
-		if file.IsDirectory() {
-			continue
-		}
-
+func (m *BlockMap) Update(files []protocol.FileInfo) {
+	for i, file := range files {
 		if file.IsDeleted() || file.IsInvalid() {
-			for _, block := range file.Blocks {
-				batch.Delete(m.blockKey(block.Hash, file.Name))
-			}
-			continue
-		}
-
-		for i, block := range file.Blocks {
-			binary.BigEndian.PutUint32(buf, uint32(i))
-			batch.Put(m.blockKey(block.Hash, file.Name), buf)
+			m.Discard(files[i : i+1])
+		} else {
+			m.Add(files[i : i+1])
 		}
 	}
-	return m.db.Write(batch, nil)
 }
 
 // Discard block map state, removing the given files
 func (m *BlockMap) Discard(files []protocol.FileInfo) error {
-	batch := new(leveldb.Batch)
 	for _, file := range files {
-		for _, block := range file.Blocks {
-			batch.Delete(m.blockKey(block.Hash, file.Name))
+	nextBlock:
+		for i, block := range file.Blocks {
+			val, ok := m.trie.Lookup(block.Hash)
+			if !ok {
+				continue nextBlock
+			}
+			entries := val.([]bmEntry)
+			if len(entries) == 1 {
+				m.trie.Remove(block.Hash)
+				continue nextBlock
+			}
+			for j, entry := range entries {
+				if entry.index == i && entry.name == file.Name {
+					entries = append(entries[:j], entries[j+1:]...)
+					m.trie.Insert(block.Hash, entries)
+					continue nextBlock
+				}
+			}
 		}
 	}
-	return m.db.Write(batch, nil)
+	return nil
 }
 
 // Drop block map, removing all entries related to this block map from the db.
 func (m *BlockMap) Drop() error {
-	batch := new(leveldb.Batch)
-	iter := m.db.NewIterator(util.BytesPrefix(m.blockKey(nil, "")[:1+64]), nil)
-	defer iter.Release()
-	for iter.Next() {
-		batch.Delete(iter.Key())
-	}
-	if iter.Error() != nil {
-		return iter.Error()
-	}
-	return m.db.Write(batch, nil)
-}
-
-func (m *BlockMap) blockKey(hash []byte, file string) []byte {
-	return toBlockKey(hash, m.folder, file)
-}
-
-type BlockFinder struct {
-	db      *leveldb.DB
-	folders []string
-	mut     sync.RWMutex
-}
-
-func NewBlockFinder(db *leveldb.DB, cfg *config.Wrapper) *BlockFinder {
-	if blockFinder != nil {
-		return blockFinder
-	}
-
-	f := &BlockFinder{
-		db:  db,
-		mut: sync.NewRWMutex(),
-	}
-	f.Changed(cfg.Raw())
-	cfg.Subscribe(f)
-	return f
-}
-
-// Changed implements config.Handler interface
-func (f *BlockFinder) Changed(cfg config.Configuration) error {
-	folders := make([]string, len(cfg.Folders))
-	for i, folder := range cfg.Folders {
-		folders[i] = folder.ID
-	}
-
-	sort.Strings(folders)
-
-	f.mut.Lock()
-	f.folders = folders
-	f.mut.Unlock()
-
+	m.trie = ctrie.New(nil)
 	return nil
 }
 
@@ -176,21 +113,14 @@ func (f *BlockFinder) Changed(cfg config.Configuration) error {
 // they are happy with the block) or false to continue iterating for whatever
 // reason. The iterator finally returns the result, whether or not a
 // satisfying block was eventually found.
-func (f *BlockFinder) Iterate(hash []byte, iterFn func(string, string, int32) bool) bool {
-	f.mut.RLock()
-	folders := f.folders
-	f.mut.RUnlock()
-	for _, folder := range folders {
-		key := toBlockKey(hash, folder, "")
-		iter := f.db.NewIterator(util.BytesPrefix(key), nil)
-		defer iter.Release()
-
-		for iter.Next() && iter.Error() == nil {
-			folder, file := fromBlockKey(iter.Key())
-			index := int32(binary.BigEndian.Uint32(iter.Value()))
-			if iterFn(folder, osutil.NativeFilename(file), index) {
-				return true
-			}
+func (m *BlockMap) Iterate(hash []byte, iterFn func(file string, index int) bool) bool {
+	val, ok := m.trie.Lookup(hash)
+	if !ok {
+		return false
+	}
+	for _, entry := range val.([]bmEntry) {
+		if iterFn(osutil.NativeFilename(entry.name), entry.index) {
+			return true
 		}
 	}
 	return false
@@ -198,44 +128,12 @@ func (f *BlockFinder) Iterate(hash []byte, iterFn func(string, string, int32) bo
 
 // Fix repairs incorrect blockmap entries, removing the old entry and
 // replacing it with a new entry for the given block
-func (f *BlockFinder) Fix(folder, file string, index int32, oldHash, newHash []byte) error {
-	buf := make([]byte, 4)
+func (m *BlockMap) Fix(folder, file string, index int, oldHash, newHash []byte) {
+	/*buf := make([]byte, 4)
 	binary.BigEndian.PutUint32(buf, uint32(index))
 
 	batch := new(leveldb.Batch)
 	batch.Delete(toBlockKey(oldHash, folder, file))
 	batch.Put(toBlockKey(newHash, folder, file), buf)
-	return f.db.Write(batch, nil)
-}
-
-// m.blockKey returns a byte slice encoding the following information:
-//	   keyTypeBlock (1 byte)
-//	   folder (64 bytes)
-//	   block hash (32 bytes)
-//	   file name (variable size)
-func toBlockKey(hash []byte, folder, file string) []byte {
-	o := make([]byte, 1+64+32+len(file))
-	o[0] = KeyTypeBlock
-	copy(o[1:], []byte(folder))
-	copy(o[1+64:], []byte(hash))
-	copy(o[1+64+32:], []byte(file))
-	return o
-}
-
-func fromBlockKey(data []byte) (string, string) {
-	if len(data) < 1+64+32+1 {
-		panic("Incorrect key length")
-	}
-	if data[0] != KeyTypeBlock {
-		panic("Incorrect key type")
-	}
-
-	file := string(data[1+64+32:])
-
-	slice := data[1 : 1+64]
-	izero := bytes.IndexByte(slice, 0)
-	if izero > -1 {
-		return string(slice[:izero]), file
-	}
-	return string(slice), file
+	return f.db.Write(batch, nil)*/
 }

--- a/internal/db/set.go
+++ b/internal/db/set.go
@@ -48,7 +48,7 @@ func NewFileSet(folder string, db *leveldb.DB) *FileSet {
 		localVersion: make(map[protocol.DeviceID]int64),
 		folder:       folder,
 		db:           db,
-		blockmap:     NewBlockMap(db, folder),
+		blockmap:     NewBlockMap(),
 		mutex:        sync.NewMutex(),
 	}
 
@@ -214,6 +214,10 @@ func (s *FileSet) LocalVersion(device protocol.DeviceID) int64 {
 	return s.localVersion[device]
 }
 
+func (s *FileSet) Iterate(hash []byte, iterFn func(file string, index int) bool) bool {
+	return s.blockmap.Iterate(hash, iterFn)
+}
+
 // ListFolders returns the folder IDs seen in the database.
 func ListFolders(db *leveldb.DB) []string {
 	return ldbListFolders(db)
@@ -223,11 +227,6 @@ func ListFolders(db *leveldb.DB) []string {
 // database.
 func DropFolder(db *leveldb.DB, folder string) {
 	ldbDropFolder(db, []byte(folder))
-	bm := &BlockMap{
-		db:     db,
-		folder: folder,
-	}
-	bm.Drop()
 }
 
 func normalizeFilenames(fs []protocol.FileInfo) {

--- a/internal/db/stringcache.go
+++ b/internal/db/stringcache.go
@@ -1,0 +1,26 @@
+package db
+
+type stringCache struct {
+	strings map[string]int32
+	indexes []string
+}
+
+func newStringCache() *stringCache {
+	return &stringCache{
+		strings: make(map[string]int32),
+	}
+}
+
+func (s *stringCache) Index(val string) int32 {
+	idx, ok := s.strings[val]
+	if !ok {
+		idx = int32(len(s.indexes))
+		s.indexes = append(s.indexes, val)
+		s.strings[val] = idx
+	}
+	return idx
+}
+
+func (s *stringCache) Lookup(key int32) string {
+	return s.indexes[key]
+}

--- a/internal/model/rwfolder.go
+++ b/internal/model/rwfolder.go
@@ -935,7 +935,7 @@ func (p *rwFolder) copierRoutine(in <-chan copyBlocksState, pullChan chan<- pull
 
 		for _, block := range state.blocks {
 			buf = buf[:int(block.Size)]
-			found := p.model.finder.Iterate(block.Hash, func(folder, file string, index int32) bool {
+			found := p.model.Blocks(block.Hash, func(folder, file string, index int) bool {
 				fd, err := os.Open(filepath.Join(folderRoots[folder], file))
 				if err != nil {
 					return false
@@ -953,10 +953,10 @@ func (p *rwFolder) copierRoutine(in <-chan copyBlocksState, pullChan chan<- pull
 						if debug {
 							l.Debugf("Finder block mismatch in %s:%s:%d expected %q got %q", folder, file, index, block.Hash, hash)
 						}
-						err = p.model.finder.Fix(folder, file, index, block.Hash, hash)
+						/*err = p.model.finder.Fix(folder, file, index, block.Hash, hash)
 						if err != nil {
 							l.Warnln("finder fix:", err)
-						}
+						}*/
 					} else if debug {
 						l.Debugln("Finder failed to verify buffer", err)
 					}


### PR DESCRIPTION
This doesn't actually do ~~much~~anything to improve the run time, but fewer allocations are generally good.

```
Before: BenchmarkBlockMapAdd    10   689798584 ns/op   662380159 B/op   406612 allocs/op
After:  BenchmarkBlockMapAdd    10   684422101 ns/op   105709137 B/op   126757 allocs/op
```

The reason I'm fiddling around in there is that a `fs.Update(protocol.LocalDeviceID, []protocol.FileInfo{someQuiteLargeFile})` is heavily limited by the blockmap code, taking almost 0.7 seconds in the benchmark for a 100.000 block file. The remaining 100k allocations are those done by `batch.Put()` which is hard to work around.