### PR TITLE
lib/discovery: Receiving a new announcement should be non-blocking

### DIFF
--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -179,8 +179,11 @@ func (c *localClient) recvAnnouncements(b beacon.Interface) {
 		}
 
 		if newDevice {
+			// Force a transmit to announce ourselves, if we are ready to do
+			// so right away.
 			select {
 			case c.forcedBcastTick <- time.Now():
+			default:
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose

Pretty sure the intention of the select was for it to be non-blocking.
Not that it will matter almost ever.

### Testing

Te...what?