### PR TITLE
Scanthrottle

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -38,6 +38,7 @@ type FolderConfiguration struct {
 	MaxConflicts          int                         `xml:"maxConflicts" json:"maxConflicts"`
 	DisableSparseFiles    bool                        `xml:"disableSparseFiles" json:"disableSparseFiles"`
 	DisableTempIndexes    bool                        `xml:"disableTempIndexes" json:"disableTempIndexes"`
+	ScanFilesPerSecond    int                         `xml:"scanFilesPerSecond" json:"scanFilesPerSecond"`
 
 	Invalid    string `xml:"-" json:"invalid"` // Set at runtime when there is an error, not saved
 	cachedPath string

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -113,6 +113,9 @@ func Walk(cfg Config) (chan protocol.FileInfo, error) {
 	if w.MtimeRepo == nil {
 		w.MtimeRepo = noMtimeRepo{}
 	}
+	if w.ScanFilesPerSecond == nil {
+		w.ScanFilesPerSecond = noLimit{}
+	}
 
 	return w.walk()
 }
@@ -615,3 +618,9 @@ type noMtimeRepo struct{}
 func (noMtimeRepo) GetMtime(relPath string, mtime time.Time) time.Time {
 	return mtime
 }
+
+// A no-op rate limiter
+
+type noLimit struct{}
+
+func (noLimit) Wait(count int64) {}

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -273,14 +273,6 @@ func TestNormalization(t *testing.T) {
 	}
 }
 
-func TestIssue1507(t *testing.T) {
-	w := &walker{}
-	c := make(chan protocol.FileInfo, 100)
-	fn := w.walkAndHashFiles(c, c)
-
-	fn("", nil, protocol.ErrClosed)
-}
-
 func walkDir(dir string) ([]protocol.FileInfo, error) {
 	fchan, err := Walk(Config{
 		Dir:           dir,


### PR DESCRIPTION
### Purpose

Limit number of processed files per second during scanning. Because it's easy and simple... I'm not 100% sure this is something we really want, so feel free to pick on that.

### Testing

Manually only, by turning the limiter on and  observing that scans take a lot longer.

### Caveats

Actual scan time is twice what might be expected for n files with a rate of x/s. This is because we process most files twice - once when walking, and then once more when looking for deletes.