### PR TITLE
Cleanup markdown inline link mess

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Syncthing
-=========
+# Syncthing
 
 [![Latest Build (Official)](https://img.shields.io/jenkins/s/http/build.syncthing.net/syncthing.svg?style=flat-square)](http://build.syncthing.net/job/syncthing/lastBuild/)
 [![AppVeyor Build](https://img.shields.io/appveyor/ci/calmh/syncthing/master.svg?style=flat-square)](https://ci.appveyor.com/project/calmh/syncthing)
@@ -11,8 +10,7 @@ This is the Syncthing project which pursues the following goals:
  1. Define a protocol for synchronization of a folder between a number of
     collaborating devices. This protocol should be well defined, unambiguous,
     easily understood, free to use, efficient, secure and language neutral.
-    This is called the [Block Exchange
-    Protocol](https://github.com/syncthing/specs/blob/master/BEPv1.md).
+    This is called the [Block Exchange Protocol][1].
 
  2. Provide the reference implementation to demonstrate the usability of
     said protocol. This is the `syncthing` utility. We hope that
@@ -22,38 +20,38 @@ The two are evolving together; the protocol is not to be considered
 stable until Syncthing 1.0 is released, at which point it is locked down
 for incompatible changes.
 
-Getting Started
----------------
+## Getting Started
 
-Take a look at the [getting started
-guide](http://docs.syncthing.net/intro/getting-started.html).
+Take a look at the [getting started guide][2].
 
 There are a few examples for keeping Syncthing running in the background
-on your system in [the etc directory](https://github.com/syncthing/syncthing/blob/master/etc).
+on your system in [the etc directory][3].
 
-There is an IRC channel, `#syncthing` on Freenode, for talking directly
+There is an IRC channel, `#syncthing` on [Freenode][4], for talking directly
 to developers and users.
 
-Building
---------
+## Building
 
-Building Syncthing from source is easy, and there's a
-[guide](http://docs.syncthing.net/dev/building.html).
+Building Syncthing from source is easy, and there's a [guide][5].
 that describes it for both Unix and Windows systems.
 
-Signed Releases
----------------
+## Signed Releases
 
 As of v0.10.15 and onwards, git tags and release binaries are GPG signed
 with the key D26E6ED000654A3E (see https://syncthing.net/security.html).
 For release binaries, MD5 and SHA1 checksums are calculated and signed,
 available in the md5sum.txt.asc and sha1sum.txt.asc files.
 
-Documentation
-=============
+## Documentation
 
-Please see the [Syncthing
-documentation site](http://docs.syncthing.net/).
+Please see the [Syncthing documentation site][6].
 
-All code is licensed under the
-[MPLv2 License](https://github.com/syncthing/syncthing/blob/master/LICENSE).
+All code is licensed under the [MPLv2 License][7].
+
+[1]: https://github.com/syncthing/specs/blob/master/BEPv1.md
+[2]: http://docs.syncthing.net/intro/getting-started.html
+[3]: https://github.com/syncthing/syncthing/blob/master/etc
+[4]: https://webchat.freenode.net/
+[5]: http://docs.syncthing.net/dev/building.html
+[6]: http://docs.syncthing.net/
+[7]: https://github.com/syncthing/syncthing/blob/master/LICENSE


### PR DESCRIPTION
I just wanted to add the freenode webchat link, because people who are
not used to irc can join the chatroom instantly. I tried to clean up the
markdown file a bit and moved the links to the footer; that makes the
"source code" less ugly.

In the end I am not sure what's nicer; either having these ugly inline links or shifting link id numbers when inserting a new link in the middle... I just leave this worldshaking work here, because it is better than reverting everything again and just add the freenode link. :dancer: 