### PR TITLE
gui: Vertically center identicons in accordion titles

### DIFF
--- a/gui/dark/assets/css/theme.css
+++ b/gui/dark/assets/css/theme.css
@@ -94,8 +94,8 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     border-top: 1px solid #222 !important;
 }
 
-.identicon>rect {
-    fill: #aaa !important;
+.identicon rect {
+    fill: #aaa;
 }
 
 .panel-heading:hover, .panel-heading:focus {

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -196,17 +196,21 @@ table.table-condensed td.no-overflow-ellipse {
 }
 
 identicon {
-    display: inline-block;
-    position: relative;
     width: 1em;
     height: 1em;
     line-height: 1;
+}
+
+h4 identicon{
+    margin-top: 0.125em;
+    margin-bottom: 0.125em;
 }
 
 .identicon {
     width: 1em;
     height: 1em;
 }
+
 
 /**
  * Progress bars with centered text


### PR DESCRIPTION
before:
![untitled](https://cloud.githubusercontent.com/assets/4681349/15757021/a0906030-28fb-11e6-8383-6431a606f788.png)

after:
![untitled](https://cloud.githubusercontent.com/assets/4681349/15757038/b009517a-28fb-11e6-8a6f-0fae83969f26.png)

bonus:
removed `!important` from dark theme identicon, not needed any more.
