### PR TITLE
Humanize serialization of version vectors

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -10,6 +10,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"crypto/tls"
+	"encoding/base32"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -1138,8 +1140,11 @@ type jsonVersionVector protocol.Vector
 
 func (v jsonVersionVector) MarshalJSON() ([]byte, error) {
 	res := make([]string, len(v))
+	bs := make([]byte, 8)
 	for i, c := range v {
-		res[i] = fmt.Sprintf("%d:%d", c.ID, c.Value)
+		binary.BigEndian.PutUint64(bs, c.ID)
+		id := base32.StdEncoding.EncodeToString(bs)
+		res[i] = fmt.Sprintf("%s:%d", id[:7], c.Value)
 	}
 	return json.Marshal(res)
 }


### PR DESCRIPTION
This makes the output of version vectors easier to understand, by encoding the ID as the first character group of the device ID. I.e.

```json
"global": {
    "flags": "0644",
    "localVersion": 673634,
    "modified": "2015-12-21T14:48:28+01:00",
    "name": "Lightroom Catalog.lrcat",
    "numBlocks": 6105,
    "size": 800092160,
    "version": [
      "9186365928295258957:48",
      "16401037966434831212:1",
      "17926325417065620423:104",
      "18446744073709551615:1"
    ]
  },
```

becomes

```json
  "global": {
    "flags": "0644",
    "localVersion": 673634,
    "modified": "2015-12-21T14:48:28+01:00",
    "name": "Lightroom Catalog.lrcat",
    "numBlocks": 6105,
    "size": 800092160,
    "version": [
      "P56IOI7:48",
      "4OODCIS:1",
      "7DDRT7J:104",
      "7777777:1"
    ]
  },
```

which I think makes everyone happier. I also don't think we've ever advertised it as anything other than an opaque string so there should be no issue changing this in the middle of a minor version.

(It also exposes that something weird has happened along the way as I don't think we're supposed to have protocol.LocalDeviceID (77777....) in there. ;)