### PR TITLE
lib/ignore: Revert comma handling, upgrade globbing package

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -337,7 +337,7 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 			continue
 		}
 
-		line = escapeCommas(filepath.ToSlash(line))
+		line = filepath.ToSlash(line)
 		switch {
 		case strings.HasPrefix(line, "#"):
 			err = addPattern(line)
@@ -357,50 +357,4 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 	}
 
 	return patterns, nil
-}
-
-// escapes unescaped commas encountered outside of brackets
-func escapeCommas(s string) string {
-	buf := make([]rune, 0, len(s))
-	inEscape := false
-	inBrackets := 0
-	inSquareBrackets := 0
-	for _, r := range s {
-		// Escaped characters are passed on verbatim no matter what, and we
-		// clear the escape flag for the next character.
-		if inEscape {
-			buf = append(buf, r)
-			inEscape = false
-			continue
-		}
-
-		// Check for escapes and commas to escape. Also keep track of the
-		// brackets level by counting start and end brackets of the two
-		// types.
-
-		switch r {
-		case '\\':
-			inEscape = true
-
-		case '{':
-			inBrackets++
-		case '}':
-			inBrackets--
-		case '[':
-			inSquareBrackets++
-		case ']':
-			inSquareBrackets--
-
-		case ',':
-			// Commas should be escaped if we're not inside a brackets
-			// construction, and if they weren't already escaped (in which
-			// case we'll have taken the first branch way up top).
-			if inBrackets == 0 && inSquareBrackets == 0 {
-				buf = append(buf, '\\')
-			}
-		}
-
-		buf = append(buf, r)
-	}
-	return string(buf)
 }

--- a/vendor/github.com/gobwas/glob/lexer_test.go
+++ b/vendor/github.com/gobwas/glob/lexer_test.go
@@ -17,6 +17,27 @@ func TestLexGood(t *testing.T) {
 			},
 		},
 		{
+			pattern: "hello,world",
+			items: []item{
+				item{item_text, "hello,world"},
+				item{item_eof, ""},
+			},
+		},
+		{
+			pattern: "hello\\,world",
+			items: []item{
+				item{item_text, "hello,world"},
+				item{item_eof, ""},
+			},
+		},
+		{
+			pattern: "hello\\{world",
+			items: []item{
+				item{item_text, "hello{world"},
+				item{item_eof, ""},
+			},
+		},
+		{
 			pattern: "hello?",
 			items: []item{
 				item{item_text, "hello"},
@@ -124,12 +145,10 @@ func TestLexGood(t *testing.T) {
 		for i, exp := range test.items {
 			act := lexer.nextItem()
 			if act.t != exp.t {
-				t.Errorf("#%d wrong %d-th item type: exp: %v; act: %v (%s vs %s)", id, i, exp.t, act.t, exp, act)
-				break
+				t.Errorf("#%d %q: wrong %d-th item type: exp: %q; act: %q\n\t(%s vs %s)", id, test.pattern, i, exp.t, act.t, exp, act)
 			}
 			if act.s != exp.s {
-				t.Errorf("#%d wrong %d-th item contents: exp: %q; act: %q (%s vs %s)", id, i, exp.s, act.s, exp, act)
-				break
+				t.Errorf("#%d %q: wrong %d-th item contents: exp: %q; act: %q\n\t(%s vs %s)", id, test.pattern, i, exp.s, act.s, exp, act)
 			}
 		}
 	}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -40,7 +40,7 @@
 		{
 			"importpath": "github.com/gobwas/glob",
 			"repository": "https://github.com/gobwas/glob",
-			"revision": "d877f6352135181470c40c73ebb81aefa22115fa",
+			"revision": "82e8d7da03805cde651f981f9702a4b4d8cf58eb",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
### Purpose

This was fixed upstream due to our ticket, so we no longer need the
manual handling of commas. Keep the tests and better debug output around
though.

### Testing

unit tested