### PR TITLE
lib/symlinks need not depend on protocol

### DIFF
--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/syncthing/protocol"
 	"github.com/syncthing/syncthing/lib/ignore"
 	"github.com/syncthing/syncthing/lib/osutil"
+	"github.com/syncthing/syncthing/lib/symlinks"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -342,4 +343,32 @@ func (l testfileList) String() string {
 	}
 	b.WriteString("}")
 	return b.String()
+}
+
+func TestSymlinkTypeEqual(t *testing.T) {
+	testcases := []struct {
+		onDiskType   symlinks.TargetType
+		inIndexFlags uint32
+		equal        bool
+	}{
+		// File is only equal to file
+		{symlinks.TargetFile, 0, true},
+		{symlinks.TargetFile, protocol.FlagDirectory, false},
+		{symlinks.TargetFile, protocol.FlagSymlinkMissingTarget, false},
+		// Directory is only equal to directory
+		{symlinks.TargetDirectory, 0, false},
+		{symlinks.TargetDirectory, protocol.FlagDirectory, true},
+		{symlinks.TargetDirectory, protocol.FlagSymlinkMissingTarget, false},
+		// Unknown is equal to anything
+		{symlinks.TargetUnknown, 0, true},
+		{symlinks.TargetUnknown, protocol.FlagDirectory, true},
+		{symlinks.TargetUnknown, protocol.FlagSymlinkMissingTarget, true},
+	}
+
+	for _, tc := range testcases {
+		res := SymlinkTypeEqual(tc.onDiskType, protocol.FileInfo{Flags: tc.inIndexFlags})
+		if res != tc.equal {
+			t.Errorf("Incorrect result %v for %v, %v", res, tc.onDiskType, tc.inIndexFlags)
+		}
+	}
 }

--- a/lib/symlinks/symlink_unix.go
+++ b/lib/symlinks/symlink_unix.go
@@ -11,7 +11,6 @@ package symlinks
 import (
 	"os"
 
-	"github.com/syncthing/protocol"
 	"github.com/syncthing/syncthing/lib/osutil"
 )
 
@@ -19,23 +18,24 @@ var (
 	Supported = true
 )
 
-func Read(path string) (string, uint32, error) {
-	var mode uint32
-	stat, err := os.Stat(path)
-	if err != nil {
-		mode = protocol.FlagSymlinkMissingTarget
-	} else if stat.IsDir() {
-		mode = protocol.FlagDirectory
+func Read(path string) (string, TargetType, error) {
+	tt := TargetUnknown
+	if stat, err := os.Stat(path); err == nil {
+		if stat.IsDir() {
+			tt = TargetDirectory
+		} else {
+			tt = TargetFile
+		}
 	}
-	path, err = os.Readlink(path)
+	path, err := os.Readlink(path)
 
-	return osutil.NormalizedFilename(path), mode, err
+	return osutil.NormalizedFilename(path), tt, err
 }
 
-func Create(source, target string, flags uint32) error {
+func Create(source, target string, tt TargetType) error {
 	return os.Symlink(osutil.NativeFilename(target), source)
 }
 
-func ChangeType(path string, flags uint32) error {
+func ChangeType(path string, tt TargetType) error {
 	return nil
 }

--- a/lib/symlinks/targets.go
+++ b/lib/symlinks/targets.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2015 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package symlinks
+
+type TargetType int
+
+const (
+	TargetFile TargetType = iota
+	TargetDirectory
+	TargetUnknown
+)


### PR DESCRIPTION
This one needs some review. It makes the symlink package use it's own TargetType enumeration instead of the protocol flags, to cut one unnecessary dependency. I'm not 100% certain I got the turns around Unknown and so right, especially as I slightly simplified the logic of SymlinkTypeEqual in walk.go to what I think the comment said...