### PR TITLE
Change default max conflicts to 10 (fixes #2604)

### DIFF
--- a/gui/syncthing/core/syncthingController.js
+++ b/gui/syncthing/core/syncthingController.js
@@ -1200,7 +1200,7 @@ angular.module('syncthing.core')
             };
             $scope.currentFolder.rescanIntervalS = 60;
             $scope.currentFolder.minDiskFreePct = 1;
-            $scope.currentFolder.maxConflicts = -1;
+            $scope.currentFolder.maxConflicts = 10;
             $scope.currentFolder.order = "random";
             $scope.currentFolder.fileVersioningSelector = "none";
             $scope.currentFolder.trashcanClean = 0;
@@ -1222,7 +1222,7 @@ angular.module('syncthing.core')
                 selectedDevices: {},
                 rescanIntervalS: 60,
                 minDiskFreePct: 1,
-                maxConflicts: -1,
+                maxConflicts: 10,
                 order: "random",
                 fileVersioningSelector: "none",
                 trashcanClean: 0,


### PR DESCRIPTION
This changes the default in the GUI for max conflicts from unlimited to ten. Old configs still convert to unlimited (as that was the old behavior), and existing config values aren't touched.