### PR TITLE
rest/db/scan: Only scan the requested subdirectories/files.

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1324,14 +1324,13 @@ func (m *Model) internalScanFolderSubs(folder string, subs []string) error {
 nextSub:
 	for _, sub := range subs {
 		for sub != "" {
-			parent := filepath.Dir(sub)
-			if parent == "." || parent == string(filepath.Separator) {
-				parent = ""
-			}
-			if _, ok = fs.Get(protocol.LocalDeviceID, parent); ok {
+			if _, ok = fs.Get(protocol.LocalDeviceID, sub); ok {
 				break
 			}
-			sub = parent
+			sub = filepath.Dir(sub)
+			if sub == "." || sub == string(filepath.Separator) {
+				sub = ""
+			}
 		}
 		for _, us := range unifySubs {
 			if strings.HasPrefix(sub, us) {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1323,7 +1323,7 @@ func (m *Model) internalScanFolderSubs(folder string, subs []string) error {
 	var unifySubs []string
 nextSub:
 	for _, sub := range subs {
-		for sub != "" {
+		for sub != "" && sub != ".stfolder" && sub != ".stignore" {
 			if _, ok = fs.Get(protocol.LocalDeviceID, sub); ok {
 				break
 			}


### PR DESCRIPTION
I've verified that this does what's expected by running syncthing under ```strace -f -e trace=lstat``` and calling variations of ```curl -X POST "http://127.0.0.1:44644/rest/db/scan?folder=default&sub=02&sub=03&next=9600"```. I'm not sure how 9b9fe0d6 was supposed to work; perhaps something changed since the time it was introduced, or perhaps I've overlooked something. I'm pretty sure the relevant integration tests in ```test/scan_test.go``` will be broken because of my changes, but I currently don't know how to run them.