### PR TITLE
Correct order of pkill(1) arguments in debian script (fixes #2728)

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -2,5 +2,5 @@
 set -euo pipefail
 
 if [[ ${1:-} == configure ]]; then
-	pkill -x -HUP syncthing || true
+	pkill -HUP -x syncthing || true
 fi


### PR DESCRIPTION
According to http://linux.die.net/man/1/pkill the signal name must be **before** anything else.

This fix has to be confirmed first by anyone else. I am on debian testing now and there is a newer version which is not affected by the problem; see #2728 .