### PR TITLE
Decouple connections service from model

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/calmh/logger"
 	"github.com/juju/ratelimit"
 	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/connections"
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/events"
@@ -577,13 +578,6 @@ func syncthingMain() {
 		symlinks.Supported = false
 	}
 
-	if opts.MaxSendKbps > 0 {
-		writeRateLimit = ratelimit.NewBucketWithRate(float64(1000*opts.MaxSendKbps), int64(5*1000*opts.MaxSendKbps))
-	}
-	if opts.MaxRecvKbps > 0 {
-		readRateLimit = ratelimit.NewBucketWithRate(float64(1000*opts.MaxRecvKbps), int64(5*1000*opts.MaxRecvKbps))
-	}
-
 	if (opts.MaxRecvKbps > 0 || opts.MaxSendKbps > 0) && !opts.LimitBandwidthInLan {
 		lans, _ = osutil.GetLans()
 		networks := make([]string, 0, len(lans))
@@ -750,7 +744,7 @@ func syncthingMain() {
 
 	// Start connection management
 
-	connectionSvc := newConnectionSvc(cfg, myID, m, tlsCfg, cachedDiscovery, relaySvc)
+	connectionSvc := connections.NewConnectionSvc(cfg, myID, m, tlsCfg, cachedDiscovery, relaySvc, bepProtocolName, tlsDefaultCommonName, lans)
 	mainSvc.Add(connectionSvc)
 
 	if cpuProfile {

--- a/lib/connections/connections_tcp.go
+++ b/lib/connections/connections_tcp.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package main
+package connections
 
 import (
 	"crypto/tls"
@@ -33,7 +33,7 @@ func tcpDialer(uri *url.URL, tlsCfg *tls.Config) (*tls.Conn, error) {
 
 	raddr, err := net.ResolveTCPAddr("tcp", uri.Host)
 	if err != nil {
-		if debugNet {
+		if debug {
 			l.Debugln(err)
 		}
 		return nil, err
@@ -41,7 +41,7 @@ func tcpDialer(uri *url.URL, tlsCfg *tls.Config) (*tls.Conn, error) {
 
 	conn, err := net.DialTCP("tcp", nil, raddr)
 	if err != nil {
-		if debugNet {
+		if debug {
 			l.Debugln(err)
 		}
 		return nil, err
@@ -81,7 +81,7 @@ func tcpListener(uri *url.URL, tlsCfg *tls.Config, conns chan<- model.Intermedia
 			continue
 		}
 
-		if debugNet {
+		if debug {
 			l.Debugln("connect from", conn.RemoteAddr())
 		}
 

--- a/lib/connections/debug.go
+++ b/lib/connections/debug.go
@@ -4,22 +4,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-package main
+package connections
 
 import (
-	"io"
+	"os"
+	"strings"
 
-	"github.com/juju/ratelimit"
+	"github.com/calmh/logger"
 )
 
-type limitedWriter struct {
-	w      io.Writer
-	bucket *ratelimit.Bucket
-}
-
-func (w *limitedWriter) Write(buf []byte) (int, error) {
-	if w.bucket != nil {
-		w.bucket.Wait(int64(len(buf)))
-	}
-	return w.w.Write(buf)
-}
+var (
+	debug = strings.Contains(os.Getenv("STTRACE"), "connections") || os.Getenv("STTRACE") == "all"
+	l     = logger.DefaultLogger
+)

--- a/lib/connections/limitedreader.go
+++ b/lib/connections/limitedreader.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package connections
+
+import (
+	"io"
+
+	"github.com/juju/ratelimit"
+)
+
+type LimitedReader struct {
+	reader io.Reader
+	bucket *ratelimit.Bucket
+}
+
+func NewReadLimiter(r io.Reader, b *ratelimit.Bucket) *LimitedReader {
+	return &LimitedReader{
+		reader: r,
+		bucket: b,
+	}
+}
+
+func (r *LimitedReader) Read(buf []byte) (int, error) {
+	n, err := r.reader.Read(buf)
+	if r.bucket != nil {
+		r.bucket.Wait(int64(n))
+	}
+	return n, err
+}


### PR DESCRIPTION
The connections service no longer depends directly on the
syncthing model object, but on an interface instead. This
makes it drastically easier to write clients that handle
the model differently, but still want to benefit from
existing and future connections changes in the core.

This was motivated by burkemw3's interest in creating a
FUSE client that can present a view of the global model,
but not have all of the file data locally.

The actual decoupling was done by adding a
ConnectionHandlingModel interface. This interface is an
extension of the protocol.Model interface that also
handles connections alongside the modified service.

There were a few dependencies in connections.go to
work through.

In a couple instances, connections.go was using variables
in the main package. Since it moved packages, those
variables were no longer accessible. Some of the variables
(e.g. MyID) were available from parameters passed during
construction. Other variables (e.g. writeRateLimit) weren't
accessible and needed to passed into the constructor.

Shared dependencies (limitedreader, limitedwriter, and
servicefunc) were simple enough to move to lib and use
in the correct places.