### PR TITLE
gui: Remove tooltip shown over whole modal

### DIFF
--- a/gui/default/modal.html
+++ b/gui/default/modal.html
@@ -13,7 +13,7 @@
           <div class="panel-icon">
             <span ng-if="icon" class="fa fa-{{icon}}"></span>
           </div>
-          {{title}}
+          {{heading}}
         </h4>
       </div>
       <div class="modal-body" ng-transclude>

--- a/gui/default/syncthing/core/aboutModalView.html
+++ b/gui/default/syncthing/core/aboutModalView.html
@@ -1,4 +1,4 @@
-<modal id="about" status="info" icon="heart-o" title="{{'About' | translate}}" large="yes" close="yes">
+<modal id="about" status="info" icon="heart-o" heading="{{'About' | translate}}" large="yes" close="yes">
   <h1 class="text-center">
     <img alt="Syncthing" title="Syncthing" src="assets/img/logo-horizontal.svg" style="vertical-align: -16px" height="100" width="366"/>
     <br/>

--- a/gui/default/syncthing/core/httpErrorDialogView.html
+++ b/gui/default/syncthing/core/httpErrorDialogView.html
@@ -1,4 +1,4 @@
-<modal id="httpError" status="danger" icon="exclamation-circle" title="{{'Connection Error' | translate}}">
+<modal id="httpError" status="danger" icon="exclamation-circle" heading="{{'Connection Error' | translate}}">
 	<p translate>
 	  Syncthing seems to be experiencing a problem processing your request. Please refresh the page or restart Syncthing if the problem persists.
 	</p>

--- a/gui/default/syncthing/core/modalDirective.js
+++ b/gui/default/syncthing/core/modalDirective.js
@@ -6,7 +6,7 @@ angular.module('syncthing.core')
             replace: true,
             transclude: true,
             scope: {
-                title: '@',
+                heading: '@',
                 status: '@',
                 icon: '@',
                 close: '@',

--- a/gui/default/syncthing/core/networkErrorDialogView.html
+++ b/gui/default/syncthing/core/networkErrorDialogView.html
@@ -1,4 +1,4 @@
-<modal id="networkError" status="danger" icon="exclamation-circle" title="{{'Connection Error' | translate}}">
+<modal id="networkError" status="danger" icon="exclamation-circle" heading="{{'Connection Error' | translate}}">
 	<p translate>
 	  Syncthing seems to be down, or there is a problem with your Internet connection. Retrying&hellip;
 	</p>

--- a/gui/default/syncthing/core/restartingDialogView.html
+++ b/gui/default/syncthing/core/restartingDialogView.html
@@ -1,3 +1,3 @@
-<modal id="restarting" status="info" icon="refresh" title="{{'Restarting' | translate}}">
+<modal id="restarting" status="info" icon="refresh" heading="{{'Restarting' | translate}}">
 	<p><span translate>Syncthing is restarting.</span> <span translate>Please wait</span>...</p>
 </modal>

--- a/gui/default/syncthing/core/shutdownDialogView.html
+++ b/gui/default/syncthing/core/shutdownDialogView.html
@@ -1,3 +1,3 @@
-<modal id="shutdown" status="success" icon="power-off" title="{{'Shutdown Complete' | translate}}">
+<modal id="shutdown" status="success" icon="power-off" heading="{{'Shutdown Complete' | translate}}">
 	<p translate>Syncthing has been shut down.</p>
 </modal>

--- a/gui/default/syncthing/core/upgradingDialogView.html
+++ b/gui/default/syncthing/core/upgradingDialogView.html
@@ -1,3 +1,3 @@
-<modal id="upgrading" status="info" icon="arrow-circle-up" title="{{'Upgrading' | translate}}">
+<modal id="upgrading" status="info" icon="arrow-circle-up" heading="{{'Upgrading' | translate}}">
 	<p><span translate>Syncthing is upgrading.</span> <span translate>Please wait</span>...</p>
 </modal>

--- a/gui/default/syncthing/device/idqrModalView.html
+++ b/gui/default/syncthing/device/idqrModalView.html
@@ -1,4 +1,4 @@
-<modal id="idqr" status="info" icon="qrcode" title="{{'Device Identification' | translate}} - {{deviceName(currentDevice)}}" large="yes" close="yes">
+<modal id="idqr" status="info" icon="qrcode" heading="{{'Device Identification' | translate}} - {{deviceName(currentDevice)}}" large="yes" close="yes">
   <div class="well well-sm text-monospace text-center" select-on-click>{{currentDevice.deviceID}}</div>
   <img ng-if="currentDevice.deviceID" class="center-block img-thumbnail" ng-src="qr/?text={{currentDevice.deviceID}}"/>
 </modal>

--- a/gui/default/syncthing/transfer/failedFilesModalView.html
+++ b/gui/default/syncthing/transfer/failedFilesModalView.html
@@ -1,4 +1,4 @@
-<modal id="failed" status="warning" icon="exclamation-circle" title="{{'Failed Items' | translate}}" large="yes" close="yes">
+<modal id="failed" status="warning" icon="exclamation-circle" heading="{{'Failed Items' | translate}}" large="yes" close="yes">
   <p>
     <span translate>The following items could not be synchronized.</span>
     <span translate>They are retried automatically and will be synced when the error is resolved.</span>

--- a/gui/default/syncthing/transfer/neededFilesModalView.html
+++ b/gui/default/syncthing/transfer/neededFilesModalView.html
@@ -1,4 +1,4 @@
-<modal id="needed" status="info" icon="cloud-download" title="{{'Out of Sync Items' | translate}}" large="yes" close="yes" tabindex="-1">
+<modal id="needed" status="info" icon="cloud-download" heading="{{'Out of Sync Items' | translate}}" large="yes" close="yes" tabindex="-1">
   <div class="progress">
     <div class="progress-bar progress-bar-success" style="width: 20%"><span translate class="show">Reused</span></div>
     <div class="progress-bar" style="width: 20%"><span translate class="show">Copied from original</span></div>

--- a/gui/default/syncthing/usagereport/usageReportPreviewModalView.html
+++ b/gui/default/syncthing/usagereport/usageReportPreviewModalView.html
@@ -1,4 +1,4 @@
-<modal id="urPreview" status="success" icon="bar-chart" title="{{'Anonymous Usage Reporting' | translate}}" large="yes" close="yes" tabindex="-1">
+<modal id="urPreview" status="success" icon="bar-chart" heading="{{'Anonymous Usage Reporting' | translate}}" large="yes" close="yes" tabindex="-1">
   <p translate>The encrypted usage report is sent daily. It is used to track common platforms, folder sizes and app versions. If the reported data set is changed you will be prompted with this dialog again.</p>
   <p translate translate-value-url="<a href=&quot;https://data.syncthing.net&quot; target=&quot;_blank&quot;>https://data.syncthing.net</a>">The aggregated statistics are publicly available at {%url%}.</p>
   <form>


### PR DESCRIPTION
Changed the `<modal>` attribute `title` (which is reserved) to `heading`
It was causing a default browser tooltip to appear when hovering over some modals.
(for all modal templates)