### PR TITLE
systemd: Add syncthing-resume.service

### DIFF
--- a/etc/linux-systemd/system/syncthing-resume.service
+++ b/etc/linux-systemd/system/syncthing-resume.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Restart Syncthing after resume
+After=suspend.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/pkill -HUP -x syncthing
+
+[Install]
+WantedBy=suspend.target


### PR DESCRIPTION
This systemd service restarts Syncthing after resume from suspend via sending SIGHUP. By default Syncthing detects resume from sleep on its own by looking for jumps in the system clock. Since systemd knows exactly when the system resumes from sleep let's trigger the Syncthing restart from there. Doing this in systemd eliminates some annoying delay, as the service is restarted immediately after resume. Also, using the systemd dependency mechanism syncthing-inotify is restarted as well.

```
$ journalctl -e --identifier syncthing --identifier syncthing-inotify --identifier systemd
Feb 22 09:44:27 kronos systemd[1]: Reached target Sleep.
Feb 22 09:44:27 kronos systemd[1]: Starting Suspend...
Feb 22 09:44:33 kronos systemd[1]: Time has been changed
Feb 22 09:44:33 kronos systemd[963]: Time has been changed
Feb 22 09:44:33 kronos systemd[1]: Started Suspend.
Feb 22 09:44:33 kronos systemd[1]: sleep.target: Unit not needed anymore. Stopping.
Feb 22 09:44:33 kronos systemd[1]: Stopped target Sleep.
Feb 22 09:44:33 kronos systemd[1]: Reached target Suspend.
Feb 22 09:44:33 kronos systemd[1]: suspend.target: Unit is bound to inactive unit systemd-suspend.service. Stopping, too.
Feb 22 09:44:33 kronos systemd[1]: Stopped target Suspend.
Feb 22 09:44:33 kronos systemd[1]: Starting Restart Syncthing after resume...
Feb 22 09:44:33 kronos syncthing[2561]: [35K66] OK: Exiting
Feb 22 09:44:33 kronos systemd[1]: Started Restart Syncthing after resume.
Feb 22 09:44:34 kronos systemd[963]: syncthing.service: Service hold-off time over, scheduling restart.
Feb 22 09:44:34 kronos systemd[963]: Stopping Syncthing Inotify File Watcher...
Feb 22 09:44:34 kronos systemd[963]: Stopped Syncthing Inotify File Watcher.
Feb 22 09:44:34 kronos systemd[963]: Stopped Syncthing - Open Source Continuous File Synchronization.
Feb 22 09:44:34 kronos systemd[963]: Started Syncthing - Open Source Continuous File Synchronization.
Feb 22 09:44:34 kronos systemd[963]: Started Syncthing Inotify File Watcher.
Feb 22 09:44:34 kronos syncthing[2836]: [35K66] INFO: syncthing v0.12.19 "Beryllium Bedbug" (go1.5.3 linux-amd64) builduser@svetlemodry 2016-02-14 19:26:33 UTC
```

This system service has to be located in `/etc/systemd/system/syncthing-resume.service`, and for packages in `/usr/lib/systemd/system/syncthing-resume.service`. It can be enabled using `systemctl enable syncthing-resume.service`.