### PR TITLE
Increase contrast for readonly form controls in dark theme (fixes #2820)

### DIFF
--- a/gui/dark/assets/css/overrides.css
+++ b/gui/dark/assets/css/overrides.css
@@ -437,7 +437,7 @@ code.ng-binding{
 }
 
 .well, .form-control[readonly="readonly"] { /* read-only fields*/
-    color: #444 !important;
+    color: #666 !important;
     border-color: #444 !important;
     background-color: #111 !important;
 }


### PR DESCRIPTION
### Purpose
Increase the dark theme color value for text in readonly form controls for better contrast between text and background.

### Screenshots
Before
![](https://cloud.githubusercontent.com/assets/1026763/13697457/e9457aba-e76d-11e5-823c-862d187a40b1.png)

After
![](https://cloud.githubusercontent.com/assets/1026763/13697478/f5de8b22-e76d-11e5-9feb-dad20adbf483.png)
