### PR TITLE
Don't crash on stat error in ensureDir (fixes #2608)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -1036,13 +1036,17 @@ func ensureDir(dir string, mode os.FileMode) {
 		l.Fatalln(err)
 	}
 
-	fi, _ := os.Stat(dir)
-	currentMode := fi.Mode() & 0777
-	if mode >= 0 && currentMode != mode {
-		err := os.Chmod(dir, mode)
-		// This can fail on crappy filesystems, nothing we can do about it.
-		if err != nil {
-			l.Warnln(err)
+	if fi, err := os.Stat(dir); err == nil {
+		// Apprently the stat may fail even though the mkdirall passed. If it
+		// does, we'll just assume things are in order and let other things
+		// fail (like loading or creating the config...).
+		currentMode := fi.Mode() & 0777
+		if currentMode != mode {
+			err := os.Chmod(dir, mode)
+			// This can fail on crappy filesystems, nothing we can do about it.
+			if err != nil {
+				l.Warnln(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
I'm not really sure under what circumstances MkdirAll returns a nil
error but a subsequent stat fails, but apparently it can happen and we
need to handle it. The "mode >= 0" was a no-op, and we never call
ensureDir anyway without the intention of ensuring the mode, so removed
that.