### PR TITLE
Linear backoff on global discovery lookups.

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -739,9 +739,9 @@ func syncthingMain() {
 			}
 
 			// Each global discovery server gets its results cached for five
-			// minutes, and is not asked again for a minute when it's returned
-			// unsuccessfully.
-			cachedDiscovery.Add(gd, 5*time.Minute, time.Minute, globalDiscoveryPriority)
+			// minutes, and is not asked again for up to 60 minutes when it's
+			// returned unsuccessfully.
+			cachedDiscovery.Add(gd, 5*time.Minute, 60*time.Minute, globalDiscoveryPriority)
 		}
 	}
 

--- a/lib/discover/discover.go
+++ b/lib/discover/discover.go
@@ -26,6 +26,7 @@ type CacheEntry struct {
 	Relays []Relay   `json:"relays"`
 	when   time.Time // When did we get the result
 	found  bool      // Is it a success (cacheTime applies) or a failure (negCacheTime applies)?
+	hits   int
 }
 
 // A FinderService is a Finder that has background activity and must be run as


### PR DESCRIPTION
This adds linearly increasing negative cache times to global lookups.
The first failure gets cached for one minute, the second for two
minutes, the third for three minutes and so on up to a maximum of 60
minutes. The vast majority of load on the discovery servers are devices
asking each minute for devices that don't exist or haven't been online
for a very long time. This reduces this load, at the price of slower
connects when a device comes online after a long absence. Note that
connections *from* that device will still be quick, so if bidirectional
connects are possible it will still be fast.

Also note that the progression is fairly slow; we reach 15 minute
retries two hours after startup, and the maximum of one hour retries
after 30 hours (1+2+3+...+59 minutes).

If a device is actually found, the retry time is reset of course.