### PR TITLE
Fix 1852

### DIFF
--- a/internal/model/sharedpullerstate.go
+++ b/internal/model/sharedpullerstate.go
@@ -26,6 +26,7 @@ type sharedPullerState struct {
 	realName    string
 	reused      int // Number of blocks reused from temporary file
 	ignorePerms bool
+	modified    int64           // Known modification time
 	version     protocol.Vector // The current (old) version
 
 	// Mutable, must be locked for access


### PR DESCRIPTION
WIP, do not merge. Would like to have feedback on how to structure the code.

This PR fixes 3 major bugs:
- When we pull a file, we simply rely on the db and may overwrite a new file with the same filename (see https://github.com/syncthing/syncthing/pull/1852)
- When we pull a file, we simply rely on the db and may overwrite an updated file with the same filename
- When we send data which is not corresponding to the sha256 validation, the receiving end will throw it away and try to pull from another node. However, if there is no other node, this cycle repeats, wasting bandwidth. (related to https://github.com/syncthing/syncthing/issues/2003, https://github.com/syncthing/syncthing/issues/2043 and https://github.com/syncthing/syncthing/issues/1838)

----

* https://github.com/syncthing/syncthing/issues/1711 could help
* I think line [1249](https://github.com/syncthing/syncthing/compare/syncthing:master...Zillode:fix-1852?expand=1#diff-cd99fd425d7acb3a911a17090574d390R1249) and [811](https://github.com/syncthing/syncthing/compare/syncthing:master...Zillode:fix-1852?expand=1#diff-86326b10fb9dfebae06a27c61266c171R811) are also incorrect, but this is a copy from the current code, see [line 145 here](https://github.com/syncthing/syncthing/pull/1804/files#diff-9d41e06c64fc85e225f438897b68f92fR145).
* https://github.com/syncthing/syncthing/pull/1794 might be related
