### PR TITLE
Set permanent UPnP lease when required

### DIFF
--- a/internal/upnp/upnp.go
+++ b/internal/upnp/upnp.go
@@ -471,7 +471,7 @@ func soapRequest(url, service, function, message string) ([]byte, error) {
 
 	resp, _ = ioutil.ReadAll(r.Body)
 	if debug {
-		l.Debugln("SOAP Response:\n\n" + string(resp) + "\n")
+		l.Debugf("SOAP Response: %v\n\n%v\n\n", r.StatusCode, string(resp))
 	}
 
 	r.Body.Close()

--- a/internal/upnp/upnp_test.go
+++ b/internal/upnp/upnp_test.go
@@ -33,6 +33,33 @@ func TestExternalIPParsing(t *testing.T) {
 	}
 }
 
+func TestSoapFaultParsing(t *testing.T) {
+	soapResponse :=
+		[]byte(`<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+		<s:Body>
+			<s:Fault>
+				<faultcode>s:Client</faultcode>
+				<faultstring>UPnPError</faultstring>
+				<detail>
+					<UPnPError xmlns="urn:schemas-upnp-org:control-1-0">
+					<errorCode>725</errorCode>
+					<errorDescription>OnlyPermanentLeasesSupported</errorDescription></UPnPError>
+				</detail>
+			</s:Fault>
+		</s:Body>
+		</s:Envelope>`)
+
+	envelope := &soapErrorResponse{}
+	err := xml.Unmarshal(soapResponse, envelope)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if envelope.ErrorCode != 725 {
+		t.Error("Parse of SOAP request failed.", envelope)
+	}
+}
+
 func TestControlURLParsing(t *testing.T) {
 	rootURL := "http://192.168.243.1:80/igd.xml"
 


### PR DESCRIPTION
I cannot test this with my network setup, so check this patch carefully.
Moreover, I'm not sure if soapRequest returns an error when permanent leasing is required `if r.StatusCode >= 400 {`