### PR TITLE
Return status code 307 instead of 302 when redirecting from HTTP to HTTPS

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -424,7 +424,7 @@ func redirectToHTTPSMiddleware(h http.Handler) http.Handler {
 			// Redirect HTTP requests to HTTPS
 			r.URL.Host = r.Host
 			r.URL.Scheme = "https"
-			http.Redirect(w, r, r.URL.String(), http.StatusFound)
+			http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)
 		} else {
 			h.ServeHTTP(w, r)
 		}


### PR DESCRIPTION
```
jb@syno:~/s/g/s/syncthing $ curl -X POST -i http://localhost:8385/rest/system/config
HTTP/1.1 307 Temporary Redirect
Location: https://localhost:8385/rest/system/config
Date: Fri, 29 Jan 2016 10:09:16 GMT
Content-Length: 0
Content-Type: text/plain; charset=utf-8
```