### PR TITLE
Feature request: startTime in system/status

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -642,6 +642,7 @@ func (s *apiSvc) getSystemStatus(w http.ResponseWriter, r *http.Request) {
 	res["cpuPercent"] = cpusum / float64(len(cpuUsagePercent)) / float64(runtime.NumCPU())
 	res["pathSeparator"] = string(filepath.Separator)
 	res["uptime"] = int(time.Since(startTime).Seconds())
+	res["startTime"] = startTime
 
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	json.NewEncoder(w).Encode(res)


### PR DESCRIPTION
This is feature request and PR at once, related to <a href="https://forum.syncthing.net/t/issue-with-syncthing-gtk-on-reconnecting-to-network/5388">problem with handling sleeping / hibernation</a> in ST-GTK.

To put it simple, it is possible to Syncthing daemon to restart without Syncthing-GTK noticing, for example, when restart is handled by service manager and ST-GTK lags after PC is resuming from hibernation.

Currently only way how to detect such restart is by detecting event ids going backwards. But that has proven pretty-much impossible with HTTP implementation I'm using, as Syncthing timeouting request with no events and system timeouting request because Syncthing is not there anymore looks the same. Also, requesting event with high ID from freshly restarted Syncthing will simply hold connection until such ID is available, without any sign that client requested nonsense.

*(TL;DR; ends here :) )*

---

That's why I'm proposing adding **instanceId** field into `system/status` REST call. instanceId is any string that is guaranteed to be different every time when Syncthing daemon starts - currently it is simply unix time on startup convereted to hex string, but it can be really anything unique enough.

Using this id, any client would be able to spot unexpected restart with first `system/status` response.