### PR TITLE
cmd/syncthing: Basic smoke test of all API endpoints

### DIFF
--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -181,10 +181,11 @@ func TestDirNames(t *testing.T) {
 }
 
 type httpTestCase struct {
-	URL    string // URL to check
-	Code   int    // Expected result code
-	Type   string // Expected content type
-	Prefix string // Expected result prefix
+	URL     string        // URL to check
+	Code    int           // Expected result code
+	Type    string        // Expected content type
+	Prefix  string        // Expected result prefix
+	Timeout time.Duration // Defaults to a second
 }
 
 func TestAPIServiceRequests(t *testing.T) {
@@ -288,10 +289,11 @@ func TestAPIServiceRequests(t *testing.T) {
 			Prefix: "[",
 		},
 		{
-			URL:    "/rest/svc/report",
-			Code:   200,
-			Type:   "application/json",
-			Prefix: "{",
+			URL:     "/rest/svc/report",
+			Code:    200,
+			Type:    "application/json",
+			Prefix:  "{",
+			Timeout: 5 * time.Second,
 		},
 
 		// /rest/system
@@ -378,8 +380,12 @@ func TestAPIServiceRequests(t *testing.T) {
 // testHTTPRequest tries the given test case, comparing the result code,
 // content type, and result prefix.
 func testHTTPRequest(t *testing.T, baseURL string, tc httpTestCase) {
+	timeout := time.Second
+	if tc.Timeout > 0 {
+		timeout = tc.Timeout
+	}
 	cli := &http.Client{
-		Timeout: time.Second,
+		Timeout: timeout,
 	}
 
 	resp, err := cli.Get(baseURL + tc.URL)


### PR DESCRIPTION
OK, last one in this series for today.

### Purpose

Runs through all the API "GET" endpoints, except /upgrade, to verify that they exist and return "something". We can now extend this to test actual data and return formats using the mocks and so on.

### Testing

```
jb@syno:~/s/g/s/s/c/syncthing $ go test -v -run API
=== RUN   TestAPIServiceRequests
10:31:01 INFO: GUI and API listening on [::]:50589
10:31:01 INFO: Access the GUI via the following URL: http:///
--- PASS: TestAPIServiceRequests (0.68s)
	gui_test.go:373: Testing /rest/db/completion?device=7777777-777777N-7777777-777777N-7777777-777777N-7777777-77777Q4&folder=default ...
	gui_test.go:373: Testing /rest/db/file?folder=default&file=something ...
	gui_test.go:373: Testing /rest/db/ignores?folder=default ...
	gui_test.go:373: Testing /rest/db/need?folder=default ...
	gui_test.go:373: Testing /rest/db/status?folder=default ...
	gui_test.go:373: Testing /rest/db/browse?folder=default ...
	gui_test.go:373: Testing /rest/stats/device ...
	gui_test.go:373: Testing /rest/stats/folder ...
	gui_test.go:373: Testing /rest/svc/deviceid?id=7777777-777777N-7777777-777777N-7777777-777777N-7777777-77777Q4 ...
	gui_test.go:373: Testing /rest/svc/lang ...
	gui_test.go:373: Testing /rest/svc/report ...
	gui_test.go:373: Testing /rest/system/browse?current=~ ...
	gui_test.go:373: Testing /rest/system/config ...
	gui_test.go:373: Testing /rest/system/config/insync ...
	gui_test.go:373: Testing /rest/system/connections ...
	gui_test.go:373: Testing /rest/system/discovery ...
	gui_test.go:373: Testing /rest/system/error?since=0 ...
	gui_test.go:373: Testing /rest/system/ping ...
	gui_test.go:373: Testing /rest/system/status ...
	gui_test.go:373: Testing /rest/system/version ...
	gui_test.go:373: Testing /rest/system/debug ...
	gui_test.go:373: Testing /rest/system/log?since=0 ...
	gui_test.go:373: Testing /rest/system/log.txt?since=0 ...
PASS
ok  	github.com/syncthing/syncthing/cmd/syncthing	0.695s
```
