### PR TITLE
Temporary indexes

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -32,6 +32,7 @@ import (
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/logger"
+	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/relay"
@@ -85,7 +86,7 @@ type modelIntf interface {
 	CurrentFolderFile(folder string, file string) (protocol.FileInfo, bool)
 	CurrentGlobalFile(folder string, file string) (protocol.FileInfo, bool)
 	ResetFolder(folder string)
-	Availability(folder, file string) []protocol.DeviceID
+	Availability(folder, file string, version protocol.Vector, block protocol.BlockInfo) []model.Availability
 	GetIgnores(folder string) ([]string, []string, error)
 	SetIgnores(folder string, content []string) error
 	PauseDevice(device protocol.DeviceID)

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -696,7 +696,7 @@ func (s *apiService) getDBFile(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	av := s.model.Availability(folder, file)
+	av := s.model.Availability(folder, file, protocol.Vector{}, protocol.BlockInfo{})
 	sendJSON(w, map[string]interface{}{
 		"global":       jsonFileInfo(gf),
 		"local":        jsonFileInfo(lf),

--- a/cmd/syncthing/mocked_model_test.go
+++ b/cmd/syncthing/mocked_model_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/db"
+	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/stats"
 )
@@ -57,7 +58,7 @@ func (m *mockedModel) CurrentGlobalFile(folder string, file string) (protocol.Fi
 func (m *mockedModel) ResetFolder(folder string) {
 }
 
-func (m *mockedModel) Availability(folder, file string) []protocol.DeviceID {
+func (m *mockedModel) Availability(folder, file string, version protocol.Vector, block protocol.BlockInfo) []model.Availability {
 	return nil
 }
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -62,8 +62,6 @@ func TestDefaultValues(t *testing.T) {
 		ReleasesURL:             "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30",
 		AlwaysLocalNets:         []string{},
 		OverwriteNames:          false,
-		SendTempIndexes:         true,
-		ReceiveTempIndexes:      true,
 	}
 
 	cfg := New(device1)
@@ -194,8 +192,6 @@ func TestOverriddenValues(t *testing.T) {
 		ReleasesURL:             "https://localhost/releases",
 		AlwaysLocalNets:         []string{},
 		OverwriteNames:          true,
-		SendTempIndexes:         false,
-		ReceiveTempIndexes:      false,
 	}
 
 	cfg, err := Load("testdata/overridenvalues.xml", device1)

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -62,6 +62,8 @@ func TestDefaultValues(t *testing.T) {
 		ReleasesURL:             "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30",
 		AlwaysLocalNets:         []string{},
 		OverwriteNames:          false,
+		SendTempIndexes:         true,
+		ReceiveTempIndexes:      true,
 	}
 
 	cfg := New(device1)
@@ -192,6 +194,8 @@ func TestOverriddenValues(t *testing.T) {
 		ReleasesURL:             "https://localhost/releases",
 		AlwaysLocalNets:         []string{},
 		OverwriteNames:          true,
+		SendTempIndexes:         false,
+		ReceiveTempIndexes:      false,
 	}
 
 	cfg, err := Load("testdata/overridenvalues.xml", device1)

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -62,6 +62,7 @@ func TestDefaultValues(t *testing.T) {
 		ReleasesURL:             "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30",
 		AlwaysLocalNets:         []string{},
 		OverwriteNames:          false,
+		TempIndexMinBlocks:      10,
 	}
 
 	cfg := New(device1)
@@ -192,6 +193,7 @@ func TestOverriddenValues(t *testing.T) {
 		ReleasesURL:             "https://localhost/releases",
 		AlwaysLocalNets:         []string{},
 		OverwriteNames:          true,
+		TempIndexMinBlocks:      100,
 	}
 
 	cfg, err := Load("testdata/overridenvalues.xml", device1)

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -37,6 +37,7 @@ type FolderConfiguration struct {
 	PullerPauseS          int                         `xml:"pullerPauseS" json:"pullerPauseS"`
 	MaxConflicts          int                         `xml:"maxConflicts" json:"maxConflicts"`
 	DisableSparseFiles    bool                        `xml:"disableSparseFiles" json:"disableSparseFiles"`
+	DisableTempIndexes    bool                        `xml:"disableTempIndexes" json:"disableTempIndexes"`
 
 	Invalid    string `xml:"-" json:"invalid"` // Set at runtime when there is an error, not saved
 	cachedPath string

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -40,6 +40,7 @@ type OptionsConfiguration struct {
 	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://api.github.com/repos/syncthing/syncthing/releases?per_page=30"`
 	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
 	OverwriteNames          bool     `xml:"overwriteNames" json:"overwriteNames" default:"false"`
+	TempIndexMinBlocks      int      `xml:"tempIndexMinBlocks" json:"tempIndexMinBlocks" default:"10"`
 
 	DeprecatedUPnPEnabled  bool `xml:"upnpEnabled"`
 	DeprecatedUPnPLeaseM   int  `xml:"upnpLeaseMinutes"`

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -40,6 +40,8 @@ type OptionsConfiguration struct {
 	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://api.github.com/repos/syncthing/syncthing/releases?per_page=30"`
 	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
 	OverwriteNames          bool     `xml:"overwriteNames" json:"overwriteNames" default:"false"`
+	ReceiveTempIndexes      bool     `xml:"receiveTempIndexes" json:"receiveTempIndexes" default:"true"`
+	SendTempIndexes         bool     `xml:"sendTempIndexes" json:"sendTempIndexes" default:"true"`
 
 	DeprecatedUPnPEnabled  bool `xml:"upnpEnabled"`
 	DeprecatedUPnPLeaseM   int  `xml:"upnpLeaseMinutes"`

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -40,8 +40,6 @@ type OptionsConfiguration struct {
 	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://api.github.com/repos/syncthing/syncthing/releases?per_page=30"`
 	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
 	OverwriteNames          bool     `xml:"overwriteNames" json:"overwriteNames" default:"false"`
-	ReceiveTempIndexes      bool     `xml:"receiveTempIndexes" json:"receiveTempIndexes" default:"true"`
-	SendTempIndexes         bool     `xml:"sendTempIndexes" json:"sendTempIndexes" default:"true"`
 
 	DeprecatedUPnPEnabled  bool `xml:"upnpEnabled"`
 	DeprecatedUPnPLeaseM   int  `xml:"upnpLeaseMinutes"`

--- a/lib/config/testdata/overridenvalues.xml
+++ b/lib/config/testdata/overridenvalues.xml
@@ -35,7 +35,5 @@
         <urPostInsecurely>true</urPostInsecurely>
         <releasesURL>https://localhost/releases</releasesURL>
         <overwriteNames>true</overwriteNames>
-        <sendTempIndexes>false</sendTempIndexes>
-        <receiveTempIndexes>false</receiveTempIndexes>
     </options>
 </configuration>

--- a/lib/config/testdata/overridenvalues.xml
+++ b/lib/config/testdata/overridenvalues.xml
@@ -35,5 +35,7 @@
         <urPostInsecurely>true</urPostInsecurely>
         <releasesURL>https://localhost/releases</releasesURL>
         <overwriteNames>true</overwriteNames>
+        <sendTempIndexes>false</sendTempIndexes>
+        <receiveTempIndexes>false</receiveTempIndexes>
     </options>
 </configuration>

--- a/lib/config/testdata/overridenvalues.xml
+++ b/lib/config/testdata/overridenvalues.xml
@@ -35,5 +35,6 @@
         <urPostInsecurely>true</urPostInsecurely>
         <releasesURL>https://localhost/releases</releasesURL>
         <overwriteNames>true</overwriteNames>
+        <tempIndexMinBlocks>100</tempIndexMinBlocks>
     </options>
 </configuration>

--- a/lib/model/deviceactivity.go
+++ b/lib/model/deviceactivity.go
@@ -26,28 +26,30 @@ func newDeviceActivity() *deviceActivity {
 	}
 }
 
-func (m *deviceActivity) leastBusy(availability []protocol.DeviceID) protocol.DeviceID {
+func (m *deviceActivity) leastBusy(availability []Availability) (Availability, bool) {
 	m.mut.Lock()
 	low := 2<<30 - 1
-	var selected protocol.DeviceID
-	for _, device := range availability {
-		if usage := m.act[device]; usage < low {
+	found := false
+	var selected Availability
+	for _, info := range availability {
+		if usage := m.act[info.ID]; usage < low {
 			low = usage
-			selected = device
+			selected = info
+			found = true
 		}
 	}
 	m.mut.Unlock()
-	return selected
+	return selected, found
 }
 
-func (m *deviceActivity) using(device protocol.DeviceID) {
+func (m *deviceActivity) using(availability Availability) {
 	m.mut.Lock()
-	m.act[device]++
+	m.act[availability.ID]++
 	m.mut.Unlock()
 }
 
-func (m *deviceActivity) done(device protocol.DeviceID) {
+func (m *deviceActivity) done(availability Availability) {
 	m.mut.Lock()
-	m.act[device]--
+	m.act[availability.ID]--
 	m.mut.Unlock()
 }

--- a/lib/model/deviceactivity_test.go
+++ b/lib/model/deviceactivity_test.go
@@ -13,46 +13,48 @@ import (
 )
 
 func TestDeviceActivity(t *testing.T) {
-	n0 := protocol.DeviceID([32]byte{1, 2, 3, 4})
-	n1 := protocol.DeviceID([32]byte{5, 6, 7, 8})
-	n2 := protocol.DeviceID([32]byte{9, 10, 11, 12})
-	devices := []protocol.DeviceID{n0, n1, n2}
+	n0 := Availability{protocol.DeviceID([32]byte{1, 2, 3, 4}), 0}
+	n1 := Availability{protocol.DeviceID([32]byte{5, 6, 7, 8}), 1}
+	n2 := Availability{protocol.DeviceID([32]byte{9, 10, 11, 12}), 0}
+	devices := []Availability{n0, n1, n2}
 	na := newDeviceActivity()
 
-	if lb := na.leastBusy(devices); lb != n0 {
+	if lb, ok := na.leastBusy(devices); !ok || lb != n0 {
 		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
 	}
-	if lb := na.leastBusy(devices); lb != n0 {
+	if lb, ok := na.leastBusy(devices); !ok || lb != n0 {
 		t.Errorf("Least busy device should still be n0 (%v) not %v", n0, lb)
 	}
 
-	na.using(na.leastBusy(devices))
-	if lb := na.leastBusy(devices); lb != n1 {
+	lb, _ := na.leastBusy(devices)
+	na.using(lb)
+	if lb, ok := na.leastBusy(devices); !ok || lb != n1 {
 		t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
 	}
-
-	na.using(na.leastBusy(devices))
-	if lb := na.leastBusy(devices); lb != n2 {
+	lb, _ = na.leastBusy(devices)
+	na.using(lb)
+	if lb, ok := na.leastBusy(devices); !ok || lb != n2 {
 		t.Errorf("Least busy device should be n2 (%v) not %v", n2, lb)
 	}
 
-	na.using(na.leastBusy(devices))
-	if lb := na.leastBusy(devices); lb != n0 {
+	lb, _ = na.leastBusy(devices)
+	na.using(lb)
+	if lb, ok := na.leastBusy(devices); !ok || lb != n0 {
 		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
 	}
 
 	na.done(n1)
-	if lb := na.leastBusy(devices); lb != n1 {
+	if lb, ok := na.leastBusy(devices); !ok || lb != n1 {
 		t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
 	}
 
 	na.done(n2)
-	if lb := na.leastBusy(devices); lb != n1 {
+	if lb, ok := na.leastBusy(devices); !ok || lb != n1 {
 		t.Errorf("Least busy device should still be n1 (%v) not %v", n1, lb)
 	}
 
 	na.done(n0)
-	if lb := na.leastBusy(devices); lb != n0 {
+	if lb, ok := na.leastBusy(devices); !ok || lb != n0 {
 		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
 	}
 }

--- a/lib/model/deviceactivity_test.go
+++ b/lib/model/deviceactivity_test.go
@@ -13,9 +13,9 @@ import (
 )
 
 func TestDeviceActivity(t *testing.T) {
-	n0 := Availability{protocol.DeviceID([32]byte{1, 2, 3, 4}), 0}
-	n1 := Availability{protocol.DeviceID([32]byte{5, 6, 7, 8}), 1}
-	n2 := Availability{protocol.DeviceID([32]byte{9, 10, 11, 12}), 0}
+	n0 := Availability{protocol.DeviceID([32]byte{1, 2, 3, 4}), false}
+	n1 := Availability{protocol.DeviceID([32]byte{5, 6, 7, 8}), true}
+	n2 := Availability{protocol.DeviceID([32]byte{9, 10, 11, 12}), false}
 	devices := []Availability{n0, n1, n2}
 	na := newDeviceActivity()
 

--- a/lib/model/devicedownloadstate.go
+++ b/lib/model/devicedownloadstate.go
@@ -1,0 +1,126 @@
+// Copyright (C) 2015 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package model
+
+import (
+	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/sync"
+)
+
+// deviceFolderFileDownloadState holds current download state of a file that
+// a remote device has advertised. blockIndexes represends indexes within
+// FileInfo.Blocks that the remote device already has, and version represents
+// the version of the file that the remote device is downloading.
+type deviceFolderFileDownloadState struct {
+	blockIndexes []int32
+	version      protocol.Vector
+}
+
+// deviceFolderDownloadState holds current download state of all files that
+// a remote device is currently downloading in a specific folder.
+type deviceFolderDownloadState struct {
+	mut   sync.RWMutex
+	files map[string]deviceFolderFileDownloadState
+}
+
+// Has returns wether a block at that specific index, and that specific version of the file
+// is currently available on the remote device for pulling from a temporary file.
+func (p *deviceFolderDownloadState) Has(file string, version protocol.Vector, index int32) bool {
+	p.mut.RLock()
+	defer p.mut.RUnlock()
+
+	local, ok := p.files[file]
+
+	if !ok || !local.version.Equal(version) {
+		return false
+	}
+
+	for _, existingIndex := range local.blockIndexes {
+		if existingIndex == index {
+			return true
+		}
+	}
+	return false
+}
+
+// Update updates internal state of what has been downloaded into the temporary
+// files by the remote device for this specific folder.
+func (p *deviceFolderDownloadState) Update(updates []protocol.FileDownloadProgressUpdate) {
+	p.mut.Lock()
+	defer p.mut.Unlock()
+
+	for _, update := range updates {
+		local, ok := p.files[update.Name]
+		if update.UpdateType == protocol.UpdateTypeForget && ok && local.version.Equal(update.Version) {
+			delete(p.files, update.Name)
+		} else if update.UpdateType == protocol.UpdateTypeAppend {
+			if !ok {
+				local = deviceFolderFileDownloadState{
+					blockIndexes: update.BlockIndexes,
+					version:      update.Version,
+				}
+			} else if !local.version.Equal(update.Version) {
+				local.blockIndexes = append(local.blockIndexes[:0], update.BlockIndexes...)
+				local.version = update.Version
+			} else {
+				local.blockIndexes = append(local.blockIndexes, update.BlockIndexes...)
+			}
+			p.files[update.Name] = local
+		}
+	}
+}
+
+// deviceDownloadState represents the state of all in progress downloads
+// for all folders of a specific device.
+type deviceDownloadState struct {
+	mut     sync.RWMutex
+	folders map[string]*deviceFolderDownloadState
+}
+
+// Update updates internal state of what has been downloaded into the temporary
+// files by the remote device for this specific folder.
+func (t *deviceDownloadState) Update(folder string, updates []protocol.FileDownloadProgressUpdate) {
+	t.mut.RLock()
+	f, ok := t.folders[folder]
+	t.mut.RUnlock()
+
+	if !ok {
+		f = &deviceFolderDownloadState{
+			mut:   sync.NewRWMutex(),
+			files: make(map[string]deviceFolderFileDownloadState),
+		}
+		t.mut.Lock()
+		t.folders[folder] = f
+		t.mut.Unlock()
+	}
+
+	f.Update(updates)
+}
+
+// Has returns wether block at that specific index, and that specific version of the file
+// is currently available on the remote device for pulling from a temporary file.
+func (t *deviceDownloadState) Has(folder, file string, version protocol.Vector, index int32) bool {
+	if t == nil {
+		return false
+	}
+	t.mut.RLock()
+	f, ok := t.folders[folder]
+	t.mut.RUnlock()
+
+	if !ok {
+		return false
+	}
+
+	return f.Has(file, version, index)
+}
+
+func newDeviceDownloadState() *deviceDownloadState {
+	return &deviceDownloadState{
+		mut:     sync.NewRWMutex(),
+		folders: make(map[string]*deviceFolderDownloadState),
+	}
+}

--- a/lib/model/devicedownloadstate_test.go
+++ b/lib/model/devicedownloadstate_test.go
@@ -1,0 +1,111 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+func TestDeviceDownloadState(t *testing.T) {
+	v1 := (protocol.Vector{}).Update(0)
+	v2 := (protocol.Vector{}).Update(1)
+
+	// file 1 version 1 part 1
+	f1v1p1 := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeAppend, "f1", v1, []int32{0, 1, 2}}
+	f1v1p2 := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeAppend, "f1", v1, []int32{3, 4, 5}}
+	f1v1del := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeForget, "f1", v1, nil}
+	f1v2p1 := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeAppend, "f1", v2, []int32{10, 11, 12}}
+	f1v2p2 := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeAppend, "f1", v2, []int32{13, 14, 15}}
+	f1v2del := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeForget, "f1", v2, nil}
+
+	f2v1p1 := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeAppend, "f2", v1, []int32{20, 21, 22}}
+	f2v1p2 := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeAppend, "f2", v1, []int32{23, 24, 25}}
+	f2v1del := protocol.FileDownloadProgressUpdate{protocol.UpdateTypeForget, "f2", v1, nil}
+
+	tests := []struct {
+		updates                  []protocol.FileDownloadProgressUpdate
+		shouldHaveIndexesFrom    []protocol.FileDownloadProgressUpdate
+		shouldNotHaveIndexesFrom []protocol.FileDownloadProgressUpdate
+	}{
+		{ //1
+			[]protocol.FileDownloadProgressUpdate{f1v1p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p2, f1v2p1, f1v2p2},
+		},
+		{ //2
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2},
+			[]protocol.FileDownloadProgressUpdate{f1v2p1, f1v2p2},
+		},
+		{ //3
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v1del},
+			nil,
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p1, f1v2p2}},
+		{ //4
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2del},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2},
+			[]protocol.FileDownloadProgressUpdate{f1v2p1, f1v2p2},
+		},
+		{ //5
+			// v2 replaces old v1 data
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p1},
+			[]protocol.FileDownloadProgressUpdate{f1v2p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p2},
+		},
+		{ //6
+			// v1 delete on v2 data does nothing
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p1, f1v1del},
+			[]protocol.FileDownloadProgressUpdate{f1v2p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p2},
+		},
+		{ //7
+			// v2 replacees v1, v2 gets deleted, and v2 part 2 gets added.
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p1, f1v2del, f1v2p2},
+			[]protocol.FileDownloadProgressUpdate{f1v2p2},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p1},
+		},
+		// Multiple files in one go
+		{ //8
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f2v1p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f2v1p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p2, f2v1p2},
+		},
+		{ //9
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f2v1p1, f2v1del},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1},
+			[]protocol.FileDownloadProgressUpdate{f2v1p1, f2v1p1},
+		},
+		{ //10
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f2v1del, f2v1p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p1, f2v1p1},
+			[]protocol.FileDownloadProgressUpdate{f1v1p2, f2v1p2},
+		},
+	}
+
+	for i, test := range tests {
+		s := newDeviceDownloadState()
+		s.Update("folder", test.updates)
+
+		for _, expected := range test.shouldHaveIndexesFrom {
+			for _, n := range expected.BlockIndexes {
+				if !s.Has("folder", expected.Name, expected.Version, n) {
+					t.Error("Test", i+1, "error:", expected.Name, expected.Version, "missing", n)
+				}
+			}
+		}
+
+		for _, unexpected := range test.shouldNotHaveIndexesFrom {
+			for _, n := range unexpected.BlockIndexes {
+				if s.Has("folder", unexpected.Name, unexpected.Version, n) {
+					t.Error("Test", i+1, "error:", unexpected.Name, unexpected.Version, "has extra", n)
+				}
+			}
+		}
+	}
+}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -396,6 +396,7 @@ func (m *Model) Completion(device protocol.DeviceID, folder string) float64 {
 		return true
 	})
 
+	// This might might be more than it really is, because some blocks can be of a smaller size.
 	m.pmut.RLock()
 	need -= int64(m.deviceDownloads[device].NumberOfBlocksInProgress() * protocol.BlockSize)
 	m.pmut.RUnlock()

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -60,6 +60,11 @@ type service interface {
 	getState() (folderState, time.Time, error)
 }
 
+type Availability struct {
+	ID    protocol.DeviceID `json:"id"`
+	Flags uint32            `json:"flags"`
+}
+
 type Model struct {
 	*suture.Supervisor
 
@@ -91,6 +96,7 @@ type Model struct {
 	helloMessages     map[protocol.DeviceID]protocol.HelloMessage
 	deviceClusterConf map[protocol.DeviceID]protocol.ClusterConfigMessage
 	devicePaused      map[protocol.DeviceID]bool
+	deviceDownloads   map[protocol.DeviceID]*deviceDownloadState
 	pmut              sync.RWMutex // protects the above
 }
 
@@ -132,6 +138,7 @@ func NewModel(cfg *config.Wrapper, id protocol.DeviceID, deviceName, clientName,
 		helloMessages:      make(map[protocol.DeviceID]protocol.HelloMessage),
 		deviceClusterConf:  make(map[protocol.DeviceID]protocol.ClusterConfigMessage),
 		devicePaused:       make(map[protocol.DeviceID]bool),
+		deviceDownloads:    make(map[protocol.DeviceID]*deviceDownloadState),
 		fmut:               sync.NewRWMutex(),
 		pmut:               sync.NewRWMutex(),
 	}
@@ -742,6 +749,7 @@ func (m *Model) Close(device protocol.DeviceID, err error) {
 	delete(m.conn, device)
 	delete(m.helloMessages, device)
 	delete(m.deviceClusterConf, device)
+	delete(m.deviceDownloads, device)
 	m.pmut.Unlock()
 }
 
@@ -988,6 +996,7 @@ func (m *Model) AddConnection(conn Connection, hello protocol.HelloMessage) {
 		panic("add existing device")
 	}
 	m.conn[deviceID] = conn
+	m.deviceDownloads[deviceID] = newDeviceDownloadState()
 
 	m.helloMessages[deviceID] = hello
 
@@ -1040,6 +1049,24 @@ func (m *Model) PauseDevice(device protocol.DeviceID) {
 		m.Close(device, errors.New("device paused"))
 	}
 	events.Default.Log(events.DevicePaused, map[string]string{"device": device.String()})
+}
+
+func (m *Model) DownloadProgress(device protocol.DeviceID, folder string, updates []protocol.FileDownloadProgressUpdate, flags uint32, options []protocol.Option) {
+	if !m.folderSharedWith(folder, device) || !m.cfg.Options().ReceiveTempIndexes {
+		return
+	}
+
+	m.fmut.RLock()
+	cfg, ok := m.folderCfgs[folder]
+	m.fmut.RUnlock()
+
+	if !ok || cfg.ReadOnly {
+		return
+	}
+
+	m.pmut.RLock()
+	m.deviceDownloads[device].Update(folder, updates)
+	m.pmut.RUnlock()
 }
 
 func (m *Model) ResumeDevice(device protocol.DeviceID) {
@@ -1742,7 +1769,7 @@ func (m *Model) GlobalDirectoryTree(folder, prefix string, levels int, dirsonly 
 	return output
 }
 
-func (m *Model) Availability(folder, file string) []protocol.DeviceID {
+func (m *Model) Availability(folder, file string, version protocol.Vector, block protocol.BlockInfo) []Availability {
 	// Acquire this lock first, as the value returned from foldersFiles can
 	// get heavily modified on Close()
 	m.pmut.RLock()
@@ -1750,19 +1777,27 @@ func (m *Model) Availability(folder, file string) []protocol.DeviceID {
 
 	m.fmut.RLock()
 	fs, ok := m.folderFiles[folder]
+	devices := m.folderDevices[folder]
 	m.fmut.RUnlock()
 	if !ok {
 		return nil
 	}
 
-	availableDevices := []protocol.DeviceID{}
+	var availabilities []Availability
 	for _, device := range fs.Availability(file) {
 		_, ok := m.conn[device]
 		if ok {
-			availableDevices = append(availableDevices, device)
+			availabilities = append(availabilities, Availability{device, 0})
 		}
 	}
-	return availableDevices
+
+	for _, device := range devices {
+		if m.deviceDownloads[device].Has(folder, file, version, int32(block.Offset/protocol.BlockSize)) {
+			availabilities = append(availabilities, Availability{device, protocol.FlagFromTemporary})
+		}
+	}
+
+	return availabilities
 }
 
 // BringToFront bumps the given files priority in the job queue.

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -653,6 +653,9 @@ nextFolder:
 
 	// This breaks if we send multiple CM messages during the same connection.
 	if cm.Flags&protocol.FlagClusterConfigTemporaryIndexes != 0 {
+		m.pmut.RLock()
+		conn := m.conn[deviceID]
+		m.pmut.RUnlock()
 		m.progressEmitter.temporaryIndexSubscribe(conn, sharedFolders)
 	}
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -396,6 +396,10 @@ func (m *Model) Completion(device protocol.DeviceID, folder string) float64 {
 		return true
 	})
 
+	m.pmut.RLock()
+	need -= int64(m.deviceDownloads[device].NumberOfBlocksInProgress() * protocol.BlockSize)
+	m.pmut.RUnlock()
+
 	needRatio := float64(need) / float64(tot)
 	completionPct := 100 * (1 - needRatio)
 	l.Debugf("%v Completion(%s, %q): %f (%d / %d = %f)", m, device, folder, completionPct, need, tot, needRatio)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -661,9 +661,13 @@ nextFolder:
 	// This breaks if we send multiple CM messages during the same connection.
 	if len(tempIndexFolders) > 0 {
 		m.pmut.RLock()
-		conn := m.conn[deviceID]
+		conn, ok := m.conn[deviceID]
 		m.pmut.RUnlock()
-		m.progressEmitter.temporaryIndexSubscribe(conn, tempIndexFolders)
+		// In case we've got ClusterConfig, and the connection disappeared
+		// from infront of our nose.
+		if ok {
+			m.progressEmitter.temporaryIndexSubscribe(conn, tempIndexFolders)
+		}
 	}
 
 	var changed bool

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -335,7 +335,7 @@ func TestDeviceRename(t *testing.T) {
 
 	conn := Connection{
 		&net.TCPConn{},
-		FakeConnection{
+		&FakeConnection{
 			id:          device1,
 			requestData: []byte("some data to return"),
 		},

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -243,7 +243,7 @@ func (FakeConnection) IndexUpdate(string, []protocol.FileInfo, uint32, []protoco
 	return nil
 }
 
-func (f FakeConnection) Request(folder, name string, offset int64, size int, hash []byte, flags uint32, options []protocol.Option) ([]byte, error) {
+func (f FakeConnection) Request(folder, name string, offset int64, size int, hash []byte, fromTemporary bool) ([]byte, error) {
 	return f.requestData, nil
 }
 
@@ -301,7 +301,7 @@ func BenchmarkRequest(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		data, err := m.requestGlobal(device1, "default", files[i%n].Name, 0, 32, nil, 0, nil)
+		data, err := m.requestGlobal(device1, "default", files[i%n].Name, 0, 32, nil, false)
 		if err != nil {
 			b.Error(err)
 		}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -253,6 +253,10 @@ func (FakeConnection) Statistics() protocol.Statistics {
 	return protocol.Statistics{}
 }
 
+func (FakeConnection) DownloadProgress(string, []protocol.FileDownloadProgressUpdate, uint32, []protocol.Option) {
+
+}
+
 func BenchmarkRequest(b *testing.B) {
 	db := db.OpenMemory()
 	m := NewModel(defaultConfig, protocol.LocalDeviceID, "device", "syncthing", "dev", db, nil)

--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -69,15 +69,7 @@ func (t *ProgressEmitter) Serve() {
 			if !newLastUpdated.Equal(lastUpdate) || newCount != lastCount {
 				lastUpdate = newLastUpdated
 				lastCount = newCount
-				output := make(map[string]map[string]*pullerProgress)
-				for _, puller := range t.registry {
-					if output[puller.folder] == nil {
-						output[puller.folder] = make(map[string]*pullerProgress)
-					}
-					output[puller.folder][puller.file.Name] = puller.Progress()
-				}
-				events.Default.Log(events.DownloadProgress, output)
-				l.Debugf("progress emitter: emitting %#v", output)
+				t.sendDownloadProgressEvent()
 			} else {
 				l.Debugln("progress emitter: nothing new")
 			}
@@ -88,6 +80,19 @@ func (t *ProgressEmitter) Serve() {
 			t.mut.Unlock()
 		}
 	}
+}
+
+func (t *ProgressEmitter) sendDownloadProgressEvent() {
+	// registry lock already held
+	output := make(map[string]map[string]*pullerProgress)
+	for _, puller := range t.registry {
+		if output[puller.folder] == nil {
+			output[puller.folder] = make(map[string]*pullerProgress)
+		}
+		output[puller.folder][puller.file.Name] = puller.Progress()
+	}
+	events.Default.Log(events.DownloadProgress, output)
+	l.Debugf("progress emitter: emitting %#v", output)
 }
 
 // VerifyConfiguration implements the config.Committer interface

--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -126,7 +126,7 @@ func (t *ProgressEmitter) sendDownloadProgressMessages() {
 
 			var activePullers []*sharedPullerState
 			for _, puller := range t.registry {
-				if puller.folder != folder || puller.file.IsSymlink() || puller.file.IsDirectory() {
+				if puller.folder != folder || puller.file.IsSymlink() || puller.file.IsDirectory() || len(puller.file.Blocks) <= 10 {
 					continue
 				}
 				activePullers = append(activePullers, puller)

--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -274,7 +274,7 @@ func connsWithout(conns []protocol.Connection, conn protocol.Connection) []proto
 		return nil
 	}
 
-	newConns := make([]protocol.Connection, len(conns)-1)
+	newConns := make([]protocol.Connection, 0, len(conns)-1)
 	for _, existingConn := range conns {
 		if existingConn != conn {
 			newConns = append(newConns, existingConn)

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -185,11 +185,15 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 	v1 := (protocol.Vector{}).Update(0)
 	v2 := (protocol.Vector{}).Update(1)
 
+	// Requires more than 10 blocks to work.
+	blocks := make([]protocol.BlockInfo, 11, 11)
+
 	state1 := &sharedPullerState{
 		folder: "folder",
 		file: protocol.FileInfo{
 			Name:    "state1",
 			Version: v1,
+			Blocks:  blocks,
 		},
 		mut:              sync.NewRWMutex(),
 		availableUpdated: time.Now(),
@@ -260,6 +264,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 		file: protocol.FileInfo{
 			Name:    "state2",
 			Version: v1,
+			Blocks:  blocks,
 		},
 		mut:              sync.NewRWMutex(),
 		available:        []int32{1, 2, 3},
@@ -270,6 +275,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 		file: protocol.FileInfo{
 			Name:    "state3",
 			Version: v1,
+			Blocks:  blocks,
 		},
 		mut:              sync.NewRWMutex(),
 		available:        []int32{1, 2, 3},
@@ -280,6 +286,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 		file: protocol.FileInfo{
 			Name:    "state4",
 			Version: v1,
+			Blocks:  blocks,
 		},
 		mut:              sync.NewRWMutex(),
 		available:        []int32{1, 2, 3},
@@ -327,6 +334,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 			Name:    "state5",
 			Version: v1,
 			Flags:   protocol.FlagDirectory,
+			Blocks:  blocks,
 		},
 		mut:              sync.NewRWMutex(),
 		available:        []int32{1, 2, 3},
@@ -350,6 +358,19 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 		file: protocol.FileInfo{
 			Name:    "state7",
 			Version: v1,
+			Blocks:  blocks,
+		},
+		mut:              sync.NewRWMutex(),
+		available:        []int32{1, 2, 3},
+		availableUpdated: time.Now(),
+	}
+	// Less than 10 blocks
+	state8 := &sharedPullerState{
+		folder: "folder",
+		file: protocol.FileInfo{
+			Name:    "state8",
+			Version: v1,
+			Blocks:  blocks[:3],
 		},
 		mut:              sync.NewRWMutex(),
 		available:        []int32{1, 2, 3},
@@ -358,6 +379,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 	p.registry["5"] = state5
 	p.registry["6"] = state6
 	p.registry["7"] = state7
+	p.registry["8"] = state8
 
 	p.sendDownloadProgressMessages()
 

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/syncthing/syncthing/lib/sync"
 )
 
-var timeout = 10 * time.Millisecond
+var timeout = 100 * time.Millisecond
 
 func caller(skip int) string {
 	_, file, line, ok := runtime.Caller(skip + 1)

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -104,6 +104,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 	c := config.Wrap("/tmp/test", config.Configuration{})
 	c.SetOptions(config.OptionsConfiguration{
 		ProgressUpdateIntervalS: 0,
+		TempIndexMinBlocks:      10,
 	})
 
 	fc := &FakeConnection{}

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1007,7 +1007,8 @@ func (p *rwFolder) handleFile(file protocol.FileInfo, copyChan chan<- copyBlocks
 			osutil.InWritableDir(osutil.Remove, tempName)
 		}
 	} else {
-		blocks = file.Blocks
+		// Copy the blocks, as we don't want to shuffle them on the FileInfo
+		blocks = append(blocks, file.Blocks...)
 		blocksSize = file.Size()
 	}
 
@@ -1017,6 +1018,12 @@ func (p *rwFolder) handleFile(file protocol.FileInfo, copyChan chan<- copyBlocks
 			p.newError(file.Name, errors.New("insufficient space"))
 			return
 		}
+	}
+
+	// Shuffle the blocks
+	for i := range blocks {
+		j := rand.Intn(i + 1)
+		blocks[i], blocks[j] = blocks[j], blocks[i]
 	}
 
 	events.Default.Log(events.ItemStarted, map[string]string{

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1247,7 +1247,7 @@ func (p *rwFolder) pullerRoutine(in <-chan pullBlockState, out chan<- *sharedPul
 			// Fetch the block, while marking the selected device as in use so that
 			// leastBusy can select another device when someone else asks.
 			activity.using(selected)
-			buf, lastError := p.model.requestGlobal(selected.ID, p.folder, state.file.Name, state.block.Offset, int(state.block.Size), state.block.Hash, selected.Flags, nil)
+			buf, lastError := p.model.requestGlobal(selected.ID, p.folder, state.file.Name, state.block.Offset, int(state.block.Size), state.block.Hash, selected.FromTemporary)
 			activity.done(selected)
 			if lastError != nil {
 				l.Debugln("request:", p.folder, state.file.Name, state.block.Offset, state.block.Size, "returned error:", lastError)

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1034,6 +1034,7 @@ func (p *rwFolder) handleFile(file protocol.FileInfo, copyChan chan<- copyBlocks
 		copyTotal:        len(blocks),
 		copyNeeded:       len(blocks),
 		reused:           len(reused),
+		updated:          time.Now(),
 		available:        reused,
 		availableUpdated: time.Now(),
 		ignorePerms:      p.ignorePermissions(file),

--- a/lib/model/rwfolder_test.go
+++ b/lib/model/rwfolder_test.go
@@ -104,9 +104,16 @@ func TestHandleFile(t *testing.T) {
 		t.Errorf("Unexpected count of copy blocks: %d != 8", len(toCopy.blocks))
 	}
 
-	for i, block := range toCopy.blocks {
-		if string(block.Hash) != string(blocks[i+1].Hash) {
-			t.Errorf("Block mismatch: %s != %s", block.String(), blocks[i+1].String())
+	for _, block := range blocks[1:] {
+		found := false
+		for _, toCopyBlock := range toCopy.blocks {
+			if string(toCopyBlock.Hash) == string(block.Hash) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Did not find block %s", block.String())
 		}
 	}
 }
@@ -138,9 +145,17 @@ func TestHandleFileWithTemp(t *testing.T) {
 		t.Errorf("Unexpected count of copy blocks: %d != 4", len(toCopy.blocks))
 	}
 
-	for i, eq := range []int{1, 5, 6, 8} {
-		if string(toCopy.blocks[i].Hash) != string(blocks[eq].Hash) {
-			t.Errorf("Block mismatch: %s != %s", toCopy.blocks[i].String(), blocks[eq].String())
+	for _, idx := range []int{1, 5, 6, 8} {
+		found := false
+		block := blocks[idx]
+		for _, toCopyBlock := range toCopy.blocks {
+			if string(toCopyBlock.Hash) == string(block.Hash) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Did not find block %s", block.String())
 		}
 	}
 }
@@ -187,13 +202,22 @@ func TestCopierFinder(t *testing.T) {
 	default:
 	}
 
-	// Verify that the right blocks went into the pull list
-	for i, eq := range []int{1, 5, 6, 8} {
-		if string(pulls[i].block.Hash) != string(blocks[eq].Hash) {
-			t.Errorf("Block %d mismatch: %s != %s", eq, pulls[i].block.String(), blocks[eq].String())
+	// Verify that the right blocks went into the pull list.
+	// They are pulled in random order.
+	for _, idx := range []int{1, 5, 6, 8} {
+		found := false
+		block := blocks[idx]
+		for _, pulledBlock := range pulls {
+			if string(pulledBlock.block.Hash) == string(block.Hash) {
+				found = true
+				break
+			}
 		}
-		if string(finish.file.Blocks[eq-1].Hash) != string(blocks[eq].Hash) {
-			t.Errorf("Block %d mismatch: %s != %s", eq, finish.file.Blocks[eq-1].String(), blocks[eq].String())
+		if !found {
+			t.Errorf("Did not find block %s", block.String())
+		}
+		if string(finish.file.Blocks[idx-1].Hash) != string(blocks[idx].Hash) {
+			t.Errorf("Block %d mismatch: %s != %s", idx, finish.file.Blocks[idx-1].String(), blocks[idx].String())
 		}
 	}
 

--- a/lib/model/sentdownloadstate.go
+++ b/lib/model/sentdownloadstate.go
@@ -1,0 +1,185 @@
+// Copyright (C) 2015 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package model
+
+import (
+	"time"
+
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+// sentFolderFileDownloadState represents a state of what we've announced as available
+// to some remote device for a specific file.
+type sentFolderFileDownloadState struct {
+	blockIndexes []int32
+	version      protocol.Vector
+	updated      time.Time
+}
+
+// sentFolderDownloadState represents a state of what we've announced as available
+// to some remote device for a specific folder.
+type sentFolderDownloadState struct {
+	files map[string]*sentFolderFileDownloadState
+}
+
+// update takes a set of currently active sharedPullerStates, and returns a list
+// of updates which we need to send to the client to become up to date.
+// Any pullers that
+func (s *sentFolderDownloadState) update(pullers []*sharedPullerState) []protocol.FileDownloadProgressUpdate {
+	var name string
+	var updates []protocol.FileDownloadProgressUpdate
+	seen := make(map[string]struct{}, len(pullers))
+
+	for _, puller := range pullers {
+		name = puller.file.Name
+
+		seen[name] = struct{}{}
+
+		pullerBlockIndexes := puller.Available()
+		pullerVersion := puller.file.Version
+		pullerBlockIndexesUpdated := puller.AvailableUpdated()
+
+		localFile, ok := s.files[name]
+
+		// New file we haven't seen before
+		if !ok {
+			// Only send an update if the file actually has some blocks.
+			if len(pullerBlockIndexes) > 0 {
+				s.files[name] = &sentFolderFileDownloadState{
+					blockIndexes: pullerBlockIndexes,
+					updated:      pullerBlockIndexesUpdated,
+					version:      pullerVersion,
+				}
+
+				updates = append(updates, protocol.FileDownloadProgressUpdate{
+					Name:         name,
+					Version:      pullerVersion,
+					UpdateType:   protocol.UpdateTypeAppend,
+					BlockIndexes: pullerBlockIndexes,
+				})
+			}
+			continue
+		}
+
+		// Existing file we've already sent an update for.
+		if pullerBlockIndexesUpdated.Equal(localFile.updated) && pullerVersion.Equal(localFile.version) {
+			// The file state hasn't changed, go to next.
+			continue
+		}
+
+		if !pullerVersion.Equal(localFile.version) {
+			// The version has changed, clean up whatever we had for the old
+			// file, and advertise the new file.
+			updates = append(updates, protocol.FileDownloadProgressUpdate{
+				Name:       name,
+				Version:    localFile.version,
+				UpdateType: protocol.UpdateTypeForget,
+			})
+			updates = append(updates, protocol.FileDownloadProgressUpdate{
+				Name:         name,
+				Version:      pullerVersion,
+				UpdateType:   protocol.UpdateTypeAppend,
+				BlockIndexes: pullerBlockIndexes,
+			})
+			localFile.blockIndexes = pullerBlockIndexes
+			localFile.updated = pullerBlockIndexesUpdated
+			localFile.version = pullerVersion
+			continue
+		}
+
+		// Relies on the fact that sharedPullerState.Available() should always
+		// append.
+		newBlocks := pullerBlockIndexes[len(localFile.blockIndexes):]
+
+		localFile.blockIndexes = append(localFile.blockIndexes, newBlocks...)
+		localFile.updated = pullerBlockIndexesUpdated
+
+		// If there are new blocks, send the update.
+		if len(newBlocks) > 0 {
+			updates = append(updates, protocol.FileDownloadProgressUpdate{
+				Name:         name,
+				Version:      localFile.version,
+				UpdateType:   protocol.UpdateTypeAppend,
+				BlockIndexes: newBlocks,
+			})
+		}
+	}
+
+	// For each file that we are tracking, see if there still is a puller for it
+	// if not, the file completed or errored out.
+	for name, info := range s.files {
+		_, ok := seen[name]
+		if !ok {
+			updates = append(updates, protocol.FileDownloadProgressUpdate{
+				Name:       name,
+				Version:    info.version,
+				UpdateType: protocol.UpdateTypeForget,
+			})
+			delete(s.files, name)
+		}
+	}
+
+	return updates
+}
+
+// destroy removes all stored state, and returns a set of updates we need to
+// dispatch to clean up the state on the remote end.
+func (s *sentFolderDownloadState) destroy() []protocol.FileDownloadProgressUpdate {
+	updates := make([]protocol.FileDownloadProgressUpdate, 0, len(s.files))
+	for name, info := range s.files {
+		updates = append(updates, protocol.FileDownloadProgressUpdate{
+			Name:       name,
+			Version:    info.version,
+			UpdateType: protocol.UpdateTypeForget,
+		})
+		delete(s.files, name)
+	}
+	return updates
+}
+
+// sentDownloadState represents a state of what we've announced as available
+// to some remote device. It is used from within the progress emitter
+// which only has one routine, hence is deemed threadsafe.
+type sentDownloadState struct {
+	folderStates map[string]*sentFolderDownloadState
+}
+
+// update receives a folder, and a slice of pullers that are currently available
+// for the given folder, and according to the state of what we've seen before
+// returns a set of updates which we should send to the remote device to make
+// it aware of everything that we currently have available.
+func (s *sentDownloadState) update(folder string, pullers []*sharedPullerState) []protocol.FileDownloadProgressUpdate {
+	fs, ok := s.folderStates[folder]
+	if !ok {
+		fs = &sentFolderDownloadState{
+			files: make(map[string]*sentFolderFileDownloadState),
+		}
+		s.folderStates[folder] = fs
+	}
+	return fs.update(pullers)
+}
+
+// folders returns a set of folders this state is currently aware off.
+func (s *sentDownloadState) folders() []string {
+	folders := make([]string, 0, len(s.folderStates))
+	for key := range s.folderStates {
+		folders = append(folders, key)
+	}
+	return folders
+}
+
+// cleanup cleans up all state related to a folder, and returns a set of updates
+// which would clean up the state on the remote device.
+func (s *sentDownloadState) cleanup(folder string) []protocol.FileDownloadProgressUpdate {
+	fs, ok := s.folderStates[folder]
+	if ok {
+		updates := fs.destroy()
+		delete(s.folderStates, folder)
+		return updates
+	}
+	return nil
+}

--- a/lib/model/sentdownloadstate.go
+++ b/lib/model/sentdownloadstate.go
@@ -28,7 +28,6 @@ type sentFolderDownloadState struct {
 
 // update takes a set of currently active sharedPullerStates, and returns a list
 // of updates which we need to send to the client to become up to date.
-// Any pullers that
 func (s *sentFolderDownloadState) update(pullers []*sharedPullerState) []protocol.FileDownloadProgressUpdate {
 	var name string
 	var updates []protocol.FileDownloadProgressUpdate

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/protocol"
@@ -30,15 +31,17 @@ type sharedPullerState struct {
 	sparse      bool
 
 	// Mutable, must be locked for access
-	err        error      // The first error we hit
-	fd         *os.File   // The fd of the temp file
-	copyTotal  int        // Total number of copy actions for the whole job
-	pullTotal  int        // Total number of pull actions for the whole job
-	copyOrigin int        // Number of blocks copied from the original file
-	copyNeeded int        // Number of copy actions still pending
-	pullNeeded int        // Number of block pulls still pending
-	closed     bool       // True if the file has been finalClosed.
-	mut        sync.Mutex // Protects the above
+	err              error        // The first error we hit
+	fd               *os.File     // The fd of the temp file
+	copyTotal        int          // Total number of copy actions for the whole job
+	pullTotal        int          // Total number of pull actions for the whole job
+	copyOrigin       int          // Number of blocks copied from the original file
+	copyNeeded       int          // Number of copy actions still pending
+	pullNeeded       int          // Number of block pulls still pending
+	closed           bool         // True if the file has been finalClosed.
+	available        []int32      // Indexes of the blocks that are available in the temporary file
+	availableUpdated time.Time    // Time when list of available blocks was last updated
+	mut              sync.RWMutex // Protects the above
 }
 
 // A momentary state representing the progress of the puller
@@ -56,7 +59,7 @@ type pullerProgress struct {
 // A lockedWriterAt synchronizes WriteAt calls with an external mutex.
 // WriteAt() is goroutine safe by itself, but not against for example Close().
 type lockedWriterAt struct {
-	mut *sync.Mutex
+	mut *sync.RWMutex
 	wr  io.WriterAt
 }
 
@@ -196,15 +199,18 @@ func (s *sharedPullerState) failLocked(context string, err error) {
 }
 
 func (s *sharedPullerState) failed() error {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	s.mut.RLock()
+	err := s.err
+	s.mut.RUnlock()
 
-	return s.err
+	return err
 }
 
-func (s *sharedPullerState) copyDone() {
+func (s *sharedPullerState) copyDone(block protocol.BlockInfo) {
 	s.mut.Lock()
 	s.copyNeeded--
+	s.available = append(s.available, int32(block.Offset/protocol.BlockSize))
+	s.availableUpdated = time.Now()
 	l.Debugln("sharedPullerState", s.folder, s.file.Name, "copyNeeded ->", s.copyNeeded)
 	s.mut.Unlock()
 }
@@ -225,9 +231,11 @@ func (s *sharedPullerState) pullStarted() {
 	s.mut.Unlock()
 }
 
-func (s *sharedPullerState) pullDone() {
+func (s *sharedPullerState) pullDone(block protocol.BlockInfo) {
 	s.mut.Lock()
 	s.pullNeeded--
+	s.available = append(s.available, int32(block.Offset/protocol.BlockSize))
+	s.availableUpdated = time.Now()
 	l.Debugln("sharedPullerState", s.folder, s.file.Name, "pullNeeded done ->", s.pullNeeded)
 	s.mut.Unlock()
 }
@@ -265,10 +273,10 @@ func (s *sharedPullerState) finalClose() (bool, error) {
 	return true, s.err
 }
 
-// Returns the momentarily progress for the puller
+// Progress returns the momentarily progress for the puller
 func (s *sharedPullerState) Progress() *pullerProgress {
-	s.mut.Lock()
-	defer s.mut.Unlock()
+	s.mut.RLock()
+	defer s.mut.RUnlock()
 	total := s.reused + s.copyTotal + s.pullTotal
 	done := total - s.copyNeeded - s.pullNeeded
 	return &pullerProgress{
@@ -281,4 +289,20 @@ func (s *sharedPullerState) Progress() *pullerProgress {
 		BytesTotal:          db.BlocksToSize(total),
 		BytesDone:           db.BlocksToSize(done),
 	}
+}
+
+// AvailableUpdated returns the time last time list of available blocks was updated
+func (s *sharedPullerState) AvailableUpdated() time.Time {
+	s.mut.RLock()
+	t := s.availableUpdated
+	s.mut.RUnlock()
+	return t
+}
+
+// Available returns blocks available in the current temporary file
+func (s *sharedPullerState) Available() []int32 {
+	s.mut.RLock()
+	blocks := s.available
+	s.mut.RUnlock()
+	return blocks
 }

--- a/lib/model/sharedpullerstate_test.go
+++ b/lib/model/sharedpullerstate_test.go
@@ -16,7 +16,7 @@ import (
 func TestSourceFileOK(t *testing.T) {
 	s := sharedPullerState{
 		realName: "testdata/foo",
-		mut:      sync.NewMutex(),
+		mut:      sync.NewRWMutex(),
 	}
 
 	fd, err := s.sourceFile()
@@ -45,7 +45,7 @@ func TestSourceFileOK(t *testing.T) {
 func TestSourceFileBad(t *testing.T) {
 	s := sharedPullerState{
 		realName: "nonexistent",
-		mut:      sync.NewMutex(),
+		mut:      sync.NewRWMutex(),
 	}
 
 	fd, err := s.sourceFile()
@@ -71,7 +71,7 @@ func TestReadOnlyDir(t *testing.T) {
 
 	s := sharedPullerState{
 		tempName: "testdata/read_only_dir/.temp_name",
-		mut:      sync.NewMutex(),
+		mut:      sync.NewRWMutex(),
 	}
 
 	fd, err := s.tempFile()

--- a/lib/protocol/common_test.go
+++ b/lib/protocol/common_test.go
@@ -49,6 +49,9 @@ func (t *TestModel) Close(deviceID DeviceID, err error) {
 func (t *TestModel) ClusterConfig(deviceID DeviceID, config ClusterConfigMessage) {
 }
 
+func (t *TestModel) DownloadProgress(DeviceID, string, []FileDownloadProgressUpdate, uint32, []Option) {
+}
+
 func (t *TestModel) closedError() error {
 	select {
 	case <-t.closedCh:

--- a/lib/protocol/message.go
+++ b/lib/protocol/message.go
@@ -135,6 +135,14 @@ type ResponseMessage struct {
 
 type ClusterConfigMessage struct {
 	Folders []Folder // max:1000000
+	Flags         uint32
+	Options       []Option // max:64
+}
+
+type DownloadProgressMessage struct {
+	Folder  string                       // max:64
+	Updates []FileDownloadProgressUpdate // max:1000000
+	Flags   uint32
 	Options []Option // max:64
 }
 
@@ -164,6 +172,13 @@ type Device struct {
 	MaxLocalVersion int64
 	Flags           uint32
 	Options         []Option // max:64
+}
+
+type FileDownloadProgressUpdate struct {
+	UpdateType   uint32
+	Name         string // max:8192
+	Version      Vector
+	BlockIndexes []int32 // max:1000000
 }
 
 type Option struct {

--- a/lib/protocol/message.go
+++ b/lib/protocol/message.go
@@ -135,8 +135,7 @@ type ResponseMessage struct {
 
 type ClusterConfigMessage struct {
 	Folders []Folder // max:1000000
-	Flags         uint32
-	Options       []Option // max:64
+	Options []Option // max:64
 }
 
 type DownloadProgressMessage struct {

--- a/lib/protocol/message_xdr.go
+++ b/lib/protocol/message_xdr.go
@@ -588,8 +588,6 @@ ClusterConfigMessage Structure:
 \                Zero or more Folder Structures                 \
 /                                                               /
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-|                             Flags                             |
-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 |                       Number of Options                       |
 +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 /                                                               /
@@ -600,14 +598,13 @@ ClusterConfigMessage Structure:
 
 struct ClusterConfigMessage {
 	Folder Folders<1000000>;
-	unsigned int Flags;
 	Option Options<64>;
 }
 
 */
 
 func (o ClusterConfigMessage) XDRSize() int {
-	return 4 + xdr.SizeOfSlice(o.Folders) + 4 +
+	return 4 + xdr.SizeOfSlice(o.Folders) +
 		4 + xdr.SizeOfSlice(o.Options)
 }
 
@@ -635,7 +632,6 @@ func (o ClusterConfigMessage) MarshalXDRInto(m *xdr.Marshaller) error {
 			return err
 		}
 	}
-	m.MarshalUint32(o.Flags)
 	if l := len(o.Options); l > 64 {
 		return xdr.ElementSizeExceeded("Options", l, 64)
 	}
@@ -671,7 +667,6 @@ func (o *ClusterConfigMessage) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 			(&o.Folders[i]).UnmarshalXDRFrom(u)
 		}
 	}
-	o.Flags = u.UnmarshalUint32()
 	_OptionsSize := int(u.UnmarshalUint32())
 	if _OptionsSize < 0 {
 		return xdr.ElementSizeExceeded("Options", _OptionsSize, 64)

--- a/lib/protocol/nativemodel_darwin.go
+++ b/lib/protocol/nativemodel_darwin.go
@@ -9,32 +9,24 @@ package protocol
 import "golang.org/x/text/unicode/norm"
 
 type nativeModel struct {
-	next Model
+	Model
 }
 
 func (m nativeModel) Index(deviceID DeviceID, folder string, files []FileInfo, flags uint32, options []Option) {
 	for i := range files {
 		files[i].Name = norm.NFD.String(files[i].Name)
 	}
-	m.next.Index(deviceID, folder, files, flags, options)
+	m.Model.Index(deviceID, folder, files, flags, options)
 }
 
 func (m nativeModel) IndexUpdate(deviceID DeviceID, folder string, files []FileInfo, flags uint32, options []Option) {
 	for i := range files {
 		files[i].Name = norm.NFD.String(files[i].Name)
 	}
-	m.next.IndexUpdate(deviceID, folder, files, flags, options)
+	m.Model.IndexUpdate(deviceID, folder, files, flags, options)
 }
 
 func (m nativeModel) Request(deviceID DeviceID, folder string, name string, offset int64, hash []byte, flags uint32, options []Option, buf []byte) error {
 	name = norm.NFD.String(name)
-	return m.next.Request(deviceID, folder, name, offset, hash, flags, options, buf)
-}
-
-func (m nativeModel) ClusterConfig(deviceID DeviceID, config ClusterConfigMessage) {
-	m.next.ClusterConfig(deviceID, config)
-}
-
-func (m nativeModel) Close(deviceID DeviceID, err error) {
-	m.next.Close(deviceID, err)
+	return m.Model.Request(deviceID, folder, name, offset, hash, flags, options, buf)
 }

--- a/lib/protocol/nativemodel_unix.go
+++ b/lib/protocol/nativemodel_unix.go
@@ -7,25 +7,5 @@ package protocol
 // Normal Unixes uses NFC and slashes, which is the wire format.
 
 type nativeModel struct {
-	next Model
-}
-
-func (m nativeModel) Index(deviceID DeviceID, folder string, files []FileInfo, flags uint32, options []Option) {
-	m.next.Index(deviceID, folder, files, flags, options)
-}
-
-func (m nativeModel) IndexUpdate(deviceID DeviceID, folder string, files []FileInfo, flags uint32, options []Option) {
-	m.next.IndexUpdate(deviceID, folder, files, flags, options)
-}
-
-func (m nativeModel) Request(deviceID DeviceID, folder string, name string, offset int64, hash []byte, flags uint32, options []Option, buf []byte) error {
-	return m.next.Request(deviceID, folder, name, offset, hash, flags, options, buf)
-}
-
-func (m nativeModel) ClusterConfig(deviceID DeviceID, config ClusterConfigMessage) {
-	m.next.ClusterConfig(deviceID, config)
-}
-
-func (m nativeModel) Close(deviceID DeviceID, err error) {
-	m.next.Close(deviceID, err)
+	Model
 }

--- a/lib/protocol/nativemodel_windows.go
+++ b/lib/protocol/nativemodel_windows.go
@@ -21,30 +21,22 @@ var disallowedCharacters = string([]rune{
 })
 
 type nativeModel struct {
-	next Model
+	Model
 }
 
 func (m nativeModel) Index(deviceID DeviceID, folder string, files []FileInfo, flags uint32, options []Option) {
 	fixupFiles(folder, files)
-	m.next.Index(deviceID, folder, files, flags, options)
+	m.Model.Index(deviceID, folder, files, flags, options)
 }
 
 func (m nativeModel) IndexUpdate(deviceID DeviceID, folder string, files []FileInfo, flags uint32, options []Option) {
 	fixupFiles(folder, files)
-	m.next.IndexUpdate(deviceID, folder, files, flags, options)
+	m.Model.IndexUpdate(deviceID, folder, files, flags, options)
 }
 
 func (m nativeModel) Request(deviceID DeviceID, folder string, name string, offset int64, hash []byte, flags uint32, options []Option, buf []byte) error {
 	name = filepath.FromSlash(name)
-	return m.next.Request(deviceID, folder, name, offset, hash, flags, options, buf)
-}
-
-func (m nativeModel) ClusterConfig(deviceID DeviceID, config ClusterConfigMessage) {
-	m.next.ClusterConfig(deviceID, config)
-}
-
-func (m nativeModel) Close(deviceID DeviceID, err error) {
-	m.next.Close(deviceID, err)
+	return m.Model.Request(deviceID, folder, name, offset, hash, flags, options, buf)
 }
 
 func fixupFiles(folder string, files []FileInfo) {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -24,13 +24,14 @@ const (
 )
 
 const (
-	messageTypeClusterConfig = 0
-	messageTypeIndex         = 1
-	messageTypeRequest       = 2
-	messageTypeResponse      = 3
-	messageTypePing          = 4
-	messageTypeIndexUpdate   = 6
-	messageTypeClose         = 7
+	messageTypeClusterConfig    = 0
+	messageTypeIndex            = 1
+	messageTypeRequest          = 2
+	messageTypeResponse         = 3
+	messageTypePing             = 4
+	messageTypeIndexUpdate      = 6
+	messageTypeClose            = 7
+	messageTypeDownloadProgress = 8
 )
 
 const (
@@ -52,14 +53,20 @@ const (
 	SymlinkTypeMask = FlagDirectory | FlagSymlinkMissingTarget
 )
 
-// IndexMessage message flags (for IndexUpdate)
-const (
-	FlagIndexTemporary uint32 = 1 << iota
-)
-
 // Request message flags
 const (
-	FlagRequestTemporary uint32 = 1 << iota
+	FlagFromTemporary uint32 = 1 << iota
+)
+
+// FileDownloadProgressUpdate update types
+const (
+	UpdateTypeAppend uint32 = iota
+	UpdateTypeForget
+)
+
+// CLusterConfig flags
+const (
+	FlagClusterConfigTemporaryIndexes uint32 = 1 << 0
 )
 
 // ClusterConfigMessage.Folders flags
@@ -97,6 +104,8 @@ type Model interface {
 	ClusterConfig(deviceID DeviceID, config ClusterConfigMessage)
 	// The peer device closed the connection
 	Close(deviceID DeviceID, err error)
+	// The peer device sent progress updates for the files it is currently downloading
+	DownloadProgress(deviceID DeviceID, folder string, updates []FileDownloadProgressUpdate, flags uint32, options []Option)
 }
 
 type Connection interface {
@@ -107,6 +116,7 @@ type Connection interface {
 	IndexUpdate(folder string, files []FileInfo, flags uint32, options []Option) error
 	Request(folder string, name string, offset int64, size int, hash []byte, flags uint32, options []Option) ([]byte, error)
 	ClusterConfig(config ClusterConfigMessage)
+	DownloadProgress(folder string, updates []FileDownloadProgressUpdate, flags uint32, options []Option)
 	Statistics() Statistics
 	Closed() bool
 }
@@ -292,6 +302,16 @@ func (c *rawConnection) Closed() bool {
 	}
 }
 
+// DownloadProgress sends the progress updates for the files that are currently being downloaded.
+func (c *rawConnection) DownloadProgress(folder string, updates []FileDownloadProgressUpdate, flags uint32, options []Option) {
+	c.send(-1, messageTypeDownloadProgress, DownloadProgressMessage{
+		Folder:  folder,
+		Updates: updates,
+		Flags:   flags,
+		Options: options,
+	}, nil)
+}
+
 func (c *rawConnection) ping() bool {
 	var id int
 	select {
@@ -358,6 +378,12 @@ func (c *rawConnection) readerLoop() (err error) {
 				return fmt.Errorf("protocol error: response message in state %d", state)
 			}
 			c.handleResponse(hdr.msgID, msg)
+
+		case DownloadProgressMessage:
+			if state != stateReady {
+				return fmt.Errorf("protocol error: response message in state %d", state)
+			}
+			c.receiver.DownloadProgress(c.id, msg.Folder, msg.Updates, msg.Flags, msg.Options)
 
 		case pingMessage:
 			if state != stateReady {
@@ -468,6 +494,14 @@ func (c *rawConnection) readMessage() (hdr header, msg encodable, err error) {
 		var cm CloseMessage
 		err = cm.UnmarshalXDR(msgBuf)
 		msg = cm
+
+	case messageTypeDownloadProgress:
+		var dp DownloadProgressMessage
+		err := dp.UnmarshalXDR(msgBuf)
+		if xdrErr, ok := err.(isEofer); ok && xdrErr.IsEOF() {
+			err = nil
+		}
+		msg = dp
 
 	default:
 		err = fmt.Errorf("protocol error: %s: unknown message type %#x", c.id, hdr.msgType)

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -71,10 +71,11 @@ const (
 
 // ClusterConfigMessage.Folders flags
 const (
-	FlagFolderReadOnly     uint32 = 1 << 0
-	FlagFolderIgnorePerms         = 1 << 1
-	FlagFolderIgnoreDelete        = 1 << 2
-	FlagFolderAll                 = 1<<3 - 1
+	FlagFolderReadOnly            uint32 = 1 << 0
+	FlagFolderIgnorePerms                = 1 << 1
+	FlagFolderIgnoreDelete               = 1 << 2
+	FlagFolderDisabledTempIndexes        = 1 << 3
+	FlagFolderAll                        = 1<<4 - 1
 )
 
 // ClusterConfigMessage.Folders.Devices flags
@@ -263,7 +264,7 @@ func (c *rawConnection) Request(folder string, name string, offset int64, size i
 	var flags uint32
 
 	if fromTemporary {
-		flags = flags | FlagFromTemporary
+		flags |= FlagFromTemporary
 	}
 
 	c.awaitingMut.Lock()

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -183,7 +183,7 @@ func TestClose(t *testing.T) {
 	c0.Index("default", nil, 0, nil)
 	c0.Index("default", nil, 0, nil)
 
-	if _, err := c0.Request("default", "foo", 0, 0, nil, 0, nil); err == nil {
+	if _, err := c0.Request("default", "foo", 0, 0, nil, false); err == nil {
 		t.Error("Request should return an error")
 	}
 }

--- a/lib/protocol/wireformat.go
+++ b/lib/protocol/wireformat.go
@@ -34,7 +34,7 @@ func (c wireFormatConnection) IndexUpdate(folder string, fs []FileInfo, flags ui
 	return c.Connection.IndexUpdate(folder, myFs, flags, options)
 }
 
-func (c wireFormatConnection) Request(folder, name string, offset int64, size int, hash []byte, flags uint32, options []Option) ([]byte, error) {
+func (c wireFormatConnection) Request(folder, name string, offset int64, size int, hash []byte, fromTemporary bool) ([]byte, error) {
 	name = norm.NFC.String(filepath.ToSlash(name))
-	return c.Connection.Request(folder, name, offset, size, hash, flags, options)
+	return c.Connection.Request(folder, name, offset, size, hash, fromTemporary)
 }


### PR DESCRIPTION
Last commit is not finished, but throwing this out here to discuss the general approach before I spend more effort.
Also needs tests fixed and so on.

## TODO:
- [X] Send block index as an integer, rather than the whole block.
- [X] Add a flag to indicate this feature is off, don't send stuff if it's off.
- [X] Fallback to Request() in-case temporary request fails (no longer applicable, given we don't do validation, so it's just a if branch)
- [X] Address lint/vet/naming suggestions
- [X] Fix tests
- [X] Add tests

## Maybe:
- Limit number of entries we allow to receive, though people should just disable it.

*purpose*

> Files that are not fully downloaded are not shared, means that the initial seeding is always done from a single device which originates the change.
> Others start participating only when they have the full file.
>
> This changes that by advertising partially downloaded files (temporary).