### PR TITLE
Show date and time for web GUI notification (fixes #1833)

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -154,7 +154,7 @@
         <div class="panel panel-warning">
           <div class="panel-heading"><h3 class="panel-title"><span class="glyphicon glyphicon-exclamation-sign"></span><span translate>Notice</span></h3></div>
           <div class="panel-body">
-            <p ng-repeat="err in errorList()"><small>{{err.time | date:"H:mm:ss"}}:</small> {{friendlyDevices(err.error)}}</p>
+            <p ng-repeat="err in errorList()"><small>{{err.time | date:"medium"}}:</small> {{friendlyDevices(err.error)}}</p>
           </div>
           <div class="panel-footer">
             <button type="button" class="pull-right btn btn-sm btn-default" ng-click="clearErrors()"><span class="glyphicon glyphicon-ok"></span>&emsp;<span translate>OK</span></button>


### PR DESCRIPTION
It does not work with a custom locale.
However, locale support for the `medium` tag works on [Plunker](http://plnkr.co/edit/TdRKA3wg1aKIFZPdvrwo?p=preview), do we use a customized locale feature?