### PR TITLE
Fixed problem where Shared With list starts with comma is web GUI

### DIFF
--- a/gui/syncthing/core/syncthingController.js
+++ b/gui/syncthing/core/syncthingController.js
@@ -1322,7 +1322,8 @@ angular.module('syncthing.core')
             var names = [];
             folderCfg.devices.forEach(function (device) {
                 if (device.deviceID != $scope.myID) {
-                    names.push($scope.deviceName($scope.findDevice(device.deviceID)));
+                    var name = $scope.deviceName($scope.findDevice(device.deviceID));
+                    if (name != "") names.push(name);
                 }
             });
             names.sort();


### PR DESCRIPTION
As explained in #2626, if for some reason the user has added two devices with the same ID, the Shared With list on the folder panel starts with a comma, which looks weird. Ideally there would be some error when a user adds a device with an ID already used, but this is a visual fix until that is implemented.