### PR TITLE
cmd/syncthing, lib/config: Enable HTTP CPU/heap profile collection for users

### DIFF
--- a/cmd/syncthing/gui_csrf.go
+++ b/cmd/syncthing/gui_csrf.go
@@ -41,6 +41,13 @@ func csrfMiddleware(unique string, prefix string, cfg config.GUIConfiguration, n
 			return
 		}
 
+		if strings.HasPrefix(r.URL.Path, "/rest/debug") {
+			// Debugging functions are only available when explicitly
+			// enabled, and can be accessed without a CSRF token
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Allow requests for anything not under the protected path prefix,
 		// and set a CSRF cookie if there isn't already a valid one.
 		if !strings.HasPrefix(r.URL.Path, prefix) {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -16,7 +16,6 @@ import (
 	"log"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
 	"net/url"
 	"os"
 	"os/signal"

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -21,6 +21,7 @@ type GUIConfiguration struct {
 	APIKey              string `xml:"apikey,omitempty" json:"apiKey"`
 	InsecureAdminAccess bool   `xml:"insecureAdminAccess,omitempty" json:"insecureAdminAccess"`
 	Theme               string `xml:"theme" json:"theme" default:"default"`
+	EnableDebugging     bool   `xml:"debugging,attr" json:"debugging"`
 }
 
 func (c GUIConfiguration) Address() string {

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -21,7 +21,7 @@ type GUIConfiguration struct {
 	APIKey              string `xml:"apikey,omitempty" json:"apiKey"`
 	InsecureAdminAccess bool   `xml:"insecureAdminAccess,omitempty" json:"insecureAdminAccess"`
 	Theme               string `xml:"theme" json:"theme" default:"default"`
-	EnableDebugging     bool   `xml:"debugging,attr" json:"debugging"`
+	Debugging           bool   `xml:"debugging,attr" json:"debugging"`
 }
 
 func (c GUIConfiguration) Address() string {

--- a/test/h1/config.xml
+++ b/test/h1/config.xml
@@ -50,7 +50,7 @@
     <device id="7PBCTLL-JJRYBSA-MOWZRKL-MSDMN4N-4US4OMX-SYEXUS4-HSBGNRY-CZXRXAT" name="s4" compression="metadata" introducer="false">
         <address>tcp://127.0.0.1:22004</address>
     </device>
-    <gui enabled="true" tls="false">
+    <gui enabled="true" tls="false" debugging="true">
         <address>127.0.0.1:8081</address>
         <user>testuser</user>
         <password>$2a$10$7tKL5uvLDGn5s2VLPM2yWOK/II45az0mTel8hxAUJDRQN1Tk2QYwu</password>

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -62,7 +62,7 @@
     <device id="373HSRP-QLPNLIE-JYKZVQF-P4PKZ63-R2ZE6K3-YD442U2-JHBGBQG-WWXAHAU" name="s3" compression="metadata" introducer="false">
         <address>tcp://127.0.0.1:22003</address>
     </device>
-    <gui enabled="true" tls="false">
+    <gui enabled="true" tls="false" debugging="true">
         <address>127.0.0.1:8082</address>
         <apikey>abc123</apikey>
         <theme>default</theme>

--- a/test/h3/config.xml
+++ b/test/h3/config.xml
@@ -45,7 +45,7 @@
     <device id="373HSRP-QLPNLIE-JYKZVQF-P4PKZ63-R2ZE6K3-YD442U2-JHBGBQG-WWXAHAU" name="s3" compression="metadata" introducer="false">
         <address>tcp://127.0.0.1:22003</address>
     </device>
-    <gui enabled="true" tls="false">
+    <gui enabled="true" tls="false" debugging="true">
         <address>127.0.0.1:8083</address>
         <apikey>abc123</apikey>
         <theme>default</theme>

--- a/test/h4/config.xml
+++ b/test/h4/config.xml
@@ -18,7 +18,7 @@
     <device id="7PBCTLL-JJRYBSA-MOWZRKL-MSDMN4N-4US4OMX-SYEXUS4-HSBGNRY-CZXRXAT" name="s4" compression="metadata" introducer="false">
         <address>dynamic</address>
     </device>
-    <gui enabled="true" tls="false">
+    <gui enabled="true" tls="false" debugging="true">
         <address>127.0.0.1:8084</address>
         <apikey>PMA5yUTG-Mw98nJ0YEtWTCHlM5O4aNi0</apikey>
         <theme>default</theme>


### PR DESCRIPTION
### Purpose

This adds a config to enable debug functions on the API server, which is by default disabled. When enabled, the /rest/debug things become available and become available without requiring a CSRF token (although authentication is required if configured).

We also add a new endpoint /rest/debug/cpuprof?duration=15s (with the duration being configurable, defaulting to 30s). This runs a CPU profile for the duration and returns it as a file. It sets headers so that a browser will save the file with an informative name.

The same is done for heap profiles, /rest/debug/heapprof, which does not take any parameters. The heap profile won't contain historical allocations, but a snapshot of live data at the time it's taken.

The purpose of this is that any user can enable debugging under advanced, then point their browser to the endpoint above and get a file that contains a CPU/heap profile we can use, with the filename telling us what version and architecture the profile is from.

On the command line, this becomes

    curl -O -J http://localhost:8082/rest/debug/cpuprof?duration=5s
    curl: Saved to filename
    'syncthing-cpu-darwin-amd64-v0.14.3+4-g935bcc0-110307.pprof'

### Testing

Works for me
