### PR TITLE
lib/relay: Correctly get IP from remote addr via proxy (fixes #3223)

### DIFF
--- a/lib/relay/client/methods.go
+++ b/lib/relay/client/methods.go
@@ -55,7 +55,7 @@ func GetInvitationFromRelay(uri *url.URL, id syncthingprotocol.DeviceID, certs [
 		l.Debugln("Received invitation", msg, "via", conn.LocalAddr())
 		ip := net.IP(msg.Address)
 		if len(ip) == 0 || ip.IsUnspecified() {
-			msg.Address = conn.RemoteAddr().(*net.TCPAddr).IP[:]
+			msg.Address = remoteIPBytes(conn)
 		}
 		return msg, nil
 	default:
@@ -143,4 +143,12 @@ func configForCerts(certs []tls.Certificate) *tls.Config {
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
 		},
 	}
+}
+
+func remoteIPBytes(conn net.Conn) []byte {
+	addr := conn.RemoteAddr().String()
+	if host, _, err := net.SplitHostPort(addr); err == nil {
+		addr = host
+	}
+	return net.ParseIP(addr)[:]
 }

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -122,8 +122,7 @@ func (c *staticClient) Serve() {
 			case protocol.SessionInvitation:
 				ip := net.IP(msg.Address)
 				if len(ip) == 0 || ip.IsUnspecified() {
-					ip := net.ParseIP(c.conn.RemoteAddr().String())
-					msg.Address = ip[:]
+					msg.Address = remoteIPBytes(c.conn)
 				}
 				c.invitations <- msg
 


### PR DESCRIPTION
### Purpose

Correctly handles addresses, and fixes one more panicing place.

### Testing

Quickly verified with various formats on the playground...