### PR TITLE
cmd/syncthing: Use ReadAll + json.Unmarshal in places were we care about consuming the reader

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"io"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"sort"
@@ -92,7 +93,12 @@ func ReadJSON(r io.Reader, myID protocol.DeviceID) (Configuration, error) {
 	util.SetDefaults(&cfg.Options)
 	util.SetDefaults(&cfg.GUI)
 
-	err := json.NewDecoder(r).Decode(&cfg)
+	bs, err := ioutil.ReadAll(r)
+	if err != nil {
+		return cfg, err
+	}
+
+	err = json.Unmarshal(bs, &cfg)
 	cfg.OriginalVersion = cfg.Version
 
 	cfg.prepare(myID)

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -154,9 +155,14 @@ func (c *globalClient) Lookup(device protocol.DeviceID) (addresses []string, err
 		return nil, err
 	}
 
-	var ann announcement
-	err = json.NewDecoder(resp.Body).Decode(&ann)
+	bs, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	resp.Body.Close()
+
+	var ann announcement
+	err = json.Unmarshal(bs, &ann)
 	return ann.Addresses, err
 }
 


### PR DESCRIPTION
### Purpose

Because json.NewDecoder(r).Decode(&v) doesn't necessarily consume all data on the reader, that means an HTTP connection can't be reused. We don't do a lot of HTTP traffic where we read JSON responses, but the discovery is one such place. The other two are for POSTs from the GUI, where it's not exactly critical but still nice if the connection still can be keep-alive'd after the request as well.

Also ensure that we call req.Body.Close() for clarity, even though this should by all accounts not really be necessary.

### Testing

Unpossible to fail