### PR TITLE
build: Use forward slashes in Zip and Tar files (fixes #3330)

### DIFF
--- a/build.go
+++ b/build.go
@@ -879,7 +879,7 @@ func zipFile(out string, files []archiveFile) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fh.Name = f.dst
+		fh.Name = filepath.ToSlash(f.dst)
 		fh.Method = zip.Deflate
 
 		if strings.HasSuffix(f.dst, ".txt") {


### PR DESCRIPTION
### Purpose

Don't have crappy file names in tar/zip created on Windows.

### Testing

PR build unpacks nicely on both Windows and Mac