### PR TITLE
Reduce db writes for small files

### DIFF
--- a/internal/model/rwfolder.go
+++ b/internal/model/rwfolder.go
@@ -1182,7 +1182,6 @@ func (p *rwFolder) finisherRoutine(in <-chan *sharedPullerState) {
 					"action": "update",
 				})
 			}
-			p.model.receivedFile(p.folder, state.file.Name)
 			if p.progressEmitter != nil {
 				p.progressEmitter.Deregister(state)
 			}
@@ -1228,12 +1227,14 @@ loop:
 
 			if len(batch) == maxBatchSize {
 				p.model.updateLocals(p.folder, batch)
+				p.model.receivedFile(p.folder, batch[len(batch)-1].Name)
 				batch = batch[:0]
 			}
 
 		case <-tick.C:
 			if len(batch) > 0 {
 				p.model.updateLocals(p.folder, batch)
+				p.model.receivedFile(p.folder, batch[len(batch)-1].Name)
 				batch = batch[:0]
 			}
 		}
@@ -1241,6 +1242,7 @@ loop:
 
 	if len(batch) > 0 {
 		p.model.updateLocals(p.folder, batch)
+		p.model.receivedFile(p.folder, batch[len(batch)-1].Name)
 	}
 }
 


### PR DESCRIPTION
We introduced the dbUpdater routine to handle many small files
efficiently, but the folder stats call is almost equally expensive as it
results in two distinct write transactions to the database. This moves
it to the same routine.

(Doesn't make a *huge* difference with leveldb actually, but reduces the
50k-files benchmark time by 25% on my experimental bolt branch...)