### PR TITLE
Reset ReadOnly

### DIFF
--- a/test/h1/config.xml
+++ b/test/h1/config.xml
@@ -37,8 +37,6 @@
     </device>
     <gui enabled="true" tls="false">
         <address>127.0.0.1:8081</address>
-        <user>testuser</user>
-        <password>$2a$10$7tKL5uvLDGn5s2VLPM2yWOK/II45az0mTel8hxAUJDRQN1Tk2QYwu</password>
         <apikey>abc123</apikey>
     </gui>
     <options>

--- a/test/norestart_test.go
+++ b/test/norestart_test.go
@@ -90,7 +90,6 @@ func TestFolderWithoutRestart(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer removeAll("testfolder-p1", "testfolder-p4")
 
 	if err := generateFiles("testfolder-p1", 50, 18, "../LICENSE"); err != nil {
 		t.Fatal(err)
@@ -101,6 +100,8 @@ func TestFolderWithoutRestart(t *testing.T) {
 
 	p4 := startInstance(t, 4)
 	defer checkedStop(t, p4)
+
+	defer removeAll("testfolder-p1", "testfolder-p4")
 
 	if ok, err := p1.ConfigInSync(); err != nil || !ok {
 		t.Fatal("p1 should be in sync;", ok, err)

--- a/test/override_test.go
+++ b/test/override_test.go
@@ -29,7 +29,6 @@ func TestOverride(t *testing.T) {
 	fld.ReadOnly = true
 	cfg.SetFolder(fld)
 	os.Rename("h1/config.xml", "h1/config.xml.orig")
-	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
 	cfg.Save()
 
 	log.Println("Cleaning...")
@@ -64,6 +63,7 @@ func TestOverride(t *testing.T) {
 
 	master := startInstance(t, 1)
 	defer checkedStop(t, master)
+	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
 
 	slave := startInstance(t, 2)
 	defer checkedStop(t, slave)
@@ -158,7 +158,6 @@ func TestOverrideIgnores(t *testing.T) {
 	fld.ReadOnly = true
 	cfg.SetFolder(fld)
 	os.Rename("h1/config.xml", "h1/config.xml.orig")
-	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
 	cfg.Save()
 
 	log.Println("Cleaning...")
@@ -203,6 +202,7 @@ func TestOverrideIgnores(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer master.stop()
+	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
 
 	log.Println("Starting slave...")
 	slave := syncthingProcess{ // id2


### PR DESCRIPTION
- Disable user & pass in integration tests (I can't seem to login with that password?? IE/Firefox).
- Fix integration tests on windows by reordering defer statements. We need to shut down Syncthing before moving the config to its original place.