### PR TITLE
vendor: Update calmh/xdr to avoid unexpected string behavior (fixes #…

### DIFF
--- a/vendor/github.com/calmh/xdr/unmarshal.go
+++ b/vendor/github.com/calmh/xdr/unmarshal.go
@@ -4,11 +4,7 @@
 
 package xdr
 
-import (
-	"io"
-	"reflect"
-	"unsafe"
-)
+import "io"
 
 type Unmarshaller struct {
 	Error error
@@ -40,11 +36,7 @@ func (u *Unmarshaller) UnmarshalStringMax(max int) string {
 		return ""
 	}
 
-	var v string
-	p := (*reflect.StringHeader)(unsafe.Pointer(&v))
-	p.Data = uintptr(unsafe.Pointer(&buf[0]))
-	p.Len = len(buf)
-	return v
+	return string(buf)
 }
 
 func (u *Unmarshaller) UnmarshalBytes() []byte {

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -22,7 +22,7 @@
 		{
 			"importpath": "github.com/calmh/xdr",
 			"repository": "https://github.com/calmh/xdr",
-			"revision": "b6e0c321c9b5b28ba5ee21e828323e4b982c6976",
+			"revision": "f9b9f8f7aa27725f5cabb699bd9099ca7ce09143",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
### Purpose

Strings are now normal strings, even when they come from the XDR package.

### Testing

Scanning doesn't drive memory usage through the roof any more:

![screen shot 2016-03-29 at 18 36 56](https://cloud.githubusercontent.com/assets/125426/14115918/84e1f39a-f5dd-11e5-853c-7db1a8db4fb1.png)

(That was ~400M alloc previously.)
