### PR TITLE
Put thisDeviceName first in page tile to make small browser tabs distinguishable

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -16,7 +16,7 @@
   <meta name="author" content="">
   <link rel="shortcut icon" href="assets/img/favicon.png">
 
-  <title>Syncthing | {{thisDeviceName()}}</title>
+  <title>{{thisDeviceName()}} | Syncthing</title>
   <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="assets/font/raleway.css" rel="stylesheet">
   <link href="assets/css/overrides.css" rel="stylesheet">


### PR DESCRIPTION
Put thisDeviceName first in page tile so browser tabs can be distinguished when there are multiple Syncthing tabs that are small  and chopping off the end of the page title.
