### PR TITLE
lib/config, lib/connections: Refactor handling of ignored devices (fixes #3470)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -273,6 +273,16 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) error {
 		cfg.GUI.APIKey = rand.String(32)
 	}
 
+	// The list of ignored devices should not contain any devices that have
+	// been manually added to the config.
+	newIgnoredDevices := []protocol.DeviceID{}
+	for _, dev := range cfg.IgnoredDevices {
+		if !existingDevices[dev] {
+			newIgnoredDevices = append(newIgnoredDevices, dev)
+		}
+	}
+	cfg.IgnoredDevices = newIgnoredDevices
+
 	return nil
 }
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -697,3 +697,20 @@ func TestV14ListenAddressesMigration(t *testing.T) {
 		}
 	}
 }
+
+func TestIgnoredDevices(t *testing.T) {
+	// Verify that ignored devices that are also present in the
+	// configuration are not in fact ignored.
+
+	wrapper, err := Load("testdata/ignoreddevices.xml", device1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if wrapper.IgnoredDevice(device1) {
+		t.Errorf("Device %v should not be ignored", device1)
+	}
+	if !wrapper.IgnoredDevice(device3) {
+		t.Errorf("Device %v should be ignored", device3)
+	}
+}

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -714,3 +714,32 @@ func TestIgnoredDevices(t *testing.T) {
 		t.Errorf("Device %v should be ignored", device3)
 	}
 }
+
+func TestGetDevice(t *testing.T) {
+	// Verify that the Device() call does the right thing
+
+	wrapper, err := Load("testdata/ignoreddevices.xml", device1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// device1 is mentioned in the config
+
+	device, ok := wrapper.Device(device1)
+	if !ok {
+		t.Error(device1, "should exist")
+	}
+	if device.DeviceID != device1 {
+		t.Error("Should have returned", device1, "not", device.DeviceID)
+	}
+
+	// device3 is not
+
+	device, ok = wrapper.Device(device3)
+	if ok {
+		t.Error(device3, "should not exist")
+	}
+	if device.DeviceID == device3 {
+		t.Error("Should not returned ID", device3)
+	}
+}

--- a/lib/config/testdata/ignoreddevices.xml
+++ b/lib/config/testdata/ignoreddevices.xml
@@ -1,0 +1,10 @@
+<configuration version="15">
+    <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR">
+        <address>dynamic</address>
+    </device>
+    <device id="GYRZZQB-IRNPV4Z-T7TC52W-EQYJ3TT-FDQW6MW-DFLMU42-SSSU6EM-FBK2VAY">
+        <address>dynamic</address>
+    </device>
+    <ignoredDevice>AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR</ignoredDevice>
+    <ignoredDevice>LGFPDIT-7SKNNJL-VJZA4FC-7QNCRKA-CE753K7-2BW5QDK-2FOZ7FR-FEP57QJ</ignoredDevice>
+</configuration>

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -284,6 +284,18 @@ func (w *Wrapper) IgnoredDevice(id protocol.DeviceID) bool {
 	return false
 }
 
+// Device returns the configuration for the given device and an "ok" bool.
+func (w *Wrapper) Device(id protocol.DeviceID) (DeviceConfiguration, bool) {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+	for _, device := range w.cfg.Devices {
+		if device.DeviceID == id {
+			return device, true
+		}
+	}
+	return DeviceConfiguration{}, false
+}
+
 // Save writes the configuration to disk, and generates a ConfigSaved event.
 func (w *Wrapper) Save() error {
 	fd, err := osutil.CreateAtomic(w.path, 0600)

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -8,7 +8,6 @@ package connections
 
 import (
 	"crypto/tls"
-	"net"
 	"net/url"
 	"time"
 
@@ -69,7 +68,6 @@ type Model interface {
 	AddConnection(conn Connection, hello protocol.HelloResult)
 	ConnectedTo(remoteID protocol.DeviceID) bool
 	IsPaused(remoteID protocol.DeviceID) bool
-	OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult)
 	GetHello(protocol.DeviceID) protocol.HelloIntf
 }
 

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -68,6 +68,7 @@ type Model interface {
 	AddConnection(conn Connection, hello protocol.HelloResult)
 	ConnectedTo(remoteID protocol.DeviceID) bool
 	IsPaused(remoteID protocol.DeviceID) bool
+	OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult)
 	GetHello(protocol.DeviceID) protocol.HelloIntf
 }
 

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -8,6 +8,7 @@ package connections
 
 import (
 	"crypto/tls"
+	"net"
 	"net/url"
 	"time"
 
@@ -68,7 +69,7 @@ type Model interface {
 	AddConnection(conn Connection, hello protocol.HelloResult)
 	ConnectedTo(remoteID protocol.DeviceID) bool
 	IsPaused(remoteID protocol.DeviceID) bool
-	OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult)
+	OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult) error
 	GetHello(protocol.DeviceID) protocol.HelloIntf
 }
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1077,13 +1077,9 @@ func (m *Model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protoco
 		return errDeviceIgnored
 	}
 
