### PR TITLE
lib/sync: Skip the timing tests if the host timer is flaky

### DIFF
--- a/lib/sync/sync_test.go
+++ b/lib/sync/sync_test.go
@@ -21,6 +21,23 @@ const (
 	longWait     = 125 * time.Millisecond
 )
 
+var skipTimingTests = false
+
+func init() {
+	// Check a few times that a short sleep does not in fact overrun the log
+	// threshold. If it does, the timer accuracy is crap or the host is
+	// overloaded and we can't reliably run the tests in here. In the normal
+	// case this takes just 25*5 = 125 ms.
+	for i := 0; i < 25; i++ {
+		t0 := time.Now()
+		time.Sleep(shortWait)
+		if time.Since(t0) > logThreshold {
+			skipTimingTests = true
+			return
+		}
+	}
+}
+
 func TestTypes(t *testing.T) {
 	debug = false
 	l.SetDebug("sync", false)
@@ -57,6 +74,11 @@ func TestTypes(t *testing.T) {
 }
 
 func TestMutex(t *testing.T) {
+	if skipTimingTests {
+		t.Skip("insufficient timer accuracy")
+		return
+	}
+
 	debug = true
 	l.SetDebug("sync", true)
 	threshold = logThreshold
@@ -92,6 +114,11 @@ func TestMutex(t *testing.T) {
 }
 
 func TestRWMutex(t *testing.T) {
+	if skipTimingTests {
+		t.Skip("insufficient timer accuracy")
+		return
+	}
+
 	debug = true
 	l.SetDebug("sync", true)
 	threshold = logThreshold
@@ -152,6 +179,11 @@ func TestRWMutex(t *testing.T) {
 }
 
 func TestWaitGroup(t *testing.T) {
+	if skipTimingTests {
+		t.Skip("insufficient timer accuracy")
+		return
+	}
+
 	debug = true
 	l.SetDebug("sync", true)
 	threshold = logThreshold


### PR DESCRIPTION
### Purpose

Avoid this crap on Appveyor:

```
07:20:29 DEBUG: Mutex held for 132.8146ms. Locked at sync\sync_test.go:82 unlocked at sync\sync_test.go:84
07:20:29 DEBUG: RWMutex held for 109.3669ms. Locked at sync\sync_test.go:109: unlocked at sync\sync_test.go:111
07:20:29 DEBUG: RWMutex held for 125.0149ms. Locked at sync\sync_test.go:117: unlocked at sync\sync_test.go:119
07:20:30 DEBUG: RWMutex took 132.7338ms to lock. Locked at sync\sync_test.go:132. RUnlockers while locking: sync\sync_test.go:129
--- FAIL: TestRWMutex (0.37s)
	sync_test.go:114: Unexpected message count
	sync_test.go:122: Unexpected message count
	sync_test.go:136: Unexpected message count
	sync_test.go:139: Unexpected message
```

That 109 ms lock time on line 109/111 is supposed to be a 5 ms sleep. But the Appveyor host is overloaded or something. This tries to detect that up front and skips the tests if we can't sleep reliably.

### Testing

Still works on my computer, we'll see what Appveyor says about this commit.
