### PR TITLE
Don't allow in use CSRF tokens to expire (fixes #1008)

### DIFF
--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import "testing"
+
+func TestCSRFToken(t *testing.T) {
+	t1 := newCsrfToken()
+	t2 := newCsrfToken()
+
+	t3 := newCsrfToken()
+	if !validCsrfToken(t3) {
+		t.Fatal("t3 should be valid")
+	}
+
+	for i := 0; i < 250; i++ {
+		if i%5 == 0 {
+			// t1 and t2 should remain valid by virtue of us checking them now
+			// and then.
+			if !validCsrfToken(t1) {
+				t.Fatal("t1 should be valid at iteration", i)
+			}
+			if !validCsrfToken(t2) {
+				t.Fatal("t2 should be valid at iteration", i)
+			}
+		}
+
+		// The newly generated token is always valid
+		t4 := newCsrfToken()
+		if !validCsrfToken(t4) {
+			t.Fatal("t4 should be valid at iteration", i)
+		}
+	}
+
+	if validCsrfToken(t3) {
+		t.Fatal("t3 should have expired by now")
+	}
+}


### PR DESCRIPTION
Prior to this change, we generate a new CSRF token in response to every GET request that doesn't have one already, and we keep the 10 last tokens we generated. A problem with this is that a new browser visit generates at least one, sometimes several, requests that result in new tokens. This means that a GUI that is left running gets its token revoked after ten visits by other browsers, or sometimes much less (at least Safari generates GET for / and /apple-touch-icon-precomposed.png simultaneously, thus consuming two tokens).

This causes things like config POSTs that don't "take" and so on.

With this change, we keep a few more tokens around, and we reorder the list based on usage. So a browser session that is alive gets its token moved to the head of the list on each request, thus ensuring it stays alive for longer.