### PR TITLE
build: Use SOURCE_DATE_EPOCH for build time stamp when available

### DIFF
--- a/build.go
+++ b/build.go
@@ -717,10 +717,18 @@ func getBranchSuffix() string {
 }
 
 func buildStamp() int64 {
+	// If SOURCE_DATE_EPOCH is set, use that.
+	if s, _ := strconv.ParseInt(os.Getenv("SOURCE_DATE_EPOCH"), 10, 64); s > 0 {
+		return s
+	}
+
+	// Try to get the timestamp of the latest commit.
 	bs, err := runError("git", "show", "-s", "--format=%ct")
 	if err != nil {
+		// Fall back to "now".
 		return time.Now().Unix()
 	}
+
 	s, _ := strconv.ParseInt(string(bs), 10, 64)
 	return s
 }


### PR DESCRIPTION
Apparently common practice for reproducible builds:

   https://reproducible-builds.org/specs/source-date-epoch/