### PR TITLE
lib/model: Add option for overwriting names on connect (fixes #2912)

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -61,6 +61,7 @@ func TestDefaultValues(t *testing.T) {
 		URPostInsecurely:        false,
 		ReleasesURL:             "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30",
 		AlwaysLocalNets:         []string{},
+		OverwriteNames:          false,
 	}
 
 	cfg := New(device1)
@@ -190,6 +191,7 @@ func TestOverriddenValues(t *testing.T) {
 		URPostInsecurely:        true,
 		ReleasesURL:             "https://localhost/releases",
 		AlwaysLocalNets:         []string{},
+		OverwriteNames:          true,
 	}
 
 	cfg, err := Load("testdata/overridenvalues.xml", device1)

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -39,6 +39,7 @@ type OptionsConfiguration struct {
 	MinHomeDiskFreePct      float64  `xml:"minHomeDiskFreePct" json:"minHomeDiskFreePct" default:"1"`
 	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://api.github.com/repos/syncthing/syncthing/releases?per_page=30"`
 	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
+	OverwriteNames          bool     `xml:"overwriteNames" json:"overwriteNames" default:"false"`
 }
 
 func (orig OptionsConfiguration) Copy() OptionsConfiguration {

--- a/lib/config/testdata/overridenvalues.xml
+++ b/lib/config/testdata/overridenvalues.xml
@@ -34,5 +34,6 @@
         <urInitialDelayS>800</urInitialDelayS>
         <urPostInsecurely>true</urPostInsecurely>
         <releasesURL>https://localhost/releases</releasesURL>
+        <overwriteNames>true</overwriteNames>
     </options>
 </configuration>

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1011,7 +1011,7 @@ func (m *Model) AddConnection(conn Connection, hello protocol.HelloMessage) {
 	l.Infof(`Device %s client is "%s %s" named "%s"`, deviceID, hello.ClientName, hello.ClientVersion, hello.DeviceName)
 
 	device, ok := m.cfg.Devices()[deviceID]
-	if ok && device.Name == "" {
+	if ok && (device.Name == "" || m.cfg.Options().OverwriteNames) {
 		device.Name = hello.DeviceName
 		m.cfg.SetDevice(device)
 		m.cfg.Save()

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -357,6 +357,19 @@ func TestDeviceRename(t *testing.T) {
 	if cfgw.Devices()[device1].Name != "tester" {
 		t.Errorf("Device name not saved in config")
 	}
+
+	m.Close(device1, protocol.ErrTimeout)
+
+	opts := cfg.Options()
+	opts.OverwriteNames = true
+	cfg.SetOptions(opts)
+
+	hello.DeviceName = "tester2"
+	m.AddConnection(conn, hello)
+
+	if cfg.Devices()[device1].Name != "tester2" {
+		t.Errorf("Device name not overwritten")
+	}
 }
 
 func TestClusterConfig(t *testing.T) {


### PR DESCRIPTION
### Purpose

Overwrites device name on connect.
Perhaps we should make this the default? It would make people more organized with their stuff.

### Testing

Unit tests