### PR TITLE
Break out usage reporting into a service

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -485,22 +485,16 @@ func (s *apiSvc) postSystemConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Start or stop usage reporting as appropriate
+	// Fixup usage reporting settings
 
 	if curAcc := cfg.Options().URAccepted; newCfg.Options.URAccepted > curAcc {
 		// UR was enabled
 		newCfg.Options.URAccepted = usageReportVersion
 		newCfg.Options.URUniqueID = randomString(8)
-		err := sendUsageReport(s.model)
-		if err != nil {
-			l.Infoln("Usage report:", err)
-		}
-		go usageReportingLoop(s.model)
 	} else if newCfg.Options.URAccepted < curAcc {
 		// UR was disabled
 		newCfg.Options.URAccepted = -1
 		newCfg.Options.URUniqueID = ""
-		stopUsageReporting()
 	}
 
 	// Activate and save

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -677,15 +677,12 @@ func syncthingMain() {
 			cfg.SetOptions(opts)
 			cfg.Save()
 		}
-		go usageReportingLoop(m)
-		go func() {
-			time.Sleep(10 * time.Minute)
-			err := sendUsageReport(m)
-			if err != nil {
-				l.Infoln("Usage report:", err)
-			}
-		}()
 	}
+
+	// The usageReportingManager registers itself to listen to configuration
+	// changes, and there's nothing more we need to tell it from the outside.
+	// Hence we don't keep the returned pointer.
+	newUsageReportingManager(m, cfg)
 
 	if opts.RestartOnWakeup {
 		go standbyMonitor()


### PR DESCRIPTION
Now stops and starts based on config changes directly. It's a two step thing, with a persistent "manager" that listens for config changes and creates or deletes the actual service on demand. I think this is the last "break out *foo* into a service" in preparation of beginning to merge non-restart config changes...