### PR TITLE
fix disappeared status of folder after restart syncthing

### DIFF
--- a/gui/scripts/syncthing/core/controllers/syncthingController.js
+++ b/gui/scripts/syncthing/core/controllers/syncthingController.js
@@ -521,6 +521,11 @@ angular.module('syncthing.core')
             if ($scope.model[folderCfg.id].state == 'error') {
                 return 'stopped'; // legacy, the state is called "stopped" in the GUI
             }
+            
+            // after restart syncthing process state may be empty
+            if (!$scope.model[folderCfg.id].state) {
+                return 'unknown'; 
+            }
 
             return '' + $scope.model[folderCfg.id].state;
         };


### PR DESCRIPTION
sometimes after restart process syncthing '/rest/db/status' for folder may return data with 'state' = empty string