### PR TITLE
Documentation and examples for autostarting with Upstart

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Frank Isemann <frank@isemann.name>
 Gilli Sigurdsson <gilli@vx.is>
 Jacek Szafarkiewicz <szafar@linux.pl>
 Jakob Borg <jakob@nym.se>
+Jake Peterson <jake@acogdev.com>
 James Patterson <jamespatterson@operamail.com> <jpjp@users.noreply.github.com>
 Jaroslav Malec <dzardacz@gmail.com>
 Jens Diemer <github.com@jensdiemer.de> <git@jensdiemer.de>

--- a/etc/linux-upstart/README.md
+++ b/etc/linux-upstart/README.md
@@ -1,0 +1,16 @@
+# Upstart Configuration
+
+This directory contains example configuration files for running Syncthing under
+the "Upstart" service manager on Linux. To have syncthing start when you login
+place "user/syncthing.conf" in the "/home/[username]/.config/upstart/" folder.
+To have syncthing start when the system boots place "system/syncthing.conf"
+in the "/etc/init/" folder.
+To manualy start syncthing via Upstart when using the system configuration use:
+
+```
+    sudo initctl start syncthing
+```
+
+For further documentation see [http://docs.syncthing.net/users/autostart.html][1].
+
+[1]: http://docs.syncthing.net/users/autostart.html#Upstart

--- a/etc/linux-upstart/system/syncthing.conf
+++ b/etc/linux-upstart/system/syncthing.conf
@@ -4,9 +4,9 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [!2345]
 
 env STNORESTART=yes
-env HOME=/home/jake
-setuid "jake"
-setgid "jake"
+env HOME=/home/$USER
+setuid "$USER"
+setgid "$USER"
 
 exec /usr/local/bin/syncthing
 

--- a/etc/linux-upstart/system/syncthing.conf
+++ b/etc/linux-upstart/system/syncthing.conf
@@ -1,0 +1,13 @@
+description "Syncthing"
+
+start on (local-filesystems and net-device-up IFACE!=lo)
+stop on runlevel [!2345]
+
+env STNORESTART=yes
+env HOME=/home/jake
+setuid "jake"
+setgid "jake"
+
+exec /usr/local/bin/syncthing
+
+respawn

--- a/etc/linux-upstart/user/syncthing.conf
+++ b/etc/linux-upstart/user/syncthing.conf
@@ -1,0 +1,21 @@
+# Location of the syncthing executable
+env SYNCTHING_EXE="/usr/local/bin"
+
+# Set the name of the application
+description "Syncthing"
+
+# Start syncthing you login to your desktop
+start on desktop-start
+
+# Stop syncthing you logout of your desktop
+stop on desktop-end
+
+# Set STNORESTART to yes to have Upstart monitor the process instead
+# of having a separate syncthing process do the monitoring
+env STNORESTART=yes
+
+# If Upstart detects syncthing has failed - it should restart it
+respawn
+
+# the syncthing command Upstart is to execute when it is started up
+exec $SYNCTHING_EXE -no-browser


### PR DESCRIPTION
Added documentation and examples for Ubuntu-like linux systems using Upstart as the init system in response to syncthing/syncthing#2315.