### PR TITLE
Pick a single relay (fixes #2182)

### DIFF
--- a/lib/osutil/ping.go
+++ b/lib/osutil/ping.go
@@ -8,6 +8,7 @@ package osutil
 
 import (
 	"net"
+	"net/url"
 	"time"
 )
 
@@ -24,4 +25,15 @@ func TCPPing(address string) (time.Duration, error) {
 		conn.Close()
 	}
 	return time.Since(start), err
+}
+
+// GetLatencyForURL parses the given URL, tries opening a TCP connection to it
+// and returns the time it took to establish the connection.
+func GetLatencyForURL(addr string) (time.Duration, error) {
+	uri, err := url.Parse(addr)
+	if err != nil {
+		return 0, err
+	}
+
+	return TCPPing(uri.Host)
 }


### PR DESCRIPTION
This is getting a bit annoying.
Ideally the relay struct and all the utility functions should live in the relay package together with the utility functions, but XDR generation cannot generate stuff across packages.

Alternatively, we could have  the type defined twice, also a RelayList type which has .FromStrings([]string), and maybe .ToDiscoveryRelaySlice()