### PR TITLE
cmd/syncthing: Emit new RemoteDownloadProgress event to track remote download progress

### DIFF
--- a/cmd/syncthing/summaryservice.go
+++ b/cmd/syncthing/summaryservice.go
@@ -59,7 +59,7 @@ func (c *folderSummaryService) Stop() {
 // listenForUpdates subscribes to the event bus and makes note of folders that
 // need their data recalculated.
 func (c *folderSummaryService) listenForUpdates() {
-	sub := events.Default.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged)
+	sub := events.Default.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged | events.RemoteDownloadProgress)
 	defer events.Default.Unsubscribe(sub)
 
 	for {

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -36,6 +36,7 @@ const (
 	FolderRejected
 	ConfigSaved
 	DownloadProgress
+	RemoteDownloadProgress
 	FolderSummary
 	FolderCompletion
 	FolderErrors
@@ -80,6 +81,8 @@ func (t EventType) String() string {
 		return "ConfigSaved"
 	case DownloadProgress:
 		return "DownloadProgress"
+	case RemoteDownloadProgress:
+		return "RemoteDownloadProgress"
 	case FolderSummary:
 		return "FolderSummary"
 	case FolderCompletion:

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1083,7 +1083,14 @@ func (m *Model) DownloadProgress(device protocol.DeviceID, folder string, update
 
 	m.pmut.RLock()
 	m.deviceDownloads[device].Update(folder, updates)
+	blocks := m.deviceDownloads[device].NumberOfBlocksInProgress()
 	m.pmut.RUnlock()
+
+	events.Default.Log(events.RemoteDownloadProgress, map[string]interface{}{
+		"device": device.String(),
+		"folder": folder,
+		"blocks": blocks,
+	})
 }
 
 func (m *Model) ResumeDevice(device protocol.DeviceID) {


### PR DESCRIPTION
### Purpose

Without this the summary service doesn't know to recalculate completion percentage for remote devices when DownloadProgress messages come in. That means that completion percentage isn't updated in the GUI while transfers of large files are ongoing. With this change, it updates correctly.

### Testing

Manually only, by watching -verbose and the GUI. We lack good infrastructure to test this...