### PR TITLE
gui: Bootstrap tooltips (in modals)

### DIFF
--- a/gui/default/syncthing/core/aboutModalView.html
+++ b/gui/default/syncthing/core/aboutModalView.html
@@ -1,6 +1,6 @@
 <modal id="about" status="info" icon="heart-o" title="{{'About' | translate}}" large="yes" close="yes">
   <h1 class="text-center">
-    <img alt="Syncthing" title="Syncthing" src="assets/img/logo-horizontal.svg" style="vertical-align: -16px" height="100" width="366"/>
+    <img alt="Syncthing" tooltip data-original-title="Syncthing" src="assets/img/logo-horizontal.svg" style="vertical-align: -16px" height="100" width="366"/>
     <br/>
     <small>{{versionString()}}</small>
     <br/>

--- a/gui/default/syncthing/core/aboutModalView.html
+++ b/gui/default/syncthing/core/aboutModalView.html
@@ -1,6 +1,6 @@
 <modal id="about" status="info" icon="heart-o" title="{{'About' | translate}}" large="yes" close="yes">
   <h1 class="text-center">
-    <img alt="Syncthing" tooltip data-original-title="Syncthing" src="assets/img/logo-horizontal.svg" style="vertical-align: -16px" height="100" width="366"/>
+    <img alt="Syncthing" src="assets/img/logo-horizontal.svg" style="vertical-align: -16px" height="100" width="366"/>
     <br/>
     <small>{{versionString()}}</small>
     <br/>

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -74,7 +74,7 @@
                         <input type="checkbox" ng-model="currentDevice.selectedFolders[folder.id]">&nbsp;{{folder.id}}
                       </label>
                       <label ng-if="folder.label.length != 0">
-                        <input type="checkbox" ng-model="currentDevice.selectedFolders[folder.id]">&nbsp;<span title="{{folder.id}}">{{folder.label}}</span>
+                        <input type="checkbox" ng-model="currentDevice.selectedFolders[folder.id]">&nbsp;<span tooltip data-original-title="{{folder.id}}">{{folder.label}}</span>
                       </label>
                     </div>
                   </div>

--- a/gui/default/syncthing/transfer/failedFilesModalView.html
+++ b/gui/default/syncthing/transfer/failedFilesModalView.html
@@ -5,8 +5,8 @@
   </p>
   <table class="table table-striped table-condensed">
     <tr dir-paginate="e in failedCurrent | itemsPerPage: failedPageSize" current-page="failedCurrentPage" pagination-id="failed">
-      <td><abbr title="{{e.path}}">{{e.path | basename}}</abbr></td>
-      <td><abbr title="{{e.error}}">{{e.error | lastErrorComponent}}</abbr></td>
+      <td><abbr tooltip data-original-title="{{e.path}}">{{e.path | basename}}</abbr></td>
+      <td><abbr tooltip data-original-title="{{e.error}}">{{e.error | lastErrorComponent}}</abbr></td>
     </tr>
   </table>
   <dir-pagination-controls on-page-change="failedPageChanged(newPageNumber)" pagination-id="failed"></dir-pagination-controls>

--- a/gui/default/syncthing/transfer/neededFilesModalView.html
+++ b/gui/default/syncthing/transfer/neededFilesModalView.html
@@ -16,12 +16,12 @@
       <td class="small-data"><span class="fa fa-fw fa-{{needIcons[f.action]}}"></span> {{needActions[f.action]}}</td>
 
       <!-- Name -->
-      <td ng-if="f.type != 'queued'" title="{{f.name}}">{{f.name | basename}}</td>
+      <td ng-if="f.type != 'queued'" tooltip data-original-title="{{f.name}}">{{f.name | basename}}</td>
       <td ng-if="f.type == 'queued'">
-        <a href="" ng-click="bumpFile(neededFolder, f.name)" title="{{'Move to top of queue' | translate}}">
+        <a href="" ng-click="bumpFile(neededFolder, f.name)" tooltip data-original-title="{{'Move to top of queue' | translate}}">
           <span class="fa fa-eject"></span>
         </a>
-        <span title="{{f.name}}">&nbsp;{{f.name | basename}}</span>
+        <span tooltip data-original-title="{{f.name}}">&nbsp;{{f.name | basename}}</span>
       </td>
 
       <!-- Size/Progress -->


### PR DESCRIPTION
bootstrap tooltips in modals:

1. edit device modal > Share Folders With Device > folder labels. Before: [untitled](https://cloud.githubusercontent.com/assets/4681349/15894175/68eb4c00-2d7c-11e6-9c47-4aa948956d32.png), After: [untitled](https://cloud.githubusercontent.com/assets/4681349/15894185/73f68d9e-2d7c-11e6-8773-3ff94f24f0ad.png)
2. failed files modal > multiple places
3. needed files modal > multiple places

I DIDNT TEST 2 OR 3




