### PR TITLE
cmd/syncthing: Rename event LocalDiskUpdated -> LocalChangeDetected

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -534,7 +534,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	// Event subscription for the API; must start early to catch the early events.  The LocalDiskUpdated
 	// event might overwhelm the event reciever in some situations so we will not subscribe to it here.
-	apiSub := events.NewBufferedSubscription(events.Default.Subscribe(events.AllEvents&^events.LocalDiskUpdated), 1000)
+	apiSub := events.NewBufferedSubscription(events.Default.Subscribe(events.AllEvents&^events.LocalChangeDetected), 1000)
 
 	if len(os.Getenv("GOMAXPROCS")) == 0 {
 		runtime.GOMAXPROCS(runtime.NumCPU())

--- a/cmd/syncthing/verboseservice.go
+++ b/cmd/syncthing/verboseservice.go
@@ -92,9 +92,10 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 		data := ev.Data.(map[string]interface{})
 		return fmt.Sprintf("Folder %q is now %v", data["folder"], data["to"])
 
-	case events.LocalDiskUpdated:
+	case events.LocalChangeDetected:
 		data := ev.Data.(map[string]string)
-		return fmt.Sprintf("%s a %s: [ %s ]", data["action"], data["type"], data["path"])
+		// Local change detected in folder "foo": modified file /Users/jb/whatever
+		return fmt.Sprintf("Local change detected in folder %q: %s %s %s", data["folder"], data["action"], data["type"], data["path"])
 
 	case events.RemoteIndexUpdated:
 		data := ev.Data.(map[string]interface{})

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -63,7 +63,7 @@ func (t EventType) String() string {
 	case DeviceRejected:
 		return "DeviceRejected"
 	case LocalChangeDetected:
-		return "LocalDiskUpdated"
+		return "LocalChangeDetected"
 	case LocalIndexUpdated:
 		return "LocalIndexUpdated"
 	case RemoteIndexUpdated:

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -27,7 +27,7 @@ const (
 	DeviceRejected
 	DevicePaused
 	DeviceResumed
-	LocalDiskUpdated
+	LocalChangeDetected
 	LocalIndexUpdated
 	RemoteIndexUpdated
 	ItemStarted
@@ -62,7 +62,7 @@ func (t EventType) String() string {
 		return "DeviceDisconnected"
 	case DeviceRejected:
 		return "DeviceRejected"
-	case LocalDiskUpdated:
+	case LocalChangeDetected:
 		return "LocalDiskUpdated"
 	case LocalIndexUpdated:
 		return "LocalIndexUpdated"


### PR DESCRIPTION
### Purpose

Amends the previous commit adding the LocalDiskUpdated event.

I think this naming better reflects what it means. Also tweaks the verbose format to be more like our other things and lightly refactors the code to not have the boolean and include the folder in the event.

### Testing

Tested manually with -verbose and watching output while touch, editing and deleting files.

### Documentation

Needs an addition to the event list, which I'll do when this is in.