### PR TITLE
Revert small changes made during reorg GUI

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -462,7 +462,7 @@
   <nav class="navbar navbar-default navbar-fixed-bottom">
     <div class="container">
       <ul class="nav navbar-nav">
-        <li><a class="navbar-link" href="http://syncthing.net/" target="_blank"><span class="glyphicon glyphicon-home"></span>&nbsp;<span translate>Home page</span></a></li>
+        <li><a class="navbar-link" href="https://syncthing.net/" target="_blank"><span class="glyphicon glyphicon-home"></span>&nbsp;<span translate>Home page</span></a></li>
         <li><a class="navbar-link" href="http://docs.syncthing.net/" target="_blank"><span class="glyphicon glyphicon-book"></span>&nbsp;<span translate>Documentation</span></a></li>
         <li><a class="navbar-link" href="https://forum.syncthing.net" target="_blank"><span class="glyphicon glyphicon-question-sign"></span>&nbsp;<span translate>Support</span></a></li>
         <li><a class="navbar-link" href="https://data.syncthing.net/" target="_blank"><span class="glyphicon glyphicon-stats"></span>&nbsp;<span translate>Statistics</span></a></li>

--- a/gui/syncthing/device/editDeviceModalView.html
+++ b/gui/syncthing/device/editDeviceModalView.html
@@ -32,7 +32,7 @@
             <input ng-disabled="currentDevice.deviceID == myID" id="addresses" class="form-control" type="text" ng-model="currentDevice._addressesStr"></input>
             <p translate class="help-block">Enter comma separated "ip:port" addresses or "dynamic" to perform automatic discovery of the address.</p>
           </div>
-          <div ng-if="!editingSelf" class="form-group">
+          <div class="form-group">
             <label translate>Compression</label>
             <select class="form-control" ng-model="currentDevice.compression">
               <option value="always" translate>All Data</option>
@@ -40,7 +40,7 @@
               <option value="never" translate>Off</option>
             </select>
           </div>
-          <div ng-if="!editingSelf" class="form-group">
+          <div class="form-group">
             <div class="checkbox">
               <label>
                 <input type="checkbox" ng-model="currentDevice.introducer"> <span translate>Introducer</span>
@@ -49,7 +49,7 @@
             </div>
           </div>
 
-          <div class="row" ng-if="!editingSelf">
+          <div class="row">
             <div class="col-md-12">
               <div class="form-group">
                 <label translate for="folders">Share Folders With Device</label>
@@ -72,7 +72,7 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-primary btn-sm" ng-click="saveDevice()" ng-disabled="deviceEditor.$invalid"><span class="glyphicon glyphicon-ok"></span>&nbsp;<span translate>Save</span></button>
         <button type="button" class="btn btn-default btn-sm" data-dismiss="modal"><span class="glyphicon glyphicon-remove"></span>&nbsp;<span translate>Close</span></button>
-        <button ng-if="editingExisting && !editingSelf" type="button" class="btn btn-warning pull-left btn-sm" ng-click="deleteDevice()"><span class="glyphicon glyphicon-minus"></span>&nbsp;<span translate>Remove</span></button>
+        <button ng-if="editingExisting" type="button" class="btn btn-warning pull-left btn-sm" ng-click="deleteDevice()"><span class="glyphicon glyphicon-minus"></span>&nbsp;<span translate>Remove</span></button>
       </div>
     </div>
   </div>

--- a/gui/syncthing/folder/editFolderModalView.html
+++ b/gui/syncthing/folder/editFolderModalView.html
@@ -54,6 +54,7 @@
                   <label>
                     <input type="checkbox" ng-model="currentFolder.readOnly"> <span translate>Folder Master</span>
                   </label>
+                  &nbsp;<a href="http://docs.syncthing.net/users/foldermaster.html" target="_blank"><span class="glyphicon glyphicon-book"></span>&nbsp;<span translate>Help</span></a>
                 </div>
                 <p translate class="help-block">Files are protected from changes made on other devices, but changes made on this device will be sent to the rest of the cluster.</p>
               </div>
@@ -134,7 +135,7 @@
                 <input name="externalCommand" id="externalCommand" class="form-control" type="text" ng-model="currentFolder.externalCommand" required></input>
                 <p class="help-block">
                   <span translate ng-if="folderEditor.externalCommand.$valid || folderEditor.externalCommand.$pristine">The first command line parameter is the folder path and the second parameter is the relative path in the folder.</span>
-                  <span translate ng-if="folderEditor.externalCommand.$error.required  && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>
+                  <span translate ng-if="folderEditor.externalCommand.$error.required && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
I've carefully checked https://github.com/syncthing/syncthing/pull/1954 for further regressions and this patch reverts some remaining small changes. I don't see why `editingSelf` was added.