### PR TITLE
lib/discovery: Handle nil relayService (fixes #2890)

### DIFF
--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -124,13 +124,15 @@ func (c *localClient) announcementPkt() Announce {
 	}
 
 	var relays []Relay
-	for _, relay := range c.relayStat.Relays() {
-		latency, ok := c.relayStat.RelayStatus(relay)
-		if ok {
-			relays = append(relays, Relay{
-				URL:     relay,
-				Latency: int32(latency / time.Millisecond),
-			})
+	if c.relayStat != nil {
+		for _, relay := range c.relayStat.Relays() {
+			latency, ok := c.relayStat.RelayStatus(relay)
+			if ok {
+				relays = append(relays, Relay{
+					URL:     relay,
+					Latency: int32(latency / time.Millisecond),
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
### Purpose

Don't crash when relayService is disabled but local discovery is enabled.

### Testing

It doesn't crash when I test it manually. We should refactor the startup process a bit at some point.
