### PR TITLE
Return "No such object in the index" when /rest/db/file gets called on something that doesn't exist

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -615,8 +615,14 @@ func (s *apiService) getDBFile(w http.ResponseWriter, r *http.Request) {
 	qs := r.URL.Query()
 	folder := qs.Get("folder")
 	file := qs.Get("file")
-	gf, _ := s.model.CurrentGlobalFile(folder, file)
-	lf, _ := s.model.CurrentFolderFile(folder, file)
+	gf, gfOk := s.model.CurrentGlobalFile(folder, file)
+	lf, lfOk := s.model.CurrentFolderFile(folder, file)
+
+	if !(gfOk || lfOk) {
+		// This file for sure does not exist.
+		http.Error(w, "No such object in the index", http.StatusNotFound)
+		return
+	}
 
 	av := s.model.Availability(folder, file)
 	sendJSON(w, map[string]interface{}{


### PR DESCRIPTION
Better than the confusing result of getting a blank fileinfo that looks
valid apart from being all crap.