### PR TITLE
lib/events: Introduce per-subscription event IDs (fixes #3335)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -539,7 +539,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	errors := logger.NewRecorder(l, logger.LevelWarn, maxSystemErrors, 0)
 	systemLog := logger.NewRecorder(l, logger.LevelDebug, maxSystemLog, initialSystemLog)
 
-	// Event subscription for the API; must start early to catch the early events.  The LocalDiskUpdated
+	// Event subscription for the API; must start early to catch the early events.  The LocalChangeDetected
 	// event might overwhelm the event reciever in some situations so we will not subscribe to it here.
 	apiSub := events.NewBufferedSubscription(events.Default.Subscribe(events.AllEvents&^events.LocalChangeDetected), 1000)
 

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -111,22 +111,26 @@ func (t EventType) MarshalText() ([]byte, error) {
 const BufferSize = 64
 
 type Logger struct {
-	subs   []*Subscription
-	nextID int
-	mutex  sync.Mutex
+	subs         []*Subscription
+	nextGlobalID int
+	mutex        sync.Mutex
 }
 
 type Event struct {
-	ID   int         `json:"id"`
-	Time time.Time   `json:"time"`
-	Type EventType   `json:"type"`
-	Data interface{} `json:"data"`
+	// Per-subscription sequential event ID. Named "id" for backwards compatibility with the REST API
+	SubscriptionID int `json:"id"`
+	// Global ID of the event across all subscriptions
+	GlobalID int         `json:"global_id"`
+	Time     time.Time   `json:"time"`
+	Type     EventType   `json:"type"`
+	Data     interface{} `json:"data"`
 }
 
 type Subscription struct {
-	mask    EventType
-	events  chan Event
-	timeout *time.Timer
+	mask               EventType
+	nextSubscriptionID int
+	events             chan Event
+	timeout            *time.Timer
 }
 
 var Default = NewLogger()
@@ -144,16 +148,23 @@ func NewLogger() *Logger {
 
 func (l *Logger) Log(t EventType, data interface{}) {
 	l.mutex.Lock()
-	dl.Debugln("log", l.nextID, t, data)
-	l.nextID++
-	e := Event{
-		ID:   l.nextID,
-		Time: time.Now(),
-		Type: t,
-		Data: data,
-	}
+	dl.Debugln("log", l.nextGlobalID, t, data)
+	l.nextGlobalID++
+
+	now := time.Now()
+
 	for _, s := range l.subs {
 		if s.mask&t != 0 {
+			s.nextSubscriptionID++
+
+			e := Event{
+				GlobalID:       l.nextGlobalID,
+				SubscriptionID: s.nextSubscriptionID,
+				Time:           now,
+				Type:           t,
+				Data:           data,
+			}
+
 			select {
 			case s.events <- e:
 			default:
@@ -169,9 +180,10 @@ func (l *Logger) Subscribe(mask EventType) *Subscription {
 	dl.Debugln("subscribe", mask)
 
 	s := &Subscription{
-		mask:    mask,
-		events:  make(chan Event, BufferSize),
-		timeout: time.NewTimer(0),
+		mask:               mask,
+		nextSubscriptionID: 0,
+		events:             make(chan Event, BufferSize),
+		timeout:            time.NewTimer(0),
 	}
 
 	// We need to create the timeout timer in the stopped, non-fired state so
@@ -234,7 +246,7 @@ type bufferedSubscription struct {
 	sub  *Subscription
 	buf  []Event
 	next int
-	cur  int
+	cur  int // Current SubscriptionID
 	mut  sync.Mutex
 	cond *stdsync.Cond
 }
@@ -270,7 +282,7 @@ func (s *bufferedSubscription) pollingLoop() {
 		s.mut.Lock()
 		s.buf[s.next] = ev
 		s.next = (s.next + 1) % len(s.buf)
-		s.cur = ev.ID
+		s.cur = ev.SubscriptionID
 		s.cond.Broadcast()
 		s.mut.Unlock()
 	}
@@ -285,12 +297,12 @@ func (s *bufferedSubscription) Since(id int, into []Event) []Event {
 	}
 
 	for i := s.next; i < len(s.buf); i++ {
-		if s.buf[i].ID > id {
+		if s.buf[i].SubscriptionID > id {
 			into = append(into, s.buf[i])
 		}
 	}
 	for i := 0; i < s.next; i++ {
-		if s.buf[i].ID > id {
+		if s.buf[i].SubscriptionID > id {
 			into = append(into, s.buf[i])
 		}
 	}

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -121,7 +121,7 @@ type Event struct {
 	// Per-subscription sequential event ID. Named "id" for backwards compatibility with the REST API
 	SubscriptionID int `json:"id"`
 	// Global ID of the event across all subscriptions
-	GlobalID int         `json:"global_id"`
+	GlobalID int         `json:"globalID"`
 	Time     time.Time   `json:"time"`
 	Type     EventType   `json:"type"`
 	Data     interface{} `json:"data"`


### PR DESCRIPTION
### Purpose

Events API consumers rely on being able to detect that events were skipped
by the fact that the event ID has increased by more than 1. This is
documented, and is absolutely necessary when trying to maintain a local
model of Syncthing's state.

With the introduction of LocalChangeDetected, which is not exposed to the
Events API, this contract was broken.

This commit introduces separate concepts of a "Global ID" and a
"Subscription ID". The Global ID of an event is unique across all
subscriptions. The Subscription ID is local to a particular subscription,
and always increments by 1. They are both exposed over the Events API, but
the Subscription ID uses the key "id" for backwards compatibility, and
the "?since=xx" parameter refers to the Subscription ID (making the Global
ID for information only).

### Testing

Existing tests were updated, and new tests added.

### Documentation

The events API docs will need updating.