### PR TITLE
cmd/syncthing: Enforce stricter CSRF policy on /rest GET requests (fixes #3134)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -461,10 +461,6 @@ func corsMiddleware(next http.Handler) http.Handler {
 	//
 	// See https://www.w3.org/TR/cors/ for details.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Add a generous access-control-allow-origin header since we may be
-		// redirecting REST requests over protocols
-		w.Header().Add("Access-Control-Allow-Origin", "*")
-
 		// Process OPTIONS requests
 		if r.Method == "OPTIONS" {
 			// Only GET/POST Methods are supported

--- a/cmd/syncthing/gui_csrf.go
+++ b/cmd/syncthing/gui_csrf.go
@@ -41,7 +41,8 @@ func csrfMiddleware(unique string, prefix string, cfg config.GUIConfiguration, n
 			return
 		}
 
-		// Allow requests for the front page, and set a CSRF cookie if there isn't already a valid one.
+		// Allow requests for anything not under the protected path prefix,
+		// and set a CSRF cookie if there isn't already a valid one.
 		if !strings.HasPrefix(r.URL.Path, prefix) {
 			cookie, err := r.Cookie("CSRF-Token-" + unique)
 			if err != nil || !validCsrfToken(cookie.Value) {
@@ -51,18 +52,6 @@ func csrfMiddleware(unique string, prefix string, cfg config.GUIConfiguration, n
 					Value: newCsrfToken(),
 				}
 				http.SetCookie(w, cookie)
-			}
-			next.ServeHTTP(w, r)
-			return
-		}
-
-		if r.Method == "GET" {
-			// Allow GET requests unconditionally, but if we got the CSRF
-			// token cookie do the verification anyway so we keep the
-			// csrfTokens list sorted by recent usage. We don't care about the
-			// outcome of the validity check.
-			if cookie, err := r.Cookie("CSRF-Token-" + unique); err == nil {
-				validCsrfToken(cookie.Value)
 			}
 			next.ServeHTTP(w, r)
 			return


### PR DESCRIPTION
### Purpose

This removes the ability to do "raw" GET requests to the /rest interface. All requests must be accompanied with either an API key or a CSRF token (plus authentication, if configured).

### Testing

New unit test added to verify this behavior. GUI tested manually, still appears to work.

### Documentation

This needs to be updated in https://docs.syncthing.net/dev/rest.html