### PR TITLE
Trigger pull check on remote index updates (fixes #1765)

### DIFF
--- a/internal/model/rofolder.go
+++ b/internal/model/rofolder.go
@@ -104,6 +104,9 @@ func (s *roFolder) Stop() {
 	close(s.stop)
 }
 
+func (s *roFolder) IndexUpdated() {
+}
+
 func (s *roFolder) String() string {
 	return fmt.Sprintf("roFolder/%s@%p", s.folder, s)
 }


### PR DESCRIPTION
Without this, when an index update comes in we only do a new pull if the
remote `localVersion` was increased. But it may not be, because the
index is sent alphabetically and the file with the highest local version
may come first. In that case we'll never do a new pull when the rest of
the index comes in, and we'll be stuck in idle but with lots of out of
sync data.

A serious person might write a test for this...