### PR TITLE
gui: Add addresses for disconnected devices (fixes #3340)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -544,12 +544,16 @@
                       <th><span class="fa fa-fw fa-cloud-upload"></span>&nbsp;<span translate>Upload Rate</span></th>
                       <td class="text-right">{{connections[deviceCfg.deviceID].outbps | binary}}B/s ({{connections[deviceCfg.deviceID].outBytesTotal | binary}}B)</td>
                     </tr>
-                    <tr ng-if="connections[deviceCfg.deviceID].connected">
+                    <tr>
                       <th><span class="fa fa-fw fa-link"></span>&nbsp<span translate>Address</span></th>
-                      <td class="text-right">
+                      <td ng-if="connections[deviceCfg.deviceID].connected" class="text-right">
                         <span tooltip data-original-title="{{ connections[deviceCfg.deviceID].type.indexOf('Relay') > -1 ? '' : connections[deviceCfg.deviceID].type }}">
                           {{deviceAddr(deviceCfg)}}
                         </span>
+                      </td>
+                      <td ng-if="!connections[deviceCfg.deviceID].connected" class="text-right">
+                        <span ng-repeat="addr in deviceCfg.addresses"><span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br></span>
+                        <span ng-repeat="addr in discoveryCache[deviceCfg.deviceID].addresses"><span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br></span>
                       </td>
                     </tr>
                     <tr ng-if="connections[deviceCfg.deviceID].connected && connections[deviceCfg.deviceID].type.indexOf('Relay') > -1" tooltip data-original-title="Connections via relays might be rate limited by the relay">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -29,6 +29,7 @@ angular.module('syncthing.core')
         $scope.myID = '';
         $scope.devices = [];
         $scope.deviceRejections = {};
+        $scope.discoveryCache = {};
         $scope.folderRejections = {};
         $scope.protocolChanged = false;
         $scope.reportData = {};
@@ -85,6 +86,7 @@ angular.module('syncthing.core')
             console.log('UIOnline');
 
             refreshSystem();
+            refreshDiscoveryCache();
             refreshConfig();
             refreshConnectionStats();
             refreshDeviceStats();
@@ -418,6 +420,13 @@ angular.module('syncthing.core')
             }).error($scope.emitHTTPError);
         }
 
+        function refreshDiscoveryCache() {
+            $http.get(urlbase + '/system/discovery').success(function (data) {
+                $scope.discoveryCache = data;
+                console.log("refreshDiscoveryCache", data);
+            }).error($scope.emitHTTPError);
+        }
+
         function recalcLocalStateTotal () {
             $scope.localStateTotal = {
                 bytes: 0,
@@ -609,6 +618,7 @@ angular.module('syncthing.core')
 
         $scope.refresh = function () {
             refreshSystem();
+            refreshDiscoveryCache();
             refreshConnectionStats();
             refreshErrors();
         };

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -422,6 +422,15 @@ angular.module('syncthing.core')
 
         function refreshDiscoveryCache() {
             $http.get(urlbase + '/system/discovery').success(function (data) {
+                for (var device in data) {
+                    for (var i = 0; i < data[device].addresses.length; i++) {
+                        // Relay addresses are URLs with
+                        // .../?foo=barlongstuff that we strip away here. We
+                        // remove the final slash as well for symmetry with
+                        // tcp://192.0.2.42:1234 type addresses.
+                        data[device].addresses[i] = data[device].addresses[i].replace(/\/\?.*/, '');
+                    }
+                }
                 $scope.discoveryCache = data;
                 console.log("refreshDiscoveryCache", data);
             }).error($scope.emitHTTPError);

--- a/lib/discover/cache.go
+++ b/lib/discover/cache.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/util"
 	"github.com/thejerf/suture"
 )
 
@@ -196,25 +197,11 @@ func (m *cachingMux) Cache() map[protocol.DeviceID]CacheEntry {
 	m.mut.RUnlock()
 
 	for k, v := range res {
-		v.Addresses = uniqueSortedStrings(v.Addresses)
+		v.Addresses = util.UniqueStrings(v.Addresses)
 		res[k] = v
 	}
 
 	return res
-}
-
-func uniqueSortedStrings(strings []string) []string {
-	seen := make(map[string]struct{}, len(strings))
-	unique := make([]string, 0, len(strings))
-	for _, str := range strings {
-		_, ok := seen[str]
-		if !ok {
-			seen[str] = struct{}{}
-			unique = append(unique, str)
-		}
-	}
-	sort.Strings(unique)
-	return unique
 }
 
 // A cache can be embedded wherever useful

--- a/lib/versioner/simple.go
+++ b/lib/versioner/simple.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 
 	"github.com/syncthing/syncthing/lib/osutil"
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 func init() {
@@ -102,7 +103,7 @@ func (v Simple) Archive(filePath string) error {
 
 	// Use all the found filenames. "~" sorts after "." so all old pattern
 	// files will be deleted before any new, which is as it should be.
-	versions := uniqueSortedStrings(append(oldVersions, newVersions...))
+	versions := util.UniqueStrings(append(oldVersions, newVersions...))
 
 	if len(versions) > v.keep {
 		for _, toRemove := range versions[:len(versions)-v.keep] {

--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 func init() {
@@ -280,7 +281,7 @@ func (v Staggered) Archive(filePath string) error {
 
 	// Use all the found filenames.
 	versions := append(oldVersions, newVersions...)
-	v.expire(uniqueSortedStrings(versions))
+	v.expire(util.UniqueStrings(versions))
 
 	return nil
 }

--- a/lib/versioner/util.go
+++ b/lib/versioner/util.go
@@ -9,7 +9,6 @@ package versioner
 import (
 	"path/filepath"
 	"regexp"
-	"sort"
 )
 
 // Inserts ~tag just before the extension of the filename.
@@ -31,18 +30,4 @@ func filenameTag(path string) string {
 		return ""
 	}
 	return match[1]
-}
-
-func uniqueSortedStrings(strings []string) []string {
-	seen := make(map[string]struct{}, len(strings))
-	unique := make([]string, 0, len(strings))
-	for _, str := range strings {
-		_, ok := seen[str]
-		if !ok {
-			seen[str] = struct{}{}
-			unique = append(unique, str)
-		}
-	}
-	sort.Strings(unique)
-	return unique
 }


### PR DESCRIPTION
Also fixes an issue where the discovery cache call would only return the newest cache entry for a given device instead of the merged addresses from all cache entries (which is more useful).

I'm sure an actual designer can make this look much better, but I think it's useful even in it's current state.

![addresses](https://cloud.githubusercontent.com/assets/125426/16361616/7c9facbe-3b96-11e6-9597-b453bd8f2769.gif)
