### PR TITLE
Create missing directories

### DIFF
--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -86,8 +86,24 @@ func (s *sharedPullerState) tempFile() (io.WriterAt, error) {
 	// here.
 	dir := filepath.Dir(s.tempName)
 	if info, err := os.Stat(dir); err != nil {
-		s.failLocked("dst stat dir", err)
-		return nil, err
+		if os.IsNotExist(err) {
+			// XXX: This works around a bug elsewhere, a race condition when
+			// things are deleted while being synced. However that happens, we
+			// end up with a directory for "foo" with the delete bit, but a
+			// file "foo/bar" that we want to sync. We never create the
+			// directory, and hence fail to create the file and end up looping
+			// forever on it. This breaks that by creating the directory; on
+			// next scan it'll be found and the delete bit on it is removed.
+			// The user can then clean up as they like...
+			l.Infoln("Resurrecting directory", dir)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				s.failLocked("resurrect dir", err)
+				return nil, err
+			}
+		} else {
+			s.failLocked("dst stat dir", err)
+			return nil, err
+		}
 	} else if info.Mode()&0200 == 0 {
 		err := os.Chmod(dir, 0755)
 		if !s.ignorePerms && err == nil {


### PR DESCRIPTION
This is a workaround / incorrect fix for a bug that's bit me enough in production for me to want to do something about it... I'm open for suggestions for better ways to handle it. Basically it solves the situation where the puller is eternally stuck in

```
INFO: Puller (folder "default", file "foo/bar"): dst stat dir: stat /home/jb/Sync/foo: no such file or directory
```

The only way to fix this manually is otherwise to create the directories it's complaining about, which may be hundreds spread out in a deep hierarchy... (This typically happens when someone drops something large into the sync folder, then realizes their mistake and immediately removes it.)

And yes, we should handle that better somehow...