### PR TITLE
Correct commentary for ConnectionStats

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -261,7 +261,7 @@ func (info ConnectionInfo) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// ConnectionStats returns a map with connection statistics for each connected device.
+// ConnectionStats returns a map with connection statistics for each device.
 func (m *Model) ConnectionStats() map[string]interface{} {
 	type remoteAddrer interface {
 		RemoteAddr() net.Addr


### PR DESCRIPTION
Related to https://github.com/syncthing/syncthing-android/issues/473 and https://github.com/syncthing/syncthing/commit/944d9c84a087f70d0ab5c281b7c37fcc9c796ccd
ConnectionStats returns connection information for all devices, even when disconnected.