### PR TITLE
upnp: Use a separate error for the error unmarshalling

### DIFF
--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -531,9 +531,9 @@ func (s *IGDService) AddPortMapping(localIPAddress string, protocol Protocol, ex
 	if err != nil && timeout > 0 {
 		// Try to repair error code 725 - OnlyPermanentLeasesSupported
 		envelope := &soapErrorResponse{}
-		err = xml.Unmarshal(response, envelope)
-		if err != nil {
-			return err
+		err2 := xml.Unmarshal(response, envelope)
+		if err2 != nil {
+			return err2
 		}
 		if envelope.ErrorCode == 725 {
 			return s.AddPortMapping(localIPAddress, protocol, externalPort, internalPort, description, 0)


### PR DESCRIPTION
Previously, when unmarshing the SOAP error code data we would overwrite
the original err, typically with null since the parsing of the error
code information succeeds. If we don't have a upnp 725 error, we would fall
back to returning null or no error. This broke our upnp error handling
logic for AddPortMappings as it would think it succeeds if it gets a 718
permission error.