### PR TITLE
Run JSON decoding through the usual setting of defaults and fixing up

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -562,8 +562,7 @@ func (s *apiSvc) postSystemConfig(w http.ResponseWriter, r *http.Request) {
 	s.systemConfigMut.Lock()
 	defer s.systemConfigMut.Unlock()
 
-	var to config.Configuration
-	err := json.NewDecoder(r.Body).Decode(&to)
+	to, err := config.ReadJSON(r.Body, myID)
 	if err != nil {
 		l.Warnln("decoding posted config:", err)
 		http.Error(w, err.Error(), 500)

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -8,6 +8,7 @@
 package config
 
 import (
+	"encoding/json"
 	"encoding/xml"
 	"io"
 	"math/rand"
@@ -83,6 +84,20 @@ func ReadXML(r io.Reader, myID protocol.DeviceID) (Configuration, error) {
 	return cfg, err
 }
 
+func ReadJSON(r io.Reader, myID protocol.DeviceID) (Configuration, error) {
+	var cfg Configuration
+
+	setDefaults(&cfg)
+	setDefaults(&cfg.Options)
+	setDefaults(&cfg.GUI)
+
+	err := json.NewDecoder(r).Decode(&cfg)
+	cfg.OriginalVersion = cfg.Version
+
+	cfg.prepare(myID)
+	return cfg, err
+}
+
 type Configuration struct {
 	Version        int                   `xml:"version,attr" json:"version"`
 	Folders        []FolderConfiguration `xml:"folder" json:"folders"`
@@ -133,7 +148,7 @@ func (cfg *Configuration) WriteXML(w io.Writer) error {
 func (cfg *Configuration) prepare(myID protocol.DeviceID) {
 	fillNilSlices(&cfg.Options)
 
-	// Initialize an empty slices
+	// Initialize any empty slices
 	if cfg.Folders == nil {
 		cfg.Folders = []FolderConfiguration{}
 	}


### PR DESCRIPTION
I see no reason not to do this, and it gives a unified place (the prepare()
call) to initialize cached attributes and so on.