### PR TITLE
lib/config: Change upgrade check URL (fixes #3086)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -291,8 +291,6 @@ func convertV12V13(cfg *Configuration) {
 	}
 	cfg.Options.GlobalAnnServers = newAddrs
 
-	cfg.Version = 13
-
 	for i, fcfg := range cfg.Folders {
 		if fcfg.DeprecatedReadOnly {
 			cfg.Folders[i].Type = FolderTypeReadOnly
@@ -301,6 +299,12 @@ func convertV12V13(cfg *Configuration) {
 		}
 		cfg.Folders[i].DeprecatedReadOnly = false
 	}
+
+	if cfg.Options.ReleasesURL == "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30" {
+		cfg.Options.ReleasesURL = "https://upgrades.syncthing.net/meta.json"
+	}
+
+	cfg.Version = 13
 }
 
 func convertV11V12(cfg *Configuration) {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -57,7 +57,7 @@ func TestDefaultValues(t *testing.T) {
 		URURL:                   "https://data.syncthing.net/newdata",
 		URInitialDelayS:         1800,
 		URPostInsecurely:        false,
-		ReleasesURL:             "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30",
+		ReleasesURL:             "https://upgrades.syncthing.net/meta.json",
 		AlwaysLocalNets:         []string{},
 		OverwriteRemoteDevNames: false,
 		TempIndexMinBlocks:      10,

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -35,7 +35,7 @@ type OptionsConfiguration struct {
 	SymlinksEnabled         bool     `xml:"symlinksEnabled" json:"symlinksEnabled" default:"true"`
 	LimitBandwidthInLan     bool     `xml:"limitBandwidthInLan" json:"limitBandwidthInLan" default:"false"`
 	MinHomeDiskFreePct      float64  `xml:"minHomeDiskFreePct" json:"minHomeDiskFreePct" default:"1"`
-	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://api.github.com/repos/syncthing/syncthing/releases?per_page=30"`
+	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://upgrades.syncthing.net/meta.json"`
 	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
 	OverwriteRemoteDevNames bool     `xml:"overwriteRemoteDeviceNamesOnConnect" json:"overwriteRemoteDeviceNamesOnConnect" default:"false"`
 	TempIndexMinBlocks      int      `xml:"tempIndexMinBlocks" json:"tempIndexMinBlocks" default:"10"`


### PR DESCRIPTION
### Purpose

Control.

The URL in question is live as a proxy of the old default URL, until we decide otherwise.
