### PR TITLE
lib/model: Invalidate files with trailing white space on Windows (fixes #3227)

### DIFF
--- a/lib/protocol/nativemodel_windows.go
+++ b/lib/protocol/nativemodel_windows.go
@@ -41,7 +41,7 @@ func (m nativeModel) Request(deviceID DeviceID, folder string, name string, offs
 
 func fixupFiles(folder string, files []FileInfo) {
 	for i, f := range files {
-		if strings.ContainsAny(f.Name, disallowedCharacters) {
+		if strings.ContainsAny(f.Name, disallowedCharacters) || strings.HasSuffix(f.Name, " ") {
 			if f.IsDeleted() {
 				// Don't complain if the file is marked as deleted, since it
 				// can't possibly exist here anyway.

--- a/lib/protocol/nativemodel_windows_test.go
+++ b/lib/protocol/nativemodel_windows_test.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2016 The Protocol Authors.
+
+// +build windows
+
+package protocol
+
+import "testing"
+
+func TestFixupFiles(t *testing.T) {
+	fs := []FileInfo{
+		{Name: "ok"},  // This file is OK
+		{Name: "b<d"}, // The rest should be marked as invalid
+		{Name: "b?d"},
+		{Name: "bad "},
+	}
+
+	fixupFiles("default", fs)
+
+	if fs[0].IsInvalid() {
+		t.Error("fs[0] should not be invalid")
+	}
+	for i := 1; i < len(fs); i++ {
+		if !fs[i].IsInvalid() {
+			t.Errorf("fs[%d] should be invalid", i)
+		}
+	}
+}


### PR DESCRIPTION
### Purpose

Spaces at the end are invalid on Windows.

### Testing

There's a new unit test (that only runs on Windows)...
