### PR TITLE
Lets make the vXXXX in the version optional

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -87,7 +87,7 @@ const (
 func init() {
 	if Version != "unknown-dev" {
 		// If not a generic dev build, version string should come from git describe
-		exp := regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\+\d+-g[0-9a-f]+)?(-dirty)?$`)
+		exp := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[a-z0-9]+)*(\+\d+-g[0-9a-f]+)?(-dirty)?$`)
 		if !exp.MatchString(Version) {
 			l.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", Version, exp)
 		}


### PR DESCRIPTION
I have added a ? to make the v in the regexp optional. This will allow to build the RPM for centos. As vXX.YY is not a conventional way of versioning.  This patch makes it compatible.