### PR TITLE
cmd/syncthing: Set User-Agent on upgrade checks

### DIFF
--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -79,7 +79,8 @@ func insecureGet(url, version string) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("X-Syncthing-Version", version)
+
+	req.Header.Set("User-Agent", fmt.Sprintf(`syncthing %s (%s %s-%s)`, version, runtime.Version(), runtime.GOOS, runtime.GOARCH))
 	return insecureHTTP.Do(req)
 }
 


### PR DESCRIPTION
### Purpose

Set User-Agent to a string like `syncthing v0.12.24 (go1.6.2 darwin-amd64)` on upgrade requests. Gives more information to upgrade server to do the right thing, in the future.