### PR TITLE
cmd/stvanity: Use Go 1.3 compatible interface

### DIFF
--- a/cmd/stvanity/main.go
+++ b/cmd/stvanity/main.go
@@ -101,7 +101,7 @@ func generatePrefixed(prefix string, count *int64, found chan<- result, stop <-c
 		default:
 		}
 
-		derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.Public(), priv)
+		derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.PublicKey, priv)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)


### PR DESCRIPTION
### Purpose

Actually fix the build on Go 1.3 for reals