### PR TITLE
Add discovery source priorities (fixes #2339)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -709,14 +709,14 @@ func syncthingMain() {
 
 	if cfg.Options().LocalAnnEnabled {
 		// v4 broadcasts
-		bcd, err := discover.NewLocal(myID, fmt.Sprintf(":%d", cfg.Options().LocalAnnPort), addrList, relaySvc)
+		bcd, err := discover.NewLocal(myID, fmt.Sprintf(":%d", cfg.Options().LocalAnnPort), addrList, relaySvc, 15)
 		if err != nil {
 			l.Warnln("IPv4 local discovery:", err)
 		} else {
 			cachedDiscovery.Add(bcd, 0, 0)
 		}
 		// v6 multicasts
-		mcd, err := discover.NewLocal(myID, cfg.Options().LocalAnnMCAddr, addrList, relaySvc)
+		mcd, err := discover.NewLocal(myID, cfg.Options().LocalAnnMCAddr, addrList, relaySvc, 10)
 		if err != nil {
 			l.Warnln("IPv6 local discovery:", err)
 		} else {

--- a/lib/discover/cache_test.go
+++ b/lib/discover/cache_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 func TestCacheUnique(t *testing.T) {
-	direct := []string{"tcp://192.0.2.42:22000", "tcp://192.0.2.43:22000"}
+	// Direct addresses should be sorted by prio
+	direct := []string{"tcp://192.0.2.43:22000?prio=8", "tcp://192.0.2.44:22000?prio=10", "tcp://192.0.2.42:22000?prio=20"}
 	relays := []Relay{{URL: "relay://192.0.2.44:443"}, {URL: "tcp://192.0.2.45:443"}}
 
 	c := NewCachingMux()

--- a/lib/discover/global_test.go
+++ b/lib/discover/global_test.go
@@ -25,12 +25,13 @@ func TestParseOptions(t *testing.T) {
 		out  string
 		opts serverOptions
 	}{
-		{"https://example.com/", "https://example.com/", serverOptions{}},
-		{"https://example.com/?insecure", "https://example.com/", serverOptions{insecure: true}},
-		{"https://example.com/?insecure=true", "https://example.com/", serverOptions{insecure: true}},
-		{"https://example.com/?insecure=yes", "https://example.com/", serverOptions{insecure: true}},
-		{"https://example.com/?insecure=false&noannounce", "https://example.com/", serverOptions{noAnnounce: true}},
-		{"https://example.com/?id=abc", "https://example.com/", serverOptions{id: "abc", insecure: true}},
+		{"https://example.com/", "https://example.com/", serverOptions{prio: defaultGlobalPrio}},
+		{"https://example.com/?insecure", "https://example.com/", serverOptions{insecure: true, prio: defaultGlobalPrio}},
+		{"https://example.com/?insecure=true", "https://example.com/", serverOptions{insecure: true, prio: defaultGlobalPrio}},
+		{"https://example.com/?insecure=yes", "https://example.com/", serverOptions{insecure: true, prio: defaultGlobalPrio}},
+		{"https://example.com/?insecure=false&noannounce", "https://example.com/", serverOptions{noAnnounce: true, prio: defaultGlobalPrio}},
+		{"https://example.com/?id=abc", "https://example.com/", serverOptions{id: "abc", insecure: true, prio: defaultGlobalPrio}},
+		{"https://example.com/?id=abc&prio=47", "https://example.com/", serverOptions{id: "abc", insecure: true, prio: 47}},
 	}
 
 	for _, tc := range testcases {
@@ -84,7 +85,7 @@ func TestGlobalOverHTTP(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(direct) != 1 || direct[0] != "tcp://192.0.2.42::22000" {
+	if len(direct) != 1 || direct[0] != "tcp://192.0.2.42:22000?prio=100" {
 		t.Errorf("incorrect direct list: %+v", direct)
 	}
 	if len(relays) != 1 || relays[0] != (Relay{URL: "relay://192.0.2.43:443", Latency: 42}) {
@@ -132,7 +133,7 @@ func TestGlobalOverHTTPS(t *testing.T) {
 	if direct, relays, err := testLookup(url); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else {
-		if len(direct) != 1 || direct[0] != "tcp://192.0.2.42::22000" {
+		if len(direct) != 1 || direct[0] != "tcp://192.0.2.42:22000?prio=100" {
 			t.Errorf("incorrect direct list: %+v", direct)
 		}
 		if len(relays) != 1 || relays[0] != (Relay{URL: "relay://192.0.2.43:443", Latency: 42}) {
@@ -155,7 +156,7 @@ func TestGlobalOverHTTPS(t *testing.T) {
 	if direct, relays, err := testLookup(url); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else {
-		if len(direct) != 1 || direct[0] != "tcp://192.0.2.42::22000" {
+		if len(direct) != 1 || direct[0] != "tcp://192.0.2.42:22000?prio=100" {
 			t.Errorf("incorrect direct list: %+v", direct)
 		}
 		if len(relays) != 1 || relays[0] != (Relay{URL: "relay://192.0.2.43:443", Latency: 42}) {
@@ -236,7 +237,7 @@ func (s *fakeDiscoveryServer) handler(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(204)
 	} else {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"direct":["tcp://192.0.2.42::22000"], "relays":[{"url": "relay://192.0.2.43:443", "latency": 42}]}`))
+		w.Write([]byte(`{"direct":["tcp://192.0.2.42:22000"], "relays":[{"url": "relay://192.0.2.43:443", "latency": 42}]}`))
 	}
 }
 


### PR DESCRIPTION
This adds support for addresses having a ?prio=123 parameter, with lower
being better. We weight local discovery at 10 (IPv6) and 15 (IPv4), and
global by default at 100. Global discovery things can set it themselves
by a ?prio=123 parameter on the discovery server.