### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Documentation
 =============
 
 Please see the [Syncthing
-documentation site](http://docs.syncthing.net/dev/).
+documentation site](http://docs.syncthing.net).
 
 All code is licensed under the
 [MPLv2 License](https://github.com/syncthing/syncthing/blob/master/LICENSE).


### PR DESCRIPTION
The link to the documentation site is broken. I think this should be http://docs.syncthing.net or http://docs.syncthing.net/dev/intro.html