### PR TITLE
systemd: Remove exit code 2, due to #2578

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -6,10 +6,9 @@ Wants=syncthing-inotify@.service
 
 [Service]
 User=%i
-Environment=STNORESTART=yes
-ExecStart=/usr/bin/syncthing -no-browser -logflags=0
+ExecStart=/usr/bin/syncthing -no-browser -no-restart -logflags=0
 Restart=on-failure
-SuccessExitStatus=2 3 4
+SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 
 [Install]

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -5,10 +5,9 @@ After=network.target
 Wants=syncthing-inotify.service
 
 [Service]
-Environment=STNORESTART=yes
-ExecStart=/usr/bin/syncthing -no-browser -logflags=0
+ExecStart=/usr/bin/syncthing -no-browser -no-restart -logflags=0
 Restart=on-failure
-SuccessExitStatus=2 3 4
+SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 
 [Install]


### PR DESCRIPTION
PR #2578 enables us to remove the exit code 2 from the list of
success status codes, because SIGINT will be handled properly.
I have also converted STNORESTART to --no-restart for the sake
of consistency.