### PR TITLE
Xdr generate fix

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Johan Vromans <jvromans@squirrel.nl>
 Karol Różycki <rozycki.karol@gmail.com>
 Ken'ichi Kamada <kamada@nanohz.org>
 Kevin Allen <kma1660@gmail.com>
+Lars K.W. Gohlke <lkwg82@gmx.de>
 Laurent Etiemble <laurent.etiemble@gmail.com> <laurent.etiemble@monobjc.net>
 Lode Hoste <zillode@zillode.be>
 Lord Landon Agahnim <lordlandon@gmail.com>

--- a/lib/db/leveldb.go
+++ b/lib/db/leveldb.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:generate -command genxdr go run ../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go
+//go:generate -command genxdr go run ../../vendor/github.com/calmh/xdr/cmd/genxdr/main.go
 //go:generate genxdr -o leveldb_xdr.go leveldb.go
 
 package db

--- a/lib/discover/localpackets.go
+++ b/lib/discover/localpackets.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:generate -command genxdr go run ../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go
+//go:generate -command genxdr go run ../../vendor/github.com/calmh/xdr/cmd/genxdr/main.go
 //go:generate genxdr -o localpackets_xdr.go localpackets.go
 
 package discover

--- a/lib/protocol/message.go
+++ b/lib/protocol/message.go
@@ -1,6 +1,6 @@
 // Copyright (C) 2014 The Protocol Authors.
 
-//go:generate -command genxdr go run ../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go
+//go:generate -command genxdr go run ../../vendor/github.com/calmh/xdr/cmd/genxdr/main.go
 //go:generate genxdr -o message_xdr.go message.go
 
 package protocol

--- a/lib/relay/protocol/packets.go
+++ b/lib/relay/protocol/packets.go
@@ -1,6 +1,6 @@
 // Copyright (C) 2015 Audrius Butkevicius and Contributors (see the CONTRIBUTORS file).
 
-//go:generate -command genxdr go run ../../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go
+//go:generate -command genxdr go run ../../../vendor/github.com/calmh/xdr/cmd/genxdr/main.go
 //go:generate genxdr -o packets_xdr.go packets.go
 
 package protocol


### PR DESCRIPTION
### Purpose

This fixes xdr regeneration using ```go run build.go xdr```.

```bash
$ go run build.go xdr
go generate ./lib/discover ./lib/db ./lib/protocol ./lib/relay/protocol
stat ../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go: no such file or directory
lib/discover/localpackets.go:8: running "go": exit status 1
stat ../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go: no such file or directory
lib/db/leveldb.go:8: running "go": exit status 1
stat ../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go: no such file or directory
lib/protocol/message.go:4: running "go": exit status 1
stat ../../../Godeps/_workspace/src/github.com/calmh/xdr/cmd/genxdr/main.go: no such file or directory
lib/relay/protocol/packets.go:4: running "go": exit status 1
exit status 1
exit status 1
```

### Testing

```bash
$ go run build.go xdr; echo "exit code: $?"
go generate ./lib/discover ./lib/db ./lib/protocol ./lib/relay/protocol
exit code: 0
```
