### PR TITLE
Terabyte file support

### DIFF
--- a/lib/db/truncated.go
+++ b/lib/db/truncated.go
@@ -27,12 +27,12 @@ func (o *FileInfoTruncated) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	o.LocalVersion = int64(u.UnmarshalUint64())
 	_BlocksSize := int(u.UnmarshalUint32())
 	if _BlocksSize < 0 {
-		return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 1000000)
+		return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 10000000)
 	} else if _BlocksSize == 0 {
 		o.Blocks = nil
 	} else {
-		if _BlocksSize > 1000000 {
-			return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 1000000)
+		if _BlocksSize > 10000000 {
+			return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 10000000)
 		}
 		for i := 0; i < _BlocksSize; i++ {
 			size := int64(u.UnmarshalUint32())

--- a/lib/protocol/message.go
+++ b/lib/protocol/message.go
@@ -27,7 +27,7 @@ type FileInfo struct {
 	Version      Vector
 	LocalVersion int64
 	CachedSize   int64       // noencode (cache only)
-	Blocks       []BlockInfo // max:1000000
+	Blocks       []BlockInfo // max:10000000
 }
 
 func (f FileInfo) String() string {

--- a/lib/protocol/message_xdr.go
+++ b/lib/protocol/message_xdr.go
@@ -176,7 +176,7 @@ struct FileInfo {
 	hyper Modified;
 	Vector Version;
 	hyper LocalVersion;
-	BlockInfo Blocks<1000000>;
+	BlockInfo Blocks<10000000>;
 }
 
 */
@@ -212,8 +212,8 @@ func (o FileInfo) MarshalXDRInto(m *xdr.Marshaller) error {
 		return err
 	}
 	m.MarshalUint64(uint64(o.LocalVersion))
-	if l := len(o.Blocks); l > 1000000 {
-		return xdr.ElementSizeExceeded("Blocks", l, 1000000)
+	if l := len(o.Blocks); l > 10000000 {
+		return xdr.ElementSizeExceeded("Blocks", l, 10000000)
 	}
 	m.MarshalUint32(uint32(len(o.Blocks)))
 	for i := range o.Blocks {
@@ -236,12 +236,12 @@ func (o *FileInfo) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	o.LocalVersion = int64(u.UnmarshalUint64())
 	_BlocksSize := int(u.UnmarshalUint32())
 	if _BlocksSize < 0 {
-		return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 1000000)
+		return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 10000000)
 	} else if _BlocksSize == 0 {
 		o.Blocks = nil
 	} else {
-		if _BlocksSize > 1000000 {
-			return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 1000000)
+		if _BlocksSize > 10000000 {
+			return xdr.ElementSizeExceeded("Blocks", _BlocksSize, 10000000)
 		}
 		if _BlocksSize <= len(o.Blocks) {
 			o.Blocks = o.Blocks[:_BlocksSize]

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -19,8 +19,8 @@ const (
 	// BlockSize is the standard ata block size (128 KiB)
 	BlockSize = 128 << 10
 
-	// MaxMessageLen is the largest message size allowed on the wire. (64 MiB)
-	MaxMessageLen = 64 << 20
+	// MaxMessageLen is the largest message size allowed on the wire. (512 MiB)
+	MaxMessageLen = 64 << 23
 )
 
 const (


### PR DESCRIPTION
Hi,

This PR is about the file size limit in Syncthing.

From what I understand from the specifications and the code, the current size limit is 1000000 blocks of 131072 bytes, which means that any file larger than 130 GB cannot be replicated. Am I right ?

I dived into the code and patched it to support up to 1 terabyte file size. My tests with 300 GB and 450 GB files were ok and they got replicated successfully.

Here are some points left:

- The mix of `go generate` (for the model part ) and hardcoded values (for the DB/Protocol part) make it difficult to know which are the actual limits. For example, the number of blocks of a file has a direct influence on the messages' size (during index exchange). This is not obvious when reading the code. Is is planned to have a specific doc on the subject ? A plus would be to have this information available on the command line via a specific switch.
- Is it planned to log/store/<whatever> the cases when limits are crossed so a feedback can be provided to the user ? When I tried to replicate a 300 GB file, I only knew that something went wrong by using STTRACE.
- Is there any side-effects with increasing values to support very large files ? If not, what is the rationale behind the current values ?

Regards.
