### PR TITLE
Serialize scans (fixes #1391)

### DIFF
--- a/internal/model/rofolder.go
+++ b/internal/model/rofolder.go
@@ -22,7 +22,13 @@ type roFolder struct {
 	timer     *time.Timer
 	model     *Model
 	stop      chan struct{}
+	scanNow   chan rescanRequest
 	delayScan chan time.Duration
+}
+
+type rescanRequest struct {
+	subs []string
+	err  chan error
 }
 
 func newROFolder(model *Model, folder string, interval time.Duration) *roFolder {
@@ -36,6 +42,7 @@ func newROFolder(model *Model, folder string, interval time.Duration) *roFolder 
 		timer:     time.NewTimer(time.Millisecond),
 		model:     model,
 		stop:      make(chan struct{}),
+		scanNow:   make(chan rescanRequest),
 		delayScan: make(chan time.Duration),
 	}
 }
@@ -76,7 +83,7 @@ func (s *roFolder) Serve() {
 				l.Debugln(s, "rescan")
 			}
 
-			if err := s.model.ScanFolder(s.folder); err != nil {
+			if err := s.model.internalScanFolderSubs(s.folder, nil); err != nil {
 				// Potentially sets the error twice, once in the scanner just
 				// by doing a check, and once here, if the error returned is
 				// the same one as returned by CheckFolderHealth, though
@@ -92,10 +99,33 @@ func (s *roFolder) Serve() {
 			}
 
 			if s.intv == 0 {
-				return
+				continue
 			}
 
 			reschedule()
+
+		case req := <-s.scanNow:
+			if err := s.model.CheckFolderHealth(s.folder); err != nil {
+				l.Infoln("Skipping folder", s.folder, "scan due to folder error:", err)
+				req.err <- err
+				continue
+			}
+
+			if debug {
+				l.Debugln(s, "forced rescan")
+			}
+
+			if err := s.model.internalScanFolderSubs(s.folder, req.subs); err != nil {
+				// Potentially sets the error twice, once in the scanner just
+				// by doing a check, and once here, if the error returned is
+				// the same one as returned by CheckFolderHealth, though
+				// duplicate set is handled by setError.
+				s.setError(err)
+				req.err <- err
+				continue
+			}
+
+			req.err <- nil
 
 		case next := <-s.delayScan:
 			s.timer.Reset(next)
@@ -108,6 +138,15 @@ func (s *roFolder) Stop() {
 }
 
 func (s *roFolder) IndexUpdated() {
+}
+
+func (s *roFolder) Scan(subs []string) error {
+	req := rescanRequest{
+		subs: subs,
+		err:  make(chan error),
+	}
+	s.scanNow <- req
+	return <-req.err
 }
 
 func (s *roFolder) String() string {

--- a/test/sync_test.go
+++ b/test/sync_test.go
@@ -10,6 +10,7 @@ package integration
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -80,6 +81,18 @@ func TestSyncClusterStaggeredVersioning(t *testing.T) {
 	cfg.Save()
 
 	testSyncCluster(t)
+}
+
+func TestSyncClusterForcedRescan(t *testing.T) {
+	// Use no versioning
+	id, _ := protocol.DeviceIDFromString(id2)
+	cfg, _ := config.Load("h2/config.xml", id)
+	fld := cfg.Folders()["default"]
+	fld.Versioning = config.VersioningConfiguration{}
+	cfg.SetFolder(fld)
+	cfg.Save()
+
+	testSyncClusterForcedRescan(t)
 }
 
 func testSyncCluster(t *testing.T) {
@@ -284,6 +297,116 @@ func testSyncCluster(t *testing.T) {
 			t.Fatal(err)
 		}
 		expected = [][]fileInfo{e1, e2, e3}
+	}
+}
+
+func testSyncClusterForcedRescan(t *testing.T) {
+	// During this test, we create 1K files, remove and then create them
+	// again. However, during these operations we will perform scan operations
+	// such that other nodes will retrieve these options while data is
+	// changing.
+
+	// When -short is passed, keep it more reasonable.
+	timeLimit := longTimeLimit
+	if testing.Short() {
+		timeLimit = shortTimeLimit
+	}
+
+	log.Println("Cleaning...")
+	err := removeAll("s1", "s12-1",
+		"s2", "s12-2", "s23-2",
+		"s3", "s23-3",
+		"h1/index*", "h2/index*", "h3/index*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create initial folder contents. All three devices have stuff in
+	// "default", which should be merged. The other two folders are initially
+	// empty on one side.
+
+	log.Println("Generating files...")
+	if err := os.MkdirAll("s1/test-stable-files", 0755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 1000; i++ {
+		name := fmt.Sprintf("s1/test-stable-files/%d", i)
+		if err := ioutil.WriteFile(name, []byte(time.Now().Format(time.RFC3339Nano)), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Prepare the expected state of folders after the sync
+	expected, err := directoryContents("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the syncers
+	p0 := startInstance(t, 1)
+	defer checkedStop(t, p0)
+	p1 := startInstance(t, 2)
+	defer checkedStop(t, p1)
+	p2 := startInstance(t, 3)
+	defer checkedStop(t, p2)
+
+	p := []*rc.Process{p0, p1, p2}
+
+	start := time.Now()
+	for time.Since(start) < timeLimit {
+		rescan := func() {
+			for i := range p {
+				if err := p[i].Rescan("default"); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+
+		log.Println("Forcing rescan...")
+		rescan()
+
+		// Sync stuff and verify it looks right
+		err = scSyncAndCompare(p, [][]fileInfo{expected})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		log.Println("Altering...")
+
+		// Delete and recreate stable files while scanners and pullers are active
+		for i := 0; i < 1000; i++ {
+			name := fmt.Sprintf("s1/test-stable-files/%d", i)
+			if err := os.Remove(name); err != nil {
+				t.Fatal(err)
+			}
+			if rand.Intn(10) == 0 {
+				rescan()
+			}
+		}
+
+		rescan()
+
+		time.Sleep(50 * time.Millisecond)
+		for i := 0; i < 1000; i++ {
+			name := fmt.Sprintf("s1/test-stable-files/%d", i)
+			if err := ioutil.WriteFile(name, []byte(time.Now().Format(time.RFC3339Nano)), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if rand.Intn(10) == 0 {
+				rescan()
+			}
+		}
+
+		rescan()
+
+		// Prepare the expected state of folders after the sync
+		expected, err = directoryContents("s1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(expected) != 1001 {
+			t.Fatal("s1 does not have 1001 files;", len(expected))
+		}
 	}
 }
 


### PR DESCRIPTION
(Not really done yet, PR for integration tests etc)

This does the basically minimal changes to make scans not run in parallell with pulling. There is great cleanup potential with the various "scanFolderBlah" functions that shouldn't really live in model, but in some folder type I think... But that's the next thing.