### PR TITLE
lib/upgrade: Auto upgrade signature should cover version & arch

### DIFF
--- a/lib/upgrade/upgrade_unsupp.go
+++ b/lib/upgrade/upgrade_unsupp.go
@@ -14,7 +14,7 @@ func upgradeTo(binary string, rel Release) error {
 	return ErrUpgradeUnsupported
 }
 
-func upgradeToURL(binary, url string) error {
+func upgradeToURL(archiveName, binary, url string) error {
 	return ErrUpgradeUnsupported
 }
 


### PR DESCRIPTION
### Purpose

New signature is the HMAC of archive name (which includes the release
version and architecture) plus the contents of the binary. This is
expected in a new file "release.sig" which may be present in a
subdirectory. The new release tools put this in [.]metadata/release.sig.

### Testing

So far, just manually. We should add some coverage over this though...