### PR TITLE
Track and show folder last scan time (fixes #3143)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -361,7 +361,7 @@
                       <td class="text-right">{{sharesFolder(folder)}}</td>
                     </tr>
                     <tr>
-                      <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Last Scan Time</span></th>
+                      <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Last Scan</span></th>
                       <td translate ng-if="folderStats[folder.id].lastScanDays >= 365" class="text-right">Never</td>
                       <td ng-if="folderStats[folder.id].lastScanDays < 365" class="text-right">
                         <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -360,7 +360,7 @@
                       <th><span class="fa fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span></th>
                       <td class="text-right">{{sharesFolder(folder)}}</td>
                     </tr>
-                    <tr ng-if="folder.type != 'readonly'">
+                    <tr>
                       <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Last Scan Time</span></th>
                       <td class="text-right">
                         <span>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -360,6 +360,14 @@
                       <th><span class="fa fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span></th>
                       <td class="text-right">{{sharesFolder(folder)}}</td>
                     </tr>
+                    <tr ng-if="folder.type != 'readonly'">
+                      <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Last Scan Time</span></th>
+                      <td class="text-right">
+                        <span>
+                          {{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}
+                        </span>
+                      </td>
+                    </tr>
                     <tr ng-if="folder.type != 'readonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">
                       <th><span class="fa fa-fw fa-exchange"></span>&nbsp;<span translate>Last File Received</span></th>
                       <td class="text-right">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -362,10 +362,9 @@
                     </tr>
                     <tr>
                       <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Last Scan Time</span></th>
-                      <td class="text-right">
-                        <span>
-                          {{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}
-                        </span>
+                      <td translate ng-if="folderStats[folder.id].lastScanDays >= 365" class="text-right">Never</td>
+                      <td ng-if="folderStats[folder.id].lastScanDays < 365" class="text-right">
+                        <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
                       </td>
                     </tr>
                     <tr ng-if="folder.type != 'readonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -591,6 +591,9 @@ angular.module('syncthing.core')
                     if ($scope.folderStats[folder].lastFile) {
                         $scope.folderStats[folder].lastFile.at = new Date($scope.folderStats[folder].lastFile.at);
                     }
+
+                    $scope.folderStats[folder].lastScan = new Date($scope.folderStats[folder].lastScan);
+                    $scope.folderStats[folder].lastScanDays = (new Date() - $scope.folderStats[folder].lastScan) / 1000 / 86400;
                 }
                 console.log("refreshfolderStats", data);
             }).error($scope.emitHTTPError);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -171,6 +171,12 @@ angular.module('syncthing.core')
                 if (data.to === 'scanning') {
                     delete $scope.scanProgress[data.folder];
                 }
+
+                // If a folder finished scanning, then refresh folder stats
+                // to update last scan time.
+                if(data.from === 'scanning' && data.to === 'idle') {
+                    refreshFolderStats();
+                }
             }
         });
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1602,6 +1602,7 @@ func (m *Model) internalScanFolderSubdirs(folder string, subs []string) error {
 		m.updateLocalsFromScanning(folder, batch)
 	}
 
+	m.folderStatRef(folder).ScanCompleted()
 	runner.setState(FolderIdle)
 	return nil
 }

--- a/lib/stats/folder.go
+++ b/lib/stats/folder.go
@@ -13,7 +13,8 @@ import (
 )
 
 type FolderStatistics struct {
-	LastFile LastFile `json:"lastFile"`
+	LastFile LastFile  `json:"lastFile"`
+	LastScan time.Time `json:"lastScan"`
 }
 
 type FolderStatisticsReference struct {
@@ -59,8 +60,21 @@ func (s *FolderStatisticsReference) ReceivedFile(file string, deleted bool) {
 	s.ns.PutBool("lastFileDeleted", deleted)
 }
 
+func (s *FolderStatisticsReference) ScanCompleted() {
+	s.ns.PutTime("lasScan", time.Now())
+}
+
+func (s *FolderStatisticsReference) GetLastScanTime() time.Time {
+	lasScan, ok := s.ns.Time("lasScan")
+	if !ok {
+		return time.Time{}
+	}
+	return lasScan
+}
+
 func (s *FolderStatisticsReference) GetStatistics() FolderStatistics {
 	return FolderStatistics{
 		LastFile: s.GetLastFile(),
+		LastScan: s.GetLastScanTime(),
 	}
 }

--- a/lib/stats/folder.go
+++ b/lib/stats/folder.go
@@ -61,15 +61,15 @@ func (s *FolderStatisticsReference) ReceivedFile(file string, deleted bool) {
 }
 
 func (s *FolderStatisticsReference) ScanCompleted() {
-	s.ns.PutTime("lasScan", time.Now())
+	s.ns.PutTime("lastScan", time.Now())
 }
 
 func (s *FolderStatisticsReference) GetLastScanTime() time.Time {
-	lasScan, ok := s.ns.Time("lasScan")
+	lastScan, ok := s.ns.Time("lastScan")
 	if !ok {
 		return time.Time{}
 	}
-	return lasScan
+	return lastScan
 }
 
 func (s *FolderStatisticsReference) GetStatistics() FolderStatistics {


### PR DESCRIPTION
### Purpose

Keep track of folders last scan time and show it on GUI.

### Testing

Tested with 2 folders using manual scan (by pressing scan button on GUI) and auto rescan interval.

### Screenshots

![screenshot](http://i.imgur.com/dNkVECu.png)

### Documentation

REST API documentation for `/rest/stats/folder` endpoint should be updated to include `lastScan` in JSON reply