### PR TITLE
lib/config: Don't require restart when adding folders/devices or changing listen address

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -138,6 +138,10 @@ func (f *FolderConfiguration) prepare() {
 	} else if f.RescanIntervalS < 0 {
 		f.RescanIntervalS = 0
 	}
+
+	if f.Versioning.Params == nil {
+		f.Versioning.Params = make(map[string]string)
+	}
 }
 
 func (f *FolderConfiguration) cleanedPath() string {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2018,6 +2018,7 @@ func (m *Model) CommitConfiguration(from, to config.Configuration) bool {
 	// by themselves.
 	from.Options.URAccepted = to.Options.URAccepted
 	from.Options.URUniqueID = to.Options.URUniqueID
+	from.Options.ListenAddresses = to.Options.ListenAddresses
 	// All of the other generic options require restart. Or at least they may;
 	// removing this check requires going through those options carefully and
 	// making sure there are individual services that handle them correctly.


### PR DESCRIPTION
### Purpose

The VersioningConfig change is because it defaults to nil but gets
deserialized to map[string]string{}. Now prepare() enforces a single
representation of the empty map.

### Testing

Manually :(