### PR TITLE
lib/ignore: Correct case insensitive matching on Mac/Windows

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -229,8 +229,12 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 		}
 
 		if strings.HasPrefix(line, "(?i)") {
-			line = strings.ToLower(line[4:])
 			pattern.foldCase = true
+			line = line[4:]
+		}
+
+		if pattern.foldCase {
+			line = strings.ToLower(line)
 		}
 
 		var err error

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -535,3 +535,28 @@ func TestWindowsPatterns(t *testing.T) {
 		}
 	}
 }
+
+func TestAutomaticCaseInsensitivity(t *testing.T) {
+	// We should do case insensitive matching by default on some platforms.
+	if runtime.GOOS != "windows" && runtime.GOOS != "darwin" {
+		t.Skip("Windows/Mac specific test")
+		return
+	}
+
+	stignore := `
+	A/B
+	c/d
+	`
+	pats := New(true)
+	err := pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []string{`a/B`, `C/d`}
+	for _, pat := range tests {
+		if !pats.Match(pat) {
+			t.Errorf("Should match %s", pat)
+		}
+	}
+}


### PR DESCRIPTION
### Purpose

There was a bug (since the glob package change) in that we only did the lowercase folding when the pattern had an explicit (?i), which is not the case on Windows/Mac necessarily.

### Testing

Covered by a new unit test on Windows/Mac