### PR TITLE
lib/model, lib/protocol: Sequence ClusterConfig properly (fixes #3448)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -649,8 +649,11 @@ func (m *Model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	tempIndexFolders := make([]string, 0, len(cm.Folders))
 
 	m.pmut.RLock()
-	conn := m.conn[deviceID]
+	conn, ok := m.conn[deviceID]
 	m.pmut.RUnlock()
+	if !ok {
+		panic("bug: ClusterConfig called on closed or nonexistent connection")
+	}
 
 	m.fmut.Lock()
 	for _, folder := range cm.Folders {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -302,7 +302,7 @@ func (c *rawConnection) readerLoop() (err error) {
 			if state != stateInitial {
 				return fmt.Errorf("protocol error: cluster config message in state %d", state)
 			}
-			go c.receiver.ClusterConfig(c.id, *msg)
+			c.receiver.ClusterConfig(c.id, *msg)
 			state = stateReady
 
 		case *Index:


### PR DESCRIPTION
### Purpose

Fix it...

### Testing

I'm running some integration stuff, but I'm not 100% sure of this one. There ought to have been a good reason for the async call to ClusterConfig, typically to avoid mutex deadlocks. But I can't remember directly. Help me think this through?