### PR TITLE
lib/util: Should seed random number generator on startup

### DIFF
--- a/lib/util/random.go
+++ b/lib/util/random.go
@@ -17,6 +17,11 @@ import (
 // randomCharset contains the characters that can make up a randomString().
 const randomCharset = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
 
+func init() {
+	// The default RNG should be seeded with something good.
+	mathRand.Seed(RandomInt64())
+}
+
 // RandomString returns a string of random characters (taken from
 // randomCharset) of the specified length.
 func RandomString(l int) string {


### PR DESCRIPTION
### Purpose

This was removed in the connection refactor; not sure why, hopefully by mistake?

(I'm going to change so that our default folder also uses a random ID generated in the same way as when adding a new folder in the UI, and this made us generate the same ID every time...)