### PR TITLE
added documentation key to syncthing-resume.service

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,7 @@ Anderson Mesquita <andersonvom@gmail.com>
 Andrew Dunham <andrew@du.nham.ca>
 Antony Male <antony.male@gmail.com>
 Arthur Axel fREW Schmidt <frew@afoolishmanifesto.com> <frioux@gmail.com>
+Alexandre Viau <alexandre@alexandreviau.net> <aviau@debian.org>
 Audrius Butkevicius <audrius.butkevicius@gmail.com>
 Bart De Vries <devriesb@gmail.com>
 Ben Curthoys <ben@bencurthoys.com>

--- a/NICKS
+++ b/NICKS
@@ -7,6 +7,7 @@ andersonvom	<andersonvom@gmail.com>
 andrew-d	<andrew@du.nham.ca>
 asdil12		<dominik@heidler.eu>
 AudriusButkevicius	<audrius.butkevicius@gmail.com>
+aviau       <alexandre@alexandreviau.net> <aviau@debian.org>
 bencurthoys	<ben@bencurthoys.com>
 bigbear2nd	<bigbear2nd@gmail.com>
 brbecker	<brbecker@gmail.com>

--- a/etc/linux-systemd/system/syncthing-resume.service
+++ b/etc/linux-systemd/system/syncthing-resume.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Restart Syncthing after resume
+Documentation=man:syncthing(1)
 After=suspend.target
 
 [Service]


### PR DESCRIPTION
this fixes lintian warning:
```
systemd-service-file-missing-documentation-key lib/systemd/system/syncthing-resume.service
```