### PR TITLE
Local discovery should use the same port on v4 as v6 (fixes #2201)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -217,7 +217,7 @@ type OptionsConfiguration struct {
 	GlobalAnnServers        []string `xml:"globalAnnounceServer" json:"globalAnnounceServers" json:"globalAnnounceServer" default:"udp4://announce.syncthing.net:22027, udp6://announce-v6.syncthing.net:22027"`
 	GlobalAnnEnabled        bool     `xml:"globalAnnounceEnabled" json:"globalAnnounceEnabled" default:"true"`
 	LocalAnnEnabled         bool     `xml:"localAnnounceEnabled" json:"localAnnounceEnabled" default:"true"`
-	LocalAnnPort            int      `xml:"localAnnouncePort" json:"localAnnouncePort" default:"21025"`
+	LocalAnnPort            int      `xml:"localAnnouncePort" json:"localAnnouncePort" default:"21027"`
 	LocalAnnMCAddr          string   `xml:"localAnnounceMCAddr" json:"localAnnounceMCAddr" default:"[ff12::8384]:21027"`
 	RelayServers            []string `xml:"relayServer" json:"relayServers" default:"dynamic+https://relays.syncthing.net"`
 	MaxSendKbps             int      `xml:"maxSendKbps" json:"maxSendKbps"`
@@ -507,6 +507,11 @@ func convertV11V12(cfg *Configuration) {
 	// Use new multicast group
 	if cfg.Options.LocalAnnMCAddr == "[ff32::5222]:21026" {
 		cfg.Options.LocalAnnMCAddr = "[ff12::8384]:21027"
+	}
+
+	// Use new local discovery port
+	if cfg.Options.LocalAnnPort == 21025 {
+		cfg.Options.LocalAnnPort = 21027
 	}
 
 	cfg.Version = 12

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -35,7 +35,7 @@ func TestDefaultValues(t *testing.T) {
 		GlobalAnnServers:        []string{"udp4://announce.syncthing.net:22027", "udp6://announce-v6.syncthing.net:22027"},
 		GlobalAnnEnabled:        true,
 		LocalAnnEnabled:         true,
-		LocalAnnPort:            21025,
+		LocalAnnPort:            21027,
 		LocalAnnMCAddr:          "[ff12::8384]:21027",
 		RelayServers:            []string{"dynamic+https://relays.syncthing.net"},
 		MaxSendKbps:             0,

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -52,7 +52,7 @@
         <listenAddress>tcp://127.0.0.1:22002</listenAddress>
         <globalAnnounceServer>udp4://announce.syncthing.net:22027</globalAnnounceServer>
         <globalAnnounceServer>udp6://announce-v6.syncthing.net:22027</globalAnnounceServer>
-        <globalAnnounceEnabled>false</globalAnnounceEnabled>
+        <globalAnnounceEnabled>true</globalAnnounceEnabled>
         <localAnnounceEnabled>true</localAnnounceEnabled>
         <localAnnouncePort>21025</localAnnouncePort>
         <localAnnounceMCAddr>[ff12::8384]:21027</localAnnounceMCAddr>


### PR DESCRIPTION
Note that I added this to the existinvg 11-to-12 migration, as we haven't made a release with config version 12 yet. Developers will need to fix up manually.