### PR TITLE
Update path.

### DIFF
--- a/etc/macosx-launchd/syncthing.plist
+++ b/etc/macosx-launchd/syncthing.plist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--
-	Make sure the "syncthing" executable is located in ~/bin/syncthing.
+	Make sure the "syncthing" executable is located at ~/bin/syncthing/syncthing.
 	Replace the string "USERNAME" in this file with your username, such as "jb".
 	Copy this file to ~/Library/LaunchAgents/syncthing.plist.
 	Execute "launchctl load ~/Library/LaunchAgents/syncthing.plist".

--- a/etc/macosx-launchd/syncthing.plist
+++ b/etc/macosx-launchd/syncthing.plist
@@ -13,7 +13,7 @@
 
 		<key>ProgramArguments</key>
 		<array>
-			<string>/Users/USERNAME/bin/syncthing</string>
+			<string>/Users/USERNAME/bin/syncthing/syncthing</string>
 		</array>
 
 		<key>EnvironmentVariables</key>


### PR DESCRIPTION
The comment says `Make sure the "syncthing" executable is located in ~/bin/syncthing`.

Shouldn’t the comment say `Make sure the "syncthing" executable is located at ~/bin/syncthing` or the path changed as proposed?

This configuration is working for me with the executable `syncthing` in a folder `~/bin/syncthing/`