### PR TITLE
lib/connections: Handle wrapped connection in SetTCPOptions (fixes #3223)

### DIFF
--- a/lib/connections/relay_dial.go
+++ b/lib/connections/relay_dial.go
@@ -8,7 +8,6 @@ package connections
 
 import (
 	"crypto/tls"
-	"net"
 	"net/url"
 	"time"
 
@@ -40,7 +39,7 @@ func (d *relayDialer) Dial(id protocol.DeviceID, uri *url.URL) (IntermediateConn
 		return IntermediateConnection{}, err
 	}
 
-	err = dialer.SetTCPOptions(conn.(*net.TCPConn))
+	err = dialer.SetTCPOptions(conn)
 	if err != nil {
 		conn.Close()
 		return IntermediateConnection{}, err

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -8,7 +8,6 @@ package connections
 
 import (
 	"crypto/tls"
-	"net"
 	"net/url"
 	"sync"
 	"time"
@@ -74,7 +73,7 @@ func (t *relayListener) Serve() {
 				continue
 			}
 
-			err = dialer.SetTCPOptions(conn.(*net.TCPConn))
+			err = dialer.SetTCPOptions(conn)
 			if err != nil {
 				l.Infoln(err)
 			}

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -102,7 +102,7 @@ func (t *tcpListener) Serve() {
 
 		l.Debugln("connect from", conn.RemoteAddr())
 
-		err = dialer.SetTCPOptions(conn.(*net.TCPConn))
+		err = dialer.SetTCPOptions(conn)
 		if err != nil {
 			l.Infoln(err)
 		}

--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -57,9 +57,7 @@ func dialWithFallback(proxyDialFunc dialFunc, fallbackDialFunc dialFunc, network
 	conn, err := proxyDialFunc(network, addr)
 	if err == nil {
 		l.Debugf("Dialing %s address %s via proxy - success, %s -> %s", network, addr, conn.LocalAddr(), conn.RemoteAddr())
-		if tcpconn, ok := conn.(*net.TCPConn); ok {
-			SetTCPOptions(tcpconn)
-		}
+		SetTCPOptions(conn)
 		return dialerConn{
 			conn, newDialerAddr(network, addr),
 		}, nil
@@ -73,9 +71,7 @@ func dialWithFallback(proxyDialFunc dialFunc, fallbackDialFunc dialFunc, network
 	conn, err = fallbackDialFunc(network, addr)
 	if err == nil {
 		l.Debugf("Dialing %s address %s via fallback - success, %s -> %s", network, addr, conn.LocalAddr(), conn.RemoteAddr())
-		if tcpconn, ok := conn.(*net.TCPConn); ok {
-			SetTCPOptions(tcpconn)
-		}
+		SetTCPOptions(conn)
 	} else {
 		l.Debugf("Dialing %s address %s via fallback - error %s", network, addr, err)
 	}

--- a/lib/protocol/benchmark_test.go
+++ b/lib/protocol/benchmark_test.go
@@ -131,8 +131,8 @@ func getTCPConnectionPair() (net.Conn, net.Conn, error) {
 	}
 
 	// Set the buffer sizes etc as usual
-	dialer.SetTCPOptions(conn0.(*net.TCPConn))
-	dialer.SetTCPOptions(conn1.(*net.TCPConn))
+	dialer.SetTCPOptions(conn0)
+	dialer.SetTCPOptions(conn1)
 
 	return conn0, conn1, nil
 }

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -122,7 +122,8 @@ func (c *staticClient) Serve() {
 			case protocol.SessionInvitation:
 				ip := net.IP(msg.Address)
 				if len(ip) == 0 || ip.IsUnspecified() {
-					msg.Address = c.conn.RemoteAddr().(*net.TCPAddr).IP[:]
+					ip := net.ParseIP(c.conn.RemoteAddr().String())
+					msg.Address = ip[:]
 				}
 				c.invitations <- msg
 


### PR DESCRIPTION
This fixes two panics, and I've verified that by forcing relay connections. However, relay connections still don't work through proxy. I'll open another ticket on that shortly.