### PR TITLE
Move CORS middleware to process un-authenticated OPTIONS requests

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -236,12 +236,12 @@ func (s *apiService) Serve() {
 
 	guiCfg := s.cfg.GUI()
 
+	// Add the CORS handling
+	handler := corsMiddleware(mux)
+
 	// Wrap everything in CSRF protection. The /rest prefix should be
 	// protected, other requests will grant cookies.
-	handler := csrfMiddleware(s.id.String()[:5], "/rest", guiCfg, mux)
-
-	// Add the CORS handling
-	handler = corsMiddleware(handler)
+	handler = csrfMiddleware(s.id.String()[:5], "/rest", guiCfg, handler)
 
 	// Add our version and ID as a header to responses
 	handler = withDetailsMiddleware(s.id, handler)
@@ -382,6 +382,10 @@ func corsMiddleware(next http.Handler) http.Handler {
 	// Handle CORS headers and CORS OPTIONS request.
 	// CORS OPTIONS request are typically sent by browser during AJAX preflight
 	// when the browser initiate a POST request.
+	//
+	// As the OPTIONS request is unauthorized, this handler must be the first
+	// of the chain.
+	//
 	// See https://www.w3.org/TR/cors/ for details.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Add a generous access-control-allow-origin header since we may be


### PR DESCRIPTION
While performing additional testing on CORS with browsers (Chrome/Firefox), I have spotted an issue with the current order of the middleware (CSRF and CORS). During a [pre-flight request](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests), the X-API-Key header is not sent which cause the `csrfMiddleware` to perform a redirect. As a result, the pre-flight request fails.

By swapping the corsMiddleware and the csrfMiddleware, the OPTIONS requests are first processed before any security checks.
