### PR TITLE
discosrv: Respect the listen address scheme (fixes #3346)

### DIFF
--- a/cmd/discosrv/querysrv.go
+++ b/cmd/discosrv/querysrv.go
@@ -330,6 +330,16 @@ func (s *querysrv) handleAnnounce(ctx context.Context, remote net.IP, deviceID p
 
 		ip := net.ParseIP(host)
 		if host == "" || ip.IsUnspecified() {
+			// Do not use IPv6 remote address if requested scheme is tcp4
+			if uri.Scheme == "tcp4" && remote.To4() == nil {
+				continue
+			}
+
+			// Do not use IPv4 remote address if requested scheme is tcp6
+			if uri.Scheme == "tcp6" && remote.To4() != nil {
+				continue
+			}
+
 			host = remote.String()
 		}
 


### PR DESCRIPTION
If the listen address scheme is set to tcp4:// or tcp6://, it needs to
be made sure that the remote address matches this scheme before it is
added to the database.

This prevents invalid URIs like `tcp4://<IPv6 address>:<port>` or
`tcp6://<IPv4 address>:<port>`.

---
**UNTESTED!**
Sorry, I currently don't have a setup to test the discosrv.