### PR TITLE
Add my "community email address" to NICKS

### DIFF
--- a/NICKS
+++ b/NICKS
@@ -52,7 +52,7 @@ pluby		<phill.luby@newredo.com>
 pyfisch		<pyfisch@gmail.com>
 qbit		<qbit@deftly.net>
 ralder		<ralder@yandex.ru>
-rumpelsepp	<stefan@sevenbyte.org>
+rumpelsepp	<stefan@sevenbyte.org> <rumpelsepp@sevenbyte.org>
 sciurius	<jvromans@squirrel.nl>
 seehuhn		<voss@seehuhn.de>
 snnd		<dw@risu.io>


### PR DESCRIPTION
Since my amount of received emails increased over the time, I would like
to separate my private email address from my "community email address".