### PR TITLE
gui: Make warning titles more readable in Dark Theme

### DIFF
--- a/gui/dark/assets/css/theme.css
+++ b/gui/dark/assets/css/theme.css
@@ -71,10 +71,13 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     border-color: #222 !important;
 }
 
-.panel-default>.panel-heading {
+.panel-default > .panel-heading {
     color: #aaa !important;
     border-color: #222 !important;
     background-color: #222 !important;
+}
+.panel-warning > .panel-heading {
+    color: #222 !important;
 }
 
 .panel-progress {


### PR DESCRIPTION
before:
![untitled](https://cloud.githubusercontent.com/assets/4681349/15758039/899dbce2-2900-11e6-8ec3-d08f3bd70457.png)

after:
![untitled](https://cloud.githubusercontent.com/assets/4681349/15758053/980e5df4-2900-11e6-9a0c-962b2d7900d4.png)
