### PR TITLE
cmd/syncthing: Use random folder ID for default folder, limit random charset

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -946,8 +946,9 @@ func defaultConfig(myName string) config.Configuration {
 
 	if !noDefaultFolder {
 		l.Infoln("Default folder created and/or linked to new config")
-
-		defaultFolder = config.NewFolderConfiguration("default", locations[locDefFolder])
+		folderID := util.RandomString(5) + "-" + util.RandomString(5)
+		defaultFolder = config.NewFolderConfiguration(folderID, locations[locDefFolder])
+		defaultFolder.Label = "Default Folder"
 		defaultFolder.RescanIntervalS = 60
 		defaultFolder.MinDiskFreePct = 1
 		defaultFolder.Devices = []config.FolderDeviceConfiguration{{DeviceID: myID}}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -948,7 +948,7 @@ func defaultConfig(myName string) config.Configuration {
 		l.Infoln("Default folder created and/or linked to new config")
 		folderID := util.RandomString(5) + "-" + util.RandomString(5)
 		defaultFolder = config.NewFolderConfiguration(folderID, locations[locDefFolder])
-		defaultFolder.Label = "Default Folder"
+		defaultFolder.Label = "Default Folder (" + folderID + ")"
 		defaultFolder.RescanIntervalS = 60
 		defaultFolder.MinDiskFreePct = 1
 		defaultFolder.Devices = []config.FolderDeviceConfiguration{{DeviceID: myID}}

--- a/lib/util/random.go
+++ b/lib/util/random.go
@@ -15,7 +15,7 @@ import (
 )
 
 // randomCharset contains the characters that can make up a randomString().
-const randomCharset = "01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-"
+const randomCharset = "2345679abcdefghijkmnopqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ"
 
 // RandomString returns a string of random characters (taken from
 // randomCharset) of the specified length.


### PR DESCRIPTION
### Purpose

The default folder should use a random folder ID like all other folders. This uses the same charset as the Javascript code, excluding confusing characters like 0, O, I, 1, l etc.

### Testing

Tested manually using `./bin/syncthing -generate foo` and observing the random folder ID created.