### PR TITLE
Add ISSUE_TEMPLATE

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+If your issue is a bug report, replace this paragraph with a description of the problem, being sure to include at least:
+ - what happened,
+ - what you expected to happen instead, and
+ - any steps to reproduce the problem.
+Also fill out the version information below and add log output or screenshots as appropriate.
+
+If your issue is a feature request, simply replace this template text in it's entirety.
+
+### Version Information
+Syncthing Version: v0.x.y
+OS Version: Windows 7 / Ubuntu 14.04 / ...


### PR DESCRIPTION
Template for newly created issues. We want this text to be short and clear and request the required information from the user, and also be clear that it is a template and should be removed/replaced in the actual issue before saving...