### PR TITLE
Add helper function to format JSON responses

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,8 +36,8 @@ Francois-Xavier Gsell <fxgsell@gmail.com>
 Frank Isemann <frank@isemann.name>
 Gilli Sigurdsson <gilli@vx.is>
 Jacek Szafarkiewicz <szafar@linux.pl>
-Jakob Borg <jakob@nym.se>
 Jake Peterson <jake@acogdev.com>
+Jakob Borg <jakob@nym.se>
 James Patterson <jamespatterson@operamail.com> <jpjp@users.noreply.github.com>
 Jaroslav Malec <dzardacz@gmail.com>
 Jens Diemer <github.com@jensdiemer.de> <git@jensdiemer.de>
@@ -64,15 +64,15 @@ Piotr Bejda <piotrb10@gmail.com>
 Ryan Sullivan <kayoticsully@gmail.com>
 Scott Klupfel <kluppy@going2blue.com>
 Sergey Mishin <ralder@yandex.ru>
-Stefan Tatschner <stefan@sevenbyte.org> <rumpelsepp@sevenbyte.org>
 Stefan Kuntz <stefan.github@gmail.com> <Stefan.github@gmail.com>
+Stefan Tatschner <stefan@sevenbyte.org> <rumpelsepp@sevenbyte.org>
 Tim Abell <tim@timwise.co.uk>
 Tobias Nygren <tnn@nygren.pp.se>
 Tomas Cerveny <kozec@kozec.com>
 Tully Robinson <tully@tojr.org>
 Tyler Brazier <tyler@tylerbrazier.com>
 Veeti Paananen <veeti.paananen@rojekti.fi>
-Vil Brekin <vilbrekin@gmail.com>
 Victor Buinsky <vix_booja@tut.by>
+Vil Brekin <vilbrekin@gmail.com>
 William A. Kennington III <william@wkennington.com>
 Yannic A. <eipiminusone+github@gmail.com> <eipiminus1@users.noreply.github.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@
 Aaron Bieber <qbit@deftly.net>
 Adam Piggott	<aD@simplypeachy.co.uk> <simplypeachy@users.noreply.github.com>
 Alexander Graf <register-github@alex-graf.de>
+Anderson Mesquita <andersonvom@gmail.com>
 Andrew Dunham <andrew@du.nham.ca>
 Antony Male <antony.male@gmail.com>
 Arthur Axel fREW Schmidt <frew@afoolishmanifesto.com> <frioux@gmail.com>


### PR DESCRIPTION
Every time a JSON object is returned in an HTTP response, the
appropriate header needs to be set and the object itself needs to be
encoded. Doing this in every function is repetitive and error prone
(getDBFile and postDBScan, for instance, never set any headers).

This adds a helper function to centralize the appropriate JSON response
handling.