### PR TITLE
Log problems fetching releases

### DIFF
--- a/lib/upgrade/upgrade_common.go
+++ b/lib/upgrade/upgrade_common.go
@@ -30,7 +30,8 @@ type Asset struct {
 
 var (
 	ErrVersionUpToDate    = errors.New("current version is up to date")
-	ErrVersionUnknown     = errors.New("couldn't fetch release information")
+	ErrNoReleaseDownload  = errors.New("couldn't find a release to download")
+	ErrNoVersionToSelect  = errors.New("no version to select")
 	ErrUpgradeUnsupported = errors.New("upgrade unsupported")
 	ErrUpgradeInProgress  = errors.New("upgrade already in progress")
 	upgradeUnlocked       = make(chan bool, 1)

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -49,7 +49,7 @@ var insecureHTTP = &http.Client{
 
 // FetchLatestReleases returns the latest releases, including prereleases or
 // not depending on the argument
-func FetchLatestReleases(releasesURL, version string) ([]Release) {
+func FetchLatestReleases(releasesURL, version string) []Release {
 	resp, err := insecureHTTP.Get(releasesURL)
 	if err != nil {
 		l.Infoln("Couldn't fetch release information:", err)
@@ -86,7 +86,7 @@ func LatestRelease(releasesURL, version string) (Release, error) {
 
 func SelectLatestRelease(version string, rels []Release) (Release, error) {
 	if len(rels) == 0 {
-		return Release{}, ErrVersionUnknown
+		return Release{}, ErrNoVersionToSelect
 	}
 
 	sort.Sort(SortByRelease(rels))
@@ -108,7 +108,7 @@ func SelectLatestRelease(version string, rels []Release) (Release, error) {
 			}
 		}
 	}
-	return Release{}, ErrVersionUnknown
+	return Release{}, ErrNoReleaseDownload
 }
 
 // Upgrade to the given release, saving the previous binary with a ".old" extension.
@@ -124,7 +124,7 @@ func upgradeTo(binary string, rel Release) error {
 		}
 	}
 
-	return ErrVersionUnknown
+	return ErrNoReleaseDownload
 }
 
 // Upgrade to the given release, saving the previous binary with a ".old" extension.

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -49,20 +49,22 @@ var insecureHTTP = &http.Client{
 
 // FetchLatestReleases returns the latest releases, including prereleases or
 // not depending on the argument
-func FetchLatestReleases(releasesURL, version string) ([]Release, error) {
+func FetchLatestReleases(releasesURL, version string) ([]Release) {
 	resp, err := insecureHTTP.Get(releasesURL)
 	if err != nil {
-		return nil, err
+		l.Infoln("Couldn't fetch release information:", err)
+		return nil
 	}
 	if resp.StatusCode > 299 {
-		return nil, fmt.Errorf("API call returned HTTP error: %s", resp.Status)
+		l.Infoln("API call returned HTTP error: %s", resp.Status)
+		return nil
 	}
 
 	var rels []Release
 	json.NewDecoder(resp.Body).Decode(&rels)
 	resp.Body.Close()
 
-	return rels, nil
+	return rels
 }
 
 type SortByRelease []Release
@@ -78,7 +80,7 @@ func (s SortByRelease) Less(i, j int) bool {
 }
 
 func LatestRelease(releasesURL, version string) (Release, error) {
-	rels, _ := FetchLatestReleases(releasesURL, version)
+	rels := FetchLatestReleases(releasesURL, version)
 	return SelectLatestRelease(version, rels)
 }
 

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -47,9 +47,9 @@ var insecureHTTP = &http.Client{
 	},
 }
 
-// LatestGithubReleases returns the latest releases, including prereleases or
+// FetchLatestReleases returns the latest releases, including prereleases or
 // not depending on the argument
-func LatestGithubReleases(releasesURL, version string) ([]Release, error) {
+func FetchLatestReleases(releasesURL, version string) ([]Release, error) {
 	resp, err := insecureHTTP.Get(releasesURL)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s SortByRelease) Less(i, j int) bool {
 }
 
 func LatestRelease(releasesURL, version string) (Release, error) {
-	rels, _ := LatestGithubReleases(releasesURL, version)
+	rels, _ := FetchLatestReleases(releasesURL, version)
 	return SelectLatestRelease(version, rels)
 }
 


### PR DESCRIPTION
This allows me to see errors like:
```
[F2C6I] 17:05:32 INFO: Couldn't query Github:  Get https:/
/api.github.com/repos/syncthing/syncthing/releases?per_page=30: x509: failed to 
load system roots and no roots provided```
```
On my FreeNAS (minimal FreeBSD) installation rather than the ambiguous ```Automatic upgrade: couldn't fetch release information``` (which could be caused by two different cases in ```SelectLatestRelease```).