### PR TITLE
gui: copy recent css changes to dark theme (consolidate themes)

### DIFF
--- a/gui/dark/assets/css/overrides.css
+++ b/gui/dark/assets/css/overrides.css
@@ -39,6 +39,9 @@ ul+h5 {
     text-overflow: ellipsis;
     overflow: hidden;
 }
+.panel-title a:hover {
+  text-decoration: none;
+}
 
 identicon {
     display: inline-block;
@@ -144,6 +147,31 @@ table.table-condensed td {
     text-overflow: ellipsis;
     white-space: nowrap;
 }
+
+table.table-condensed td.no-overflow-ellipse {
+    white-space: normal;
+}
+
+.folder-advanced{
+    background-color: hsla(0,0%,99%,1);
+    border: 1px solid hsla(0, 0%, 95%, 1);
+    padding: 1rem;
+    margin-bottom: 15px;
+}
+
+.folder-advanced-toggle{
+    cursor: pointer;
+}
+.folder-advanced-toggle .collapse,
+.folder-advanced-toggle.collapsed .expand{
+    display: inline-block;
+}
+
+.folder-advanced-toggle.collapsed .collapse,
+.folder-advanced-toggle .expand{
+    display: none;
+}
+
 @media (max-width:767px) {
     table.table-condensed td {
         /* for mobile phones to allow linebreaks in long repro folder/shared with
@@ -250,15 +278,35 @@ ul.three-columns li, ul.two-columns li {
 /** Footer nav on small devices **/
 
 @media (max-width: 1199px) {
+    /* Stay at the end of the page, with space reserved for the footer
+    usually taking up two rows. */
+
+    html {
+        position: relative;
+        min-height: 100%;
+    }
+
     body {
-        padding-bottom: 0;
+        padding-bottom: 60px;
     }
 
     .navbar-fixed-bottom {
-        position: static;
+        position: absolute;
     }
 }
 
+@media (max-width: 768px) {
+    /* Layout after the normal contents, as this is when the footer switches
+    to a vertical layout. */
+
+    body {
+        padding-bottom: 0px;
+    }
+
+    .navbar-fixed-bottom {
+        position: relative;
+    }
+}
 
 /**
 


### PR DESCRIPTION
diff of the two theme's css files reveals changes that have been made to
the default theme only. I'm not sure what the changes do, but this
commit should potentially fixes inconsistencies between how the two
themes function or display. **untested**.