### PR TITLE
cmd/syncthing: Delay starting global discovery to give local discovery time to work

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -717,9 +717,11 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 			}
 
 			// Each global discovery server gets its results cached for five
-			// minutes, and is not asked again for a minute when it's returned
-			// unsuccessfully.
-			cachedDiscovery.Add(gd, 5*time.Minute, time.Minute, globalDiscoveryPriority)
+			// minutes, and is not asked again for a minute when it's
+			// returned unsuccessfully. It is not valid to use until
+			// discover.BroadcastInterval has passed, to allow local
+			// discovery a chance to work before using global.
+			cachedDiscovery.Add(gd, 5*time.Minute, time.Minute, globalDiscoveryPriority, discover.BroadcastInterval)
 		}
 	}
 
@@ -729,14 +731,14 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		if err != nil {
 			l.Warnln("IPv4 local discovery:", err)
 		} else {
-			cachedDiscovery.Add(bcd, 0, 0, ipv4LocalDiscoveryPriority)
+			cachedDiscovery.Add(bcd, 0, 0, ipv4LocalDiscoveryPriority, 0)
 		}
 		// v6 multicasts
 		mcd, err := discover.NewLocal(myID, cfg.Options().LocalAnnMCAddr, connectionsService)
 		if err != nil {
 			l.Warnln("IPv6 local discovery:", err)
 		} else {
-			cachedDiscovery.Add(mcd, 0, 0, ipv6LocalDiscoveryPriority)
+			cachedDiscovery.Add(mcd, 0, 0, ipv6LocalDiscoveryPriority, 0)
 		}
 	}
 

--- a/cmd/syncthing/mocked_discovery_test.go
+++ b/cmd/syncthing/mocked_discovery_test.go
@@ -44,7 +44,7 @@ func (m *mockedCachingMux) Cache() map[protocol.DeviceID]discover.CacheEntry {
 
 // from events.CachingMux
 
-func (m *mockedCachingMux) Add(finder discover.Finder, cacheTime, negCacheTime time.Duration, priority int) {
+func (m *mockedCachingMux) Add(finder discover.Finder, cacheTime, negCacheTime time.Duration, priority int, delay time.Duration) {
 }
 
 func (m *mockedCachingMux) ChildErrors() map[string]error {

--- a/lib/discover/cache_test.go
+++ b/lib/discover/cache_test.go
@@ -163,7 +163,7 @@ func TestCacheDelay(t *testing.T) {
 		t.Errorf("Incorrect response %q should be %q", res[0], second)
 	}
 
-	// Wait for the second source to become valid
+	// Wait for the first source to become valid
 
 	time.Sleep(150 * time.Millisecond)
 


### PR DESCRIPTION
### Purpose

Avoid the situation where we during startup get an answer from a global disco server but haven't yet had time to get any local discovery packets.

### Testing

STTRACE output shows that the startup gets delayed, but we should wait for the dude in the [forum thread](https://forum.syncthing.net/t/global-discovery-getting-priority-over-local-discovery/7585) to give this a spin.