### PR TITLE
Fix ItemFinished

### DIFF
--- a/cmd/syncthing/verbose.go
+++ b/cmd/syncthing/verbose.go
@@ -102,8 +102,12 @@ func (s *verboseSvc) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Started syncing %q / %q (%v %v)", data["folder"], data["item"], data["action"], data["type"])
 	case events.ItemFinished:
 		data := ev.Data.(map[string]interface{})
-		if err := data["err"]; err != nil {
-			return fmt.Sprintf("Finished syncing %q / %q (%v %v): %v", data["folder"], data["item"], data["action"], data["type"], err)
+		if err := data["error"]; err != nil {
+			// If the err interface{} is not nil, it is a string pointer.
+			// Dereference it to get the actual error or Sprintf will print
+			// the pointer value....
+			errStr := *err.(*string)
+			return fmt.Sprintf("Finished syncing %q / %q (%v %v): %v", data["folder"], data["item"], data["action"], data["type"], errStr)
 		}
 		return fmt.Sprintf("Finished syncing %q / %q (%v %v): Success", data["folder"], data["item"], data["action"], data["type"])
 

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -258,3 +258,14 @@ func (s *BufferedSubscription) Since(id int, into []Event) []Event {
 
 	return into
 }
+
+// Error returns a string pointer suitable for JSON marshalling errors. It
+// retains the "null on sucess" semantics, but ensures the error result is a
+// string regardless of the underlying concrete error type.
+func Error(err error) *string {
+	if err == nil {
+		return nil
+	}
+	str := err.Error()
+	return &str
+}

--- a/internal/model/sharedpullerstate.go
+++ b/internal/model/sharedpullerstate.go
@@ -36,6 +36,7 @@ type sharedPullerState struct {
 	copyOrigin int        // Number of blocks copied from the original file
 	copyNeeded int        // Number of copy actions still pending
 	pullNeeded int        // Number of block pulls still pending
+	closed     bool       // True if the file has been finalClosed.
 	mut        sync.Mutex // Protects the above
 }
 
@@ -218,16 +219,28 @@ func (s *sharedPullerState) finalClose() (bool, error) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 
-	if s.pullNeeded+s.copyNeeded != 0 && s.err == nil {
-		// Not done yet.
+	if s.closed {
+		// Already closed
 		return false, nil
 	}
 
-	if fd := s.fd; fd != nil {
-		s.fd = nil
-		return true, fd.Close()
+	if s.pullNeeded+s.copyNeeded != 0 && s.err == nil {
+		// Not done yet, and not errored
+		return false, nil
 	}
-	return false, nil
+
+	if s.fd != nil {
+		if closeErr := s.fd.Close(); closeErr != nil && s.err == nil {
+			// This is our error if we weren't errored before. Otherwise we
+			// keep the earlier error.
+			s.err = closeErr
+		}
+		s.fd = nil
+	}
+
+	s.closed = true
+
+	return true, s.err
 }
 
 // Returns the momentarily progress for the puller


### PR DESCRIPTION
We forgot to generate ItemFinished when the initial temp file creation failed. This make sure we do, and also we don't need to continue passing it though the chain as there is nothing to close or deregister.

Also fixes the "error" item in the event to be either a `null` or a string (as documented), instead of however the JSON serializer wants to interpret the actual error type we happen to get.