### PR TITLE
Add custom networks that are considered local (internal routing, VPN etc)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -595,6 +595,14 @@ func syncthingMain() {
 		for _, lan := range lans {
 			networks = append(networks, lan.String())
 		}
+		for _, lan := range opts.AlwaysLocalNets {
+			_, ipnet, err := net.ParseCIDR(lan)
+			if err != nil {
+				l.Infoln("Network", lan, "is malformed:", err)
+				continue
+			}
+			networks = append(networks, ipnet.String())
+		}
 		l.Infoln("Local networks:", strings.Join(networks, ", "))
 	}
 

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -249,6 +249,7 @@ type OptionsConfiguration struct {
 	PingIdleTimeS           int      `xml:"pingIdleTimeS" json:"pingIdleTimeS" default:"60"`
 	MinHomeDiskFreePct      float64  `xml:"minHomeDiskFreePct" json:"minHomeDiskFreePct" default:"1"`
 	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://api.github.com/repos/syncthing/syncthing/releases?per_page=30"`
+	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
 }
 
 func (orig OptionsConfiguration) Copy() OptionsConfiguration {


### PR DESCRIPTION
Allows things like this in the `<options>` element:

```
  <alwaysLocalNet>10.0.0.0/8</alwaysLocalNet>
```