### PR TITLE
cmd/syncthing: Add mock types for API service testing

### DIFF
--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -175,3 +175,23 @@ func TestDirNames(t *testing.T) {
 		t.Errorf("Unexpected dirNames return: %#v\n%s", names, diff)
 	}
 }
+
+func TestInstantiateAPIService(t *testing.T) {
+	model := new(mockedModel)
+	cfg := new(mockedConfig)
+	httpsCertFile := "../../test/h1/https-cert.pem"
+	httpsKeyFile := "../../test/h1/https-key.pem"
+	assetDir := "../../gui"
+	eventSub := new(mockedEventSub)
+	discoverer := new(mockedCachingMux)
+	relayService := new(mockedRelayService)
+	errorLog := new(mockedLoggerRecorder)
+	systemLog := new(mockedLoggerRecorder)
+
+	svc, err := newAPIService(protocol.LocalDeviceID, cfg, httpsCertFile, httpsKeyFile, assetDir, model,
+		eventSub, discoverer, relayService, errorLog, systemLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = svc
+}

--- a/cmd/syncthing/mocked_config_test.go
+++ b/cmd/syncthing/mocked_config_test.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+type mockedConfig struct{}
+
+func (c *mockedConfig) GUI() config.GUIConfiguration {
+	return config.GUIConfiguration{}
+}
+
+func (c *mockedConfig) Raw() config.Configuration {
+	return config.Configuration{}
+}
+
+func (c *mockedConfig) Options() config.OptionsConfiguration {
+	return config.OptionsConfiguration{}
+}
+
+func (c *mockedConfig) Replace(cfg config.Configuration) config.CommitResponse {
+	return config.CommitResponse{}
+}
+
+func (c *mockedConfig) Subscribe(cm config.Committer) {}
+
+func (c *mockedConfig) Folders() map[string]config.FolderConfiguration {
+	return nil
+}
+
+func (c *mockedConfig) Devices() map[protocol.DeviceID]config.DeviceConfiguration {
+	return nil
+}
+
+func (c *mockedConfig) Save() error {
+	return nil
+}

--- a/cmd/syncthing/mocked_discovery_test.go
+++ b/cmd/syncthing/mocked_discovery_test.go
@@ -1,0 +1,52 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"time"
+
+	"github.com/syncthing/syncthing/lib/discover"
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+type mockedCachingMux struct{}
+
+// from suture.Service
+
+func (m *mockedCachingMux) Serve() {
+	select {}
+}
+
+func (m *mockedCachingMux) Stop() {
+}
+
+// from events.Finder
+
+func (m *mockedCachingMux) Lookup(deviceID protocol.DeviceID) (direct []string, relays []discover.Relay, err error) {
+	return nil, nil, nil
+}
+
+func (m *mockedCachingMux) Error() error {
+	return nil
+}
+
+func (m *mockedCachingMux) String() string {
+	return "mockedCachingMux"
+}
+
+func (m *mockedCachingMux) Cache() map[protocol.DeviceID]discover.CacheEntry {
+	return nil
+}
+
+// from events.CachingMux
+
+func (m *mockedCachingMux) Add(finder discover.Finder, cacheTime, negCacheTime time.Duration, priority int) {
+}
+
+func (m *mockedCachingMux) ChildErrors() map[string]error {
+	return nil
+}

--- a/cmd/syncthing/mocked_events_test.go
+++ b/cmd/syncthing/mocked_events_test.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import "github.com/syncthing/syncthing/lib/events"
+
+type mockedEventSub struct{}
+
+func (s *mockedEventSub) Since(id int, into []events.Event) []events.Event {
+	select {}
+}

--- a/cmd/syncthing/mocked_logger_test.go
+++ b/cmd/syncthing/mocked_logger_test.go
@@ -1,0 +1,21 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"time"
+
+	"github.com/syncthing/syncthing/lib/logger"
+)
+
+type mockedLoggerRecorder struct{}
+
+func (r *mockedLoggerRecorder) Since(t time.Time) []logger.Line {
+	select {}
+}
+
+func (r *mockedLoggerRecorder) Clear() {}

