### PR TITLE
Harmonize Color of FA-Icons and Identicons

### DIFF
--- a/gui/assets/css/overrides.css
+++ b/gui/assets/css/overrides.css
@@ -255,3 +255,8 @@ ul.three-columns li, ul.two-columns li {
         position: static;
     }
 }
+
+/** Font Awesome Icons **/
+.fa {
+    color: #666;
+}


### PR DESCRIPTION
Set the FA Icons Color to #666 (Same as the Identicons)