### PR TITLE
cmd/syncthing: Skip a calculation if timediff is zero (fixes #2854)

### DIFF
--- a/cmd/syncthing/gui_windows.go
+++ b/cmd/syncthing/gui_windows.go
@@ -42,6 +42,10 @@ func trackCPUUsage() {
 
 		curTime := time.Now().UnixNano()
 		timeDiff := curTime - prevTime
+		// This is sometimes 0, no clue why.
+		if timeDiff == 0 {
+			continue
+		}
 		curUsage := ktime.Nanoseconds() + utime.Nanoseconds()
 		usageDiff := curUsage - prevUsage
 		cpuUsageLock.Lock()


### PR DESCRIPTION
### Purpose

No idea under what conditions this happens, but it does as far as we can see from debugging.

