### PR TITLE
Change relaypoolsrv endpoint

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -249,7 +249,7 @@ type OptionsConfiguration struct {
 	LocalAnnEnabled         bool     `xml:"localAnnounceEnabled" json:"localAnnounceEnabled" default:"true"`
 	LocalAnnPort            int      `xml:"localAnnouncePort" json:"localAnnouncePort" default:"21027"`
 	LocalAnnMCAddr          string   `xml:"localAnnounceMCAddr" json:"localAnnounceMCAddr" default:"[ff12::8384]:21027"`
-	RelayServers            []string `xml:"relayServer" json:"relayServers" default:"dynamic+https://relays.syncthing.net"`
+	RelayServers            []string `xml:"relayServer" json:"relayServers" default:"dynamic+https://relays.syncthing.net/endpoint"`
 	MaxSendKbps             int      `xml:"maxSendKbps" json:"maxSendKbps"`
 	MaxRecvKbps             int      `xml:"maxRecvKbps" json:"maxRecvKbps"`
 	ReconnectIntervalS      int      `xml:"reconnectionIntervalS" json:"reconnectionIntervalS" default:"60"`

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -37,7 +37,7 @@ func TestDefaultValues(t *testing.T) {
 		LocalAnnEnabled:         true,
 		LocalAnnPort:            21027,
 		LocalAnnMCAddr:          "[ff12::8384]:21027",
-		RelayServers:            []string{"dynamic+https://relays.syncthing.net"},
+		RelayServers:            []string{"dynamic+https://relays.syncthing.net/endpoint"},
 		MaxSendKbps:             0,
 		MaxRecvKbps:             0,
 		ReconnectIntervalS:      60,


### PR DESCRIPTION
Just incase we want to show some stats in the future, such as a Geo-IP based map of where relays are, their dot size being proportional to global rate limits,
together with potentially how much data in total has been transferred, and how many sessions there by crawling relay status pages etc ;)

Changes already done in relaysrv and relaypoolsrv.