### PR TITLE
gui: Extract URL from translated string (fixes #3204)

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -192,6 +192,7 @@
    "Syncthing seems to be down, or there is a problem with your Internet connection. Retrying…": "Syncthing seems to be down, or there is a problem with your Internet connection. Retrying…",
    "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.": "Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.",
    "The Syncthing admin interface is configured to allow remote access without a password.": "The Syncthing admin interface is configured to allow remote access without a password.",
+   "The aggregated statistics are publicly available at the URL below.": "The aggregated statistics are publicly available at the URL below.",
    "The aggregated statistics are publicly available at {%url%}.": "The aggregated statistics are publicly available at {{url}}.",
    "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.": "The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.",
    "The device ID cannot be blank.": "The device ID cannot be blank.",

--- a/gui/default/syncthing/usagereport/usageReportModalView.html
+++ b/gui/default/syncthing/usagereport/usageReportModalView.html
@@ -6,7 +6,8 @@
     </div>
     <div class="modal-body">
       <p translate>The encrypted usage report is sent daily. It is used to track common platforms, folder sizes and app versions. If the reported data set is changed you will be prompted with this dialog again.</p>
-      <p translate translate-value-url="<a href=&quot;https://data.syncthing.net&quot; target=&quot;_blank&quot;>https://data.syncthing.net</a>">The aggregated statistics are publicly available at {%url%}.</p>
+      <p translate>The aggregated statistics are publicly available at the URL below.</p>
+      <p><a href="https://data.syncthing.net/" target="_blank">https://data.syncthing.net/</a></p>
       <button type="button" class="btn btn-default btn-sm" ng-click="showReportPreview()" ng-show="!reportPreview">
         <span class="fa fa-file-text-o"></span>&nbsp;<span translate>Preview Usage Report</span>
       </button>


### PR DESCRIPTION
Will require some retranslation unfortunately, but the sanitation code in the translation library (rightly) doesn't allow us to do this any more.