### PR TITLE
Default GUI override dir

### DIFF
--- a/cmd/syncthing/locations.go
+++ b/cmd/syncthing/locations.go
@@ -31,6 +31,7 @@ const (
 	locCsrfTokens                 = "csrfTokens"
 	locPanicLog                   = "panicLog"
 	locAuditLog                   = "auditLog"
+	locGUIAssets                  = "GUIAssets"
 	locDefFolder                  = "defFolder"
 )
 
@@ -52,6 +53,7 @@ var locations = map[locationEnum]string{
 	locCsrfTokens:    "${config}/csrftokens.txt",
 	locPanicLog:      "${config}/panic-${timestamp}.log",
 	locAuditLog:      "${config}/audit-${timestamp}.log",
+	locGUIAssets:     "${config}/gui",
 	locDefFolder:     "${home}/Sync",
 }
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -252,6 +252,10 @@ func main() {
 		l.Fatalln(err)
 	}
 
+	if guiAssets == "" {
+		guiAssets = locations[locGUIAssets]
+	}
+
 	if runtime.GOOS == "windows" {
 		if logFile == "" {
 			// Use the default log file location


### PR DESCRIPTION
If STGUIASSETS is not set, look for assets in $confdir/gui by default.
Simplifies deploying overrides and stuff.