### PR TITLE
lib/model: Don't set ignore bit when it's already set

### DIFF
--- a/lib/db/leveldb_transactions.go
+++ b/lib/db/leveldb_transactions.go
@@ -68,10 +68,10 @@ func (t readWriteTransaction) checkFlush() {
 }
 
 func (t readWriteTransaction) flush() {
-	atomic.AddInt64(&t.db.committed, int64(t.Batch.Len()))
 	if err := t.db.Write(t.Batch, nil); err != nil {
 		panic(err)
 	}
+	atomic.AddInt64(&t.db.committed, int64(t.Batch.Len()))
 }
 
 func (t readWriteTransaction) insertFile(folder, device []byte, file protocol.FileInfo) int64 {

--- a/lib/db/leveldb_transactions.go
+++ b/lib/db/leveldb_transactions.go
@@ -45,7 +45,6 @@ func (t readOnlyTransaction) getFile(folder, device, file []byte) (protocol.File
 type readWriteTransaction struct {
 	readOnlyTransaction
 	*leveldb.Batch
-	counter *int64
 }
 
 func (db *Instance) newReadWriteTransaction() readWriteTransaction {
@@ -53,7 +52,6 @@ func (db *Instance) newReadWriteTransaction() readWriteTransaction {
 	return readWriteTransaction{
 		readOnlyTransaction: t,
 		Batch:               new(leveldb.Batch),
-		counter:             &db.committed,
 	}
 }
 
@@ -70,7 +68,7 @@ func (t readWriteTransaction) checkFlush() {
 }
 
 func (t readWriteTransaction) flush() {
-	atomic.AddInt64(t.counter, int64(t.Batch.Len()))
+	atomic.AddInt64(&t.db.committed, int64(t.Batch.Len()))
 	if err := t.db.Write(t.Batch, nil); err != nil {
 		panic(err)
 	}

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -624,6 +624,39 @@ func TestLongPath(t *testing.T) {
 	}
 }
 
+func TestCommitted(t *testing.T) {
+	// Verify that the Committed counter increases when we change things and
+	// doesn't increase when we don't.
+
+	ldb := db.OpenMemory()
+
+	s := db.NewFileSet("test", ldb)
+
+	local := []protocol.FileInfo{
+		{Name: string("file"), Version: protocol.Vector{{ID: myID, Value: 1000}}},
+	}
+
+	// Adding a file should increase the counter
+
+	c0 := ldb.Committed()
+
+	s.Replace(protocol.LocalDeviceID, local)
+
+	c1 := ldb.Committed()
+	if c1 <= c0 {
+		t.Errorf("committed data didn't increase; %d <= %d", c1, c0)
+	}
+
+	// Updating with something identical should not do anything
+
+	s.Update(protocol.LocalDeviceID, local)
+
+	c2 := ldb.Committed()
+	if c2 > c1 {
+		t.Errorf("replace with same contents should do nothing but %d > %d", c2, c1)
+	}
+}
+
 func BenchmarkUpdateOneFile(b *testing.B) {
 	local0 := fileList{
 		protocol.FileInfo{Name: "a", Version: protocol.Vector{{ID: myID, Value: 1000}}, Blocks: genBlocks(1)},

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1551,7 +1551,7 @@ func (m *Model) internalScanFolderSubdirs(folder string, subs []string) error {
 					batch = batch[:0]
 				}
 
-				if ignores.Match(f.Name).IsIgnored() || symlinkInvalid(folder, f) {
+				if !f.IsInvalid() && (ignores.Match(f.Name).IsIgnored() || symlinkInvalid(folder, f)) {
 					// File has been ignored or an unsupported symlink. Set invalid bit.
 					l.Debugln("setting invalid bit on ignored", f)
 					nf := protocol.FileInfo{


### PR DESCRIPTION
### Purpose

This adds a metric for "committed items" to the database instance that I use in the test code, and a couple of tests that ensure that scans that don't change anything also don't commit anything.

There was a case in the scanner where we set the invalid bit on files that are ignored, even though they were already ignored and had the invalid bit set. I had assumed this would result in an extra database
commit, but it was in fact filtered out by the Set... Anyway, I think we can save some work on not pushing that change to the Set at all.

### Testing

Unit tests added.