### PR TITLE
lib/osutil: Try very hard to preserve mtimes when renaming

### DIFF
--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -122,7 +122,8 @@ func (s *sharedPullerState) tempFile() (io.WriterAt, error) {
 	}
 
 	// Attempt to create the temp file
-	flags := os.O_WRONLY
+	// RDWR because of issue #2994.
+	flags := os.O_RDWR
 	if s.reused == 0 {
 		flags |= os.O_CREATE | os.O_EXCL
 	} else {


### PR DESCRIPTION
### Purpose

Worked this one out on a test setup provided by @cmarsura.

Very nice debugging procedures:

```diff
diff --git a/lib/model/rwfolder.go b/lib/model/rwfolder.go
index ab384d4..3e29672 100644
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -494,7 +490,7 @@ func (p *rwFolder) pullerIteration(ignores *ignore.Matcher) int {
                        return true
                }

-               l.Debugln(p, "handling", file.Name)
+               l.Debugln(p, "handling", file.Name, file.Modified)

                if !handleFile(file) {
                        // A new or changed file or symlink. This is the only case where we

diff --git a/lib/model/rwfolder.go b/lib/model/rwfolder.go
index ab384d4..3e29672 100644
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1283,6 +1284,16 @@ func (p *rwFolder) pullerRoutine(in <-chan pullBlockState, out chan<- *sharedPul
        }
 }

+func dumpDebug(msg, path string) {
+       stat, err := os.Stat(path)
+       if err != nil {
+               l.Infoln("FAILED", msg, path)
+               return
+       }
+
+       l.Infoln("XXXXXXXXXXXXXXXXXXXX", msg, path, stat.ModTime().Unix())
+}
+
 func (p *rwFolder) performFinish(state *sharedPullerState) error {
        // Set the correct permission bits on the new file
        if !p.ignorePermissions(state.file) {
@@ -1290,10 +1301,14 @@ func (p *rwFolder) performFinish(state *sharedPullerState) error {
                        return err
                }
        }
+
+       dumpDebug("EXPECTED", state.file.Name)
+       dumpDebug("TEMP", state.tempName)

        // Set the correct timestamp on the new file
        t := time.Unix(state.file.Modified, 0)
        if err := os.Chtimes(state.tempName, t, t); err != nil {
+               l.Infoln("CHTIMES FAILED")
                // Try using virtual mtimes instead
                info, err := os.Stat(state.tempName)
                if err != nil {
@@ -1301,6 +1316,8 @@ func (p *rwFolder) performFinish(state *sharedPullerState) error {
                }
                p.virtualMtimeRepo.UpdateMtime(state.file.Name, info.ModTime(), t)
        }
+
+       dumpDebug("TEMP AFTER CHTIMES", state.tempName)

        if stat, err := osutil.Lstat(state.realName); err == nil {
                // There is an old file or directory already in place. We need to
@@ -1346,6 +1363,8 @@ func (p *rwFolder) performFinish(state *sharedPullerState) error {
        if err := osutil.Rename(state.tempName, state.realName); err != nil {
                return err
        }
+
+       dumpDebug("REAL AFTER RENAME", state.realName)

        // If it's a symlink, the target of the symlink is inside the file.
        if state.file.IsSymlink() {
```

Yields:

```
[4M335] 2016/04/20 00:18:59.495218 rwfolder.go:493: DEBUG: rwFolder/TestSmbBug@0x112d80c0 handling incr.txt 1461104338
...
[4M335] 2016/04/20 00:18:59.631937 rwfolder.go:1290: INFO: FAILED EXPECTED incr.txt
[4M335] 2016/04/20 00:18:59.631937 rwfolder.go:1294: INFO: XXXXXXXXXXXXXXXXXXXX TEMP \\storagevm\RemoteStorage\~syncthing~incr.txt.tmp 1461104340
[4M335] 2016/04/20 00:18:59.835062 rwfolder.go:1294: INFO: XXXXXXXXXXXXXXXXXXXX TEMP AFTER CHTIMES \\storagevm\RemoteStorage\~syncthing~incr.txt.tmp 1461104338
[4M335] 2016/04/20 00:18:59.835062 rwfolder.go:1294: INFO: XXXXXXXXXXXXXXXXXXXX REAL AFTER RENAME \\storagevm\RemoteStorage\incr.txt 1461104341
```

### Testing

None at all, but it's for the reviewer to verify.