### PR TITLE
gui: differentiate current and remote devices more clearly

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -390,7 +390,7 @@
       <!-- This device -->
 
       <div class="col-md-6">
-        <h3 translate>Devices</h3>
+        <h3 translate>This Device</h3>
         <div class="panel panel-default" ng-repeat="deviceCfg in [thisDevice()]">
           <div class="panel-heading" data-toggle="collapse" href="#device-this" style="cursor: pointer">
             <h3 class="panel-title">
@@ -464,7 +464,7 @@
         </div>
 
         <!-- Remote devices -->
-
+        <h3 translate>Remote Devices</h3>
         <div class="panel-group" id="devices">
           <div class="panel panel-default" ng-repeat="deviceCfg in otherDevices()">
             <div class="panel-heading" data-toggle="collapse" data-parent="#devices" href="#device-{{$index}}" style="cursor: pointer">
@@ -548,7 +548,7 @@
         </div>
         <div class="form-group">
           <button type="button" class="btn btn-sm btn-default pull-right" ng-click="addDevice()">
-            <span class="fa fa-plus"></span>&nbsp;<span translate>Add Device</span>
+            <span class="fa fa-plus"></span>&nbsp;<span translate>Add Remote Device</span>
           </button>
           <div class="clearfix"></div>
         </div>


### PR DESCRIPTION
### Purpose

Add an additional Headline to separate the current (this) device from the remote devices and update the existing headline and button text accordingly.

### Screenshots
![bildschirmfoto vom 2016-03-17 20 39 00](https://cloud.githubusercontent.com/assets/1026763/13858982/627e4f0c-ec81-11e5-98f6-91104a1f7d36.png)

