### PR TITLE
Cache the folderconfig Path() call

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -175,7 +175,7 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) {
 	cfg.Options.ListenAddress = uniqueStrings(cfg.Options.ListenAddress)
 	cfg.Options.GlobalAnnServers = uniqueStrings(cfg.Options.GlobalAnnServers)
 
-	if cfg.Version < OldestHandledVersion {
+	if cfg.Version > 0 && cfg.Version < OldestHandledVersion {
 		l.Warnf("Configuration version %d is deprecated. Attempting best effort conversion, but please verify manually.", cfg.Version)
 	}
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -104,6 +104,13 @@ func TestDeviceConfig(t *testing.T) {
 			},
 		}
 
+		// The cachedPath will have been resolved to an absolute path,
+		// depending on where the tests are running. Zero it out so we don't
+		// fail based on that.
+		for i := range cfg.Folders {
+			cfg.Folders[i].cachedPath = ""
+		}
+
 		if runtime.GOOS != "windows" {
 			expectedFolders[0].RawPath += string(filepath.Separator)
 		}


### PR DESCRIPTION
The Path() call is quite expensive as it does a lot of string splits and joins, and ends up being responsible for a sizable percentage of the allocations done in Request() since it's called there every time.

We can't actually *cache* it because the FolderConfig is copied everywhere, so we populate the cachedPath field on deserialization. That leaves stuff that creates the object from scratch, which is basically the tests, using the slow method.
