### PR TITLE
lib/model: Leave temp file in place when final rename fails (fixes #3146)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1297,8 +1297,9 @@ func (f *rwFolder) performFinish(state *sharedPullerState) error {
 		}
 	}
 
-	// Replace the original content with the new one
-	if err := osutil.Rename(state.tempName, state.realName); err != nil {
+	// Replace the original content with the new one. If it didn't work,
+	// leave the temp file in place for reuse.
+	if err := osutil.TryRename(state.tempName, state.realName); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### Purpose

Allow reuse to happen.

### Testing

Manually. But it's obviously correct, come on.