### PR TITLE
gui: Swap edit / pause buttons on devices

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -585,14 +585,14 @@
               </div>
               <div class="panel-footer">
                 <span class="pull-right">
-                  <button type="button" class="btn btn-sm btn-default" ng-click="editDevice(deviceCfg)">
-                    <span class="fa fa-pencil"></span>&nbsp;<span translate>Edit</span>
-                  </button>
                   <button ng-if="!connections[deviceCfg.deviceID].paused" type="button" class="btn btn-sm btn-default" ng-click="pauseDevice(deviceCfg.deviceID)">
                     <span class="fa fa-pause"></span>&nbsp;<span translate>Pause</span>
                   </button>
                   <button ng-if="connections[deviceCfg.deviceID].paused" type="button" class="btn btn-sm btn-default" ng-click="resumeDevice(deviceCfg.deviceID)">
                     <span class="fa fa-play"></span>&nbsp;<span translate>Resume</span>
+                  </button>
+                  <button type="button" class="btn btn-sm btn-default" ng-click="editDevice(deviceCfg)">
+                    <span class="fa fa-pencil"></span>&nbsp;<span translate>Edit</span>
                   </button>
                 </span>
                 <div class="clearfix"></div>


### PR DESCRIPTION

### Purpose
Swap edit / pause buttons on devices, to bring folders and devices into same button order - with edit being last.

### before
![untitled](https://cloud.githubusercontent.com/assets/4681349/15807668/db674ee6-2b5b-11e6-93a2-49e7fd840196.png)

### after
![untitled](https://cloud.githubusercontent.com/assets/4681349/15807671/fc228dd0-2b5b-11e6-9de5-87074bdb641e.png)

