### PR TITLE
Centralize config loading logic (also fixes #2509)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -603,7 +603,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	}
 
 	if err := checkShortIDs(cfg); err != nil {
-		l.Fatalln("Short device IDs are in conflict. Unlucky!\n  Regenerate the device ID of one if the following:\n  ", err)
+		l.Fatalln("Short device IDs are in conflict. Unlucky!\n  Regenerate the device ID of one of the following:\n  ", err)
 	}
 
 	if len(runtimeOptions.profiler) > 0 {


### PR DESCRIPTION
This gets rid of redundant checks and centralizes the logic of loading
the config files so that we don't have to keep doing the same thing in
multiple places.