### PR TITLE
Remove some global variables from main.go

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -209,7 +209,7 @@ type RuntimeOptions struct {
 	generateDir    string
 	noRestart      bool
 	profiler       string
-	guiAssets      string
+	assetDir       string
 	cpuProfile     bool
 	stRestarting   bool
 	logFlags       int
@@ -219,15 +219,15 @@ func defaultRuntimeOptions() RuntimeOptions {
 	options := RuntimeOptions{
 		noRestart:    os.Getenv("STNORESTART") != "",
 		profiler:     os.Getenv("STPROFILER"),
-		guiAssets:    os.Getenv("STGUIASSETS"),
+		assetDir:     os.Getenv("STGUIASSETS"),
 		cpuProfile:   os.Getenv("STCPUPROFILE") != "",
 		stRestarting: os.Getenv("STRESTART") != "",
 		logFile:      "-", // Output to stdout
 		logFlags:     log.Ltime,
 	}
 
-	if options.guiAssets != "" {
-		options.guiAssets = locations[locGUIAssets]
+	if options.assetDir != "" {
+		options.assetDir = locations[locGUIAssets]
 	}
 
 	if os.Getenv("STTRACE") != "" {
@@ -976,7 +976,7 @@ func setupGUI(mainSvc *suture.Supervisor, cfg *config.Wrapper, m *model.Model, a
 		l.Warnln("Insecure admin access is enabled.")
 	}
 
-	api, err := newAPISvc(myID, cfg, runtimeOptions.guiAssets, m, apiSub, discoverer, relaySvc, errors, systemLog)
+	api, err := newAPISvc(myID, cfg, runtimeOptions.assetDir, m, apiSub, discoverer, relaySvc, errors, systemLog)
 	if err != nil {
 		l.Fatalln("Cannot start GUI:", err)
 	}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -366,17 +366,7 @@ func generate(generateDir string) {
 	if err != nil {
 		l.Fatalln("generate:", err)
 	}
-
-	info, err := os.Stat(dir)
-	if err == nil && !info.IsDir() {
-		l.Fatalln(dir, "is not a directory")
-	}
-	if err != nil && os.IsNotExist(err) {
-		err = osutil.MkdirAll(dir, 0700)
-		if err != nil {
-			l.Fatalln("generate:", err)
-		}
-	}
+	ensureDir(dir, 0700)
 
 	certFile, keyFile := filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem")
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -199,7 +199,7 @@ type RuntimeOptions struct {
 	upgradeTo      string
 	noBrowser      bool
 	browserOnly    bool
-	noConsole      bool
+	hideConsole    bool
 	logFile        string
 	auditEnabled   bool
 	verbose        bool
@@ -263,7 +263,7 @@ func parseCommandLineOptions() RuntimeOptions {
 	flag.StringVar(&options.logFile, "logfile", options.logFile, "Log file name (use \"-\" for stdout)")
 	if runtime.GOOS == "windows" {
 		// Allow user to hide the console window
-		flag.BoolVar(&options.noConsole, "no-console", false, "Hide console window")
+		flag.BoolVar(&options.hideConsole, "no-console", false, "Hide console window")
 	}
 
 	longUsage := fmt.Sprintf(extraUsage, baseDirs["config"], debugFacilities())
@@ -286,7 +286,7 @@ func main() {
 		os.Setenv("STGUIAPIKEY", options.guiAPIKey)
 	}
 
-	if options.noConsole {
+	if options.hideConsole {
 		osutil.HideConsole()
 	}
 

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -34,13 +34,14 @@ const (
 	logFileMaxOpenTime    = time.Minute
 )
 
-func monitorMain() {
+func monitorMain(runtimeOptions RuntimeOptions) {
 	os.Setenv("STNORESTART", "yes")
 	os.Setenv("STMONITORED", "yes")
 	l.SetPrefix("[monitor] ")
 
 	var dst io.Writer = os.Stdout
 
+	logFile := runtimeOptions.logFile
 	if logFile != "-" {
 		var fileDst io.Writer = newAutoclosedFile(logFile, logFileAutoCloseDelay, logFileMaxOpenTime)
 


### PR DESCRIPTION
This is a first step towards getting rid of the global variables currently in use (plus some minor improvements along the way). The remaining globals will take quite a bit of refactoring, so they will have to be addressed in later commits.