### PR TITLE
lib/httputil: Refactor out common HTTP things

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/httputil"
 	"github.com/syncthing/syncthing/lib/logger"
 	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/osutil"
@@ -111,6 +112,8 @@ func init() {
 
 	date := BuildDate.UTC().Format("2006-01-02 15:04:05 MST")
 	LongVersion = fmt.Sprintf(`syncthing %s "%s" (%s %s-%s) %s@%s %s`, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildUser, BuildHost, date)
+
+	httputil.InitWithVersion(Version)
 }
 
 var (

--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -10,17 +10,15 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"runtime"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/dialer"
+	"github.com/syncthing/syncthing/lib/httputil"
 	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/upgrade"
@@ -245,15 +243,7 @@ func (s *usageReportingService) sendUsageReport() error {
 	var b bytes.Buffer
 	json.NewEncoder(&b).Encode(d)
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			Dial:  dialer.Dial,
-			Proxy: http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: s.cfg.Options().URPostInsecurely,
-			},
-		},
-	}
+	client := httputil.New(s.cfg.Options().URPostInsecurely)
 	_, err := client.Post(s.cfg.Options().URURL, "application/json", &b)
 	return err
 }

--- a/lib/httputil/httputil.go
+++ b/lib/httputil/httputil.go
@@ -1,0 +1,139 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package httputil
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"time"
+
+	"github.com/syncthing/syncthing/lib/dialer"
+)
+
+// The Client performs HTTP operations.
+type Client interface {
+	Get(url string) (*http.Response, error)
+	Post(url, ctype string, data io.Reader) (*http.Response, error)
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// No HTTP request may take longer than this to complete
+const readTimeout = 30 * time.Minute
+
+// The version that we claim in User-Agents. Can be changed by calling
+// InitWithVersion().
+var defaultVersion string
+
+var (
+	// The Default client is a normal HTTP/HTTPS client.
+	Default Client
+
+	// The Insecure client does not perform certificate validation.
+	Insecure Client
+)
+
+func init() {
+	// Run the init with a default version string so the package is usable
+	// as is. Hopefully main.main() will run InitWithVersion() again to set
+	// a real version for the User-Agent header.
+	InitWithVersion("unknown-dev")
+}
+
+// InitWithVersion (re-)initializes the package with the given version
+// string, which should be just the usual "v1.2.3" format. This sets the
+// User-Agent for all requests performed by this package.
+func InitWithVersion(version string) {
+	defaultVersion = version
+	Default = New(false)
+	Insecure = New(true)
+}
+
+// New returns a new HTTP client, potentially with certificate checking disabled.
+func New(insecure bool) Client {
+	return newUserAgentClient(userAgent(defaultVersion), &http.Client{
+		Timeout: readTimeout,
+		Transport: &http.Transport{
+			Dial:  dialer.Dial,
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecure,
+			},
+		},
+	})
+}
+
+// WithClientCert returns a new HTTP client that can authenticate using the
+// given client certificate, potentially with certificate checking disabled.
+func WithClientCert(insecure bool, cert tls.Certificate) Client {
+	return newUserAgentClient(userAgent(defaultVersion), &http.Client{
+		Timeout: readTimeout,
+		Transport: &http.Transport{
+			Dial:  dialer.Dial,
+			Proxy: http.ProxyFromEnvironment,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: insecure,
+				Certificates:       []tls.Certificate{cert},
+			},
+		},
+	})
+}
+
+// Get issues a GET to the specified URL using the Default client.
+func Get(url string) (*http.Response, error) {
+	return Default.Get(url)
+}
+
+func userAgent(version string) string {
+	return fmt.Sprintf(`syncthing %s (%s %s-%s)`, version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+}
+
+type userAgentClient struct {
+	userAgent string
+	next      Client
+}
+
+func newUserAgentClient(userAgent string, next Client) Client {
+	return &userAgentClient{
+		userAgent: userAgent,
+		next:      next,
+	}
+}
+
+func (a *userAgentClient) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.Do(req)
+}
+
+func (a *userAgentClient) Post(url, ctype string, data io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, data)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", ctype)
+	return a.Do(req)
+}
+
+func (a *userAgentClient) Do(req *http.Request) (*http.Response, error) {
+	// The GitHub asset server (S3?) requires application/octet-stream
+	// specifically here. The */* should cover everything else, much as if
+	// we didn't set the header at all.
+	req.Header.Set("Accept", "application/octet-stream; */*")
+
+	// Set our user agent as a courtesy to the server, and to possibly
+	// tailor upgrade and other responses to the calling version.
+	req.Header.Set("User-Agent", a.userAgent)
+
+	return a.next.Do(req)
+}

--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -7,11 +7,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"net/url"
 	"sort"
 	"time"
 
+	"github.com/syncthing/syncthing/lib/httputil"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/relay/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
@@ -59,7 +59,7 @@ func (c *dynamicClient) Serve() {
 
 	l.Debugln(c, "looking up dynamic relays")
 
-	data, err := http.Get(uri.String())
+	data, err := httputil.Get(uri.String())
 	if err != nil {
 		l.Debugln(c, "failed to lookup dynamic relays", err)
 		c.setError(err)

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -48,6 +48,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/dialer"
+	"github.com/syncthing/syncthing/lib/httputil"
 	"github.com/syncthing/syncthing/lib/nat"
 	"github.com/syncthing/syncthing/lib/sync"
 )
@@ -229,7 +230,7 @@ func parseResponse(deviceType string, resp []byte) (IGD, error) {
 		l.Infoln("Invalid IGD response: invalid device UUID", deviceUUID, "(continuing anyway)")
 	}
 
-	response, err = http.Get(deviceDescriptionLocation)
+	response, err = httputil.Get(deviceDescriptionLocation)
 	if err != nil {
 		return IGD{}, err
 	}
@@ -414,7 +415,6 @@ func soapRequest(url, service, function, message string) ([]byte, error) {
 	}
 	req.Close = true
 	req.Header.Set("Content-Type", `text/xml; charset="utf-8"`)
-	req.Header.Set("User-Agent", "syncthing/1.0")
 	req.Header["SOAPAction"] = []string{fmt.Sprintf(`"%s#%s"`, service, function)} // Enforce capitalization in header-entry for sensitive routers. See issue #1696
 	req.Header.Set("Connection", "Close")
 	req.Header.Set("Cache-Control", "no-cache")
@@ -424,7 +424,7 @@ func soapRequest(url, service, function, message string) ([]byte, error) {
 	l.Debugln("SOAP Action: " + req.Header.Get("SOAPAction"))
 	l.Debugln("SOAP Request:\n\n" + body)
 
-	r, err := http.DefaultClient.Do(req)
+	r, err := httputil.Default.Do(req)
 	if err != nil {
 		l.Debugln(err)
 		return resp, err


### PR DESCRIPTION
### Purpose

This factors out the parts we often do around insecure HTTPS connections, client certificates and setting the User-Agent properly.

### Testing

I've tested upgrades and global discovery with this, the rest seems fairly low risk.
