### PR TITLE
Allow #editIgnores to scroll in browser (fixes #2041)

### DIFF
--- a/gui/scripts/syncthing/core/controllers/syncthingController.js
+++ b/gui/scripts/syncthing/core/controllers/syncthingController.js
@@ -1230,17 +1230,19 @@ angular.module('syncthing.core')
                 .success(function (data) {
                     data.ignore = data.ignore || [];
 
-                    $('#editFolder').modal('hide');
-                    var textArea = $('#editIgnores textarea');
+                    $('#editFolder').modal('hide')
+                        .one('hidden.bs.modal', function() {
+                            var textArea = $('#editIgnores textarea');
 
-                    textArea.val(data.ignore.join('\n'));
+                            textArea.val(data.ignore.join('\n'));
 
-                    $('#editIgnores').modal()
-                        .on('hidden.bs.modal', function () {
-                            $('#editFolder').modal();
-                        })
-                        .on('shown.bs.modal', function () {
-                            textArea.focus();
+                            $('#editIgnores').modal()
+                                .one('hidden.bs.modal', function () {
+                                    $('#editFolder').modal();
+                                })
+                                .one('shown.bs.modal', function () {
+                                    textArea.focus();
+                                });
                         });
                 })
                 .then(function () {


### PR DESCRIPTION
#editIgnores can be opened from #editFolder. When a modal is open, the
class modal-open is applied to <body>, which ultimately means that the
browser will scoll to the modal's content. However, #editFolder was
finishing its close animation (and removing this modal-open class)
after #editIgnores had set modal-open (and had started its open
animation). The end result is that <body> ends up without modal-open
when #editIgnores is open, and so the browser doesn't properly scroll.

Instead, only open the #editIgnores once #editFolder has finished closing.