### PR TITLE
cmd/syncthing: Listening on a 0 port is not valid (fixes #2926)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -721,6 +721,9 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	if err != nil {
 		l.Fatalln("Bad listen address:", err)
 	}
+	if addr.Port == 0 {
+		l.Fatalf("Listen address %s: invalid port", uri)
+	}
 
 	// Start UPnP
 	var upnpService *upnp.Service


### PR DESCRIPTION
### Purpose

`tcp://0.0.0.0:` results in a 0 port.

Ideally this should be fixed by starting to listen first, and only then asking for UPnP mapping.
This is to be solved by my UPnP refactor at some point I guess.

### Testing

Manually tested `tcp://0.0.0.0:0`, `tcp://0.0.0.0:`