### PR TITLE
gui: Be more explicit about how assets should be cached (fixes #3182)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -1267,7 +1267,10 @@ func (s embeddedStatic) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(bs)))
 	w.Header().Set("Last-Modified", modified.UTC().Format(http.TimeFormat))
-	w.Header().Set("Cache-Control", "public")
+	// Strictly, no-cache means the same as this. However FF and IE treat no-cache as
+	// "don't hold a local cache at all", whereas everyone seems to treat this as
+	// you can hold a local cache, but you must revalidate it before using it.
+	w.Header().Set("Cache-Control", "max-age=0, must-revalidate")
 
 	w.Write(bs)
 }


### PR DESCRIPTION
### Purpose

With the previous setup, browsers were free to use a local cache for any
length of time they pleased: we didn't set an 'Expires' header (or
max-age directive), and Cache-Control just said "you're free to cache
this".

Therefore be more explicit: we don't mind if browsers cache things, but
they MUST revalidate everything on every request.

### Testing

Set `STTRACE=http`, reloaded lots in some browsers, saw that browsers always revalidated.