### PR TITLE
Colourful identicons

### DIFF
--- a/gui/dark/assets/css/overrides.css
+++ b/gui/dark/assets/css/overrides.css
@@ -54,10 +54,6 @@ identicon {
     height: 1em;
 }
 
-.identicon rect {
-    fill: #333;
-}
-
 .checkbox {
     margin-top: 0px;
 }
@@ -348,9 +344,6 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     border-top: 1px solid #222 !important;
 }
 
-.identicon>rect {
-    fill: #aaa !important;
-}
 
 /* buttons */
 .btn {

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -54,10 +54,6 @@ identicon {
     height: 1em;
 }
 
-.identicon rect {
-    fill: #333;
-}
-
 .checkbox {
     margin-top: 0px;
 }

--- a/gui/default/syncthing/core/identiconDirective.js
+++ b/gui/default/syncthing/core/identiconDirective.js
@@ -13,6 +13,11 @@ angular.module('syncthing.core')
             var mirrorColFor = function (col) {
                 return size - col - 1;
             };
+            var strToHue = function (str) {
+                var h=0;
+                for (var i=0; i<str.length; i++) h += str.charCodeAt(i);
+                return h%255;
+            }
             var fillRectAt = function (row, col) {
                 var rect = document.createElementNS(svgNS, 'rect');
 
@@ -20,6 +25,7 @@ angular.module('syncthing.core')
                 rect.setAttribute('y', (row * rectSize) + '%');
                 rect.setAttribute('width', rectSize + '%');
                 rect.setAttribute('height', rectSize + '%');
+                rect.setAttribute('fill','hsl('+strToHue(value)+',100%,50%)');
 
                 svg.appendChild(rect);
             };


### PR DESCRIPTION
Most simple way of add colour to the identicons guaranteed!

How:
Adds the charCodes of each letter in the Syncthing ID and then mods by
255 to get the hue.
Colour's saturation and lightness can be set, using CSS3 HSL colors (to
provide matching random colours).

* added colourful identicons
* removed existing identicon colouring from both themes (default and
dark)