### PR TITLE
lib/connections: TLS handshake must complete in a timely fashion (fixes #3375)

### DIFF
--- a/lib/connections/relay_dial.go
+++ b/lib/connections/relay_dial.go
@@ -52,7 +52,7 @@ func (d *relayDialer) Dial(id protocol.DeviceID, uri *url.URL) (IntermediateConn
 		tc = tls.Client(conn, d.tlsCfg)
 	}
 
-	err = tc.Handshake()
+	err = tlsTimedHandshake(tc)
 	if err != nil {
 		tc.Close()
 		return IntermediateConnection{}, err

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -85,7 +85,7 @@ func (t *relayListener) Serve() {
 				tc = tls.Client(conn, t.tlsCfg)
 			}
 
-			err = tc.Handshake()
+			err = tlsTimedHandshake(tc)
 			if err != nil {
 				tc.Close()
 				l.Infoln("TLS handshake (BEP/relay):", err)

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -36,7 +36,10 @@ var (
 	listeners = make(map[string]listenerFactory, 0)
 )
 
-const perDeviceWarningRate = 1.0 / (15 * 60) // Once per 15 minutes
+const (
+	perDeviceWarningRate = 1.0 / (15 * 60) // Once per 15 minutes
+	tlsHandshakeTimeout  = 10 * time.Second
+)
 
 // Service listens and dials all configured unconnected devices, via supported
 // dialers. Successful connections are handed to the model.
@@ -606,4 +609,10 @@ func warningFor(dev protocol.DeviceID, msg string) {
 	if lim.TakeAvailable(1) == 1 {
 		l.Warnln(msg)
 	}
+}
+
+func tlsTimedHandshake(tc *tls.Conn) error {
+	tc.SetDeadline(time.Now().Add(tlsHandshakeTimeout))
+	defer tc.SetDeadline(time.Time{})
+	return tc.Handshake()
 }

--- a/lib/connections/tcp_dial.go
+++ b/lib/connections/tcp_dial.go
@@ -40,7 +40,7 @@ func (d *tcpDialer) Dial(id protocol.DeviceID, uri *url.URL) (IntermediateConnec
 	}
 
 	tc := tls.Client(conn, d.tlsCfg)
-	err = tc.Handshake()
+	err = tlsTimedHandshake(tc)
 	if err != nil {
 		tc.Close()
 		return IntermediateConnection{}, err

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -108,7 +108,7 @@ func (t *tcpListener) Serve() {
 		}
 
 		tc := tls.Server(conn, t.tlsCfg)
-		err = tc.Handshake()
+		err = tlsTimedHandshake(tc)
 		if err != nil {
 			l.Infoln("TLS handshake (BEP/tcp):", err)
 			tc.Close()


### PR DESCRIPTION
### Purpose

The initial TLS handshake can take infinite time (or the regular TCP timeout at an hour or so) unless explicitly controlled.

### Testing

I ran an integration benchmark thing, looks like things can still talk to each other. Haven't verified that the deadline actually kicks in, but I don't see why it wouldn't...