### PR TITLE
gui: fix accordion titles

### DIFF
--- a/gui/dark/assets/css/theme.css
+++ b/gui/dark/assets/css/theme.css
@@ -77,6 +77,10 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     background-color: #222 !important;
 }
 
+.panel-progress {
+    background: #3498db;
+}
+
 .panel-footer {
     background-color: #111 !important;
     border-width: 0 !important;

--- a/gui/dark/assets/css/theme.css
+++ b/gui/dark/assets/css/theme.css
@@ -94,6 +94,11 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     fill: #aaa !important;
 }
 
+.panel-heading:hover, .panel-heading:focus {
+    text-decoration: none;
+}
+
+
 /* buttons */
 .btn {
     border-radius: 3px !important;

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -6,6 +6,7 @@
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
 */
+
 body {
     padding-bottom: 70px;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -33,9 +33,9 @@ ul+h5 {
     display: block;
 }
 
-    /*position: relative;*/
-    /*text-overflow: ellipsis;*/
-    /*overflow: hidden;*/
+.panel-title-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 a.panel-heading:hover {
     text-decoration: none;
@@ -52,6 +52,10 @@ identicon {
 .identicon {
     width: 1em;
     height: 1em;
+}
+
+.panel-icon{
+    float:left;
 }
 
 .checkbox {

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -63,7 +63,9 @@ identicon {
     float: none; /* issue #1197 */
 }
 
-.dropdown-toggle:focus{outline:thin dotted !important;} /* override bootstrap, retain outline with keyboard tab */
+.dropdown-toggle:focus{
+    outline:thin dotted !important; /* override bootstrap, retain outline with keyboard tab */
+}
 
 .popover {
     max-width: none;

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -50,7 +50,7 @@ ul+h5 {
     word-wrap:break-word;
 }
 
-.modal-header .fa{
+.modal-header .fa {
     margin-right: 15px;
 }
 

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -33,7 +33,6 @@ ul+h5 {
     display: block;
 }
 
-.panel-title {
     /*position: relative;*/
     /*text-overflow: ellipsis;*/
     /*overflow: hidden;*/

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -6,7 +6,6 @@
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
 */
-
 body {
     padding-bottom: 70px;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -48,7 +47,6 @@ identicon {
     width: 1em;
     height: 1em;
     line-height: 1;
-    margin-right: 5px;
 }
 
 .identicon {
@@ -73,8 +71,8 @@ identicon {
     word-wrap:break-word;
 }
 
-.panel-heading .fa, .modal-header .fa {
-    margin-right: 10px;
+.panel-heading .fa, .modal-header .fa, identicon {
+    margin-right: 15px;
 }
 
 .panel-heading {

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -62,6 +62,8 @@ identicon {
     float: none; /* issue #1197 */
 }
 
+.dropdown-toggle:focus{outline:thin dotted !important;} /* override bootstrap, retain outline with keyboard tab */
+
 .popover {
     max-width: none;
     min-width: 250px;

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -63,10 +63,6 @@ identicon {
     float: none; /* issue #1197 */
 }
 
-.dropdown-toggle:focus{
-    outline:thin dotted !important; /* override bootstrap, retain outline with keyboard tab */
-}
-
 .popover {
     max-width: none;
     min-width: 250px;

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -167,6 +167,7 @@ table.table-condensed td.no-overflow-ellipse {
 .panel-heading {
     display: block;
     cursor: pointer;
+    position: relative;
 }
 
 .panel-heading .panel-title-text {

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -54,10 +54,6 @@ identicon {
     height: 1em;
 }
 
-.panel-icon{
-    float:left;
-}
-
 .checkbox {
     margin-top: 0px;
 }
@@ -75,7 +71,11 @@ identicon {
     word-wrap:break-word;
 }
 
-.panel-heading .fa, .modal-header .fa, identicon {
+.panel-icon{
+    float:left;
+}
+
+.panel-icon, .modal-header .fa{
     margin-right: 15px;
 }
 

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -34,9 +34,9 @@ ul+h5 {
 }
 
 .panel-title {
-    position: relative;
-    text-overflow: ellipsis;
-    overflow: hidden;
+    /*position: relative;*/
+    /*text-overflow: ellipsis;*/
+    /*overflow: hidden;*/
 }
 a.panel-heading:hover {
     text-decoration: none;
@@ -77,8 +77,8 @@ identicon {
 }
 
 .panel-heading {
-    position: relative;
-    overflow: hidden;
+    /*position: relative;*/
+    /*overflow: hidden;*/
 }
 
 .text-monospace {

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -33,27 +33,6 @@ ul+h5 {
     display: block;
 }
 
-.panel-title-text {
-    text-overflow: ellipsis;
-    overflow: hidden;
-}
-a.panel-heading:hover {
-    text-decoration: none;
-}
-
-identicon {
-    display: inline-block;
-    position: relative;
-    width: 1em;
-    height: 1em;
-    line-height: 1;
-}
-
-.identicon {
-    width: 1em;
-    height: 1em;
-}
-
 .checkbox {
     margin-top: 0px;
 }
@@ -71,17 +50,8 @@ identicon {
     word-wrap:break-word;
 }
 
-.panel-icon{
-    float:left;
-}
-
-.panel-icon, .modal-header .fa{
+.modal-header .fa{
     margin-right: 15px;
-}
-
-.panel-heading {
-    /*position: relative;*/
-    /*overflow: hidden;*/
 }
 
 .text-monospace {
@@ -183,6 +153,43 @@ table.table-condensed td.no-overflow-ellipse {
 
 .dl-horizontal.dl-narrow dd {
     margin-left: 60px;
+}
+
+/**
+ * Accordion Title bars
+ */
+
+.panel-icon{
+    float:left;
+    margin-right: 15px;
+}
+
+.panel-heading {
+    display: block;
+    cursor: pointer;
+}
+
+.panel-heading .panel-title-text {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+}
+
+.panel-heading .panel-status {
+    margin-left:15px;
+}
+
+identicon {
+    display: inline-block;
+    position: relative;
+    width: 1em;
+    height: 1em;
+    line-height: 1;
+}
+
+.identicon {
+    width: 1em;
+    height: 1em;
 }
 
 /**

--- a/gui/default/assets/css/theme.css
+++ b/gui/default/assets/css/theme.css
@@ -19,3 +19,7 @@
     background-color: rgb(236, 240, 241);
     border-radius: 3px;
 }
+
+.panel-heading:hover, .panel-heading:focus {
+    text-decoration: none;
+}

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -231,8 +231,9 @@
               <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id)}}%"></div>
               <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id)}}%"></div>
               <h4 class="panel-title">
-                <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span>
-                <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>
+                <div class="panel-icon">
+                  <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span>
+                </div>
                 <span class="pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
                   <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs">&#9724;</span></span>
@@ -251,6 +252,9 @@
                   </span>
                   <span ng-switch-when="outofsync"><span class="hidden-xs" translate>Out of Sync</span><span class="visible-xs">&#9724;</span></span>
                 </span>
+                <div class="panel-title-text">
+                  <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>
+                </div>
               </h4>
             </a>
             <div id="folder-{{$index}}" class="panel-collapse collapse">
@@ -400,7 +404,8 @@
         <div class="panel panel-default" ng-repeat="deviceCfg in [thisDevice()]">
           <a class="panel-heading" data-toggle="collapse" href="#device-this" style="cursor: pointer; display: block;">
             <h4 class="panel-title">
-              <identicon data-value="deviceCfg.deviceID"></identicon>{{deviceName(deviceCfg)}}
+              <identicon class="panel-icon" data-value="deviceCfg.deviceID"></identicon>
+              <div class="panel-title-text">{{deviceName(deviceCfg)}}</div>
             </h4>
           </a>
           <div id="device-this" class="panel-collapse collapse in">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -481,7 +481,7 @@
             <a class="panel-heading" data-toggle="collapse" data-parent="#devices" href="#device-{{$index}}">
               <div class="panel-progress" ng-show="deviceStatus(deviceCfg) == 'syncing'" ng-attr-style="width: {{completion[deviceCfg.deviceID]._total | number:0}}%"></div>
               <h4 class="panel-title">
-                <identicon data-value="deviceCfg.deviceID"></identicon>{{deviceName(deviceCfg)}}
+                <identicon class="panel-icon" data-value="deviceCfg.deviceID"></identicon>{{deviceName(deviceCfg)}}
                 <span ng-switch="deviceStatus(deviceCfg)" class="pull-right text-{{deviceClass(deviceCfg)}}">
                   <span ng-switch-when="insync"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="syncing">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -231,9 +231,7 @@
               <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id)}}%"></div>
               <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id)}}%"></div>
               <h4 class="panel-title">
-                <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span>
-                <span ng-show="folder.label.length == 0">{{folder.id}}</span>
-                <span tooltip data-original-title="{{folder.id}}" ng-show="folder.label.length != 0">{{folder.label}}</span>
+                <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span><span ng-show="folder.label.length == 0">{{folder.id}}</span><span tooltip data-original-title="{{folder.id}}" ng-show="folder.label.length != 0">{{folder.label}}</span>
                 <span class="pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
                   <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs">&#9724;</span></span>
@@ -401,7 +399,7 @@
         <div class="panel panel-default" ng-repeat="deviceCfg in [thisDevice()]">
           <a class="panel-heading" data-toggle="collapse" href="#device-this" style="cursor: pointer; display: block;">
             <h4 class="panel-title">
-              <identicon data-value="deviceCfg.deviceID"></identicon>&emsp;{{deviceName(deviceCfg)}}
+              <identicon data-value="deviceCfg.deviceID"></identicon>{{deviceName(deviceCfg)}}
             </h4>
           </a>
           <div id="device-this" class="panel-collapse collapse in">
@@ -477,7 +475,7 @@
             <a class="panel-heading" data-toggle="collapse" data-parent="#devices" href="#device-{{$index}}" style="cursor: pointer; display: block;">
               <div class="panel-progress" ng-show="deviceStatus(deviceCfg) == 'syncing'" ng-attr-style="width: {{completion[deviceCfg.deviceID]._total | number:0}}%"></div>
               <h4 class="panel-title">
-                <identicon data-value="deviceCfg.deviceID"></identicon>&emsp;{{deviceName(deviceCfg)}}
+                <identicon data-value="deviceCfg.deviceID"></identicon>{{deviceName(deviceCfg)}}
                 <span ng-switch="deviceStatus(deviceCfg)" class="pull-right text-{{deviceClass(deviceCfg)}}">
                   <span ng-switch-when="insync"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="syncing">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -227,14 +227,14 @@
         <h3 translate>Folders</h3>
         <div class="panel-group" id="folders">
           <div class="panel panel-default" ng-repeat="folder in folderList()">
-            <a class="panel-heading" data-toggle="collapse" data-parent="#folders" href="#folder-{{$index}}" style="cursor: pointer; display: block;">
+            <a class="panel-heading" data-toggle="collapse" data-parent="#folders" href="#folder-{{$index}}">
               <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id)}}%"></div>
               <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id)}}%"></div>
               <h4 class="panel-title">
                 <div class="panel-icon">
                   <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span>
                 </div>
-                <span class="pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
+                <div class="panel-status pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
                   <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="stopped"><span class="hidden-xs" translate>Stopped</span><span class="visible-xs">&#9724;</span></span>
@@ -251,7 +251,7 @@
                     ({{syncPercentage(folder.id)}}%)
                   </span>
                   <span ng-switch-when="outofsync"><span class="hidden-xs" translate>Out of Sync</span><span class="visible-xs">&#9724;</span></span>
-                </span>
+                </div>
                 <div class="panel-title-text">
                   <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>
                 </div>
@@ -402,7 +402,7 @@
       <div class="col-md-6">
         <h3 translate>This Device</h3>
         <div class="panel panel-default" ng-repeat="deviceCfg in [thisDevice()]">
-          <a class="panel-heading" data-toggle="collapse" href="#device-this" style="cursor: pointer; display: block;">
+          <a class="panel-heading" data-toggle="collapse" href="#device-this">
             <h4 class="panel-title">
               <identicon class="panel-icon" data-value="deviceCfg.deviceID"></identicon>
               <div class="panel-title-text">{{deviceName(deviceCfg)}}</div>
@@ -478,7 +478,7 @@
         <h3 translate>Remote Devices</h3>
         <div class="panel-group" id="devices">
           <div class="panel panel-default" ng-repeat="deviceCfg in otherDevices()">
-            <a class="panel-heading" data-toggle="collapse" data-parent="#devices" href="#device-{{$index}}" style="cursor: pointer; display: block;">
+            <a class="panel-heading" data-toggle="collapse" data-parent="#devices" href="#device-{{$index}}">
               <div class="panel-progress" ng-show="deviceStatus(deviceCfg) == 'syncing'" ng-attr-style="width: {{completion[deviceCfg.deviceID]._total | number:0}}%"></div>
               <h4 class="panel-title">
                 <identicon data-value="deviceCfg.deviceID"></identicon>{{deviceName(deviceCfg)}}

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -231,7 +231,9 @@
               <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id)}}%"></div>
               <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id)}}%"></div>
               <h4 class="panel-title">
-                <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span><span ng-show="folder.label.length == 0">{{folder.id}}</span><span tooltip data-original-title="{{folder.id}}" ng-show="folder.label.length != 0">{{folder.label}}</span>
+                <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span>
+                <span ng-show="folder.label.length == 0">{{folder.id}}</span>
+                <span tooltip data-original-title="{{folder.id}}" ng-show="folder.label.length != 0">{{folder.label}}</span>
                 <span class="pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
                   <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs">&#9724;</span></span>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -232,8 +232,7 @@
               <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id)}}%"></div>
               <h4 class="panel-title">
                 <span class="fa hidden-xs fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span>
-                <span ng-show="folder.label.length == 0">{{folder.id}}</span>
-                <span tooltip data-original-title="{{folder.id}}" ng-show="folder.label.length != 0">{{folder.label}}</span>
+                <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>
                 <span class="pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
                   <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs">&#9724;</span></span>


### PR DESCRIPTION
### Purpose
attempt to address some visual styling and accessability issues with all accordion title bars.
essentially following on from https://github.com/syncthing/syncthing/pull/3139

1. convert entire accordion title bars to `a` links, rather than clickable `div`s.
2. changed layout mode from `inline` to `float` for accordion title bars for pixel perfect spacing.
3. fixed bootstrap tooltip that shows folder id when hovering folder labels.
4. underlines are now never present in accordion titles (previously present with `:focus`).
5. accordion titles appear on a single line (not multiline) with ellipsis for longer titles.
6. `this device` is now available in the keyboard tab order.


### Screenshots
**v0.13.4**
![old](https://cloud.githubusercontent.com/assets/4681349/15615360/bca4f7ce-2435-11e6-9d21-a252dfcd7f25.png)

**This PR**
![new](https://cloud.githubusercontent.com/assets/4681349/15615361/bfb0c51a-2435-11e6-9851-a83e0dd3c2f6.png)




