### PR TITLE
lib/connections: Silence vet and lint warnings

### DIFF
--- a/cmd/stindex/dumpsize.go
+++ b/cmd/stindex/dumpsize.go
@@ -15,7 +15,6 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 )
 
-// An IntHeap is a min-heap of ints.
 type SizedElement struct {
 	key  string
 	size int

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -199,7 +199,10 @@ func (s *apiService) getListener(guiCfg config.GUIConfiguration) (net.Listener, 
 		return nil, err
 	}
 
-	listener := &tlsutil.DowngradingListener{rawListener, tlsCfg}
+	listener := &tlsutil.DowngradingListener{
+		Listener:  rawListener,
+		TLSConfig: tlsCfg,
+	}
 	return listener, nil
 }
 

--- a/lib/connections/connections.go
+++ b/lib/connections/connections.go
@@ -268,9 +268,9 @@ next:
 
 				s.mut.Lock()
 				s.model.AddConnection(model.Connection{
-					c,
-					protoConn,
-					c.Type,
+					Conn:       c,
+					Connection: protoConn,
+					Type:       c.Type,
 				}, hello)
 				s.connType[remoteID] = c.Type
 				s.mut.Unlock()
@@ -319,7 +319,8 @@ func (s *Service) connect() {
 						s.model.Close(deviceID, fmt.Errorf("switching connections"))
 					}
 					s.conns <- model.IntermediateConnection{
-						conn, model.ConnectionTypeDirectDial,
+						Conn: conn,
+						Type: model.ConnectionTypeDirectDial,
 					}
 					continue nextDevice
 				}
@@ -350,7 +351,8 @@ func (s *Service) connect() {
 				if conn := s.connectViaRelay(deviceID, addr); conn != nil {
 					l.Debugln("Connecting to", deviceID, "via", addr, "succeeded")
 					s.conns <- model.IntermediateConnection{
-						conn, model.ConnectionTypeRelayDial,
+						Conn: conn,
+						Type: model.ConnectionTypeRelayDial,
 					}
 					continue nextDevice
 				}

--- a/lib/connections/connections_tcp.go
+++ b/lib/connections/connections_tcp.go
@@ -91,7 +91,8 @@ func makeTCPListener(network string) ListenerFactory {
 			}
 
 			conns <- model.IntermediateConnection{
-				tc, model.ConnectionTypeDirectAccept,
+				Conn: tc,
+				Type: model.ConnectionTypeDirectAccept,
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose

Get rid of a few remaining "composite literal uses unkeyed fields" vet errors and one lint warning on a bad comment.

(I want to make the vet check required, so it's good if we're clean going into that.)