### PR TITLE
Silence discovery warnings (fixes #1388)

### DIFF
--- a/internal/beacon/broadcast.go
+++ b/internal/beacon/broadcast.go
@@ -47,7 +47,9 @@ func (b *Broadcast) writer() {
 
 		addrs, err := net.InterfaceAddrs()
 		if err != nil {
-			l.Warnln("Broadcast: interface addresses:", err)
+			if debug {
+				l.Debugln("Broadcast: interface addresses:", err)
+			}
 			continue
 		}
 


### PR DESCRIPTION
Not performing net.InterfaceAddrs() check in the constructor, as that means we wouldn't start
the read loop, which completely kills it.