### PR TITLE
Fix STGUIASSETS search paths & order (fixes #2827)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -1307,5 +1307,6 @@ func dirNames(dir string) []string {
 		}
 	}
 
+	sort.Strings(dirs)
 	return dirs
 }

--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -7,10 +7,16 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/thejerf/suture"
 )
 
@@ -88,4 +94,78 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 	// Nonetheless, it should be fine to Stop() it without panic.
 
 	sup.Stop()
+}
+
+func TestAssetsDir(t *testing.T) {
+	// For any given request to $FILE, we should return the first found of
+	//  - assetsdir/$THEME/$FILE
+	//  - compiled in asset $THEME/$FILE
+	//  - assetsdir/default/$FILE
+	//  - compiled in asset default/$FILE
+
+	// The asset map contains compressed assets, so create a couple of gzip compressed assets here.
+	buf := new(bytes.Buffer)
+	gw := gzip.NewWriter(buf)
+	gw.Write([]byte("default"))
+	gw.Close()
+	def := buf.Bytes()
+
+	buf = new(bytes.Buffer)
+	gw = gzip.NewWriter(buf)
+	gw.Write([]byte("foo"))
+	gw.Close()
+	foo := buf.Bytes()
+
+	e := embeddedStatic{
+		theme:    "foo",
+		mut:      sync.NewRWMutex(),
+		assetDir: "testdata",
+		assets: map[string][]byte{
+			"foo/a":     foo, // overridden in foo/a
+			"foo/b":     foo,
+			"default/a": def, // overridden in default/a (but foo/a takes precedence)
+			"default/b": def, // overridden in default/b (but foo/b takes precedence)
+			"default/c": def,
+		},
+	}
+
+	s := httptest.NewServer(e)
+	defer s.Close()
+
+	// assetsdir/foo/a exists, overrides compiled in
+	expectURLToContain(t, s.URL+"/a", "overridden-foo")
+
+	// foo/b is compiled in, default/b is overriden, return compiled in
+	expectURLToContain(t, s.URL+"/b", "foo")
+
+	// only exists as compiled in default/c so use that
+	expectURLToContain(t, s.URL+"/c", "default")
+
+	// only exists as overriden default/d so use that
+	expectURLToContain(t, s.URL+"/d", "overridden-default")
+}
+
+func expectURLToContain(t *testing.T, url, exp string) {
+	res, err := http.Get(url)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if res.StatusCode != 200 {
+		t.Errorf("Got %s instead of 200 OK", res.Status)
+		return
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if string(data) != exp {
+		t.Errorf("Got %q instead of %q on %q", data, exp, url)
+		return
+	}
 }

--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -175,6 +175,6 @@ func TestDirNames(t *testing.T) {
 	names := dirNames("testdata")
 	expected := []string{"default", "foo", "testfolder"}
 	if diff, equal := messagediff.PrettyDiff(names, expected); !equal {
-		t.Error("Unexpected assetDirNames return:", diff)
+		t.Errorf("Unexpected dirNames return: %#v\n%s", names, diff)
 	}
 }

--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/d4l3k/messagediff"
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
@@ -167,5 +168,13 @@ func expectURLToContain(t *testing.T, url, exp string) {
 	if string(data) != exp {
 		t.Errorf("Got %q instead of %q on %q", data, exp, url)
 		return
+	}
+}
+
+func TestDirNames(t *testing.T) {
+	names := dirNames("testdata")
+	expected := []string{"default", "foo", "testfolder"}
+	if diff, equal := messagediff.PrettyDiff(names, expected); !equal {
+		t.Error("Unexpected assetDirNames return:", diff)
 	}
 }

--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -174,7 +174,7 @@ func expectURLToContain(t *testing.T, url, exp string) {
 func TestDirNames(t *testing.T) {
 	names := dirNames("testdata")
 	expected := []string{"default", "foo", "testfolder"}
-	if diff, equal := messagediff.PrettyDiff(names, expected); !equal {
+	if diff, equal := messagediff.PrettyDiff(expected, names); !equal {
 		t.Errorf("Unexpected dirNames return: %#v\n%s", names, diff)
 	}
 }

--- a/cmd/syncthing/testdata/default/a
+++ b/cmd/syncthing/testdata/default/a
@@ -1,0 +1,1 @@
+overridden-default

--- a/cmd/syncthing/testdata/default/b
+++ b/cmd/syncthing/testdata/default/b
@@ -1,0 +1,1 @@
+overridden-default

--- a/cmd/syncthing/testdata/default/d
+++ b/cmd/syncthing/testdata/default/d
@@ -1,0 +1,1 @@
+overridden-default

--- a/cmd/syncthing/testdata/foo/a
+++ b/cmd/syncthing/testdata/foo/a
@@ -1,0 +1,1 @@
+overridden-foo


### PR DESCRIPTION
### Purpose

Fix STGUIASSETS processing to be as I expect it to be; that is, you point it at `gui` in the source distribution, and whatever you have in there overrides what is compiled in. ~~What is *not* fixed here is that if you add a new theme, it won't show up in the theme selector. You need to actually manually configure that theme name for the moment; next PR...~~

### Testing

A unit test is added to verify the correct assets are served.

