### PR TITLE
gui: Add support for multiple stacked modals

### DIFF
--- a/gui/default/syncthing/core/modalDirective.js
+++ b/gui/default/syncthing/core/modalDirective.js
@@ -62,6 +62,11 @@ angular.module('syncthing.core')
                     // reset z-index of modal to normal
                     $(element).css('zIndex', 1040);
 
+                    // fix scrolling by re-adding .modal-open to body
+                    if ($('.modal:visible').length > 0) {
+                        $('body').addClass('modal-open');
+                    }
+
                 });
             }
         };

--- a/gui/default/syncthing/core/modalDirective.js
+++ b/gui/default/syncthing/core/modalDirective.js
@@ -21,7 +21,9 @@ angular.module('syncthing.core')
                     var largestZ = 1040;
                     $('.modal:visible').each(function (i) {
                         var thisZ = parseInt($(this).css('zIndex'));
-                        largestZ = thisZ > largestZ ? thisZ : largestZ;
+                        if (thisZ > largestZ) {
+                            largestZ = thisZ;
+                        }
                     });
 
                     // set this modal's z-index to be 10 above the highest z
@@ -30,15 +32,34 @@ angular.module('syncthing.core')
 
                     // set backdrop z-index. timeout used because element does not exist immediatly
                     setTimeout(function () {
-                        $('.modal-backdrop:last').css('zIndex', aboveLargestZ-5);
-                    },0);
+                        $('.modal-backdrop:not(:last)').addClass('hidden');
+                        $('.modal-backdrop:last').attr('for-modal-id', $(element).attr('id')).css('zIndex', aboveLargestZ - 5);
+                    }, 0);
 
                 });
 
-                // after modal hide animation
+                // BEFORE modal hide animation
+                $(element).on('hide.bs.modal', function () {
+
+                    // find and unhide the next backdrop down in z order
+                    var sel = false, largestZ = 0;
+                    $('.modal-backdrop').each(function (i) {
+                        console.log('sel each');
+                        var thisZ = parseInt($(this).css('zIndex'));
+                        if (thisZ > largestZ && $(this).attr('for-modal-id') !== $(element).attr('id')) {
+                            largestZ = thisZ;
+                            sel = i;
+                        }
+                    });
+                    if (sel !== false) {
+                        $('.modal-backdrop:eq(' + sel + ')').removeClass('hidden');
+                    }
+                });
+
+                // AFTER modal hide animation
                 $(element).on('hidden.bs.modal', function () {
 
-                    // reset z-index of modal to normal (backdrop element gets deleted, so no need to reset its z-index)
+                    // reset z-index of modal to normal
                     $(element).css('zIndex', 1040);
 
                 });

--- a/gui/default/syncthing/core/modalDirective.js
+++ b/gui/default/syncthing/core/modalDirective.js
@@ -32,7 +32,7 @@ angular.module('syncthing.core')
 
                     // set backdrop z-index. timeout used because element does not exist immediatly
                     setTimeout(function () {
-                        $('.modal-backdrop:not(:last)').addClass('hidden');
+                        $('.modal-backdrop:not(:last)').removeClass('in').addClass('out');
                         $('.modal-backdrop:last').attr('for-modal-id', $(element).attr('id')).css('zIndex', aboveLargestZ - 5);
                     }, 0);
 
@@ -52,7 +52,7 @@ angular.module('syncthing.core')
                         }
                     });
                     if (sel !== false) {
-                        $('.modal-backdrop:eq(' + sel + ')').removeClass('hidden');
+                        $('.modal-backdrop:eq(' + sel + ')').removeClass('out').addClass('in');
                     }
                 });
 

--- a/gui/default/syncthing/core/modalDirective.js
+++ b/gui/default/syncthing/core/modalDirective.js
@@ -11,6 +11,37 @@ angular.module('syncthing.core')
                 icon: '@',
                 close: '@',
                 large: '@'
+            },
+            link: function (scope, element, attrs, tabsCtrl) {
+
+                // before modal show animation
+                $(element).on('show.bs.modal', function () {
+
+                    // cycle through open modals, acertain modal with highest z-index
+                    var largestZ = 1040;
+                    $('.modal:visible').each(function (i) {
+                        var thisZ = parseInt($(this).css('zIndex'));
+                        largestZ = thisZ > largestZ ? thisZ : largestZ;
+                    });
+
+                    // set this modal's z-index to be 10 above the highest z
+                    var aboveLargestZ = largestZ + 10;
+                    $(element).css('zIndex', aboveLargestZ);
+
+                    // set backdrop z-index. timeout used because element does not exist immediatly
+                    setTimeout(function () {
+                        $('.modal-backdrop:last').css('zIndex', aboveLargestZ-5);
+                    },0);
+
+                });
+
+                // after modal hide animation
+                $(element).on('hidden.bs.modal', function () {
+
+                    // reset z-index of modal to normal (backdrop element gets deleted, so no need to reset its z-index)
+                    $(element).css('zIndex', 1040);
+
+                });
             }
         };
     });


### PR DESCRIPTION
Hi, I thought this may be of some value... 

It looks like someone has taken the time to hide the parent modal when i go into a child modal, example:
Actions > Settings > Anonymous Usage Reporting > click Preview > shows 'child' modal
However, the method used is heavily scripted and only works in specific situations.

There are situations where 2 modals will appear at the same time. For example; with any modal dialogue open, if I close the `syncthing` process - two dialogues do actually appear, but the 'connection error dialogue' modal is behind... (unrevealed bug?)

This happens because of the order of modals in index.html, where first in the document order means behind in the z-index.

The code I have included here allows the `modalDirective` to calculate a z-index when opening modals, the new z-index is based on the z-index of other open modal(s).

It currently works for modals that are generated with `modalDirective.js`, which fyi is currently not all of them (some have their own directive files).

