### PR TITLE
lib/config: use correct ReleasesURL when upgrading from v0.13-beta

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -302,6 +302,10 @@ func convertV13V14(cfg *Configuration) {
 		}
 		cfg.Folders[i].DeprecatedReadOnly = false
 	}
+	// v0.13-beta already had config version 13 but did not get the new URL
+	if cfg.Options.ReleasesURL == "https://api.github.com/repos/syncthing/syncthing/releases?per_page=30" {
+		cfg.Options.ReleasesURL = "https://upgrades.syncthing.net/meta.json"
+	}
 
 	cfg.Version = 14
 }


### PR DESCRIPTION
### Purpose

Migrating to the new URL seems important enough to do it automatically for those few beta users as you don't notice that there is something wrong and there should not be a negative effect on upgrades from other versions.

### Testing

only tested upgrading v0.13-beta4 but I don't see how this could hurt when upgrading from other versions...
