### PR TITLE
Increase deadline of  exchangeHello

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -554,7 +554,7 @@ func (s *Service) getListenerFactory(cfg config.Configuration, uri *url.URL) (li
 }
 
 func exchangeHello(c net.Conn, h protocol.HelloMessage) (protocol.HelloMessage, error) {
-	if err := c.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+	if err := c.SetDeadline(time.Now().Add(20 * time.Second)); err != nil {
 		return protocol.HelloMessage{}, err
 	}
 	defer c.SetDeadline(time.Time{})


### PR DESCRIPTION
### Purpose

Fix exchangeHello time out over high latency links

 -- currently exchangeHello will close connections too soon for links with latency above 1,000ms. This not a common case, but NGOs in general works with remote locations with high latency links. 
Increasing the deadline to 20s will allow links with latency up to 10,000ms to not fail exchangeHello handshake.

tenorio