--- a/cmd/syncthing/mocked_model_test.go
+++ b/cmd/syncthing/mocked_model_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"time"
+
+	"github.com/syncthing/syncthing/lib/db"
+	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/stats"
+)
+
+type mockedModel struct{}
+
+func (m *mockedModel) GlobalDirectoryTree(folder, prefix string, levels int, dirsonly bool) map[string]interface{} {
+	return nil
+}
+
+func (m *mockedModel) Completion(device protocol.DeviceID, folder string) float64 {
+	return 0
+}
+
+func (m *mockedModel) Override(folder string) {}
+
+func (m *mockedModel) NeedFolderFiles(folder string, page, perpage int) ([]db.FileInfoTruncated, []db.FileInfoTruncated, []db.FileInfoTruncated, int) {
+	return nil, nil, nil, 0
+}
+
+func (m *mockedModel) NeedSize(folder string) (nfiles int, bytes int64) {
+	return 0, 0
+}
+
+func (m *mockedModel) ConnectionStats() map[string]interface{} {
+	return nil
+}
+
+func (m *mockedModel) DeviceStatistics() map[string]stats.DeviceStatistics {
+	return nil
+}
+
+func (m *mockedModel) FolderStatistics() map[string]stats.FolderStatistics {
+	return nil
+}
+
+func (m *mockedModel) CurrentFolderFile(folder string, file string) (protocol.FileInfo, bool) {
+	return protocol.FileInfo{}, false
+}
+
+func (m *mockedModel) CurrentGlobalFile(folder string, file string) (protocol.FileInfo, bool) {
+	return protocol.FileInfo{}, false
+}
+
+func (m *mockedModel) ResetFolder(folder string) {
+}
+
+func (m *mockedModel) Availability(folder, file string) []protocol.DeviceID {
+	return nil
+}
+
+func (m *mockedModel) GetIgnores(folder string) ([]string, []string, error) {
+	return nil, nil, nil
+}
+
+func (m *mockedModel) SetIgnores(folder string, content []string) error {
+	return nil
+}
+
+func (m *mockedModel) PauseDevice(device protocol.DeviceID) {
+}
+
+func (m *mockedModel) ResumeDevice(device protocol.DeviceID) {}
+
+func (m *mockedModel) DelayScan(folder string, next time.Duration) {}
+
+func (m *mockedModel) ScanFolder(folder string) error {
+	return nil
+}
+
+func (m *mockedModel) ScanFolders() map[string]error {
+	return nil
+}
+
+func (m *mockedModel) ScanFolderSubs(folder string, subs []string) error {
+	return nil
+}
+
+func (m *mockedModel) BringToFront(folder, file string) {}
+
+func (m *mockedModel) ConnectedTo(deviceID protocol.DeviceID) bool {
+	return false
+}
+
+func (m *mockedModel) GlobalSize(folder string) (nfiles, deleted int, bytes int64) {
+	return 0, 0, 0
+}
+
+func (m *mockedModel) LocalSize(folder string) (nfiles, deleted int, bytes int64) {
+	return 0, 0, 0
+}
+
+func (m *mockedModel) CurrentLocalVersion(folder string) (int64, bool) {
+	return 0, false
+}
+
+func (m *mockedModel) RemoteLocalVersion(folder string) (int64, bool) {
+	return 0, false
+}
+
+func (m *mockedModel) State(folder string) (string, time.Time, error) {
+	return "", time.Time{}, nil
+}

--- a/cmd/syncthing/mocked_relay_test.go
+++ b/cmd/syncthing/mocked_relay_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+type mockedRelayService struct{}
+
+// from suture.Service
+
+func (s *mockedRelayService) Serve() {
+	select {}
+}
+
+func (s *mockedRelayService) Stop() {
+}
+
+// from relay.Service
+
+func (s *mockedRelayService) Accept() *tls.Conn {
+	return nil
+}
+
+func (s *mockedRelayService) Relays() []string {
+	return nil
+}
+
+func (s *mockedRelayService) RelayStatus(uri string) (time.Duration, bool) {
+	return 0, false
+}


### PR DESCRIPTION
### Purpose

This just adds a shitload of empty boilerplate mock types to be able to start an apiService. It doesn't actually do anything right now except call newAPIService() to verify that the mock types satisfy their required interfaces. The intention is to over time fill out the mock types as necessary to be able to test the actual request methods on the API service.

### Testing

There's a unit test that ensures the mock types fulfill their interfaces.
