### PR TITLE
gui: Remove race when saving configuration (fixes #3136)

### DIFF
--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -90,8 +90,17 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 			RawUseTLS:  false,
 		},
 	}
-	if srv.CommitConfiguration(cfg, newCfg) {
-		t.Fatal("Config commit should have failed")
+
+	srv.started = make(chan struct{})
+
+	if !srv.CommitConfiguration(cfg, newCfg) {
+		t.Fatal("CommitConfiguration should have succeeded")
+	}
+
+	select {
+	case <-srv.started:
+		t.Fatal("API should not be started")
+	case <-time.After(time.Second):
 	}
 
 	// Nonetheless, it should be fine to Stop() it without panic.


### PR DESCRIPTION
### Purpose

There was a race in CommitConfiguration in gui.go. TCPListener.Close()
does not run synchronously: if there are open connections, it will
return straight away, but the listener will not actually be closed until
sometime later. CommitConfiguration then tried to create a new listener,
which failed because the old listener was still alive on the same port.

Part of the solution was realising that having CommitConfiguration try
to create the new listener did not gain us anything: if it failed to
create the new listener, then that prompts the user to restart
Syncthing. However since we needed to destroy the old listener, the user
now has no way of accessing the GUI and seeing the "need to restart"
message.

This meant that we could create the new listener from inside
Serve(), which we can do safely after listener.Accept() has returned.

We still try and create the first-ever listener from within
newAPIService, rather than Serve(), as it allows us to return an error.

### Testing

Numerous cycles of changing and saving the configuration, watching for the race condition.