### PR TITLE
gui: Fix #1300 - weighting % of devices according to folder size

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -317,8 +317,8 @@ angular.module('syncthing.core')
                 if (cmp === "_total") {
                     continue;
                 }
-                tot += $scope.completion[data.device][cmp];
-                cnt += 1;
+                tot += $scope.completion[data.device][cmp] * $scope.model[cmp].globalBytes;
+                cnt += $scope.model[cmp].globalBytes;
             }
             $scope.completion[data.device]._total = tot / cnt;
         });
@@ -465,8 +465,8 @@ angular.module('syncthing.core')
                     if (cmp === "_total") {
                         continue;
                     }
-                    tot += $scope.completion[device][cmp];
-                    cnt += 1;
+                    tot += $scope.completion[device][cmp] * $scope.model[cmp].globalBytes;
+                    cnt += $scope.model[cmp].globalBytes;
                 }
                 $scope.completion[device]._total = tot / cnt;
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -312,15 +312,25 @@ angular.module('syncthing.core')
             $scope.completion[data.device][data.folder] = data.completion;
 
             var tot = 0,
-                cnt = 0;
+                cnt = 0,
+                isComplete = true;
             for (var cmp in $scope.completion[data.device]) {
                 if (cmp === "_total") {
                     continue;
                 }
                 tot += $scope.completion[data.device][cmp] * $scope.model[cmp].globalBytes;
                 cnt += $scope.model[cmp].globalBytes;
+                if ($scope.completion[data.device][cmp] != 100) {
+                    isComplete = false;
+                }
             }
-            $scope.completion[data.device]._total = tot / cnt;
+            //To be sure that we won't get any rounding errors resulting in non-100% status when it should be
+            if (isComplete) {
+                $scope.completion[data.device]._total = 100;
+            }
+            else {
+                $scope.completion[data.device]._total = tot / cnt;
+            }
         });
 
         $scope.$on(Events.FOLDER_ERRORS, function (event, arg) {
@@ -460,15 +470,25 @@ angular.module('syncthing.core')
                 $scope.completion[device][folder] = data.completion;
 
                 var tot = 0,
-                    cnt = 0;
+                    cnt = 0,
+                    isComplete = true;
                 for (var cmp in $scope.completion[device]) {
                     if (cmp === "_total") {
                         continue;
                     }
                     tot += $scope.completion[device][cmp] * $scope.model[cmp].globalBytes;
                     cnt += $scope.model[cmp].globalBytes;
+                    if ($scope.completion[device][cmp] != 100) {
+                        isComplete = false;
+                    }
                 }
-                $scope.completion[device]._total = tot / cnt;
+                //To be sure that we won't get any rounding errors resulting in non-100% status when it should be
+                if (isComplete) {
+                    $scope.completion[device]._total = 100;
+                }
+                else {
+                    $scope.completion[device]._total = tot / cnt;
+                }
 
                 console.log("refreshCompletion", device, folder, $scope.completion[device]);
             }).error($scope.emitHTTPError);


### PR DESCRIPTION
### Purpose

When 2 or more folders are shared with a remote device, the completion displayed in the device section on the right was based on a simple average of the completion of the shared folders. This is irrelevant when the folders have different sizes (e.g. a folder _X_ of 20MiB and a folder _Y_ of 100GiB; the _X_ folder will be quickly completely synchronised and bring the completion to 50%, even if just a very few part of the data has been send).

I weighted this average with the global size to reflect more accurately the progress of the synchronization.

### Testing

I have created two folders on an instance _A_ with very different sizes (1MiB and 2.3GiB). After asking to synchronised thooses two folders with an other device _B_, I checked regularly the percentage displayed on _A_ next-to the name of the device _B_.

### Authorship

This is my first contribution to syncthing.
