### PR TITLE
lib/scanner: When scanning a file, stick to the size given by Lstat (fixes #3440)

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -31,7 +31,8 @@ func Blocks(r io.Reader, blocksize int, sizehint int64, counter Counter) ([]prot
 
 	if sizehint > 0 {
 		// Allocate contiguous blocks for the BlockInfo structures and their
-		// hashes once and for all.
+		// hashes once and for all, and stick to the specified size.
+		r = io.LimitReader(r, sizehint)
 		numBlocks := int(sizehint / int64(blocksize))
 		blocks = make([]protocol.BlockInfo, 0, numBlocks)
 		hashes = make([]byte, 0, hashLength*numBlocks)


### PR DESCRIPTION
### Purpose

Otherwise if the file grows during scanning the block list will be out of sync with the stated size and things get confused. We could fixup the size afterwards based on the block list, but then we might see other inconsistencies as the mtime should have changed to reflect the new size etc. Better stick to the original state and let the next scan pick up the change.

### Testing

Tested with the script linked from the issue, which no longer generates any conflicts...