### PR TITLE
cmd/syncthing: Don't compact database at startup

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -662,13 +662,6 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		}
 	}
 
-	// Pack and optimize the database
-	if err := ldb.Compact(); err != nil {
-		// I don't think this is fatal, but who knows. If it is, we'll surely
-		// get an error when trying to write to the db later.
-		l.Infoln("Compacting database:", err)
-	}
-
 	m := model.NewModel(cfg, myID, myDeviceName(cfg), "syncthing", Version, ldb, protectedFiles)
 	cfg.Subscribe(m)
 

--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -91,10 +91,6 @@ func newDBInstance(db *leveldb.DB) *Instance {
 	return i
 }
 
-func (db *Instance) Compact() error {
-	return db.CompactRange(util.Range{})
-}
-
 func (db *Instance) genericReplace(folder, device []byte, fs []protocol.FileInfo, localSize, globalSize *sizeTracker, deleteFn deletionHandler) int64 {
 	sort.Sort(fileList(fs)) // sort list on name, same as in the database
 


### PR DESCRIPTION
### Purpose

This happens automatically in the background anyway, and it can take a long time on low powered devices at an inconvenient time. We just want to get up and running as quickly as possible.

### Testing

None needed, really