### PR TITLE
lib/model: Discard download progress upon receiving an index update (fixes #2993)

### DIFF
--- a/lib/model/devicedownloadstate.go
+++ b/lib/model/devicedownloadstate.go
@@ -97,6 +97,9 @@ type deviceDownloadState struct {
 // Update updates internal state of what has been downloaded into the temporary
 // files by the remote device for this specific folder.
 func (t *deviceDownloadState) Update(folder string, updates []protocol.FileDownloadProgressUpdate) {
+	if t == nil {
+		return
+	}
 	t.mut.RLock()
 	f, ok := t.folders[folder]
 	t.mut.RUnlock()


### PR DESCRIPTION
We still send updates for the same files we've removed.
Reason we need that mechanism is for files that have failed.