### PR TITLE
Add (?d) ignore prefix, allowing them to be deleted

### DIFF
--- a/lib/ignore/cache.go
+++ b/lib/ignore/cache.go
@@ -14,7 +14,7 @@ type cache struct {
 }
 
 type cacheEntry struct {
-	value  bool
+	result Result
 	access time.Time
 }
 
@@ -33,17 +33,17 @@ func (c *cache) clean(d time.Duration) {
 	}
 }
 
-func (c *cache) get(key string) (result, ok bool) {
-	res, ok := c.entries[key]
+func (c *cache) get(key string) (Result, bool) {
+	entry, ok := c.entries[key]
 	if ok {
-		res.access = time.Now()
-		c.entries[key] = res
+		entry.access = time.Now()
+		c.entries[key] = entry
 	}
-	return res.value, ok
+	return entry.result, ok
 }
 
-func (c *cache) set(key string, val bool) {
-	c.entries[key] = cacheEntry{val, time.Now()}
+func (c *cache) set(key string, result Result) {
+	c.entries[key] = cacheEntry{result, time.Now()}
 }
 
 func (c *cache) len() int {

--- a/lib/ignore/cache_test.go
+++ b/lib/ignore/cache_test.go
@@ -15,22 +15,22 @@ func TestCache(t *testing.T) {
 	c := newCache(nil)
 
 	res, ok := c.get("nonexistent")
-	if res != false || ok != false {
+	if res.IsIgnored() || res.IsDeletable() || ok != false {
 		t.Errorf("res %v, ok %v for nonexistent item", res, ok)
 	}
 
 	// Set and check some items
 
-	c.set("true", true)
-	c.set("false", false)
+	c.set("true", Result{true, true})
+	c.set("false", Result{false, false})
 
 	res, ok = c.get("true")
-	if res != true || ok != true {
+	if !res.IsIgnored() || !res.IsDeletable() || ok != true {
 		t.Errorf("res %v, ok %v for true item", res, ok)
 	}
 
 	res, ok = c.get("false")
-	if res != false || ok != true {
+	if res.IsIgnored() || res.IsDeletable() || ok != true {
 		t.Errorf("res %v, ok %v for false item", res, ok)
 	}
 
@@ -41,12 +41,12 @@ func TestCache(t *testing.T) {
 	// Same values should exist
 
 	res, ok = c.get("true")
-	if res != true || ok != true {
+	if !res.IsIgnored() || !res.IsDeletable() || ok != true {
 		t.Errorf("res %v, ok %v for true item", res, ok)
 	}
 
 	res, ok = c.get("false")
-	if res != false || ok != true {
+	if res.IsIgnored() || res.IsDeletable() || ok != true {
 		t.Errorf("res %v, ok %v for false item", res, ok)
 	}
 

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -8,6 +8,7 @@ package ignore
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -52,7 +53,7 @@ func TestIgnore(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		if r := pats.Match(tc.f); r != tc.r {
+		if r := pats.Match(tc.f); r.IsIgnored() != tc.r {
 			t.Errorf("Incorrect ignoreFile() #%d (%s); E: %v, A: %v", i, tc.f, tc.r, r)
 		}
 	}
@@ -90,8 +91,86 @@ func TestExcludes(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if r := pats.Match(tc.f); r != tc.r {
+		if r := pats.Match(tc.f); r.IsIgnored() != tc.r {
 			t.Errorf("Incorrect match for %s: %v != %v", tc.f, r, tc.r)
+		}
+	}
+}
+
+func TestFlagOrder(t *testing.T) {
+	stignore := `
+	## Ok cases
+	(?i)(?d)!ign1
+	(?d)(?i)!ign2
+	(?i)!(?d)ign3
+	(?d)!(?i)ign4
+	!(?i)(?d)ign5
+	!(?d)(?i)ign6
+	## Bad cases
+	!!(?i)(?d)ign7
+	(?i)(?i)(?d)ign8
+	(?i)(?d)(?d)!ign9
+	(?d)(?d)!ign10
+	`
+	pats := New(true)
+	err := pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 1; i < 7; i++ {
+		pat := fmt.Sprintf("ign%d", i)
+		if r := pats.Match(pat); r.IsIgnored() || r.IsDeletable() {
+			t.Errorf("incorrect %s", pat)
+		}
+	}
+	for i := 7; i < 10; i++ {
+		pat := fmt.Sprintf("ign%d", i)
+		if r := pats.Match(pat); r.IsDeletable() {
+			t.Errorf("incorrect %s", pat)
+		}
+	}
+
+	if r := pats.Match("(?d)!ign10"); !r.IsIgnored() {
+		t.Errorf("incorrect")
+	}
+}
+
+func TestDeletables(t *testing.T) {
+	stignore := `
+	(?d)ign1
+	(?d)(?i)ign2
+	(?i)(?d)ign3
+	!(?d)ign4
+	!ign5
+	!(?i)(?d)ign6
+	ign7
+	(?i)ign8
+	`
+	pats := New(true)
+	err := pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var tests = []struct {
+		f string
+		i bool
+		d bool
+	}{
+		{"ign1", true, true},
+		{"ign2", true, true},
+		{"ign3", true, true},
+		{"ign4", false, false},
+		{"ign5", false, false},
+		{"ign6", false, false},
+		{"ign7", true, false},
+		{"ign8", true, false},
+	}
+
+	for _, tc := range tests {
+		if r := pats.Match(tc.f); r.IsIgnored() != tc.i || r.IsDeletable() != tc.d {
+			t.Errorf("Incorrect match for %s: %v != Result{%t, %t}", tc.f, r, tc.i, tc.d)
 		}
 	}
 }
@@ -132,13 +211,13 @@ func TestCaseSensitivity(t *testing.T) {
 	}
 
 	for _, tc := range match {
-		if !ign.Match(tc) {
+		if !ign.Match(tc).IsIgnored() {
 			t.Errorf("Incorrect match for %q: should be matched", tc)
 		}
 	}
 
 	for _, tc := range dontMatch {
-		if ign.Match(tc) {
+		if ign.Match(tc).IsIgnored() {
 			t.Errorf("Incorrect match for %q: should not be matched", tc)
 		}
 	}
@@ -277,7 +356,7 @@ func TestCommentsAndBlankLines(t *testing.T) {
 	}
 }
 
-var result bool
+var result Result
 
 func BenchmarkMatch(b *testing.B) {
 	stignore := `
@@ -381,13 +460,13 @@ func TestCacheReload(t *testing.T) {
 
 	// Verify that both are ignored
 
-	if !pats.Match("f1") {
+	if !pats.Match("f1").IsIgnored() {
 		t.Error("Unexpected non-match for f1")
 	}
-	if !pats.Match("f2") {
+	if !pats.Match("f2").IsIgnored() {
 		t.Error("Unexpected non-match for f2")
 	}
-	if pats.Match("f3") {
+	if pats.Match("f3").IsIgnored() {
 		t.Error("Unexpected match for f3")
 	}
 
@@ -413,13 +492,13 @@ func TestCacheReload(t *testing.T) {
 
 	// Verify that the new patterns are in effect
 
-	if !pats.Match("f1") {
+	if !pats.Match("f1").IsIgnored() {
 		t.Error("Unexpected non-match for f1")
 	}
-	if pats.Match("f2") {
+	if pats.Match("f2").IsIgnored() {
 		t.Error("Unexpected match for f2")
 	}
-	if !pats.Match("f3") {
+	if !pats.Match("f3").IsIgnored() {
 		t.Error("Unexpected non-match for f3")
 	}
 }
@@ -526,7 +605,7 @@ func TestWindowsPatterns(t *testing.T) {
 
 	tests := []string{`a\b`, `c\d`}
 	for _, pat := range tests {
-		if !pats.Match(pat) {
+		if !pats.Match(pat).IsIgnored() {
 			t.Errorf("Should match %s", pat)
 		}
 	}
@@ -551,7 +630,7 @@ func TestAutomaticCaseInsensitivity(t *testing.T) {
 
 	tests := []string{`a/B`, `C/d`}
 	for _, pat := range tests {
-		if !pats.Match(pat) {
+		if !pats.Match(pat).IsIgnored() {
 			t.Errorf("Should match %s", pat)
 		}
 	}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -209,7 +209,7 @@ func (m *Model) warnAboutOverwritingProtectedFiles(folder string) {
 		}
 
 		// check if file is ignored
-		if ignores.Match(protectedFilePath) {
+		if ignores.Match(protectedFilePath).IsIgnored() {
 			continue
 		}
 
@@ -800,7 +800,7 @@ func (m *Model) Request(deviceID protocol.DeviceID, folder, name string, offset 
 		// cleaned from any possible funny business.
 		if rn, err := filepath.Rel(folderPath, fn); err != nil {
 			return err
-		} else if folderIgnores.Match(rn) {
+		} else if folderIgnores.Match(rn).IsIgnored() {
 			l.Debugf("%v REQ(in) for ignored file: %s: %q / %q o=%d s=%d", m, deviceID, folder, name, offset, len(buf))
 			return protocol.ErrNoSuchFile
 		}
@@ -1149,7 +1149,7 @@ func sendIndexTo(initial bool, minLocalVer int64, conn protocol.Connection, fold
 			maxLocalVer = f.LocalVersion
 		}
 
-		if ignores.Match(f.Name) || symlinkInvalid(folder, f) {
+		if ignores.Match(f.Name).IsIgnored() || symlinkInvalid(folder, f) {
 			l.Debugln("not sending update for ignored/unsupported symlink", f)
 			return true
 		}
@@ -1441,7 +1441,7 @@ func (m *Model) internalScanFolderSubs(folder string, subs []string) error {
 					batch = batch[:0]
 				}
 
-				if ignores.Match(f.Name) || symlinkInvalid(folder, f) {
+				if ignores.Match(f.Name).IsIgnored() || symlinkInvalid(folder, f) {
 					// File has been ignored or an unsupported symlink. Set invalid bit.
 					l.Debugln("setting invalid bit on ignored", f)
 					nf := protocol.FileInfo{


### PR DESCRIPTION
### Purpose

Adds a (?d) prefix which marks the file as deletable, so that when we are deleting a directory, we can delete anything that is ignored and in our way.

Also, removes the need to specify the prefixes in a certain order.

### Testing

Users will tell me if I deleted all of their photos

### Screenshots

![](http://integral-integrity.info/DRimages/pic_computerdisaster.jpg)

### Documentation

Need some
