### PR TITLE
Small refactorings on relay

### DIFF
--- a/cmd/syncthing/connections.go
+++ b/cmd/syncthing/connections.go
@@ -290,7 +290,7 @@ func (s *connectionSvc) connect() {
 				}
 
 				s.conns <- model.IntermediateConnection{
-					conn, model.ConnectionTypeBasicDial,
+					conn, model.ConnectionTypeDirectDial,
 				}
 				continue nextDevice
 			}

--- a/cmd/syncthing/connections.go
+++ b/cmd/syncthing/connections.go
@@ -143,7 +143,7 @@ next:
 		s.mut.RLock()
 		ct, ok := s.connType[remoteID]
 		s.mut.RUnlock()
-		if ok && !ct.IsDirect() && c.ConnType.IsDirect() {
+		if ok && !ct.IsDirect() && c.Type.IsDirect() {
 			if debugNet {
 				l.Debugln("Switching connections", remoteID)
 			}
@@ -194,7 +194,7 @@ next:
 					rd = &limitedReader{c.Conn, readRateLimit}
 				}
 
-				name := fmt.Sprintf("%s-%s (%s)", c.Conn.LocalAddr(), c.Conn.RemoteAddr(), c.ConnType)
+				name := fmt.Sprintf("%s-%s (%s)", c.Conn.LocalAddr(), c.Conn.RemoteAddr(), c.Type)
 				protoConn := protocol.NewConnection(remoteID, rd, wr, s.model, name, deviceCfg.Compression)
 
 				l.Infof("Established secure connection to %s at %s", remoteID, name)
@@ -205,10 +205,10 @@ next:
 				s.model.AddConnection(model.Connection{
 					c.Conn,
 					protoConn,
-					c.ConnType,
+					c.Type,
 				})
 				s.mut.Lock()
-				s.connType[remoteID] = c.ConnType
+				s.connType[remoteID] = c.Type
 				s.mut.Unlock()
 				continue next
 			}
@@ -219,11 +219,9 @@ next:
 				"device":  remoteID.String(),
 				"address": c.Conn.RemoteAddr().String(),
 			})
-			l.Infof("Connection from %s (%s) with unknown device ID %s", c.Conn.RemoteAddr(), c.ConnType, remoteID)
-		} else {
-			l.Infof("Connection from %s (%s) with ignored device ID %s", c.Conn.RemoteAddr(), c.ConnType, remoteID)
 		}
 
+		l.Infof("Connection from %s (%s) with ignored device ID %s", c.Conn.RemoteAddr(), c.Type, remoteID)
 		c.Conn.Close()
 	}
 }

--- a/cmd/syncthing/connections_tcp.go
+++ b/cmd/syncthing/connections_tcp.go
@@ -99,7 +99,7 @@ func tcpListener(uri *url.URL, tlsCfg *tls.Config, conns chan<- model.Intermedia
 		}
 
 		conns <- model.IntermediateConnection{
-			tc, model.ConnectionTypeBasicAccept,
+			tc, model.ConnectionTypeDirectAccept,
 		}
 	}
 }

--- a/lib/model/connection.go
+++ b/lib/model/connection.go
@@ -25,8 +25,8 @@ type Connection struct {
 }
 
 const (
-	ConnectionTypeBasicAccept ConnectionType = iota
-	ConnectionTypeBasicDial
+	ConnectionTypeDirectAccept ConnectionType = iota
+	ConnectionTypeDirectDial
 	ConnectionTypeRelayAccept
 	ConnectionTypeRelayDial
 )
@@ -35,10 +35,10 @@ type ConnectionType int
 
 func (t ConnectionType) String() string {
 	switch t {
-	case ConnectionTypeBasicAccept:
-		return "basic-accept"
-	case ConnectionTypeBasicDial:
-		return "basic-dial"
+	case ConnectionTypeDirectAccept:
+		return "direct-accept"
+	case ConnectionTypeDirectDial:
+		return "direct-dial"
 	case ConnectionTypeRelayAccept:
 		return "relay-accept"
 	case ConnectionTypeRelayDial:
@@ -48,5 +48,5 @@ func (t ConnectionType) String() string {
 }
 
 func (t ConnectionType) IsDirect() bool {
-	return t == ConnectionTypeBasicAccept || t == ConnectionTypeBasicDial
+	return t == ConnectionTypeDirectAccept || t == ConnectionTypeDirectDial
 }

--- a/lib/model/connection.go
+++ b/lib/model/connection.go
@@ -14,8 +14,8 @@ import (
 )
 
 type IntermediateConnection struct {
-	Conn     *tls.Conn
-	ConnType ConnectionType
+	*tls.Conn
+	Type ConnectionType
 }
 
 type Connection struct {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -285,7 +285,7 @@ func BenchmarkRequest(b *testing.B) {
 	m.AddConnection(Connection{
 		&net.TCPConn{},
 		fc,
-		ConnectionTypeBasicAccept,
+		ConnectionTypeDirectAccept,
 	})
 	m.Index(device1, "default", files, 0, nil)
 
@@ -328,7 +328,7 @@ func TestDeviceRename(t *testing.T) {
 	m.AddConnection(Connection{
 		&net.TCPConn{},
 		fc,
-		ConnectionTypeBasicAccept,
+		ConnectionTypeDirectAccept,
 	})
 
 	m.ServeBackground()


### PR DESCRIPTION
I'm picking through the relay code in order to fully understand it and made some changes along the way that makes sense to me... Basically,

 - Rename Basic connections to Direct to better match IsDirect and how I think about the whole thing... :)
 - Tweak the field names of IntermediateConnection
 - Remove some unused stuff and simplify the start/stop code on relay.Svc

I think these should be safe. Relaying seems to work still. :)