### PR TITLE
fix(core): prevent endless reload on cache requests

### DIFF
--- a/gui/scripts/syncthing/app.js
+++ b/gui/scripts/syncthing/app.js
@@ -15,11 +15,12 @@ var syncthing = angular.module('syncthing', [
 ]);
 
 var urlbase = 'rest';
-var guiVersion = null;
-var deviceId = null;
 
 syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvider) {
     $httpProvider.interceptors.push(function xHeadersResponseInterceptor() {
+        var guiVersion = null;
+        var deviceId = null;
+        
         return {
             response: function onResponse(response) {
                 var headers = response.headers();

--- a/gui/scripts/syncthing/app.js
+++ b/gui/scripts/syncthing/app.js
@@ -19,26 +19,32 @@ var guiVersion = null;
 var deviceId = null;
 
 syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvider) {
-    $httpProvider.interceptors.push(function () {
+    $httpProvider.interceptors.push(function xHeadersResponseInterceptor() {
         return {
-            response: function (response) {
+            response: function onResponse(response) {
                 var headers = response.headers();
+                var responseVersion;
+                var deviceIdShort;
                 
                 // angular template cache sends no headers
-                if(Object.keys(headers).length > 0) {
-                    var responseVersion = headers['x-syncthing-version'];
-                    if (!guiVersion) {
-                        guiVersion = responseVersion;
-                    } else if (guiVersion != responseVersion) {
-                        document.location.reload(true);
-                    }
-                    if (!deviceId) {
-                        deviceId = headers['x-syncthing-id'];
-                        if (deviceId) {
-                            var deviceIdShort = deviceId.substring(0, 5);
-                            $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token-' + deviceIdShort;
-                            $httpProvider.defaults.xsrfCookieName = 'CSRF-Token-' + deviceIdShort;
-                        }
+                if(Object.keys(headers).length === 0) {
+                    return response;
+                }
+                
+                responseVersion = headers['x-syncthing-version'];
+                
+                if (!guiVersion) {
+                    guiVersion = responseVersion;
+                } else if (guiVersion != responseVersion) {
+                    document.location.reload(true);
+                }
+                
+                if (!deviceId) {
+                    deviceId = headers['x-syncthing-id'];
+                    if (deviceId) {
+                        deviceIdShort = deviceId.substring(0, 5);
+                        $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token-' + deviceIdShort;
+                        $httpProvider.defaults.xsrfCookieName = 'CSRF-Token-' + deviceIdShort;
                     }
                 }
                 

--- a/gui/scripts/syncthing/app.js
+++ b/gui/scripts/syncthing/app.js
@@ -22,20 +22,26 @@ syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvi
     $httpProvider.interceptors.push(function () {
         return {
             response: function (response) {
-                var responseVersion = response.headers()['x-syncthing-version'];
-                if (!guiVersion) {
-                    guiVersion = responseVersion;
-                } else if (guiVersion != responseVersion) {
-                    document.location.reload(true);
-                }
-                if (!deviceId) {
-                    deviceId = response.headers()['x-syncthing-id'];
-                    if (deviceId) {
-                        var deviceIdShort = deviceId.substring(0, 5);
-                        $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token-' + deviceIdShort;
-                        $httpProvider.defaults.xsrfCookieName = 'CSRF-Token-' + deviceIdShort;
+                var headers = response.headers();
+                
+                // angular template cache sends no headers
+                if(Object.keys(headers).length > 0) {
+                    var responseVersion = headers['x-syncthing-version'];
+                    if (!guiVersion) {
+                        guiVersion = responseVersion;
+                    } else if (guiVersion != responseVersion) {
+                        document.location.reload(true);
+                    }
+                    if (!deviceId) {
+                        deviceId = headers['x-syncthing-id'];
+                        if (deviceId) {
+                            var deviceIdShort = deviceId.substring(0, 5);
+                            $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-Token-' + deviceIdShort;
+                            $httpProvider.defaults.xsrfCookieName = 'CSRF-Token-' + deviceIdShort;
+                        }
                     }
                 }
+                
                 return response;
             }
         };


### PR DESCRIPTION
Excuse me in advance for writing a bit of a long story. The source of the error isn't quite obvious so I wanted to explain the szenario in detail. There is a TLDR at the end. of this PR.

So, this error popped up after I extracted the "needed files" modal dialog to a separate component. At first I was wondering why the bug did not pop up earlier. This is most likely due to a "race condition alike" situation. It is caused by the vendor/angular/angular-dirPagination.js component. Usually the directive gets rendered/executed, when window.guiVersion has been initialized by one of the previous requests, whose respose carries 'x-syncthing-version'. angular-dirPagination itself makes use of HTML templates, which are embedded as a JS string and stored into angulars $templateCache. This is a very common strategy for angular directives, since one can avoid many problems while handling external views. Syncthing's UI components don't need this technique since we don't concat/minimize the webgui sources yet and actually since some months ago, had all the HTML in just a single file. 

As I mentioned in my modal refactoring PR, here is the proposal for a particular bugfix. It never the less actually feels a bit more like symptom fixing. I think the idea, to continuesly track the GUI version number and if necessary force reload the GUI, might be the conceptual error here (race conditions, empty headers, etc). Also this $templateCache technique can come up in future development, when we integrate more third party libraries or decide to concat and minimize our webgui sources.

TLDR: Anyhow after the refactoring, the pagination got rendered earlier, makes a kind of fake HTTP request to the templateCache and our custom HTTP Interceptor finds no header in the reponse. So it runs into the errornous case and hangs up into a reload loop. So I symptom fixed this by skipping the guiVersion validation when there are no headers in the response, which actually only should happen in case of a manually stored $templateCache item.

If anyone can offer a better solution here, I would be pleased to know about your idea. :)
