### PR TITLE
gui: Prevent log bar from flashing up while page is loading

### DIFF
--- a/gui/default/assets/css/dev.css
+++ b/gui/default/assets/css/dev.css
@@ -1,5 +1,4 @@
 .dev-top-bar{
-    display: none;
     background-color: yellow;
 }
 

--- a/gui/default/syncthing/development/logbar.html
+++ b/gui/default/syncthing/development/logbar.html
@@ -1,4 +1,4 @@
-<div class="dev-top-bar" id="dev-top-bar">
+<div class="dev-top-bar" id="dev-top-bar" style="display: none">
     <link href="assets/css/dev.css" rel="stylesheet">
     <div class="row">
         <div class="col-xs-4"><b>DEV</b></div>


### PR DESCRIPTION
### Purpose

The log bar is hidden by CSS, but will appear briefly while the page is
loading (after the html is fetched, but before dev.css is fetched).

Hide it by using an inline style instead, so this does not happen.

### Testing

Loaded the page with the cache disabled, verified that the log bar does not flash up.