### PR TITLE
Configuration commit thingy

### DIFF
--- a/cmd/syncthing/connections.go
+++ b/cmd/syncthing/connections.go
@@ -353,3 +353,24 @@ func (s *connectionSvc) shouldLimit(addr net.Addr) bool {
 	}
 	return !tcpaddr.IP.IsLoopback()
 }
+
+func (s *connectionSvc) VerifyConfiguration(from, to config.Configuration) error {
+	return nil
+}
+
+func (s *connectionSvc) CommitConfiguration(from, to config.Configuration) bool {
+	// We require a restart if a device as been removed.
+
+	newDevices := make(map[protocol.DeviceID]bool, len(to.Devices))
+	for _, dev := range to.Devices {
+		newDevices[dev.DeviceID] = true
+	}
+
+	for _, dev := range from.Devices {
+		if !newDevices[dev.DeviceID] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/cmd/syncthing/debug.go
+++ b/cmd/syncthing/debug.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
-	debugNet  = strings.Contains(os.Getenv("STTRACE"), "net") || os.Getenv("STTRACE") == "all"
-	debugHTTP = strings.Contains(os.Getenv("STTRACE"), "http") || os.Getenv("STTRACE") == "all"
+	debugNet    = strings.Contains(os.Getenv("STTRACE"), "net") || os.Getenv("STTRACE") == "all"
+	debugHTTP   = strings.Contains(os.Getenv("STTRACE"), "http") || os.Getenv("STTRACE") == "all"
+	debugSuture = strings.Contains(os.Getenv("STTRACE"), "suture") || os.Getenv("STTRACE") == "all"
 )

--- a/internal/config/commit_test.go
+++ b/internal/config/commit_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"errors"
+	"testing"
+)
+
+type requiresRestart struct{}
+
+func (requiresRestart) VerifyConfiguration(_, _ Configuration) error {
+	return nil
+}
+func (requiresRestart) CommitConfiguration(_, _ Configuration) bool {
+	return false
+}
+func (requiresRestart) String() string {
+	return "requiresRestart"
+}
+
+type validationError struct{}
+
+func (validationError) VerifyConfiguration(_, _ Configuration) error {
+	return errors.New("some error")
+}
+func (validationError) CommitConfiguration(_, _ Configuration) bool {
+	return true
+}
+func (validationError) String() string {
+	return "validationError"
+}
+
+func TestReplaceCommit(t *testing.T) {
+	w := Wrap("/dev/null", Configuration{Version: 0})
+	if w.Raw().Version != 0 {
+		t.Fatal("Config incorrect")
+	}
+
+	// Replace config. We should get back a clean response and the config
+	// should change.
+
+	resp := w.Replace(Configuration{Version: 1})
+	if resp.ValidationError != nil {
+		t.Fatal("Should not have a validation error")
+	}
+	if resp.RequiresRestart {
+		t.Fatal("Should not require restart")
+	}
+	if w.Raw().Version != 1 {
+		t.Fatal("Config should have changed")
+	}
+
+	// Now with a subscriber requiring restart. We should get a clean response
+	// but with the restart flag set, and the config should change.
+
+	w.Subscribe(requiresRestart{})
+
+	resp = w.Replace(Configuration{Version: 2})
+	if resp.ValidationError != nil {
+		t.Fatal("Should not have a validation error")
+	}
+	if !resp.RequiresRestart {
+		t.Fatal("Should require restart")
+	}
+	if w.Raw().Version != 2 {
+		t.Fatal("Config should have changed")
+	}
+
+	// Now with a subscriber that throws a validation error. The config should
+	// not change.
+
+	w.Subscribe(validationError{})
+
+	resp = w.Replace(Configuration{Version: 3})
+	if resp.ValidationError == nil {
+		t.Fatal("Should have a validation error")
+	}
+	if resp.RequiresRestart {
+		t.Fatal("Should not require restart")
+	}
+	if w.Raw().Version != 2 {
+		t.Fatal("Config should not have changed")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,13 +20,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/calmh/logger"
 	"github.com/syncthing/protocol"
 	"github.com/syncthing/syncthing/internal/osutil"
 	"golang.org/x/crypto/bcrypt"
 )
-
-var l = logger.DefaultLogger
 
 const (
 	OldestHandledVersion = 5

--- a/internal/config/debug.go
+++ b/internal/config/debug.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2015 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package config
+
+import (
+	"os"
+	"strings"
+
+	"github.com/calmh/logger"
+)
+
+var (
+	debug = strings.Contains(os.Getenv("STTRACE"), "config") || os.Getenv("STTRACE") == "all"
+	l     = logger.DefaultLogger
+)

--- a/internal/model/model_test.go
+++ b/internal/model/model_test.go
@@ -317,21 +317,22 @@ func TestDeviceRename(t *testing.T) {
 
 	defer os.Remove("tmpconfig.xml")
 
-	cfg := config.New(device1)
-	cfg.Devices = []config.DeviceConfiguration{
+	rawCfg := config.New(device1)
+	rawCfg.Devices = []config.DeviceConfiguration{
 		{
 			DeviceID: device1,
 		},
 	}
+	cfg := config.Wrap("tmpconfig.xml", rawCfg)
 
 	db, _ := leveldb.Open(storage.NewMemStorage(), nil)
-	m := NewModel(config.Wrap("tmpconfig.xml", cfg), protocol.LocalDeviceID, "device", "syncthing", "dev", db)
-	if cfg.Devices[0].Name != "" {
+	m := NewModel(cfg, protocol.LocalDeviceID, "device", "syncthing", "dev", db)
+	if cfg.Devices()[device1].Name != "" {
 		t.Errorf("Device already has a name")
 	}
 
 	m.ClusterConfig(device1, ccm)
-	if cfg.Devices[0].Name != "" {
+	if cfg.Devices()[device1].Name != "" {
 		t.Errorf("Device already has a name")
 	}
 
@@ -342,13 +343,13 @@ func TestDeviceRename(t *testing.T) {
 		},
 	}
 	m.ClusterConfig(device1, ccm)
-	if cfg.Devices[0].Name != "tester" {
+	if cfg.Devices()[device1].Name != "tester" {
 		t.Errorf("Device did not get a name")
 	}
 
 	ccm.Options[0].Value = "tester2"
 	m.ClusterConfig(device1, ccm)
-	if cfg.Devices[0].Name != "tester" {
+	if cfg.Devices()[device1].Name != "tester" {
 		t.Errorf("Device name got overwritten")
 	}
 


### PR DESCRIPTION
So this is the thing that might lead up to non-restart config changes. This doesn't get there, but lays the groundwork. It's not complete yet, but some comments would be nice. Please check the description for the `Committer` interface at the top of `config/wrapper.go` to see if that makes sense going forward; the rest is basically just plumbing to implement the interface in a couple of places, and the API does attempt restartless config changes just to show it works, kinda...