### PR TITLE
lib/config: Don't migrate non-HTTPS-URL discovery servers to new path

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
 	"sort"
 	"strings"
 
@@ -307,12 +308,13 @@ func convertV13V14(cfg *Configuration) {
 
 	var newAddrs []string
 	for _, addr := range cfg.Options.GlobalAnnServers {
-		if addr != "default" {
-			uri, err := url.Parse(addr)
-			if err != nil {
-				panic(err)
-			}
-			uri.Path += "v2/"
+		uri, err := url.Parse(addr)
+		if err != nil {
+			// That's odd. Skip the broken address.
+			continue
+		}
+		if uri.Scheme == "https" {
+			uri.Path = path.Join(uri.Path, "v2") + "/"
 			addr = uri.String()
 		}
 

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	OldestHandledVersion = 10
-	CurrentVersion       = 14
+	CurrentVersion       = 15
 	MaxRescanIntervalS   = 365 * 24 * 60 * 60
 )
 
@@ -202,6 +202,9 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) {
 	if cfg.Version == 13 {
 		convertV13V14(cfg)
 	}
+	if cfg.Version == 14 {
+		convertV14V15(cfg)
+	}
 
 	// Build a list of available devices
 	existingDevices := make(map[protocol.DeviceID]bool)
@@ -253,6 +256,21 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) {
 	if cfg.GUI.APIKey == "" {
 		cfg.GUI.APIKey = util.RandomString(32)
 	}
+}
+
+func convertV14V15(cfg *Configuration) {
+	// Undo v0.13.0 broken migration
+
+	for i, addr := range cfg.Options.GlobalAnnServers {
+		switch addr {
+		case "default-v4v2/":
+			cfg.Options.GlobalAnnServers[i] = "default-v4"
+		case "default-v6v2/":
+			cfg.Options.GlobalAnnServers[i] = "default-v6"
+		}
+	}
+
+	cfg.Version = 15
 }
 
 func convertV13V14(cfg *Configuration) {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -365,12 +365,12 @@ func TestIssue1750(t *testing.T) {
 		t.Errorf("%q != %q", cfg.Options().ListenAddresses[1], "tcp://:23001")
 	}
 
-	if cfg.Options().GlobalAnnServers[0] != "udp4://syncthing.nym.se:22026/v2/" {
-		t.Errorf("%q != %q", cfg.Options().GlobalAnnServers[0], "udp4://syncthing.nym.se:22026/v2/")
+	if cfg.Options().GlobalAnnServers[0] != "udp4://syncthing.nym.se:22026" {
+		t.Errorf("%q != %q", cfg.Options().GlobalAnnServers[0], "udp4://syncthing.nym.se:22026")
 	}
 
-	if cfg.Options().GlobalAnnServers[1] != "udp4://syncthing.nym.se:22027/v2/" {
-		t.Errorf("%q != %q", cfg.Options().GlobalAnnServers[1], "udp4://syncthing.nym.se:22027/v2/")
+	if cfg.Options().GlobalAnnServers[1] != "udp4://syncthing.nym.se:22027" {
+		t.Errorf("%q != %q", cfg.Options().GlobalAnnServers[1], "udp4://syncthing.nym.se:22027")
 	}
 }
 

--- a/lib/config/testdata/v15.xml
+++ b/lib/config/testdata/v15.xml
@@ -1,0 +1,14 @@
+<configuration version="15">
+    <folder id="test" path="testdata" type="readonly" ignorePerms="false" rescanIntervalS="600" autoNormalize="true">
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+        <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2"></device>
+        <minDiskFreePct>1</minDiskFreePct>
+        <maxConflicts>-1</maxConflicts>
+    </folder>
+    <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR" name="node one" compression="metadata">
+        <address>tcp://a</address>
+    </device>
+    <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2" name="node two" compression="metadata">
+        <address>tcp://b</address>
+    </device>
+</configuration>


### PR DESCRIPTION
### Purpose

Don't screw up unknown URLs in the migration (i.e. `default-v4` -> `default-v4v2/`). Don't panic.

### Testing

Tested manually on a v13 config...