### PR TITLE
Optionally ignore remote deletes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,6 +79,7 @@ type FolderConfiguration struct {
 	Pullers         int                         `xml:"pullers" json:"pullers"` // Defines how many blocks are fetched at the same time, possibly between separate copier routines.
 	Hashers         int                         `xml:"hashers" json:"hashers"` // Less than one sets the value to the number of cores. These are CPU bound due to hashing.
 	Order           PullOrder                   `xml:"order" json:"order"`
+	IgnoreDelete    bool                        `xml:"ignoreDelete" json:"ignoreDelete"`
 
 	Invalid string `xml:"-" json:"invalid"` // Set at runtime when there is an error, not saved
 


### PR DESCRIPTION
This seemed like a fairly simple addition. If configured to ignore deletes, just drop incoming index updates with that bit set. There ought to have been an enhancement ticket for this behavior somewhere, but I can't find it.