### PR TITLE
Bind to IPv6 multicast group instead of ::

### DIFF
--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -8,7 +8,6 @@ package beacon
 
 import (
 	"errors"
-	"fmt"
 	"net"
 
 	"golang.org/x/net/ipv6"
@@ -28,7 +27,7 @@ func NewMulticast(addr string) (*Multicast, error) {
 		return nil, err
 	}
 
-	conn, err := net.ListenPacket("udp6", fmt.Sprintf("[::]:%d", gaddr.Port))
+	conn, err := net.ListenPacket("udp6", addr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This makes it possible to run multiple instances on the same box, all
receiving local discovery packets. Tested on Mac, Windows, supposed to
work on at least Linux too. For Windows, there may be issues with XP and
earlier, but meh...