### PR TITLE
lib/config, cmd/syncthing: Better handle committing configuration (fixes #3077)

### DIFF
--- a/cmd/syncthing/mocked_config_test.go
+++ b/cmd/syncthing/mocked_config_test.go
@@ -31,8 +31,8 @@ func (c *mockedConfig) Options() config.OptionsConfiguration {
 	return config.OptionsConfiguration{}
 }
 
-func (c *mockedConfig) Replace(cfg config.Configuration) config.CommitResponse {
-	return config.CommitResponse{}
+func (c *mockedConfig) Replace(cfg config.Configuration) error {
+	return nil
 }
 
 func (c *mockedConfig) Subscribe(cm config.Committer) {}
@@ -47,4 +47,8 @@ func (c *mockedConfig) Devices() map[protocol.DeviceID]config.DeviceConfiguratio
 
 func (c *mockedConfig) Save() error {
 	return nil
+}
+
+func (c *mockedConfig) RequiresRestart() bool {
+	return false
 }

--- a/lib/config/commit_test.go
+++ b/lib/config/commit_test.go
@@ -11,12 +11,18 @@ import (
 	"testing"
 )
 
-type requiresRestart struct{}
+type requiresRestart struct {
+	committed chan struct{}
+}
 
 func (requiresRestart) VerifyConfiguration(_, _ Configuration) error {
 	return nil
 }
-func (requiresRestart) CommitConfiguration(_, _ Configuration) bool {
+func (c requiresRestart) CommitConfiguration(_, _ Configuration) bool {
+	select {
+	case c.committed <- struct{}{}:
+	default:
+	}
 	return false
 }
 func (requiresRestart) String() string {
@@ -28,7 +34,7 @@ type validationError struct{}
 func (validationError) VerifyConfiguration(_, _ Configuration) error {
 	return errors.New("some error")
 }
-func (validationError) CommitConfiguration(_, _ Configuration) bool {
+func (c validationError) CommitConfiguration(_, _ Configuration) bool {
 	return true
 }
 func (validationError) String() string {
@@ -44,11 +50,11 @@ func TestReplaceCommit(t *testing.T) {
 	// Replace config. We should get back a clean response and the config
 	// should change.
 
-	resp := w.Replace(Configuration{Version: 1})
-	if resp.ValidationError != nil {
-		t.Fatal("Should not have a validation error")
+	err := w.Replace(Configuration{Version: 1})
+	if err != nil {
+		t.Fatal("Should not have a validation error:", err)
 	}
-	if resp.RequiresRestart {
+	if w.RequiresRestart() {
 		t.Fatal("Should not require restart")
 	}
 	if w.Raw().Version != 1 {
@@ -58,13 +64,16 @@ func TestReplaceCommit(t *testing.T) {
 	// Now with a subscriber requiring restart. We should get a clean response
 	// but with the restart flag set, and the config should change.
 
-	w.Subscribe(requiresRestart{})
+	sub0 := requiresRestart{committed: make(chan struct{}, 1)}
+	w.Subscribe(sub0)
 
-	resp = w.Replace(Configuration{Version: 2})
-	if resp.ValidationError != nil {
-		t.Fatal("Should not have a validation error")
+	err = w.Replace(Configuration{Version: 2})
+	if err != nil {
+		t.Fatal("Should not have a validation error:", err)
 	}
-	if !resp.RequiresRestart {
+
+	<-sub0.committed
+	if !w.RequiresRestart() {
 		t.Fatal("Should require restart")
 	}
 	if w.Raw().Version != 2 {
@@ -76,12 +85,12 @@ func TestReplaceCommit(t *testing.T) {
 
 	w.Subscribe(validationError{})
 
-	resp = w.Replace(Configuration{Version: 3})
-	if resp.ValidationError == nil {
+	err = w.Replace(Configuration{Version: 3})
+	if err == nil {
 		t.Fatal("Should have a validation error")
 	}
-	if resp.RequiresRestart {
-		t.Fatal("Should not require restart")
+	if !w.RequiresRestart() {
+		t.Fatal("Should still require restart")
 	}
 	if w.Raw().Version != 2 {
 		t.Fatal("Config should not have changed")


### PR DESCRIPTION
### Purpose

This slightly changes the interface used for committing configuration
changes. The two parts are now:

 - VerifyConfiguration, which runs synchronously and locked, and can
   abort the config change. These callbacks shouldn't *do* anything
   apart from looking at the config changes and saying yes or no. No
   change from previously.

 - CommitConfiguration, which runs asynchronously (one goroutine per
   call) *after* replacing the config and releasing any locks. Returning
   false from these methods sets the "requires restart" flag, which now
   lives in the config.Wrapper.

This should be deadlock free as the CommitConfiguration calls can take
as long as they like and can wait for locks to be released when they
need to tweak things. I think this should be safe compared to before as
the CommitConfiguration calls were always made from a random background
goroutine (typically one from the HTTP server), so it was always
concurrent with everything else anyway.

    
Hence the CommitResponse type is gone, instead you get an error back on
verification failure only, and need to explicitly check w.RequiresRestart()
afterwards if you care.

As an added bonus this fixes a bug where we would reset the "requires
restart" indicator if a config that did not require restart was saved,
even if we already were in the requires-restart state.

### Testing

I hammered on it a bit manually, and the tests that exist still pass.
