### PR TITLE
cmd/syncthing: Use API to generate API Key and folder ID (fixes #3179)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -250,6 +250,7 @@ func (s *apiService) Serve() {
 	getRestMux.HandleFunc("/rest/svc/deviceid", s.getDeviceID)                   // id
 	getRestMux.HandleFunc("/rest/svc/lang", s.getLang)                           // -
 	getRestMux.HandleFunc("/rest/svc/report", s.getReport)                       // -
+	getRestMux.HandleFunc("/rest/svc/random/string", s.getRandomString)          // [length]
 	getRestMux.HandleFunc("/rest/system/browse", s.getSystemBrowse)              // current
 	getRestMux.HandleFunc("/rest/system/config", s.getSystemConfig)              // -
 	getRestMux.HandleFunc("/rest/system/config/insync", s.getSystemConfigInsync) // -
@@ -928,6 +929,16 @@ func (s *apiService) getSystemDiscovery(w http.ResponseWriter, r *http.Request) 
 
 func (s *apiService) getReport(w http.ResponseWriter, r *http.Request) {
 	sendJSON(w, reportData(s.cfg, s.model))
+}
+
+func (s *apiService) getRandomString(w http.ResponseWriter, r *http.Request) {
+	length := 32
+	if val, _ := strconv.Atoi(r.URL.Query().Get("length")); val > 0 {
+		length = val
+	}
+	str := rand.String(length)
+
+	sendJSON(w, map[string]string{"random": str})
 }
 
 func (s *apiService) getDBIgnores(w http.ResponseWriter, r *http.Request) {

--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -89,19 +89,6 @@ function decimals(val, num) {
     return decs;
 }
 
-function randomString(len) {
-    var chars = '01234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-';
-    return randomStringFromCharset(len, chars);
-}
-
-function randomStringFromCharset(len, charset) {
-    var result = '';
-    for (var i = 0; i < len; i++) {
-        result += charset[Math.round(Math.random() * (charset.length - 1))];
-    }
-    return result;
-}
-
 function isEmptyObject(obj) {
     var name;
     for (name in obj) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1196,7 +1196,6 @@ angular.module('syncthing.core')
         $scope.addFolder = function () {
             $scope.currentFolder = {
                 selectedDevices: {},
-                id: $scope.createRandomFolderId(),
                 type: "readwrite",
                 rescanIntervalS: 60,
                 minDiskFreePct: 1,
@@ -1213,7 +1212,10 @@ angular.module('syncthing.core')
             };
             $scope.editingExisting = false;
             $scope.folderEditor.$setPristine();
-            $('#editFolder').modal();
+            $http.get(urlbase + '/svc/random/string?length=10').success(function (data) {
+                $scope.currentFolder.id = data.random.substr(0, 5) + '-' + data.random.substr(5, 5);
+                $('#editFolder').modal();
+            });
         };
 
         $scope.addFolderAndShare = function (folder, folderLabel, device) {
@@ -1406,7 +1408,9 @@ angular.module('syncthing.core')
         };
 
         $scope.setAPIKey = function (cfg) {
-            cfg.apiKey = randomString(32);
+            $http.get(urlbase + '/svc/random/string?length=32').success(function (data) {
+                cfg.apiKey = data.random;
+            });
         };
 
         $scope.showURPreview = function () {
@@ -1542,11 +1546,6 @@ angular.module('syncthing.core')
                 return 'skip';
             }
             return 'text';
-        };
-
-        $scope.createRandomFolderId = function(){
-            var charset = '2345679abcdefghijkmnopqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ';
-            return randomStringFromCharset(5, charset) + "-" + randomStringFromCharset(5, charset);
         };
 
         $scope.themeName = function (theme) {


### PR DESCRIPTION
### Purpose

Expose a random string generator in the API and use it when the GUI needs random strings for API key and folder ID.

### Testing

API method is unit tested. GUI tested manually by verifying the "new folder" and "generate API key" things work.