### PR TITLE
Ensure loaded config is free of duplicate devices (fixes #2627)

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -592,3 +592,29 @@ func TestGUIConfigURL(t *testing.T) {
 		}
 	}
 }
+
+func TestRemoveDuplicateDevicesFolders(t *testing.T) {
+	wrapper, err := Load("testdata/duplicates.xml", device1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// All folders are loaded, but the duplicate ones are disabled.
+	if l := len(wrapper.Raw().Folders); l != 3 {
+		t.Errorf("Incorrect number of folders, %d != 3", l)
+	}
+	for i, f := range wrapper.Raw().Folders {
+		if f.ID == "f1" && f.Invalid == "" {
+			t.Errorf("Folder %d (%q) is not set invalid", i, f.ID)
+		}
+	}
+
+	if l := len(wrapper.Raw().Devices); l != 3 {
+		t.Errorf("Incorrect number of devices, %d != 3", l)
+	}
+
+	f := wrapper.Folders()["f2"]
+	if l := len(f.Devices); l != 2 {
+		t.Errorf("Incorrect number of folder devices, %d != 2", l)
+	}
+}

--- a/lib/config/testdata/duplicates.xml
+++ b/lib/config/testdata/duplicates.xml
@@ -1,0 +1,33 @@
+<configuration version="12">
+    <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR">
+        <address>192.0.2.1</address>
+        <address>192.0.2.2</address>
+    </device>
+    <device id="GYRZZQBIRNPV4T7TC52WEQYJ3TFDQW6MWDFLMU4SSSU6EMFBK2VA">
+        <address>192.0.2.3:6070</address>
+        <address>[2001:db8::42]:4242</address>
+    </device>
+    <device id="LGFPDIT7SKNNJVJZA4FC7QNCRKCE753K72BW5QD2FOZ7FRFEP57Q">
+        <address>[2001:db8::44]:4444</address>
+        <address>192.0.2.4:6090</address>
+    </device>
+    <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR">
+        <!-- duplicate, will be removed -->
+        <address>192.0.2.5</address>
+    </device>
+    <folder id="f1" directory="testdata/">
+        <!-- duplicate, will be disabled -->
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+        <device id="GYRZZQBIRNPV4T7TC52WEQYJ3TFDQW6MWDFLMU4SSSU6EMFBK2VA"></device>
+    </folder>
+    <folder id="f1" directory="testdata/">
+        <!-- duplicate, will be disabled -->
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+    </folder>
+    <folder id="f2" directory="testdata/">
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+        <device id="GYRZZQBIRNPV4T7TC52WEQYJ3TFDQW6MWDFLMU4SSSU6EMFBK2VA"></device>
+        <!-- duplicate device, will be removed -->
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+    </folder>
+</configuration>


### PR DESCRIPTION
We pick the first one and keep that.