### PR TITLE
lib/protocol: Hello message length is an int16

### DIFF
--- a/lib/protocol/hello_test.go
+++ b/lib/protocol/hello_test.go
@@ -26,9 +26,9 @@ func TestVersion14Hello(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	hdrBuf := make([]byte, 8)
+	hdrBuf := make([]byte, 6)
 	binary.BigEndian.PutUint32(hdrBuf, HelloMessageMagic)
-	binary.BigEndian.PutUint32(hdrBuf[4:], uint32(len(msgBuf)))
+	binary.BigEndian.PutUint16(hdrBuf[4:], uint16(len(msgBuf)))
 
 	outBuf := new(bytes.Buffer)
 	outBuf.Write(hdrBuf)


### PR DESCRIPTION
### Purpose

It used to be an int32, but that's unnecessary and the spec now says int16. Also relaxes the size requirement to that which fits in a signed int16 instead of limiting to 1024 bytes, to allow for future growth.

As reported in
https://forum.syncthing.net/t/difference-between-documented-and-implemented-protocol/7798

### Testing

I ran an integration benchmark to verify we can still talk to ourselves. Haven't tested successful parsing of a v0.13 message as I'm on an iPad and sort of annoyingly remote-hacking - but there's a unit test for that.