### PR TITLE
Case insensitive renames, part 1

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1370,6 +1370,7 @@ nextSub:
 	// TODO: We should limit the Have scanning to start at sub
 	seenPrefix := false
 	var iterError error
+	css := osutil.NewCachedCaseSensitiveStat(folderCfg.Path())
 	fs.WithHaveTruncated(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
 		f := fi.(db.FileInfoTruncated)
 		hasPrefix := len(subs) == 0
@@ -1413,7 +1414,7 @@ nextSub:
 					Version:  f.Version, // The file is still the same, so don't bump version
 				}
 				batch = append(batch, nf)
-			} else if _, err := osutil.Lstat(filepath.Join(folderCfg.Path(), f.Name)); err != nil {
+			} else if _, err := css.Lstat(filepath.Join(folderCfg.Path(), f.Name)); err != nil {
 				// File has been deleted.
 
 				// We don't specifically verify that the error is


### PR DESCRIPTION
This is part one in a series of attempts to solve the "case insensitive renames break stuff" problem. This handles *files* renamed from `foo` to `Foo`, but not directories. Basically it makes the scanner case sensitive always, so that it picks up on the change. The puller sees it as a rename and does the right thing (there might be an issue if the contents change as well).

For directories it's not that easy, as the puller (in the case of a "normal" directory rename) wants to create the new directory and move the files over there. But we can't do that, because the existing variant of the directory is in the way and makes it look like we don't need to, and then we detect it as missing due to the case sensitive scanner... Tricky business.