### PR TITLE
lib/osutil: Return "/" as filesystem root on non-windows (fixes #3321)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -1134,9 +1134,9 @@ func (s *apiService) getPeerCompletion(w http.ResponseWriter, r *http.Request) {
 func (s *apiService) getSystemBrowse(w http.ResponseWriter, r *http.Request) {
 	qs := r.URL.Query()
 	current := qs.Get("current")
-	if current == "" && runtime.GOOS == "windows" {
-		if drives, err := osutil.GetDriveLetters(); err == nil {
-			sendJSON(w, drives)
+	if current == "" {
+		if roots, err := osutil.GetFilesystemRoots(); err == nil {
+			sendJSON(w, roots)
 		} else {
 			http.Error(w, err.Error(), 500)
 		}

--- a/lib/osutil/fsroots_unix.go
+++ b/lib/osutil/fsroots_unix.go
@@ -8,6 +8,6 @@
 
 package osutil
 
-func GetDriveLetters() ([]string, error) {
-	return nil, nil
+func GetFilesystemRoots() ([]string, error) {
+	return []string{"/"}, nil
 }

--- a/lib/osutil/fsroots_windows.go
+++ b/lib/osutil/fsroots_windows.go
@@ -15,7 +15,7 @@ import (
 	"unsafe"
 )
 
-func GetDriveLetters() ([]string, error) {
+func GetFilesystemRoots() ([]string, error) {
 	kernel32, err := syscall.LoadDLL("kernel32.dll")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Self explanatory