### PR TITLE
lib/config: Retain slash at end of path after expanding ~ (fixes #2782)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -168,6 +168,12 @@ func (f *FolderConfiguration) cleanedPath() string {
 		return `\\?\` + cleaned
 	}
 
+	// If we're not on Windows, we want the path to end with a slash to
+	// penetrate symlinks. On Windows, paths must not end with a slash.
+	if runtime.GOOS != "windows" && cleaned[len(cleaned)-1] != filepath.Separator {
+		cleaned = cleaned + string(filepath.Separator)
+	}
+
 	return cleaned
 }
 


### PR DESCRIPTION
The various path cleaning operations done in in cleanedPath() removes it, so we make sure it's added again at the end. This makes adding the slash in prepare() unnecessary, but keep it anyway for display purposes (people looking at the config).