### PR TITLE
Handle sparse files (fixes #245)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -35,6 +35,7 @@ type FolderConfiguration struct {
 	PullerSleepS          int                         `xml:"pullerSleepS" json:"pullerSleepS"`
 	PullerPauseS          int                         `xml:"pullerPauseS" json:"pullerPauseS"`
 	MaxConflicts          int                         `xml:"maxConflicts" json:"maxConflicts"`
+	DisableSparseFiles    bool                        `xml:"disableSparseFiles" json:"disableSparseFiles"`
 
 	Invalid    string `xml:"-" json:"invalid"` // Set at runtime when there is an error, not saved
 	cachedPath string

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -27,6 +27,7 @@ type sharedPullerState struct {
 	reused      int // Number of blocks reused from temporary file
 	ignorePerms bool
 	version     protocol.Vector // The current (old) version
+	sparse      bool
 
 	// Mutable, must be locked for access
 	err        error      // The first error we hit
@@ -136,6 +137,15 @@ func (s *sharedPullerState) tempFile() (io.WriterAt, error) {
 	if err != nil {
 		s.failLocked("dst create", err)
 		return nil, err
+	}
+
+	if s.sparse {
+		// Truncate sets the size of the file. This creates a sparse file or a
+		// space reservation, depending on the underlying filesystem.
+		if err := fd.Truncate(s.file.Size()); err != nil {
+			s.failLocked("dst truncate", err)
+			return nil, err
+		}
 	}
 
 	// Same fd will be used by all writers

--- a/lib/protocol/message.go
+++ b/lib/protocol/message.go
@@ -5,7 +5,13 @@
 
 package protocol
 
-import "fmt"
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+)
+
+var sha256OfEmptyBlock = sha256.Sum256(make([]byte, BlockSize))
 
 type IndexMessage struct {
 	Folder  string     // max:256
@@ -96,6 +102,11 @@ type BlockInfo struct {
 
 func (b BlockInfo) String() string {
 	return fmt.Sprintf("Block{%d/%d/%x}", b.Offset, b.Size, b.Hash)
+}
+
+// IsEmpty returns true if the block is a full block of zeroes.
+func (b BlockInfo) IsEmpty() bool {
+	return b.Size == BlockSize && bytes.Equal(b.Hash, sha256OfEmptyBlock[:])
 }
 
 type RequestMessage struct {

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -550,3 +550,27 @@ func (p *Process) eventLoop() {
 		}
 	}
 }
+
+type ConnectionStats struct {
+	Address       string
+	Type          string
+	Connected     bool
+	Paused        bool
+	ClientVersion string
+	InBytesTotal  int64
+	OutBytesTotal int64
+}
+
+func (p *Process) Connections() (map[string]ConnectionStats, error) {
+	bs, err := p.Get("/rest/system/connections")
+	if err != nil {
+		return nil, err
+	}
+
+	var res map[string]ConnectionStats
+	if err := json.Unmarshal(bs, &res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}


### PR DESCRIPTION
This implements sparse file support. It does this by

 - Using `Truncate()` on the temp file to set it to the final size immediately. On NTFS and Unixes this creates a sparse file; on Mac it's just a large file full of zeroes.

 - Not transferring / copying full blocks of zeroes, as these are already present in the file. The exception is if we're reusing a temp file, which might not have zeroes in the right place.

End result is that we don't transfer full blocks of zeroes and may or may not create a sparse file on the destination depending on the filesystem in use. It also means we automatically sparsify existing files when transferring them (again, when supported by the fs).

Blocks of all zeroes that are not exactly BlockSize-sized are not handled specially, so the last block of zeroes in a file may actually get written and also blocks that start with nonzero data. Don't care.