### PR TITLE
Don't crash on folder remove while pulling (fixes #2705)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1168,6 +1168,10 @@ func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 	m.fmut.RLock()
 	files := m.folderFiles[folder]
 	m.fmut.RUnlock()
+	if files == nil {
+		// The folder doesn't exist.
+		return
+	}
 	files.Update(protocol.LocalDeviceID, fs)
 
 	filenames := make([]string, len(fs))

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -527,6 +527,13 @@ func (p *rwFolder) pullerIteration(ignores *ignore.Matcher) int {
 
 nextFile:
 	for {
+		select {
+		case <-p.stop:
+			// Stop processing files if the puller has been told to stop.
+			break
+		default:
+		}
+
 		fileName, ok := p.queue.Pop()
 		if !ok {
 			break


### PR DESCRIPTION
This isn't exactly squeaky clean, but much of this code is already marked for deletion, so... It handles the symtom, in that we don't try to perform operations on a nil fileset after the folder has been removed, and stops handling pulling operations a bit quicker when the folder has been removed.

This really needs some automated testing but I'm not sure where to add it currently; writing an integration test for this scenario is rather cumbersome and a bit error prone.