### PR TITLE
Add external address tracker object

### DIFF
--- a/cmd/stfinddevice/main.go
+++ b/cmd/stfinddevice/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	discoverer := discover.NewDiscoverer(protocol.LocalDeviceID, nil, nil)
-	discoverer.StartGlobal([]string{server}, 1)
+	discoverer.StartGlobal([]string{server}, nil)
 	addresses, relays := discoverer.Lookup(id)
 	for _, addr := range addresses {
 		log.Println("address:", addr)

--- a/cmd/syncthing/externaladdr.go
+++ b/cmd/syncthing/externaladdr.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2015 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/syncthing/syncthing/lib/config"
+)
+
+type externalAddr struct {
+	upnpSvc *upnpSvc
+	cfg     *config.Wrapper
+}
+
+func newExternalAddr(upnpSvc *upnpSvc, cfg *config.Wrapper) *externalAddr {
+	return &externalAddr{
+		upnpSvc: upnpSvc,
+		cfg:     cfg,
+	}
+}
+
+// ExternalAddresses returns a list of addresses that are our best guess for
+// where we are reachable from the outside. As a special case, we may return
+// one or more addresses with an empty IP address (0.0.0.0 or ::) and just
+// port number - this means that the outside address of a NAT gateway should
+// be substituted.
+func (e *externalAddr) ExternalAddresses() []string {
+	var addrs []string
+
+	// Grab our listen addresses from the config. Unspecified ones are passed
+	// on verbatim (to be interpreted by a global discovery server or local
+	// discovery peer). Public addresses are passed on verbatim. Private
+	// addresses are filtered.
+	for _, addrStr := range e.cfg.Options().ListenAddress {
+		addrURL, err := url.Parse(addrStr)
+		if err != nil {
+			l.Infoln("Listen address", addrStr, "is invalid:", err)
+			continue
+		}
+		addr, err := net.ResolveTCPAddr("tcp", addrURL.Host)
+		if err != nil {
+			l.Infoln("Listen address", addrStr, "is invalid:", err)
+			continue
+		}
+
+		if addr.IP == nil || addr.IP.IsUnspecified() {
+			// Address like 0.0.0.0:22000 or [::]:22000 or :22000; include as is.
+			addrs = append(addrs, "tcp://"+addr.String())
+		} else if isPublicIPv4(addr.IP) || isPublicIPv6(addr.IP) {
+			// A public address; include as is.
+			addrs = append(addrs, "tcp://"+addr.String())
+		}
+	}
+
+	// Get an external port mapping from the upnpSvc, if it has one. If so,
+	// add it as another unspecified address.
+	if e.upnpSvc != nil {
+		if port := e.upnpSvc.ExternalPort(); port != 0 {
+			addrs = append(addrs, fmt.Sprintf("tcp://:%d", port))
+		}
+	}
+
+	l.Infoln("External addresses:", addrs)
+
+	return addrs
+}
+
+func isPublicIPv4(ip net.IP) bool {
+	ip = ip.To4()
+	if ip == nil {
+		// Not an IPv4 address (IPv6)
+		return false
+	}
+
+	// IsGlobalUnicast below only checks that it's not link local or
+	// multicast, and we want to exclude private (NAT:ed) addresses as well.
+	rfc1918 := []net.IPNet{
+		{IP: net.IP{10, 0, 0, 0}, Mask: net.IPMask{255, 0, 0, 0}},
+		{IP: net.IP{172, 16, 0, 0}, Mask: net.IPMask{255, 240, 0, 0}},
+		{IP: net.IP{192, 168, 0, 0}, Mask: net.IPMask{255, 255, 0, 0}},
+	}
+	for _, n := range rfc1918 {
+		if n.Contains(ip) {
+			return false
+		}
+	}
+
+	return ip.IsGlobalUnicast()
+}
+
+func isPublicIPv6(ip net.IP) bool {
+	if ip.To4() != nil {
+		// Not an IPv6 address (IPv4)
+		// (To16() returns a v6 mapped v4 address so can't be used to check
+		// that it's an actual v6 address)
+		return false
+	}
+
+	return ip.IsGlobalUnicast()
+}

--- a/lib/discover/discover_test.go
+++ b/lib/discover/discover_test.go
@@ -103,7 +103,7 @@ func TestGlobalDiscovery(t *testing.T) {
 		"test1://23.23.23.23:234",
 		"test2://234.234.234.234.2345",
 	}
-	d.StartGlobal(servers, 1234)
+	d.StartGlobal(servers, nil)
 
 	if len(d.clients) != 3 {
 		t.Fatal("Wrong number of clients")

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -39,6 +39,7 @@ const (
 	FolderCompletion
 	FolderErrors
 	FolderScanProgress
+	ExternalPortMappingChanged
 
 	AllEvents = (1 << iota) - 1
 )
@@ -87,6 +88,8 @@ func (t EventType) String() string {
 		return "DeviceResumed"
 	case FolderScanProgress:
 		return "FolderScanProgress"
+	case ExternalPortMappingChanged:
+		return "ExternalPortMappingChanged"
 	default:
 		return "Unknown"
 	}


### PR DESCRIPTION
This adds a thing that provides a list of external addresses, similar to how the relay service provides a list of active relays. It's passed to the discovery thing and used to build the discovery packet. The reason I want this is that I want to be able to pass this thing to both the local discovery package and the soon to be created global discovery package. I envision that as a separate package to the local discovery one as I don't see it sharing any mechanisms once we move to the TLS based discovery (as I think we agreed to do, sort of).

(I see that discovery as doing an HTTPS POST with our certificate to announce, and HTTPS GET (without providing our certificate, as it's not necessary) for lookups.)

(Both the local and global discovery packages/services would implement some simple `Lookup(protocol.DeviceID or string) []string` kind of interface for usage by the connection service.

It introduces a behavior change in that we now announce all of our listen ports instead of just the first one. I think this is a good thing.