-	for deviceID := range m.cfg.Devices() {
-		if deviceID == remoteID {
-			// Existing device, we will get the hello message in AddConnection
-			// hence do not persist any state here, as the connection might
-			// get killed before AddConnection
-			return nil
-		}
+	if _, ok := m.cfg.Device(remoteID); ok {
+		// The device exists
+		return nil
 	}
 
 	events.Default.Log(events.DeviceRejected, map[string]string{

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1064,13 +1065,13 @@ func (m *Model) SetIgnores(folder string, content []string) error {
 // OnHello is called when an device connects to us.
 // This allows us to extract some information from the Hello message
 // and add it to a list of known devices ahead of any checks.
-func (m *Model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protocol.HelloResult) {
+func (m *Model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protocol.HelloResult) error {
 	for deviceID := range m.cfg.Devices() {
 		if deviceID == remoteID {
 			// Existing device, we will get the hello message in AddConnection
 			// hence do not persist any state here, as the connection might
 			// get killed before AddConnection
-			return
+			return nil
 		}
 	}
 
@@ -1081,6 +1082,8 @@ func (m *Model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protoco
 			"address": addr.String(),
 		})
 	}
+
+	return errUnknownDevice
 }
 
 // GetHello is called when we are about to connect to some remote device.

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -14,7 +14,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1060,28 +1059,6 @@ func (m *Model) SetIgnores(folder string, content []string) error {
 	osutil.HideFile(path)
 
 	return m.ScanFolder(folder)
-}
-
-// OnHello is called when an device connects to us.
-// This allows us to extract some information from the Hello message
-// and add it to a list of known devices ahead of any checks.
-func (m *Model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protocol.HelloResult) {
-	for deviceID := range m.cfg.Devices() {
-		if deviceID == remoteID {
-			// Existing device, we will get the hello message in AddConnection
-			// hence do not persist any state here, as the connection might
-			// get killed before AddConnection
-			return
-		}
-	}
-
-	if !m.cfg.IgnoredDevice(remoteID) {
-		events.Default.Log(events.DeviceRejected, map[string]string{
-			"name":    hello.DeviceName,
-			"device":  remoteID.String(),
-			"address": addr.String(),
-		})
-	}
 }
 
 // GetHello is called when we are about to connect to some remote device.


### PR DESCRIPTION
### Purpose

Fix the logging around ignored devices. But I also noticed that I think we do too much processing for ignored devices and redid that to drop them earlier. That removed the only thing that `model.OnHello` did, so I removed that method. I'm not at all opposed to having it, but since it doesn't do anything after this change I don't think it makes sense to keep it around - we can reinstate it when necessary?

### Testing

Added a test to make sure we handle the case of manually adding a device to override an older ignore. Manually verified to have a device connect, ignore it, then add it manually.