### PR TITLE
[wip] Add comments to configuration file

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -214,8 +214,11 @@ type FolderDeviceConfiguration struct {
 }
 
 type OptionsConfiguration struct {
+	CommentListenAddress    string   `xml:",comment" json:"-" default:"An address (URL format) that we listen on for incoming sync connections. Supports the tcp:// scheme only."`
 	ListenAddress           []string `xml:"listenAddress" json:"listenAddress" default:"tcp://0.0.0.0:22000"`
+	CommentGlobalAnnServers string   `xml:",comment" json:"-" default:"An address (URL format) to a global discovery server. Uses udp4:// or udp6:// schemes."`
 	GlobalAnnServers        []string `xml:"globalAnnounceServer" json:"globalAnnounceServers" json:"globalAnnounceServer" default:"udp4://announce.syncthing.net:22027, udp6://announce-v6.syncthing.net:22027"`
+	CommentGlobalAnnEnabled string   `xml:",comment" json:"-" default:"When set to true, global discovery servers are announced to and queried for dynamic addresses."`
 	GlobalAnnEnabled        bool     `xml:"globalAnnounceEnabled" json:"globalAnnounceEnabled" default:"true"`
 	LocalAnnEnabled         bool     `xml:"localAnnounceEnabled" json:"localAnnounceEnabled" default:"true"`
 	LocalAnnPort            int      `xml:"localAnnouncePort" json:"localAnnouncePort" default:"21027"`


### PR DESCRIPTION
This results in this in the config file:

```
   ...
   <options>
        <!--An address (URL format) that we listen on for incoming sync connections. Supports the tcp:// scheme only.-->
        <listenAddress>tcp://0.0.0.0:22000</listenAddress>
        <!--An address (URL format) to a global discovery server. Uses udp4:// or udp6:// schemes.-->
        <globalAnnounceServer>udp4://announce.syncthing.net:22027</globalAnnounceServer>
        <globalAnnounceServer>udp6://announce-v6.syncthing.net:22027</globalAnnounceServer>
        <!--When set to true, global discovery servers are announced to and queried for dynamic addresses.-->
        <globalAnnounceEnabled>true</globalAnnounceEnabled>
   ...
```

So that's kind of nice, as it means the config is self documenting, and we have the documentation of the config values in the code. We can trivially push this to the docs site. However it pollutes the config structs with a lot of crap, and the fields must be exported for the xml marshaller to see them. Do we want this? Another option would be some kind of custom XML marshaller, but I'm not sure exactly how that would work... Or maybe the fields themselves could be a custom type of some sorts that marshal into their value and a comment describing them.

I only did this for the first three fields to show what it looks like...