### PR TITLE
Pull syncthing-inotify.service as an optional dep

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -2,6 +2,7 @@
 Description=Syncthing - Open Source Continuous File Synchronization for %I
 Documentation=http://docs.syncthing.net/
 After=network.target
+Wants=syncthing-inotify@.service
 
 [Service]
 User=%i

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -2,6 +2,7 @@
 Description=Syncthing - Open Source Continuous File Synchronization
 Documentation=http://docs.syncthing.net/
 After=network.target
+Wants=syncthing-inotify.service
 
 [Service]
 Environment=STNORESTART=yes


### PR DESCRIPTION
This patch adds syncthing-inotify.service as an optional dependency to
syncthing.service. That means, if syncthing-inotify.service is
available, it is started and stopped with syncthing.

See discussion here:
https://forum.syncthing.net/t/gnome-shell-extension-syncthing-icon/5759