### PR TITLE
Correctly report errors encountered parsing ignores (fixes #2309)

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -12,7 +12,6 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -217,28 +216,28 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 			// Pattern is rooted in the current dir only
 			exp, err := fnmatch.Convert(line[1:], flags)
 			if err != nil {
-				return fmt.Errorf("Invalid pattern %q in ignore file", line)
+				return fmt.Errorf("invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, Pattern{exp, include})
 		} else if strings.HasPrefix(line, "**/") {
 			// Add the pattern as is, and without **/ so it matches in current dir
 			exp, err := fnmatch.Convert(line, flags)
 			if err != nil {
-				return fmt.Errorf("Invalid pattern %q in ignore file", line)
+				return fmt.Errorf("invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, Pattern{exp, include})
 
 			exp, err = fnmatch.Convert(line[3:], flags)
 			if err != nil {
-				return fmt.Errorf("Invalid pattern %q in ignore file", line)
+				return fmt.Errorf("invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, Pattern{exp, include})
 		} else if strings.HasPrefix(line, "#include ") {
-			includeFile := filepath.Join(filepath.Dir(currentFile), line[len("#include "):])
+			includeRel := line[len("#include "):]
+			includeFile := filepath.Join(filepath.Dir(currentFile), includeRel)
 			includes, err := loadIgnoreFile(includeFile, seen)
 			if err != nil {
-				log.Println(err)
-				return err
+				return fmt.Errorf("include of %q: %v", includeRel, err)
 			}
 			patterns = append(patterns, includes...)
 		} else {
@@ -246,13 +245,13 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 			// current directory and subdirs.
 			exp, err := fnmatch.Convert(line, flags)
 			if err != nil {
-				return fmt.Errorf("Invalid pattern %q in ignore file", line)
+				return fmt.Errorf("invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, Pattern{exp, include})
 
 			exp, err = fnmatch.Convert("**/"+line, flags)
 			if err != nil {
-				return fmt.Errorf("Invalid pattern %q in ignore file", line)
+				return fmt.Errorf("invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, Pattern{exp, include})
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1183,7 +1183,9 @@ func (m *Model) AddFolder(cfg config.FolderConfiguration) {
 	}
 
 	ignores := ignore.New(m.cacheIgnoredFiles)
-	_ = ignores.Load(filepath.Join(cfg.Path(), ".stignore")) // Ignore error, there might not be an .stignore
+	if err := ignores.Load(filepath.Join(cfg.Path(), ".stignore")); err != nil && !os.IsNotExist(err) {
+		l.Warnln("Loading ignores:", err)
+	}
 	m.folderIgnores[cfg.ID] = ignores
 
 	m.fmut.Unlock()
@@ -1270,10 +1272,17 @@ func (m *Model) internalScanFolderSubs(folder string, subs []string) error {
 	}
 
 	if err := m.CheckFolderHealth(folder); err != nil {
+		runner.setError(err)
+		l.Infof("Stopping folder %s due to error: %s", folder, err)
 		return err
 	}
 
-	_ = ignores.Load(filepath.Join(folderCfg.Path(), ".stignore")) // Ignore error, there might not be an .stignore
+	if err := ignores.Load(filepath.Join(folderCfg.Path(), ".stignore")); err != nil && !os.IsNotExist(err) {
+		err = fmt.Errorf("loading ignores: %v", err)
+		runner.setError(err)
+		l.Infof("Stopping folder %s due to error: %s", folder, err)
+		return err
+	}
 
 	// Required to make sure that we start indexing at a directory we're already
 	// aware off.


### PR DESCRIPTION
An error on opening .stignore will satisfy os.IsNotExist() and not be
reported. Other errors will be reported and stop the folder, including
is-not-exist errors from #include as these are passed through fmt.Errorf.

Also fixes minor issue where we would not print cause of folder stopping
to the log.

Also fixes minor issue with capitalization of errors.