### PR TITLE
cmd/syncthing: Re-enable auto upgrade for dev builds (fixes #901)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -786,10 +786,8 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	if opts.AutoUpgradeIntervalH > 0 {
 		if noUpgrade {
 			l.Infof("No automatic upgrades; STNOUPGRADE environment variable defined.")
-		} else if IsRelease {
-			go autoUpgrade(cfg)
 		} else {
-			l.Infof("No automatic upgrades; %s is not a release version.", Version)
+			go autoUpgrade(cfg)
 		}
 	}
 


### PR DESCRIPTION
### Purpose

As noted in the ticket I no longer agree that dev builds should not auto upgrade. The main reason is that we give dev builds to users to test specific fixes, and noone is happier by them being inadvertently stuck on that version when a newer version including the fix is released.

For developers, it's first of all probably unlikely that development is happening on a build that's older than release, and secondly STNOUPGRADE can be set in the environment once and for all if it an issue.

### Testing

Nah...