### PR TITLE
cmd/syncthing: Return 500 with an error object instead of empty 200 on marshalling error in REST response

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -163,7 +163,16 @@ func (s *apiService) getListener(guiCfg config.GUIConfiguration) (net.Listener, 
 
 func sendJSON(w http.ResponseWriter, jsonObject interface{}) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
-	json.NewEncoder(w).Encode(jsonObject)
+	// Marshalling might fail, in which case we should return a 500 with the
+	// actual error.
+	bs, err := json.Marshal(jsonObject)
+	if err != nil {
+		// This Marshal() can't fail though.
+		bs, _ = json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(bs), http.StatusInternalServerError)
+		return
+	}
+	w.Write(bs)
 }
 
 func (s *apiService) Serve() {


### PR DESCRIPTION
### Purpose

If we pass an invalid object to sendJSON, it'll silently write an empty 200 response. With this change we should return a 500 with an `{"error": "something"}` in it instead. I think.

### Testing

None whatsoever as I can't reproduce an error here right now. Lets have canton7 see if he can get something from this in #2854 before merging.