### PR TITLE
Don't chmod in Atomic on android (fixes  #2472)

### DIFF
--- a/lib/osutil/atomic.go
+++ b/lib/osutil/atomic.go
@@ -37,10 +37,13 @@ func CreateAtomic(path string, mode os.FileMode) (*AtomicWriter, error) {
 		return nil, err
 	}
 
-	if err := os.Chmod(fd.Name(), mode); err != nil {
-		fd.Close()
-		os.Remove(fd.Name())
-		return nil, err
+	// chmod fails on Android so don't even try
+	if runtime.GOOS != "android" {
+		if err := os.Chmod(fd.Name(), mode); err != nil {
+			fd.Close()
+			os.Remove(fd.Name())
+			return nil, err
+		}
 	}
 
 	w := &AtomicWriter{


### PR DESCRIPTION
I haven't touched Go before so though this would be a simple fix.
Turns out I am having trouble getting it to compile and run on android so I thought Zillode  or Nutomic could check if I made a ridiculous mistake.