### PR TITLE
Stops user from adding duplicate ID in gui

### DIFF
--- a/gui/syncthing/core/validDeviceidDirective.js
+++ b/gui/syncthing/core/validDeviceidDirective.js
@@ -12,15 +12,19 @@ angular.module('syncthing.core')
                             if (resp.error) {
                                 ctrl.$setValidity('validDeviceid', false);
                             } else {
-                                ctrl.$setValidity('validDeviceid', true);
+                                ctrl.$setValidity('validDeviceid', true); 
                             }
                         });
                         //Prevents user from adding a duplicate ID
                         var matches = scope.devices.filter(function (n) {
                             return n.deviceID == viewValue;
                         }).length;
-                        if (matches > 0) ctrl.$setValidity('unique', false);
-                        else ctrl.$setValidity('unique', true);
+                        if (matches > 0) {
+                            ctrl.$setValidity('unique', false);
+                        }
+                        else {
+                            ctrl.$setValidity('unique', true);
+                        }
                     }
                     return viewValue;
                 });

--- a/gui/syncthing/core/validDeviceidDirective.js
+++ b/gui/syncthing/core/validDeviceidDirective.js
@@ -12,7 +12,7 @@ angular.module('syncthing.core')
                             if (resp.error) {
                                 ctrl.$setValidity('validDeviceid', false);
                             } else {
-                                ctrl.$setValidity('validDeviceid', true); 
+                                ctrl.$setValidity('validDeviceid', true);
                             }
                         });
                         //Prevents user from adding a duplicate ID

--- a/gui/syncthing/core/validDeviceidDirective.js
+++ b/gui/syncthing/core/validDeviceidDirective.js
@@ -15,6 +15,12 @@ angular.module('syncthing.core')
                                 ctrl.$setValidity('validDeviceid', true);
                             }
                         });
+                        //Prevents user from adding a duplicate ID
+                        var matches = scope.devices.filter(function (n) {
+                            return n.deviceID == viewValue;
+                        }).length;
+                        if (matches > 0) ctrl.$setValidity('unique', false);
+                        else ctrl.$setValidity('unique', true);
                     }
                     return viewValue;
                 });

--- a/gui/syncthing/core/validDeviceidDirective.js
+++ b/gui/syncthing/core/validDeviceidDirective.js
@@ -21,8 +21,7 @@ angular.module('syncthing.core')
                         }).length;
                         if (matches > 0) {
                             ctrl.$setValidity('unique', false);
-                        }
-                        else {
+                        } else {
                             ctrl.$setValidity('unique', true);
                         }
                     }

--- a/gui/syncthing/device/editDeviceModalView.html
+++ b/gui/syncthing/device/editDeviceModalView.html
@@ -21,6 +21,7 @@
               <span translate ng-show="!editingExisting && (deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine)">When adding a new device, keep in mind that this device must be added on the other side too.</span>
               <span translate ng-if="deviceEditor.deviceID.$error.required && deviceEditor.deviceID.$dirty">The device ID cannot be blank.</span>
               <span translate ng-if="deviceEditor.deviceID.$error.validDeviceid && deviceEditor.deviceID.$dirty">The entered device ID does not look valid. It should be a 52 or 56 character string consisting of letters and numbers, with spaces and dashes being optional.</span>
+              <span translate ng-if="deviceEditor.deviceID.$error.unique && deviceEditor.deviceID.$dirty">A device with that ID is already added.</span>
             </p>
           </div>
           <div class="form-group">


### PR DESCRIPTION
Adds check in valid device id directive to check for uniqueness. If user wants to force a duplicate, cli or manual config change is still available. But for most users, it should be a good check. I can't think of a valid use case for a duplicate id, and it seems to introduce some problems.

Mentioned in  #1675,#2465, and some other issues.

Feel free to change error message, I just wrote a sample one. 

Also, am I required to update the translation files in any way to have a GUI change accepted?
