### PR TITLE
cmd/syncthing: Delete old format indexes after a while (fixes #3468)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -1122,6 +1122,8 @@ func cleanConfigDirectory() {
 		"panic-*.log":      7 * 24 * time.Hour,  // keep panic logs for a week
 		"audit-*.log":      7 * 24 * time.Hour,  // keep audit logs for a week
 		"index":            14 * 24 * time.Hour, // keep old index format for two weeks
+		"index-v0.11.0.db": 14 * 24 * time.Hour, // keep old index format for two weeks
+		"index-v0.13.0.db": 14 * 24 * time.Hour, // keep old index format for two weeks
 		"index*.converted": 14 * 24 * time.Hour, // keep old converted indexes for two weeks
 		"config.xml.v*":    30 * 24 * time.Hour, // old config versions for a month
 		"*.idx.gz":         30 * 24 * time.Hour, // these should for sure no longer exist


### PR DESCRIPTION
### Purpose

As per subject.

### Testing

It deleted my old indexes.