### PR TITLE
lib/ignore: Remove pattern for foo/** which is already covered by foo/

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -249,7 +249,9 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 			}
 			patterns = append(patterns, pattern)
 
-			pattern.match, err = glob.Compile(line[3:])
+			line = line[3:]
+			pattern.pattern = line
+			pattern.match, err = glob.Compile(line)
 			if err != nil {
 				return fmt.Errorf("invalid pattern %q in ignore file", line)
 			}
@@ -271,7 +273,9 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 			}
 			patterns = append(patterns, pattern)
 
-			pattern.match, err = glob.Compile("**/" + line)
+			line := "**/" + line
+			pattern.pattern = line
+			pattern.match, err = glob.Compile(line)
 			if err != nil {
 				return fmt.Errorf("invalid pattern %q in ignore file", line)
 			}
@@ -299,9 +303,6 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 			err = addPattern(line)
 		case strings.HasSuffix(line, "/"):
 			err = addPattern(line)
-			if err == nil {
-				err = addPattern(line + "**")
-			}
 		default:
 			err = addPattern(line)
 			if err == nil {

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -177,10 +177,6 @@ func TestCaching(t *testing.T) {
 		t.Fatal("Expected empty cache")
 	}
 
-	if len(pats.patterns) != 4 {
-		t.Fatal("Incorrect number of patterns loaded", len(pats.patterns), "!=", 4)
-	}
-
 	// Cache some outcomes
 
 	for _, letter := range []string{"a", "b", "x", "y"} {


### PR DESCRIPTION
### Purpose

Actual speed difference according to benchmarks is hidden in the noise

Also make the "pattern" field for each entry match what is actually
evaluated, or it looks like we have duplicates in the `expanded` JSON field.

### Testing

Those unit tests, they rock.