### PR TITLE
cmd/syncthing: Fix upgrade of running syncthing from CLI (fixes #3193)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -17,8 +17,10 @@ import (
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"net/url"
 	"os"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -476,8 +478,13 @@ func performUpgrade(release upgrade.Release) {
 
 func upgradeViaRest() error {
 	cfg, _ := loadConfig()
-	target := cfg.GUI().URL()
-	r, _ := http.NewRequest("POST", target+"/rest/system/upgrade", nil)
+	u, err := url.Parse(cfg.GUI().URL())
+	if err != nil {
+		return err
+	}
+	u.Path = path.Join(u.Path, "rest/system/upgrade")
+	target := u.String()
+	r, _ := http.NewRequest("POST", target, nil)
 	r.Header.Set("X-API-Key", cfg.GUI().APIKey)
 
 	tr := &http.Transport{


### PR DESCRIPTION
Not sure if we can trust that `target` always has a `/` at the end or if this should work no matter if it is there or not. If yes this should be fine, if not I could add some check and update the PR.

### Testing

could upgrade v0.13.2 -> v0.13.4 via command line

