### PR TITLE
lib/config: Update size constraints and URL (ref #3086)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	OldestHandledVersion = 10
-	CurrentVersion       = 12
+	CurrentVersion       = 13
 	MaxRescanIntervalS   = 365 * 24 * 60 * 60
 )
 
@@ -185,6 +185,9 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) {
 	if cfg.Version == 11 {
 		convertV11V12(cfg)
 	}
+	if cfg.Version == 12 {
+		convertV12V13(cfg)
+	}
 
 	// Build a list of available devices
 	existingDevices := make(map[protocol.DeviceID]bool)
@@ -232,6 +235,14 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) {
 	if cfg.GUI.APIKey == "" {
 		cfg.GUI.APIKey = randomString(32)
 	}
+}
+
+func convertV12V13(cfg *Configuration) {
+	if cfg.Options.ReleasesURL == "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30" {
+		cfg.Options.ReleasesURL = "https://upgrades.syncthing.net/meta.json"
+	}
+
+	cfg.Version = 13
 }
 
 func convertV11V12(cfg *Configuration) {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -59,7 +59,7 @@ func TestDefaultValues(t *testing.T) {
 		URURL:                   "https://data.syncthing.net/newdata",
 		URInitialDelayS:         1800,
 		URPostInsecurely:        false,
-		ReleasesURL:             "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30",
+		ReleasesURL:             "https://upgrades.syncthing.net/meta.json",
 		AlwaysLocalNets:         []string{},
 	}
 

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -37,7 +37,7 @@ type OptionsConfiguration struct {
 	SymlinksEnabled         bool     `xml:"symlinksEnabled" json:"symlinksEnabled" default:"true"`
 	LimitBandwidthInLan     bool     `xml:"limitBandwidthInLan" json:"limitBandwidthInLan" default:"false"`
 	MinHomeDiskFreePct      float64  `xml:"minHomeDiskFreePct" json:"minHomeDiskFreePct" default:"1"`
-	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://api.github.com/repos/syncthing/syncthing/releases?per_page=30"`
+	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://upgrades.syncthing.net/meta.json"`
 	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
 }
 

--- a/lib/config/testdata/v13.xml
+++ b/lib/config/testdata/v13.xml
@@ -1,0 +1,14 @@
+<configuration version="13">
+    <folder id="test" path="testdata" ro="true" ignorePerms="false" rescanIntervalS="600" autoNormalize="true">
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+        <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2"></device>
+        <minDiskFreePct>1</minDiskFreePct>
+        <maxConflicts>-1</maxConflicts>
+    </folder>
+    <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR" name="node one" compression="metadata">
+        <address>tcp://a</address>
+    </device>
+    <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2" name="node two" compression="metadata">
+        <address>tcp://b</address>
+    </device>
+</configuration>

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -39,7 +39,7 @@ const (
 	maxBinarySize = 64 << 20 // 64 MiB
 
 	// The max expected size of the signature file.
-	maxSignatureSize = 1 << 10 // 1 KiB
+	maxSignatureSize = 10 << 10 // 10 KiB
 
 	// We set the same limit on the archive. The binary will compress and we
 	// include som other stuff - currently the release archive size is
@@ -55,7 +55,7 @@ const (
 	readTimeout = 30 * time.Minute
 
 	// The limit on the size of metadata that we accept.
-	maxMetadataSize = 100 << 10 // 100 KiB
+	maxMetadataSize = 10 << 20 // 10 MiB
 )
 
 // This is an HTTP/HTTPS client that does *not* perform certificate


### PR DESCRIPTION
### Purpose

Bring v0.12 branch up to date with reality and enable future upgrades.

We'll have to rework v0.13 to bump the config format to 14, but that's no issue.

**Do not merge with st-review!** It'll probably merge to master and fuck up. Use the button.