### PR TITLE
gui: Sort device folder lists by label

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1453,7 +1453,7 @@ angular.module('syncthing.core')
                 }
             }
 
-            folders.sort();
+            folders.sort(folderCompare);
             return folders;
         };
 


### PR DESCRIPTION
The device specific folder lists in the "Remote Devices" section on the index page did not use the folderCompare comparator and therefore were not sorted by the folder label.