### PR TITLE
Remove Android hacks (fixes #2505)

### DIFF
--- a/build.go
+++ b/build.go
@@ -448,7 +448,6 @@ func ldflags() string {
 	fmt.Fprintf(b, " -X main.BuildStamp%c%d", sep, buildStamp())
 	fmt.Fprintf(b, " -X main.BuildUser%c%s", sep, buildUser())
 	fmt.Fprintf(b, " -X main.BuildHost%c%s", sep, buildHost())
-	fmt.Fprintf(b, " -X main.BuildEnv%c%s", sep, buildEnvironment())
 	return b.String()
 }
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -49,7 +49,6 @@ import (
 var (
 	Version     = "unknown-dev"
 	Codename    = "Beryllium Bedbug"
-	BuildEnv    = "default"
 	BuildStamp  = "0"
 	BuildDate   time.Time
 	BuildHost   = "unknown"
@@ -108,7 +107,7 @@ func init() {
 	BuildDate = time.Unix(int64(stamp), 0)
 
 	date := BuildDate.UTC().Format("2006-01-02 15:04:05 MST")
-	LongVersion = fmt.Sprintf(`syncthing %s "%s" (%s %s-%s %s) %s@%s %s`, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildEnv, BuildUser, BuildHost, date)
+	LongVersion = fmt.Sprintf(`syncthing %s "%s" (%s %s-%s) %s@%s %s`, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildUser, BuildHost, date)
 
 	if os.Getenv("STTRACE") != "" {
 		logFlags = log.Ltime | log.Ldate | log.Lmicroseconds | log.Lshortfile

--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -13,7 +13,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"runtime"
 	"sort"
@@ -249,19 +248,14 @@ func (s *usageReportingService) sendUsageReport() error {
 	var b bytes.Buffer
 	json.NewEncoder(&b).Encode(d)
 
-	transp := &http.Transport{}
-	client := &http.Client{Transport: transp}
-	if BuildEnv == "android" {
-		// This works around the lack of DNS resolution on Android... :(
-		transp.Dial = func(network, addr string) (net.Conn, error) {
-			return dialer.Dial(network, "194.126.249.13:443")
-		}
-	}
-
-	if s.cfg.Options().URPostInsecurely {
-		transp.TLSClientConfig = &tls.Config{
-			InsecureSkipVerify: true,
-		}
+	client := &http.Client{
+		Transport: &http.Transport{
+			Dial:  dialer.Dial,
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: s.cfg.Options().URPostInsecurely,
+			},
+		},
 	}
 	_, err := client.Post(s.cfg.Options().URURL, "application/json", &b)
 	return err

--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -183,8 +183,6 @@ func reportData(cfg *config.Wrapper, m *model.Model) map[string]interface{} {
 	for _, addr := range cfg.Options().GlobalAnnServers {
 		if addr == "default" || addr == "default-v4" || addr == "default-v6" {
 			defaultAnnounceServersDNS++
-		} else if stringIn(addr, config.DefaultDiscoveryServersIP) {
-			defaultAnnounceServersIP++
 		} else {
 			otherAnnounceServers++
 		}
@@ -218,15 +216,6 @@ func reportData(cfg *config.Wrapper, m *model.Model) map[string]interface{} {
 	res["upgradeAllowedAuto"] = !(upgrade.DisabledByCompilation || noUpgrade) && cfg.Options().AutoUpgradeIntervalH > 0
 
 	return res
-}
-
-func stringIn(needle string, haystack []string) bool {
-	for _, s := range haystack {
-		if needle == s {
-			return true
-		}
-	}
-	return false
 }
 
 type usageReportingService struct {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -48,16 +48,6 @@ var (
 	// DefaultDiscoveryServers should be substituted when the configuration
 	// contains <globalAnnounceServer>default</globalAnnounceServer>.
 	DefaultDiscoveryServers = append(DefaultDiscoveryServersV4, DefaultDiscoveryServersV6...)
-
-	// DefaultDiscoveryServersIP is used by the usage reporting.
-	DefaultDiscoveryServersIP = []string{
-		"https://194.126.249.5/?id=SR7AARM-TCBUZ5O-VFAXY4D-CECGSDE-3Q6IZ4G-XG7AH75-OBIXJQV-QJ6NLQA",
-		"https://45.55.230.38/?id=AQEHEO2-XOS7QRA-X2COH5K-PO6OPVA-EWOSEGO-KZFMD32-XJ4ZV46-CUUVKAS",
-		"https://128.199.95.124/?id=VK6HNJ3-VVMM66S-HRVWSCR-IXEHL2H-U4AQ4MW-UCPQBWX-J2L2UBK-NVZRDQZ",
-		"https://[2001:470:28:4d6::5]/?id=SR7AARM-TCBUZ5O-VFAXY4D-CECGSDE-3Q6IZ4G-XG7AH75-OBIXJQV-QJ6NLQA",
-		"https://[2604:a880:800:10::182:a001]/?id=AQEHEO2-XOS7QRA-X2COH5K-PO6OPVA-EWOSEGO-KZFMD32-XJ4ZV46-CUUVKAS",
-		"https://[2400:6180:0:d0::d9:d001]/?id=VK6HNJ3-VVMM66S-HRVWSCR-IXEHL2H-U4AQ4MW-UCPQBWX-J2L2UBK-NVZRDQZ",
-	}
 )
 
 func New(myID protocol.DeviceID) Configuration {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -50,7 +50,6 @@ var (
 	DefaultDiscoveryServers = append(DefaultDiscoveryServersV4, DefaultDiscoveryServersV6...)
 
 	// DefaultDiscoveryServersIP is used by the usage reporting.
-	// XXX: Detect Android, and use this is we still don't have working DNS?
 	DefaultDiscoveryServersIP = []string{
 		"https://194.126.249.5/?id=SR7AARM-TCBUZ5O-VFAXY4D-CECGSDE-3Q6IZ4G-XG7AH75-OBIXJQV-QJ6NLQA",
 		"https://45.55.230.38/?id=AQEHEO2-XOS7QRA-X2COH5K-PO6OPVA-EWOSEGO-KZFMD32-XJ4ZV46-CUUVKAS",


### PR DESCRIPTION
Also fixes what I think migh thave been a bug where we did not use the
proxy for usage reports. And removes the BuildEnv field that we don't
need any more.