### PR TITLE
Detect nonstandard hash algo and stop folder (ref #2314)

### DIFF
--- a/lib/protocol/hashalgorithm.go
+++ b/lib/protocol/hashalgorithm.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 The Protocol Authors.
+
+package protocol
+
+import "fmt"
+
+type HashAlgorithm int
+
+const (
+	SHA256 HashAlgorithm = iota
+)
+
+func (h HashAlgorithm) String() string {
+	switch h {
+	case SHA256:
+		return "sha256"
+	default:
+		return "unknown"
+	}
+}
+
+// FlagBits returns the bits that we should or into the folder flag field to
+// indicate the hash algorithm.
+func (h HashAlgorithm) FlagBits() uint32 {
+	switch h {
+	case SHA256:
+		return FolderHashSHA256 << FolderHashShiftBits
+	default:
+		panic("unknown hash algorithm")
+	}
+}
+
+func (h *HashAlgorithm) UnmarshalText(bs []byte) error {
+	switch string(bs) {
+	case "sha256":
+		*h = SHA256
+		return nil
+	}
+	return fmt.Errorf("Unknown hash algorithm %q", string(bs))
+}
+
+func (h *HashAlgorithm) MarshalText() ([]byte, error) {
+	return []byte(h.String()), nil
+}
+
+func HashAlgorithmFromFlagBits(flags uint32) (HashAlgorithm, error) {
+	algo := flags >> FolderHashShiftBits & FolderHashMask
+	switch algo {
+	case FolderHashSHA256:
+		return SHA256, nil
+	default:
+		return 0, fmt.Errorf("Unknown hash algorithm %d", algo)
+	}
+}

--- a/lib/protocol/hashalgorithm_test.go
+++ b/lib/protocol/hashalgorithm_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2016 The Protocol Authors.
+
+package protocol
+
+import "testing"
+
+/*
+   0                   1                   2                   3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                       Reserved                  | Hash  |D|P|R|
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+*/
+func TestHashAlgorithmFromFlagBits(t *testing.T) {
+	// SHA256 is algorithm zero, shifted three bits to the left (for clarity,
+	// I know it doesn't actually do anything).
+
+	sha256 := uint32(0 << 3)
+
+	h, err := HashAlgorithmFromFlagBits(sha256)
+	if err != nil {
+		t.Error(err)
+	}
+	if h != SHA256 {
+		t.Error("Zero should have unmarshalled as SHA256")
+	}
+
+	// Any other algorithm is unknown
+	unknown := uint32(1 << 3)
+
+	_, err = HashAlgorithmFromFlagBits(unknown)
+	if err == nil {
+		t.Error("Unknown algo should not have unmarshalled")
+	}
+}

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -66,6 +66,13 @@ const (
 	FlagFolderReadOnly     uint32 = 1 << 0
 	FlagFolderIgnorePerms         = 1 << 1
 	FlagFolderIgnoreDelete        = 1 << 2
+
+	// The folder hash algorithm IDs, to be put in the flags field by shifting
+	// left FolderHashShiftBits
+	FolderHashSHA256 = 0
+	// ... 1 through 15 currently reserved
+	FolderHashMask      = 15
+	FolderHashShiftBits = 3
 )
 
 // ClusterConfigMessage.Folders.Devices flags


### PR DESCRIPTION
This implements the changed part of the protocol spec in that it interprets the hash algorithm bits in the ClusterConfig message. These must currently always be zero (SHA256), otherwise the folder is stopped with an "unknown hash algorithm from [some device id]" error.

Moves the FolderRejected event from the index message to the clusterconfig message as we now actually look through the folder list there.