### PR TITLE
lib/connections: Don't look at devices that are already optimally connected

### DIFF
--- a/lib/connections/relay_dial.go
+++ b/lib/connections/relay_dial.go
@@ -21,7 +21,7 @@ import (
 const relayPriority = 200
 
 func init() {
-	dialers["relay"] = newRelayDialer
+	dialers["relay"] = relayDialerFactory{}
 }
 
 type relayDialer struct {
@@ -74,9 +74,15 @@ func (d *relayDialer) String() string {
 	return "Relay Dialer"
 }
 
-func newRelayDialer(cfg *config.Wrapper, tlsCfg *tls.Config) genericDialer {
+type relayDialerFactory struct{}
+
+func (relayDialerFactory) New(cfg *config.Wrapper, tlsCfg *tls.Config) genericDialer {
 	return &relayDialer{
 		cfg:    cfg,
 		tlsCfg: tlsCfg,
 	}
+}
+
+func (relayDialerFactory) Priority() int {
+	return relayPriority
 }

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -240,7 +240,7 @@ func (s *Service) connect() {
 	delay := time.Second
 	sleep := time.Second
 
-	bestDialerPrio := 1<<32 - 1 // worse prio won't build on 32 bit
+	bestDialerPrio := 1<<31 - 1 // worse prio won't build on 32 bit
 	for _, df := range dialers {
 		if prio := df.Priority(); prio < bestDialerPrio {
 			bestDialerPrio = prio

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -240,6 +240,13 @@ func (s *Service) connect() {
 	delay := time.Second
 	sleep := time.Second
 
+	bestDialerPrio := 1<<32 - 1 // worse prio won't build on 32 bit
+	for _, df := range dialers {
+		if prio := df.Priority(); prio < bestDialerPrio {
+			bestDialerPrio = prio
+		}
+	}
+
 	for {
 		l.Debugln("Reconnect loop")
 
@@ -257,12 +264,17 @@ func (s *Service) connect() {
 				continue
 			}
 
-			l.Debugln("Reconnect loop for", deviceID)
-
 			connected := s.model.ConnectedTo(deviceID)
 			s.curConMut.Lock()
 			ct := s.currentConnection[deviceID]
 			s.curConMut.Unlock()
+
+			if connected && ct.Priority == bestDialerPrio {
+				// Things are already as good as they can get.
+				continue
+			}
+
+			l.Debugln("Reconnect loop for", deviceID)
 
 			var addrs []string
 			for _, addr := range deviceCfg.Addresses {
@@ -292,7 +304,7 @@ func (s *Service) connect() {
 					continue
 				}
 
-				dialer := dialerFactory(s.cfg, s.tlsCfg)
+				dialer := dialerFactory.New(s.cfg, s.tlsCfg)
 
 				nextDialAt, ok := nextDial[uri.String()]
 				// See below for comments on this delay >= sleep check

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -28,7 +28,10 @@ type Connection struct {
 	protocol.Connection
 }
 
-type dialerFactory func(*config.Wrapper, *tls.Config) genericDialer
+type dialerFactory interface {
+	New(*config.Wrapper, *tls.Config) genericDialer
+	Priority() int
+}
 
 type genericDialer interface {
 	Dial(protocol.DeviceID, *url.URL) (IntermediateConnection, error)

--- a/lib/connections/tcp_dial.go
+++ b/lib/connections/tcp_dial.go
@@ -21,7 +21,7 @@ const tcpPriority = 10
 
 func init() {
 	for _, scheme := range []string{"tcp", "tcp4", "tcp6"} {
-		dialers[scheme] = newTCPDialer
+		dialers[scheme] = tcpDialerFactory{}
 	}
 }
 
@@ -67,9 +67,15 @@ func (d *tcpDialer) String() string {
 	return "TCP Dialer"
 }
 
-func newTCPDialer(cfg *config.Wrapper, tlsCfg *tls.Config) genericDialer {
+type tcpDialerFactory struct{}
+
+func (tcpDialerFactory) New(cfg *config.Wrapper, tlsCfg *tls.Config) genericDialer {
 	return &tcpDialer{
 		cfg:    cfg,
 		tlsCfg: tlsCfg,
 	}
+}
+
+func (tcpDialerFactory) Priority() int {
+	return tcpPriority
 }


### PR DESCRIPTION
### Purpose

Just an optimization. Required exposing the priority from the factory,
so made that an interface with an extra method instead of just a func
type.

### Testing

Manually, by looking at the STTRACE=connections output