### PR TITLE
Determine conflict winner based on change type and modification time (fixes #1848)

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -35,7 +35,7 @@
 		},
 		{
 			"ImportPath": "github.com/syncthing/protocol",
-			"Rev": "7996ef0d45b7743ff930048b6413b37b2c33cd85"
+			"Rev": "fcbd12b42176237d48985c1bfafbc43b2107aa31"
 		},
 		{
 			"ImportPath": "github.com/syndtr/goleveldb/leveldb",

--- a/Godeps/_workspace/src/github.com/syncthing/protocol/conflict_test.go
+++ b/Godeps/_workspace/src/github.com/syncthing/protocol/conflict_test.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2015 The Protocol Authors.
+
+package protocol
+
+import "testing"
+
+func TestWinsConflict(t *testing.T) {
+	testcases := [][2]FileInfo{
+		// The first should always win over the second
+		{{Modified: 42}, {Modified: 41}},
+		{{Modified: 41}, {Modified: 42, Flags: FlagDeleted}},
+		{{Modified: 41, Version: Vector{{42, 2}, {43, 1}}}, {Modified: 41, Version: Vector{{42, 1}, {43, 2}}}},
+	}
+
+	for _, tc := range testcases {
+		if !tc[0].WinsConflict(tc[1]) {
+			t.Errorf("%v should win over %v", tc[0], tc[1])
+		}
+		if tc[1].WinsConflict(tc[0]) {
+			t.Errorf("%v should not win over %v", tc[1], tc[0])
+		}
+	}
+}

--- a/test/conflict_test.go
+++ b/test/conflict_test.go
@@ -9,6 +9,7 @@
 package integration
 
 import (
+	"bytes"
 	"io/ioutil"
 	"log"
 	"os"
@@ -156,15 +157,23 @@ func TestConflictsDefault(t *testing.T) {
 	}
 	rc.AwaitSync("default", sender, receiver)
 
-	// The conflict should manifest on the s2 side again, where we should have
-	// moved the file to a conflict copy instead of just deleting it.
+	// The conflict is resolved to the advantage of the edit over the delete.
+	// As such, we get the edited content synced back to s1 where it was
+	// removed.
 
 	files, err = osutil.Glob("s2/*sync-conflict*")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(files) != 2 {
-		t.Errorf("Expected 2 conflicted files instead of %d", len(files))
+	if len(files) != 1 {
+		t.Errorf("Expected 1 conflicted files instead of %d", len(files))
+	}
+	bs, err := ioutil.ReadFile("s1/testfile.txt")
+	if err != nil {
+		t.Error("reading file:", err)
+	}
+	if !bytes.Contains(bs, []byte("more text added to s2")) {
+		t.Error("s1/testfile.txt should contain data added in s2")
 	}
 }
 


### PR DESCRIPTION
This modifies the leveldb stuff to send the full file data to `ldbUpdateGlobal`, so that it can make a better decision on which file to promote to "global". If there's a conflict it grabs the data for the conflicting file and uses the new method on `FileInfo` to decide who wins.

The intention is that:

1. Modifications wins over deletes. This means the deleting side sees the file resurrected, but I think that's fine.
2. Newer modification time wins over older
3. Lowest device ID wins (as before)

Actual resolution algo in https://github.com/syncthing/protocol/pull/15