### PR TITLE
lib: Use bytes.Equal instead of bytes.Compare where possible

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -497,10 +497,10 @@ func TestCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if bytes.Compare(bsOrig, bsChanged) == 0 {
+	if bytes.Equal(bsOrig, bsChanged) {
 		t.Error("Config should have changed")
 	}
-	if bytes.Compare(bsOrig, bsCopy) != 0 {
+	if !bytes.Equal(bsOrig, bsCopy) {
 		//ioutil.WriteFile("a", bsOrig, 0644)
 		//ioutil.WriteFile("b", bsCopy, 0644)
 		t.Error("Copy should be unchanged")

--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -454,7 +454,7 @@ nextFile:
 		need := false // If we have a lower version of the file
 		var haveVersion protocol.Vector
 		for _, v := range vl.versions {
-			if bytes.Compare(v.device, device) == 0 {
+			if bytes.Equal(v.device, device) {
 				have = true
 				haveVersion = v.version
 				// XXX: This marks Concurrent (i.e. conflicting) changes as
@@ -550,7 +550,7 @@ func (db *Instance) dropFolder(folder []byte) {
 	dbi := t.NewIterator(util.BytesPrefix([]byte{KeyTypeDevice}), nil)
 	for dbi.Next() {
 		itemFolder := db.deviceKeyFolder(dbi.Key())
-		if bytes.Compare(folder, itemFolder) == 0 {
+		if bytes.Equal(folder, itemFolder) {
 			db.Delete(dbi.Key(), nil)
 		}
 	}
@@ -560,7 +560,7 @@ func (db *Instance) dropFolder(folder []byte) {
 	dbi = t.NewIterator(util.BytesPrefix([]byte{KeyTypeGlobal}), nil)
 	for dbi.Next() {
 		itemFolder := db.globalKeyFolder(dbi.Key())
-		if bytes.Compare(folder, itemFolder) == 0 {
+		if bytes.Equal(folder, itemFolder) {
 			db.Delete(dbi.Key(), nil)
 		}
 	}

--- a/lib/db/leveldb_test.go
+++ b/lib/db/leveldb_test.go
@@ -23,15 +23,15 @@ func TestDeviceKey(t *testing.T) {
 	key := db.deviceKey(fld, dev, name)
 
 	fld2 := db.deviceKeyFolder(key)
-	if bytes.Compare(fld2, fld) != 0 {
+	if !bytes.Equal(fld2, fld) {
 		t.Errorf("wrong folder %q != %q", fld2, fld)
 	}
 	dev2 := db.deviceKeyDevice(key)
-	if bytes.Compare(dev2, dev) != 0 {
+	if !bytes.Equal(dev2, dev) {
 		t.Errorf("wrong device %q != %q", dev2, dev)
 	}
 	name2 := db.deviceKeyName(key)
-	if bytes.Compare(name2, name) != 0 {
+	if !bytes.Equal(name2, name) {
 		t.Errorf("wrong name %q != %q", name2, name)
 	}
 }
@@ -46,11 +46,11 @@ func TestGlobalKey(t *testing.T) {
 	key := db.globalKey(fld, name)
 
 	fld2 := db.globalKeyFolder(key)
-	if bytes.Compare(fld2, fld) != 0 {
+	if !bytes.Equal(fld2, fld) {
 		t.Errorf("wrong folder %q != %q", fld2, fld)
 	}
 	name2 := db.globalKeyName(key)
-	if bytes.Compare(name2, name) != 0 {
+	if !bytes.Equal(name2, name) {
 		t.Errorf("wrong name %q != %q", name2, name)
 	}
 }

--- a/lib/db/leveldb_transactions.go
+++ b/lib/db/leveldb_transactions.go
@@ -107,7 +107,7 @@ func (t readWriteTransaction) updateGlobal(folder, device []byte, file protocol.
 		}
 
 		for i := range fl.versions {
-			if bytes.Compare(fl.versions[i].device, device) == 0 {
+			if bytes.Equal(fl.versions[i].device, device) {
 				if fl.versions[i].version.Equal(file.Version) {
 					// No need to do anything
 					return false
@@ -213,7 +213,7 @@ func (t readWriteTransaction) removeFromGlobal(folder, device, file []byte, glob
 
 	removed := false
 	for i := range fl.versions {
-		if bytes.Compare(fl.versions[i].device, device) == 0 {
+		if bytes.Equal(fl.versions[i].device, device) {
 			if i == 0 && globalSize != nil {
 				f, ok := t.getFile(folder, device, file)
 				if !ok {

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -174,7 +174,7 @@ func (c *localClient) recvAnnouncements(b beacon.Interface) {
 		l.Debugf("discover: Received local announcement from %s for %s", addr, protocol.DeviceIDFromBytes(pkt.This.ID))
 
 		var newDevice bool
-		if bytes.Compare(pkt.This.ID, c.myID[:]) != 0 {
+		if !bytes.Equal(pkt.This.ID, c.myID[:]) {
 			newDevice = c.registerDevice(addr, pkt.This)
 		}
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -97,7 +97,7 @@ func TestRequest(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if bytes.Compare(bs, []byte("foobar")) != 0 {
+	if !bytes.Equal(bs, []byte("foobar")) {
 		t.Errorf("Incorrect data from request: %q", string(bs))
 	}
 
@@ -407,13 +407,13 @@ func TestClusterConfig(t *testing.T) {
 	if l := len(r.Devices); l != 2 {
 		t.Errorf("Incorrect number of devices %d != 2", l)
 	}
-	if id := r.Devices[0].ID; bytes.Compare(id, device1[:]) != 0 {
+	if id := r.Devices[0].ID; !bytes.Equal(id, device1[:]) {
 		t.Errorf("Incorrect device ID %x != %x", id, device1)
 	}
 	if r.Devices[0].Flags&protocol.FlagIntroducer == 0 {
 		t.Error("Device1 should be flagged as Introducer")
 	}
-	if id := r.Devices[1].ID; bytes.Compare(id, device2[:]) != 0 {
+	if id := r.Devices[1].ID; !bytes.Equal(id, device2[:]) {
 		t.Errorf("Incorrect device ID %x != %x", id, device2)
 	}
 	if r.Devices[1].Flags&protocol.FlagIntroducer != 0 {
@@ -427,13 +427,13 @@ func TestClusterConfig(t *testing.T) {
 	if l := len(r.Devices); l != 2 {
 		t.Errorf("Incorrect number of devices %d != 2", l)
 	}
-	if id := r.Devices[0].ID; bytes.Compare(id, device1[:]) != 0 {
+	if id := r.Devices[0].ID; !bytes.Equal(id, device1[:]) {
 		t.Errorf("Incorrect device ID %x != %x", id, device1)
 	}
 	if r.Devices[0].Flags&protocol.FlagIntroducer == 0 {
 		t.Error("Device1 should be flagged as Introducer")
 	}
-	if id := r.Devices[1].ID; bytes.Compare(id, device2[:]) != 0 {
+	if id := r.Devices[1].ID; !bytes.Equal(id, device2[:]) {
 		t.Errorf("Incorrect device ID %x != %x", id, device2)
 	}
 	if r.Devices[1].Flags&protocol.FlagIntroducer != 0 {

--- a/lib/protocol/deviceid.go
+++ b/lib/protocol/deviceid.go
@@ -66,7 +66,7 @@ func (n DeviceID) Compare(other DeviceID) int {
 }
 
 func (n DeviceID) Equals(other DeviceID) bool {
-	return bytes.Compare(n[:], other[:]) == 0
+	return bytes.Equal(n[:], other[:])
 }
 
 // Short returns an integer representing bits 0-63 of the device ID.

--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -107,7 +107,7 @@ func BlockDiff(src, tgt []protocol.BlockInfo) (have, need []protocol.BlockInfo) 
 	}
 
 	for i := range tgt {
-		if i >= len(src) || bytes.Compare(tgt[i].Hash, src[i].Hash) != 0 {
+		if i >= len(src) || !bytes.Equal(tgt[i].Hash, src[i].Hash) {
 			// Copy differing block
 			need = append(need, tgt[i])
 		} else {
@@ -132,7 +132,7 @@ func Verify(r io.Reader, blocksize int, blocks []protocol.BlockInfo) error {
 		hash := hf.Sum(nil)
 		hf.Reset()
 
-		if bytes.Compare(hash, block.Hash) != 0 {
+		if !bytes.Equal(hash, block.Hash) {
 			return fmt.Errorf("hash mismatch %x != %x for block %d", hash, block.Hash, i)
 		}
 	}


### PR DESCRIPTION
### Purpose

Simpler, faster, cleaner.

Done by machine:

```
gofmt -w -l -r 'bytes.Compare(a, b) == 0 -> bytes.Equal(a,b)' lib/*/*.go
gofmt -w -l -r 'bytes.Compare(a, b) != 0 -> !bytes.Equal(a,b)' lib/*/*.go

```

### Testing

Can't fail?