### PR TITLE
Add metrics for HTTP calls

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rcrowley/go-metrics"
 	"github.com/syncthing/syncthing/lib/auto"
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/db"
@@ -180,10 +181,11 @@ func (s *apiSvc) Serve() {
 
 	// Debug endpoints, not for general use
 	getRestMux.HandleFunc("/rest/debug/peerCompletion", s.getPeerCompletion)
+	getRestMux.HandleFunc("/rest/debug/httpmetrics", s.getSystemHTTPMetrics)
 
 	// A handler that splits requests between the two above and disables
 	// caching
-	restMux := noCacheMiddleware(getPostHandler(getRestMux, postRestMux))
+	restMux := noCacheMiddleware(metricsMiddleware(getPostHandler(getRestMux, postRestMux)))
 
 	// The main routing handler
 	mux := http.NewServeMux()
@@ -317,6 +319,15 @@ func debugMiddleware(h http.Handler) http.Handler {
 			}
 			l.Debugf("http: %s %q: status %d, %d bytes in %.02f ms", r.Method, r.URL.String(), status, written, ms)
 		}
+	})
+}
+
+func metricsMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t := metrics.GetOrRegisterTimer(r.URL.Path, nil)
+		t0 := time.Now()
+		h.ServeHTTP(w, r)
+		t.UpdateSince(t0)
 	})
 }
 
@@ -741,6 +752,26 @@ func (s *apiSvc) getSystemLogTxt(w http.ResponseWriter, r *http.Request) {
 	for _, line := range s.systemLog.Since(since) {
 		fmt.Fprintf(w, "%s: %s\n", line.When.Format(time.RFC3339), line.Message)
 	}
+}
+
+func (s *apiSvc) getSystemHTTPMetrics(w http.ResponseWriter, r *http.Request) {
+	stats := make(map[string]interface{})
+	metrics.Each(func(name string, intf interface{}) {
+		if m, ok := intf.(*metrics.StandardTimer); ok {
+			pct := m.Percentiles([]float64{0.50, 0.95, 0.99})
+			for i := range pct {
+				pct[i] /= 1e6 // ns to ms
+			}
+			stats[name] = map[string]interface{}{
+				"count":         m.Count(),
+				"sumMs":         m.Sum() / 1e6, // ns to ms
+				"ratesPerS":     []float64{m.Rate1(), m.Rate5(), m.Rate15()},
+				"percentilesMs": pct,
+			}
+		}
+	})
+	bs, _ := json.MarshalIndent(stats, "", "  ")
+	w.Write(bs)
 }
 
 func (s *apiSvc) getSystemDiscovery(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This adds some stuff to track calls to the /rest interface, as we're anyway carrying around the metrics package now. It gives this kind of data on the /rest/debug/httpmetrics endpoint:

```
{
  "/rest/db/completion": {
    "count": 4,      // number of times this path has been called since startup
    "percentilesMs": [
      4.146201,   // 50th, 95th and 99th percentile response times
      6.278776,
      6.278776
    ],
    "ratesPerS": [
      0.11767717391438157, // 1 minute, 5 minute and 15 minute call rates per second
      0.5452685329550784,
      0.7040391390753369
    ],
    "sumMs": 17  // total number of ms we've spent in this method since startup
  },
  "/rest/db/status": {
    "count": 3,
    "percentilesMs": [
      0.776,
      1.013,
      1.013
    ],
    "ratesPerS": [
      0.0882578804357862,
      0.40895139971630884,
      0.5280293543065027
    ],
    "sumMs": 2
  },
...
```

Actually using this data for something... Well, it tells us what the GUI and other REST clients are doing, and how it affects our performance. The `sumMs` field is essentially a metric of how expensive the call is for us, except for the events call which does a lot of waiting.