### PR TITLE
Only override TLS settings if scheme is specified

### DIFF
--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -44,7 +44,7 @@ func (c GUIConfiguration) Address() string {
 }
 
 func (c GUIConfiguration) UseTLS() bool {
-	if override := os.Getenv("STGUIADDRESS"); override != "" {
+	if override := os.Getenv("STGUIADDRESS"); override != "" && strings.HasPrefix(override, "http") {
 		return strings.HasPrefix(override, "https:")
 	}
 	return c.RawUseTLS


### PR DESCRIPTION
I feel this is more like the expected behaviour.