### PR TITLE
Avoid concurrent reset of NAT timer (fixes #3337)

### DIFF
--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -44,9 +44,8 @@ func NewService(id protocol.DeviceID, cfg *config.Wrapper) *Service {
 func (s *Service) Serve() {
 	announce := stdsync.Once{}
 
-	s.timer.Reset(0)
-
 	s.mut.Lock()
+	s.timer.Reset(0)
 	s.stop = make(chan struct{})
 	s.mut.Unlock()
 


### PR DESCRIPTION
Trivial little thing. Not bothering to test it because it's painful for other reasons (needing a working *config.Wrapper for example).