### PR TITLE
Let "systemctl help" command work

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Syncthing - Open Source Continuous File Synchronization for %I
-Documentation=http://docs.syncthing.net/
+Documentation=man:syncthing(1)
 After=network.target
 Wants=syncthing-inotify@.service
 

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Syncthing - Open Source Continuous File Synchronization
-Documentation=http://docs.syncthing.net/
+Documentation=man:syncthing(1)
 After=network.target
 Wants=syncthing-inotify.service
 


### PR DESCRIPTION
### Purpose

Minor change to allow systemctl help command to work.

### Testing

Issue systemctl help commands

### Screenshots

Before this change, issuing either
    systemctl --user help syncthing[.service]
or
    systemctl help syncthing@user[.service]
gave the message
    Can't show: http://docs.syncthing.net/

Following this change the syncthing man page is displayed