### PR TITLE
lib/db, lib/model: Create temp sorting database in config dir (fixes #3449)

### DIFF
--- a/lib/model/sorter_test.go
+++ b/lib/model/sorter_test.go
@@ -30,7 +30,7 @@ func TestOnDiskIndexSorter(t *testing.T) {
 	// An onDiskSorter should be able to absorb a few files in unsorted
 	// order, and return them sorted.
 
-	s := newOnDiskIndexSorter()
+	s := newOnDiskIndexSorter("testdata")
 	addFiles(50, s)
 	verifySorted(t, s, 50)
 	verifyBreak(t, s, 50)
@@ -58,7 +58,7 @@ func TestIndexSorter(t *testing.T) {
 	// An default IndexSorter should be able to absorb files, have them in
 	// memory, and at some point switch to an on disk database.
 
-	s := NewIndexSorter()
+	s := NewIndexSorter("testdata")
 	defer s.Close()
 
 	// We should start out as an in memory store.


### PR DESCRIPTION
### Purpose

Create temp databases beside main database.

A design issue here is that the index sorter is created at a point quite far in the call stack from the closest place or even package that knows anything about disk paths. My solution takes a quite circuitous path via letting the main database know where it lives and have the model check that when it kicks of the index sending routines... I'm all open for suggestions on better ways to do this.

### Testing

`STTRACE=model`, the log "opened sorter" line shows the expected path.