### PR TITLE
lib/protocol: Allow unknown message types

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -106,7 +106,6 @@ type rawConnection struct {
 	once        sync.Once
 	pool        sync.Pool
 	compression Compression
-	warnOnce    sync.Once
 }
 
 type asyncResult struct {
@@ -291,9 +290,6 @@ func (c *rawConnection) readerLoop() (err error) {
 		msg, err := c.readMessage()
 		if err == errUnknownMessage {
 			// Unknown message types are skipped, for future extensibility.
-			c.warnOnce.Do(func() {
-				l.Warnln("Unknown message type from %v - protocol mismatch?", c.id)
-			})
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
### Purpose

This lets us add message types in the future, for authentication or
other purposes, without completely breaking old clients. I see this as
similar behavior to adding fields to messages - newer clients must
simple be aware that older ones may ignore the message and act
accordingly.

Related to, for example, #3379.

### Testing

None whatsoever. But it looks safe. 