### PR TITLE
Set default pull order in webGUI

### DIFF
--- a/gui/scripts/syncthing/core/controllers/syncthingController.js
+++ b/gui/scripts/syncthing/core/controllers/syncthingController.js
@@ -1039,6 +1039,7 @@ angular.module('syncthing.core')
                 selectedDevices: {}
             };
             $scope.currentFolder.rescanIntervalS = 60;
+            $scope.currentFolder.order = "random";
             $scope.currentFolder.fileVersioningSelector = "none";
             $scope.currentFolder.trashcanClean = 0;
             $scope.currentFolder.simpleKeep = 5;


### PR DESCRIPTION
When adding a new folder, the selected pull order in the dropdown menu is empty. This patch sets it to random, which is the default according to config.go.