### PR TITLE
cmd/syncthing: Update code name for v0.14

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -51,7 +51,7 @@ import (
 
 var (
 	Version           = "unknown-dev"
-	Codename          = "Copper Cockroach"
+	Codename          = "Dysprosium Dragonfly"
 	BuildStamp        = "0"
 	BuildDate         time.Time
 	BuildHost         = "unknown"


### PR DESCRIPTION
### Purpose

Who knows, really?

### Testing

```
jb@syno:~/s/g/s/syncthing $ syncthing -version
syncthing v0.14.0-beta.0+1-g366824e-dd "Dysprosium Dragonfly" (go1.7beta2 darwin-amd64) jb@syno 2016-07-04 10:44:55 UTC
```