### PR TITLE
Double curly brace notation displaying

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -16,7 +16,7 @@
   <meta name="author" content="">
   <link rel="shortcut icon" href="assets/img/favicon.png">
 
-  <title>{{thisDeviceName()}} | Syncthing</title>
+  <title ng-bind="thisDeviceName() + ' | Syncthing'"></title>
   <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="assets/font/raleway.css" rel="stylesheet">
   <link href="assets/css/overrides.css" rel="stylesheet">


### PR DESCRIPTION
Prevent double curly brace notation from displaying momentarily before angular.js compiles/interpolates document