### PR TITLE
cleanup: removed deadcode in connection/tcp_listen.go

### DIFF
--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -163,40 +163,6 @@ func newTCPListener(uri *url.URL, tlsCfg *tls.Config, conns chan IntermediateCon
 	}
 }
 
-func isPublicIPv4(ip net.IP) bool {
-	ip = ip.To4()
-	if ip == nil {
-		// Not an IPv4 address (IPv6)
-		return false
-	}
-
-	// IsGlobalUnicast below only checks that it's not link local or
-	// multicast, and we want to exclude private (NAT:ed) addresses as well.
-	rfc1918 := []net.IPNet{
-		{IP: net.IP{10, 0, 0, 0}, Mask: net.IPMask{255, 0, 0, 0}},
-		{IP: net.IP{172, 16, 0, 0}, Mask: net.IPMask{255, 240, 0, 0}},
-		{IP: net.IP{192, 168, 0, 0}, Mask: net.IPMask{255, 255, 0, 0}},
-	}
-	for _, n := range rfc1918 {
-		if n.Contains(ip) {
-			return false
-		}
-	}
-
-	return ip.IsGlobalUnicast()
-}
-
-func isPublicIPv6(ip net.IP) bool {
-	if ip.To4() != nil {
-		// Not an IPv6 address (IPv4)
-		// (To16() returns a v6 mapped v4 address so can't be used to check
-		// that it's an actual v6 address)
-		return false
-	}
-
-	return ip.IsGlobalUnicast()
-}
-
 func fixupPort(uri *url.URL) *url.URL {
 	copyURI := *uri
 

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -35,9 +35,8 @@ type tcpListener struct {
 	natService *nat.Service
 	mapping    *nat.Mapping
 
-	address *url.URL
-	err     error
-	mut     sync.RWMutex
+	err error
+	mut sync.RWMutex
 }
 
 func (t *tcpListener) Serve() {


### PR DESCRIPTION
### Purpose

cleanup

### Testing

run test suite