### PR TITLE
build: Tags must be joined by space, not comma (fixes #3262)

### DIFF
--- a/build.go
+++ b/build.go
@@ -362,7 +362,7 @@ func install(target target, tags []string) {
 	os.Setenv("GOBIN", filepath.Join(cwd, "bin"))
 	args := []string{"install", "-v", "-ldflags", ldflags()}
 	if len(tags) > 0 {
-		args = append(args, "-tags", strings.Join(tags, ","))
+		args = append(args, "-tags", strings.Join(tags, " "))
 	}
 	if race {
 		args = append(args, "-race")
@@ -382,7 +382,7 @@ func build(target target, tags []string) {
 	rmr(target.binaryName)
 	args := []string{"build", "-i", "-v", "-ldflags", ldflags()}
 	if len(tags) > 0 {
-		args = append(args, "-tags", strings.Join(tags, ","))
+		args = append(args, "-tags", strings.Join(tags, " "))
 	}
 	if race {
 		args = append(args, "-race")


### PR DESCRIPTION
With the latest changes we passed `-tags purego,noupgrade` which is not correct syntax. Tags must be space separated, `-tags "purego noupgrade"`.

This fixes that. Tested by verifying that the `noupgrade` tag takes and that I can see both tags on the command line.