### PR TITLE
lib/db: Remove checkGlobals consistency check

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -101,8 +101,6 @@ func NewFileSet(folder string, db *Instance) *FileSet {
 		mutex:        sync.NewMutex(),
 	}
 
-	s.db.checkGlobals([]byte(folder), &s.globalSize)
-
 	var deviceID protocol.DeviceID
 	s.db.withAllFolderTruncated([]byte(folder), func(device []byte, f FileInfoTruncated) bool {
 		copy(deviceID[:], device)


### PR DESCRIPTION
### Purpose

This checked for inconsistencies introduced by reordered writes, which
is fixed since a while back. Doing this takes a *long* time (on the
scale of up to tens of minutes) on under powered devices like the
Raspberry Pi and adds very little value nowadays.

### Testing

We don't test this code, so coverage will increase by removing it.