### PR TITLE
Lower the "Joining relay session (BEP/relay):" error message's log level

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,6 +12,7 @@ Alexander Graf (alex2108) <register-github@alex-graf.de>
 Alexandre Viau (aviau) <alexandre@alexandreviau.net> <aviau@debian.org>
 Anderson Mesquita (andersonvom) <andersonvom@gmail.com>
 Andrew Dunham (andrew-d) <andrew@du.nham.ca>
+Andrey D (scienmind) <scintertech@cryptolab.net>
 Antony Male (canton7) <antony.male@gmail.com>
 Arthur Axel fREW Schmidt (frioux) <frew@afoolishmanifesto.com> <frioux@gmail.com>
 Audrius Butkevicius (AudriusButkevicius) <audrius.butkevicius@gmail.com>

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -69,7 +69,7 @@ func (t *relayListener) Serve() {
 
 			conn, err := client.JoinSession(inv)
 			if err != nil {
-				l.Warnln("Joining relay session (BEP/relay):", err)
+				l.Infoln("Joining relay session (BEP/relay):", err)
 				continue
 			}
 


### PR DESCRIPTION
### Purpose

This PR is a follow up to the discussion on the [forum](https://forum.syncthing.net/t/using-relays-periodically-generates-notice-messages/7550):
Poor connections often result in frequent "Warning Messages" on top of WebUI, regarding failed relay connection attempts. Since the message is neither actionable nor important for the user to be aware of (the re-connection attempts will occur on their own), there is no reason to to post it there, and it should be kept to the console.

This PR lowers the "Joining relay session (BEP/relay):" error messages' log level from warning to info.

### Testing

I'm still not too familiar with the build system, so I haven't tested it.
Though the change is literally one single word, and seem to be pretty straight forward.