### PR TITLE
lib/model, lib/config: Support "live" device removal, folder unsharin…

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -671,7 +671,6 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	}
 
 	m := model.NewModel(cfg, myID, myDeviceName(cfg), "syncthing", Version, ldb, protectedFiles)
-	cfg.Subscribe(m)
 
 	if t := os.Getenv("STDEADLOCKTIMEOUT"); len(t) > 0 {
 		it, err := strconv.Atoi(t)

--- a/lib/config/commit_test.go
+++ b/lib/config/commit_test.go
@@ -57,7 +57,7 @@ func TestReplaceCommit(t *testing.T) {
 	if w.RequiresRestart() {
 		t.Fatal("Should not require restart")
 	}
-	if w.Raw().Version != 1 {
+	if w.Raw().Version != CurrentVersion {
 		t.Fatal("Config should have changed")
 	}
 
@@ -76,7 +76,7 @@ func TestReplaceCommit(t *testing.T) {
 	if !w.RequiresRestart() {
 		t.Fatal("Should require restart")
 	}
-	if w.Raw().Version != 2 {
+	if w.Raw().Version != CurrentVersion {
 		t.Fatal("Config should have changed")
 	}
 
@@ -92,7 +92,7 @@ func TestReplaceCommit(t *testing.T) {
 	if !w.RequiresRestart() {
 		t.Fatal("Should still require restart")
 	}
-	if w.Raw().Version != 2 {
+	if w.Raw().Version != CurrentVersion {
 		t.Fatal("Config should not have changed")
 	}
 }

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -70,8 +70,9 @@ func New(myID protocol.DeviceID) Configuration {
 	util.SetDefaults(&cfg.Options)
 	util.SetDefaults(&cfg.GUI)
 
+	// Can't happen.
 	if err := cfg.prepare(myID); err != nil {
-		panic(err)
+		panic("bug: error in preparing new folder: " + err.Error())
 	}
 
 	return cfg

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -70,7 +70,9 @@ func New(myID protocol.DeviceID) Configuration {
 	util.SetDefaults(&cfg.Options)
 	util.SetDefaults(&cfg.GUI)
 
-	cfg.prepare(myID)
+	if err := cfg.prepare(myID); err != nil {
+		panic(err)
+	}
 
 	return cfg
 }
@@ -164,6 +166,36 @@ func (cfg *Configuration) WriteXML(w io.Writer) error {
 }
 
 func (cfg *Configuration) prepare(myID protocol.DeviceID) error {
+	var myName string
+
+	// Ensure this device is present in the config
+	for _, device := range cfg.Devices {
+		if device.DeviceID == myID {
+			goto found
+		}
+	}
+
+	myName, _ = os.Hostname()
+	cfg.Devices = append(cfg.Devices, DeviceConfiguration{
+		DeviceID: myID,
+		Name:     myName,
+	})
+
+found:
+
+	if err := cfg.clean(); err != nil {
+		return err
+	}
+
+	// Ensure that we are part of the devices
+	for i := range cfg.Folders {
+		cfg.Folders[i].Devices = ensureDevicePresent(cfg.Folders[i].Devices, myID)
+	}
+
+	return nil
+}
+
+func (cfg *Configuration) clean() error {
 	util.FillNilSlices(&cfg.Options)
 
 	// Initialize any empty slices
@@ -228,26 +260,14 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) error {
 		existingDevices[device.DeviceID] = true
 	}
 
-	// Ensure this device is present in the config
-	if !existingDevices[myID] {
-		myName, _ := os.Hostname()
-		cfg.Devices = append(cfg.Devices, DeviceConfiguration{
-			DeviceID: myID,
-			Name:     myName,
-		})
-		existingDevices[myID] = true
-	}
-
 	// Ensure that the device list is free from duplicates
 	cfg.Devices = ensureNoDuplicateDevices(cfg.Devices)
 
 	sort.Sort(DeviceConfigurationList(cfg.Devices))
 	// Ensure that any loose devices are not present in the wrong places
 	// Ensure that there are no duplicate devices
-	// Ensure that puller settings are sane
 	// Ensure that the versioning configuration parameter map is not nil
 	for i := range cfg.Folders {
-		cfg.Folders[i].Devices = ensureDevicePresent(cfg.Folders[i].Devices, myID)
 		cfg.Folders[i].Devices = ensureExistingDevices(cfg.Folders[i].Devices, existingDevices)
 		cfg.Folders[i].Devices = ensureNoDuplicateFolderDevices(cfg.Folders[i].Devices)
 		if cfg.Folders[i].Versioning.Params == nil {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -743,3 +743,27 @@ func TestGetDevice(t *testing.T) {
 		t.Error("Should not returned ID", device3)
 	}
 }
+
+func TestSharesRemovedOnDeviceRemoval(t *testing.T) {
+	wrapper, err := Load("testdata/example.xml", device1)
+	if err != nil {
+		t.Errorf("Failed: %s", err)
+	}
+
+	raw := wrapper.Raw()
+	raw.Devices = raw.Devices[:len(raw.Devices)-1]
+
+	if len(raw.Folders[0].Devices) <= len(raw.Devices) {
+		t.Error("Should have less devices")
+	}
+
+	err = wrapper.Replace(raw)
+	if err != nil {
+		t.Errorf("Failed: %s", err)
+	}
+
+	raw = wrapper.Raw()
+	if len(raw.Folders[0].Devices) > len(raw.Devices) {
+		t.Error("Unexpected extra device")
+	}
+}

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -136,6 +136,10 @@ func (w *Wrapper) Replace(cfg Configuration) error {
 func (w *Wrapper) replaceLocked(to Configuration) error {
 	from := w.cfg
 
+	if err := to.clean(); err != nil {
+		return err
+	}
+
 	for _, sub := range w.subs {
 		l.Debugln(sub, "verifying configuration")
 		if err := sub.VerifyConfiguration(from, to); err != nil {

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -284,10 +284,23 @@ func (s *FileSet) SetIndexID(device protocol.DeviceID, id protocol.IndexID) {
 	s.db.setIndexID(device[:], []byte(s.folder), id)
 }
 
+<<<<<<< fbe42c156dc50f7621e8e093b4d8fc9cd57cd4d6
 func (s *FileSet) MtimeFS() *fs.MtimeFS {
 	prefix := s.db.mtimesKey([]byte(s.folder))
 	kv := NewNamespacedKV(s.db, string(prefix))
 	return fs.NewMtimeFS(kv)
+=======
+func (s *FileSet) ListDevices() []protocol.DeviceID {
+	s.updateMutex.Lock()
+	devices := make([]protocol.DeviceID, 0, len(s.remoteSequence))
+	for id, seq := range s.remoteSequence {
+		if seq > 0 {
+			devices = append(devices, id)
+		}
+	}
+	s.updateMutex.Unlock()
+	return devices
+>>>>>>> lib/model, lib/config: Support "live" device removal, folder unsharing and folder configuration changes
 }
 
 // maxSequence returns the highest of the Sequence numbers found in

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -284,12 +284,12 @@ func (s *FileSet) SetIndexID(device protocol.DeviceID, id protocol.IndexID) {
 	s.db.setIndexID(device[:], []byte(s.folder), id)
 }
 
-<<<<<<< fbe42c156dc50f7621e8e093b4d8fc9cd57cd4d6
 func (s *FileSet) MtimeFS() *fs.MtimeFS {
 	prefix := s.db.mtimesKey([]byte(s.folder))
 	kv := NewNamespacedKV(s.db, string(prefix))
 	return fs.NewMtimeFS(kv)
-=======
+}
+
 func (s *FileSet) ListDevices() []protocol.DeviceID {
 	s.updateMutex.Lock()
 	devices := make([]protocol.DeviceID, 0, len(s.remoteSequence))
@@ -300,7 +300,6 @@ func (s *FileSet) ListDevices() []protocol.DeviceID {
 	}
 	s.updateMutex.Unlock()
 	return devices
->>>>>>> lib/model, lib/config: Support "live" device removal, folder unsharing and folder configuration changes
 }
 
 // maxSequence returns the highest of the Sequence numbers found in

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2253,27 +2253,6 @@ func mapDevices(devices []protocol.DeviceID) map[protocol.DeviceID]struct{} {
 	return m
 }
 
-func filterIndex(folder string, fs []protocol.FileInfo, dropDeletes bool, ignores *ignore.Matcher) []protocol.FileInfo {
-	for i := 0; i < len(fs); {
-		if fs[i].IsDeleted() && dropDeletes {
-			l.Debugln("dropping update for undesired delete", fs[i])
-			fs[i] = fs[len(fs)-1]
-			fs = fs[:len(fs)-1]
-		} else if symlinkInvalid(folder, fs[i]) {
-			l.Debugln("dropping update for unsupported symlink", fs[i])
-			fs[i] = fs[len(fs)-1]
-			fs = fs[:len(fs)-1]
-		} else if ignores != nil && ignores.Match(fs[i].Name).IsIgnored() {
-			l.Debugln("dropping update for ignored item", fs[i])
-			fs[i] = fs[len(fs)-1]
-			fs = fs[:len(fs)-1]
-		} else {
-			i++
-		}
-	}
-	return fs
-}
-
 func symlinkInvalid(folder string, fi db.FileIntf) bool {
 	if !symlinks.Supported && fi.IsSymlink() && !fi.IsInvalid() && !fi.IsDeleted() {
 		symlinkWarning.Do(func() {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -178,13 +178,13 @@ func (m *Model) StartDeadlockDetector(timeout time.Duration) {
 // StartFolder constructs the folder service and starts it.
 func (m *Model) StartFolder(folder string) {
 	m.fmut.Lock()
-	folderType := m.startFolderUnlocked(folder)
+	folderType := m.startFolderLocked(folder)
 	m.fmut.Unlock()
 
 	l.Infoln("Ready to synchronize", folder, fmt.Sprintf("(%s)", folderType))
 }
 
-func (m *Model) startFolderUnlocked(folder string) config.FolderType {
+func (m *Model) startFolderLocked(folder string) config.FolderType {
 	cfg, ok := m.folderCfgs[folder]
 	if !ok {
 		panic("cannot start nonexistent folder " + folder)
@@ -293,11 +293,11 @@ func (m *Model) AddFolder(cfg config.FolderConfiguration) {
 	}
 
 	m.fmut.Lock()
-	m.addFolderUnlocked(cfg)
+	m.addFolderLocked(cfg)
 	m.fmut.Unlock()
 }
 
-func (m *Model) addFolderUnlocked(cfg config.FolderConfiguration) {
+func (m *Model) addFolderLocked(cfg config.FolderConfiguration) {
 	m.folderCfgs[cfg.ID] = cfg
 	m.folderFiles[cfg.ID] = db.NewFileSet(cfg.ID, m.db)
 
@@ -318,7 +318,7 @@ func (m *Model) RemoveFolder(folder string) {
 	m.fmut.Lock()
 	m.pmut.Lock()
 
-	m.tearDownFolderUnlocked(folder)
+	m.tearDownFolderLocked(folder)
 	// Remove it from the database
 	db.DropFolder(m.db, folder)
 
@@ -326,7 +326,7 @@ func (m *Model) RemoveFolder(folder string) {
 	m.fmut.Unlock()
 }
 
-func (m *Model) tearDownFolderUnlocked(folder string) {
+func (m *Model) tearDownFolderLocked(folder string) {
 	// Stop the services running for this folder
 	for _, id := range m.folderRunnerTokens[folder] {
 		m.Remove(id)
@@ -360,9 +360,9 @@ func (m *Model) RestartFolder(cfg config.FolderConfiguration) {
 	m.fmut.Lock()
 	m.pmut.Lock()
 
-	m.tearDownFolderUnlocked(cfg.ID)
-	m.addFolderUnlocked(cfg)
-	folderType := m.startFolderUnlocked(cfg.ID)
+	m.tearDownFolderLocked(cfg.ID)
+	m.addFolderLocked(cfg)
+	folderType := m.startFolderLocked(cfg.ID)
 
 	m.pmut.Unlock()
 	m.fmut.Unlock()
@@ -704,10 +704,10 @@ func (m *Model) IndexUpdate(deviceID protocol.DeviceID, folder string, fs []prot
 func (m *Model) folderSharedWith(folder string, deviceID protocol.DeviceID) bool {
 	m.fmut.RLock()
 	defer m.fmut.RUnlock()
-	return m.folderSharedWithUnlocked(folder, deviceID)
+	return m.folderSharedWithLocked(folder, deviceID)
 }
 
-func (m *Model) folderSharedWithUnlocked(folder string, deviceID protocol.DeviceID) bool {
+func (m *Model) folderSharedWithLocked(folder string, deviceID protocol.DeviceID) bool {
 	for _, nfolder := range m.deviceFolders[deviceID] {
 		if nfolder == folder {
 			return true
@@ -735,7 +735,7 @@ func (m *Model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 
 	m.fmut.Lock()
 	for _, folder := range cm.Folders {
-		if !m.folderSharedWithUnlocked(folder.ID, deviceID) {
+		if !m.folderSharedWithLocked(folder.ID, deviceID) {
 			events.Default.Log(events.FolderRejected, map[string]string{
 				"folder":      folder.ID,
 				"folderLabel": folder.Label,
@@ -931,7 +931,6 @@ func (m *Model) Close(device protocol.DeviceID, err error) {
 	delete(m.helloMessages, device)
 	delete(m.deviceDownloads, device)
 	m.pmut.Unlock()
-
 }
 
 // Request returns the specified data segment by reading it from local disk.
@@ -2203,7 +2202,6 @@ func (m *Model) CommitConfiguration(from, to config.Configuration) bool {
 
 		if !reflect.DeepEqual(fromCfgCopy, toCfgCopy) {
 			m.RestartFolder(toCfg)
-			l.Debugln(m, "restarting folder", folderID, "as configuration differs")
 		}
 	}
 
@@ -2255,14 +2253,25 @@ func mapDevices(devices []protocol.DeviceID) map[protocol.DeviceID]struct{} {
 	return m
 }
 
-// mapDeviceCfgs returns a map of device ID to nothing for the given slice of
-// device configurations.
-func mapDeviceCfgs(devices []config.DeviceConfiguration) map[protocol.DeviceID]struct{} {
-	m := make(map[protocol.DeviceID]struct{}, len(devices))
-	for _, dev := range devices {
-		m[dev.DeviceID] = struct{}{}
+func filterIndex(folder string, fs []protocol.FileInfo, dropDeletes bool, ignores *ignore.Matcher) []protocol.FileInfo {
+	for i := 0; i < len(fs); {
+		if fs[i].IsDeleted() && dropDeletes {
+			l.Debugln("dropping update for undesired delete", fs[i])
+			fs[i] = fs[len(fs)-1]
+			fs = fs[:len(fs)-1]
+		} else if symlinkInvalid(folder, fs[i]) {
+			l.Debugln("dropping update for unsupported symlink", fs[i])
+			fs[i] = fs[len(fs)-1]
+			fs = fs[:len(fs)-1]
+		} else if ignores != nil && ignores.Match(fs[i].Name).IsIgnored() {
+			l.Debugln("dropping update for ignored item", fs[i])
+			fs[i] = fs[len(fs)-1]
+			fs = fs[:len(fs)-1]
+		} else {
+			i++
+		}
 	}
-	return m
+	return fs
 }
 
 func symlinkInvalid(folder string, fi db.FileIntf) bool {


### PR DESCRIPTION
### Purpose

lib/model, lib/config: Support "live" device removal, folder unsharing and folder configuration changes

Furthermore:
1. Cleans configs received, migrates them as we receive them.
2. Clears indexes of devices we no longer share the folder with

### Testing

Manual tests, unit tests of questionable quality
