### PR TITLE
Handle null case for invalid ng-model value (fixes #2392)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,6 +13,7 @@ Bart De Vries <devriesb@gmail.com>
 Ben Curthoys <ben@bencurthoys.com>
 Ben Schulz <ueomkail@gmail.com> <uok@users.noreply.github.com>
 Ben Sidhom <bsidhom@gmail.com>
+Benny Ng <benny.tpng@gmail.com>
 Brandon Philips <brandon@ifup.org>
 Brendan Long <self@brendanlong.com>
 Brian R. Becker <brbecker@gmail.com>

--- a/NICKS
+++ b/NICKS
@@ -72,6 +72,7 @@ Stefan-Code	<stefan.github@gmail.com> <Stefan.github@gmail.com>
 timabell	<tim@timwise.co.uk>
 tnn2		<tnn@nygren.pp.se>
 tojrobinson	<tully@tojr.org>
+tpng		<benny.tpng@gmail.com>
 tylerbrazier	<tyler@tylerbrazier.com>
 uok		<ueomkail@gmail.com> <uok@users.noreply.github.com>
 veeti		<veeti.paananen@rojekti.fi>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1531,6 +1531,9 @@ angular.module('syncthing.core')
             if (key.substr(0, 1) === '_') {
                 return 'skip';
             }
+            if (value === null) {
+                return 'null';
+            }
             if (typeof value === 'number') {
                 return 'number';
             }


### PR DESCRIPTION
Invalid ng-model value is assigned `null` by angular.js which is being matched as `object`, thus disappear in the UI when a minus sign is entered.