### PR TITLE
The "OK" log level is silly and should not exist

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -338,7 +338,7 @@ func main() {
 		if err != nil {
 			l.Fatalln("Upgrade:", err) // exits 1
 		}
-		l.Okln("Upgraded from", options.upgradeTo)
+		l.Infoln("Upgraded from", options.upgradeTo)
 		return
 	}
 
@@ -462,14 +462,14 @@ func performUpgrade(release upgrade.Release) {
 		if err != nil {
 			l.Fatalln("Upgrade:", err)
 		}
-		l.Okf("Upgraded to %q", release.Tag)
+		l.Infof("Upgraded to %q", release.Tag)
 	} else {
 		l.Infoln("Attempting upgrade through running Syncthing...")
 		err = upgradeViaRest()
 		if err != nil {
 			l.Fatalln("Upgrade:", err)
 		}
-		l.Okln("Syncthing upgrading")
+		l.Infoln("Syncthing upgrading")
 		os.Exit(exitUpgrading)
 	}
 }
@@ -850,7 +850,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	mainService.Stop()
 
-	l.Okln("Exiting")
+	l.Infoln("Exiting")
 
 	if runtimeOptions.cpuProfile {
 		pprof.StopCPUProfile()

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -23,7 +23,6 @@ const (
 	LevelDebug LogLevel = iota
 	LevelVerbose
 	LevelInfo
-	LevelOK
 	LevelWarn
 	LevelFatal
 	NumLevels
@@ -42,8 +41,6 @@ type Logger interface {
 	Verbosef(format string, vals ...interface{})
 	Infoln(vals ...interface{})
 	Infof(format string, vals ...interface{})
-	Okln(vals ...interface{})
-	Okf(format string, vals ...interface{})
 	Warnln(vals ...interface{})
 	Warnf(format string, vals ...interface{})
 	Fatalln(vals ...interface{})
@@ -163,24 +160,6 @@ func (l *logger) Infof(format string, vals ...interface{}) {
 	s := fmt.Sprintf(format, vals...)
 	l.logger.Output(2, "INFO: "+s)
 	l.callHandlers(LevelInfo, s)
-}
-
-// Okln logs a line with an OK prefix.
-func (l *logger) Okln(vals ...interface{}) {
-	l.mut.Lock()
-	defer l.mut.Unlock()
-	s := fmt.Sprintln(vals...)
-	l.logger.Output(2, "OK: "+s)
-	l.callHandlers(LevelOK, s)
-}
-
-// Okf logs a formatted line with an OK prefix.
-func (l *logger) Okf(format string, vals ...interface{}) {
-	l.mut.Lock()
-	defer l.mut.Unlock()
-	s := fmt.Sprintf(format, vals...)
-	l.logger.Output(2, "OK: "+s)
-	l.callHandlers(LevelOK, s)
 }
 
 // Warnln logs a formatted line with a WARNING prefix.

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -19,8 +19,6 @@ func TestAPI(t *testing.T) {
 	l.AddHandler(LevelDebug, checkFunc(t, LevelDebug, &debug))
 	info := 0
 	l.AddHandler(LevelInfo, checkFunc(t, LevelInfo, &info))
-	ok := 0
-	l.AddHandler(LevelOK, checkFunc(t, LevelOK, &ok))
 	warn := 0
 	l.AddHandler(LevelWarn, checkFunc(t, LevelWarn, &warn))
 
@@ -28,19 +26,14 @@ func TestAPI(t *testing.T) {
 	l.Debugln("test", 0)
 	l.Infof("test %d", 1)
 	l.Infoln("test", 1)
-	l.Okf("test %d", 2)
-	l.Okln("test", 2)
 	l.Warnf("test %d", 3)
 	l.Warnln("test", 3)
 
-	if debug != 8 {
+	if debug != 6 {
 		t.Errorf("Debug handler called %d != 8 times", debug)
 	}
-	if info != 6 {
+	if info != 4 {
 		t.Errorf("Info handler called %d != 6 times", info)
-	}
-	if ok != 4 {
-		t.Errorf("Ok handler called %d != 4 times", ok)
 	}
 	if warn != 2 {
 		t.Errorf("Warn handler called %d != 2 times", warn)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -189,7 +189,7 @@ func (m *Model) StartFolderRW(folder string) {
 	m.folderRunnerTokens[folder] = append(m.folderRunnerTokens[folder], token)
 	m.fmut.Unlock()
 
-	l.Okln("Ready to synchronize", folder, "(read-write)")
+	l.Infoln("Ready to synchronize", folder, "(read-write)")
 }
 
 func (m *Model) warnAboutOverwritingProtectedFiles(folder string) {
@@ -241,7 +241,7 @@ func (m *Model) StartFolderRO(folder string) {
 	m.folderRunnerTokens[folder] = append(m.folderRunnerTokens[folder], token)
 	m.fmut.Unlock()
 
-	l.Okln("Ready to synchronize", folder, "(read only; no external updates accepted)")
+	l.Infoln("Ready to synchronize", folder, "(read only; no external updates accepted)")
 }
 
 func (m *Model) RemoveFolder(folder string) {


### PR DESCRIPTION
I think I imagined it as a sort of anti-Fatal from the beginning, as the last output when we did something successfully and then exited. But we don't do that and the distinction seems unnecessary to keep around. Fewer levels is simpler.