### PR TITLE
Encapsulate local discovery address in struct

### DIFF
--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -117,7 +117,12 @@ func (c *localClient) Error() error {
 }
 
 func (c *localClient) announcementPkt() Announce {
-	addrs := c.addrList.AllAddresses()
+	var addrs []Address
+	for _, addr := range c.addrList.AllAddresses() {
+		addrs = append(addrs, Address{
+			URL: addr,
+		})
+	}
 
 	var relays []Relay
 	for _, relay := range c.relayStat.Relays() {
@@ -198,7 +203,7 @@ func (c *localClient) registerDevice(src net.Addr, device Device) bool {
 
 	var validAddresses []string
 	for _, addr := range device.Addresses {
-		u, err := url.Parse(addr)
+		u, err := url.Parse(addr.URL)
 		if err != nil {
 			continue
 		}
@@ -216,7 +221,7 @@ func (c *localClient) registerDevice(src net.Addr, device Device) bool {
 			u.Host = fmt.Sprintf("%s:%d", host, tcpAddr.Port)
 			validAddresses = append(validAddresses, u.String())
 		} else {
-			validAddresses = append(validAddresses, addr)
+			validAddresses = append(validAddresses, addr.URL)
 		}
 	}
 

--- a/lib/discover/localpackets.go
+++ b/lib/discover/localpackets.go
@@ -19,13 +19,17 @@ type Announce struct {
 	Extra []Device // max:16
 }
 
+type Device struct {
+	ID        []byte    // max:32
+	Addresses []Address // max:16
+	Relays    []Relay   // max:16
+}
+
+type Address struct {
+	URL string // max:2083
+}
+
 type Relay struct {
 	URL     string `json:"url"` // max:2083
 	Latency int32  `json:"latency"`
-}
-
-type Device struct {
-	ID        []byte   // max:32
-	Addresses []string // max:16
-	Relays    []Relay  // max:16
 }


### PR DESCRIPTION
The XDR encoder doesn't understart slices of strings very well. It can
encode and decode them, but there's no way to set limits on the length
of the strings themselves (only on the length of the slice), and the
generated diagrams are incorrect. This trivially works around this,
while also documenting what the string actually is (a URL).