### PR TITLE
cmd/stvanity: use pointer for public key

### DIFF
--- a/cmd/stvanity/main.go
+++ b/cmd/stvanity/main.go
@@ -101,7 +101,7 @@ func generatePrefixed(prefix string, count *int64, found chan<- result, stop <-c
 		default:
 		}
 
-		derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, priv.PublicKey, priv)
+		derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 		if err != nil {
 			fmt.Println(err)
 			os.Exit(1)


### PR DESCRIPTION
### Purpose

did not work before on linux/amd64 go 1.6: `x509: only RSA and ECDSA public keys supported`

### Testing

successful generation of key
