### PR TITLE
staticClient.connect(): don't handshake twice (fixes #2547, #2548)

### DIFF
--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -200,9 +200,6 @@ func (c *staticClient) connect() error {
 	c.mut.Unlock()
 
 	conn := tls.Client(tcpConn, c.config)
-	if err = conn.Handshake(); err != nil {
-		return err
-	}
 
 	if err := conn.SetDeadline(time.Now().Add(c.connectTimeout)); err != nil {
 		conn.Close()


### PR DESCRIPTION
The first handshake occurred before setting the Deadline, which could
cause an unintended hang.