### PR TITLE
lib/connections, lib/model: Refactor connection close handling (fixes #3466)

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -202,7 +202,6 @@ next:
 		// Lower priority is better, just like nice etc.
 		if priorityKnown && ct.Priority > c.Priority {
 			l.Debugln("Switching connections", remoteID)
-			s.model.Close(remoteID, protocol.ErrSwitchingConnections)
 		} else if connected {
 			// We should not already be connected to the other party. TODO: This
 			// could use some better handling. If the old connection is dead but

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -8,6 +8,7 @@ package connections
 
 import (
 	"crypto/tls"
+	"fmt"
 	"net"
 	"net/url"
 	"time"
@@ -26,6 +27,10 @@ type IntermediateConnection struct {
 type Connection struct {
 	IntermediateConnection
 	protocol.Connection
+}
+
+func (c Connection) String() string {
+	return fmt.Sprintf("%s-%s/%s", c.LocalAddr(), c.RemoteAddr(), c.Type)
 }
 
 type dialerFactory interface {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -351,7 +351,7 @@ func TestDeviceRename(t *testing.T) {
 		t.Errorf("Device already has a name")
 	}
 
-	m.Close(device1, protocol.ErrTimeout)
+	m.Closed(conn, protocol.ErrTimeout)
 	hello.DeviceName = "tester"
 	m.AddConnection(conn, hello)
 
@@ -359,7 +359,7 @@ func TestDeviceRename(t *testing.T) {
 		t.Errorf("Device did not get a name")
 	}
 
-	m.Close(device1, protocol.ErrTimeout)
+	m.Closed(conn, protocol.ErrTimeout)
 	hello.DeviceName = "tester2"
 	m.AddConnection(conn, hello)
 
@@ -376,7 +376,7 @@ func TestDeviceRename(t *testing.T) {
 		t.Errorf("Device name not saved in config")
 	}
 
-	m.Close(device1, protocol.ErrTimeout)
+	m.Closed(conn, protocol.ErrTimeout)
 
 	opts := cfg.Options()
 	opts.OverwriteRemoteDevNames = true
@@ -1527,7 +1527,7 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 	m.StartFolder(fcfg.ID)
 	m.ServeBackground()
 
-	m.AddConnection(connections.Connection{
+	conn1 := connections.Connection{
 		IntermediateConnection: connections.IntermediateConnection{
 			Conn:     tls.Client(&fakeConn{}, nil),
 			Type:     "foo",
@@ -1536,8 +1536,9 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		Connection: &FakeConnection{
 			id: device1,
 		},
-	}, protocol.HelloResult{})
-	m.AddConnection(connections.Connection{
+	}
+	m.AddConnection(conn1, protocol.HelloResult{})
+	conn2 := connections.Connection{
 		IntermediateConnection: connections.IntermediateConnection{
 			Conn:     tls.Client(d2c, nil),
 			Type:     "foo",
@@ -1546,7 +1547,8 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		Connection: &FakeConnection{
 			id: device2,
 		},
-	}, protocol.HelloResult{})
+	}
+	m.AddConnection(conn2, protocol.HelloResult{})
 
 	m.ClusterConfig(device1, protocol.ClusterConfig{
 		Folders: []protocol.Folder{
@@ -1629,7 +1631,7 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		t.Error("downloads missing early")
 	}
 
-	m.Close(device2, fmt.Errorf("foo"))
+	m.Closed(conn2, fmt.Errorf("foo"))
 
 	if _, ok := m.conn[device2]; ok {
 		t.Error("conn not missing")

--- a/lib/protocol/benchmark_test.go
+++ b/lib/protocol/benchmark_test.go
@@ -181,7 +181,7 @@ func (m *fakeModel) Request(deviceID DeviceID, folder string, name string, offse
 func (m *fakeModel) ClusterConfig(deviceID DeviceID, config ClusterConfig) {
 }
 
-func (m *fakeModel) Close(deviceID DeviceID, err error) {
+func (m *fakeModel) Closed(conn Connection, err error) {
 }
 
 func (m *fakeModel) DownloadProgress(deviceID DeviceID, folder string, updates []FileDownloadProgressUpdate) {

--- a/lib/protocol/common_test.go
+++ b/lib/protocol/common_test.go
@@ -39,7 +39,7 @@ func (t *TestModel) Request(deviceID DeviceID, folder, name string, offset int64
 	return nil
 }
 
-func (t *TestModel) Close(deviceID DeviceID, err error) {
+func (t *TestModel) Closed(conn Connection, err error) {
 	t.closedErr = err
 	close(t.closedCh)
 }

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -67,7 +67,7 @@ type Model interface {
 	// A cluster configuration message was received
 	ClusterConfig(deviceID DeviceID, config ClusterConfig)
 	// The peer device closed the connection
-	Close(deviceID DeviceID, err error)
+	Closed(conn Connection, err error)
 	// The peer device sent progress updates for the files it is currently downloading
 	DownloadProgress(deviceID DeviceID, folder string, updates []FileDownloadProgressUpdate)
 }
@@ -729,7 +729,7 @@ func (c *rawConnection) close(err error) {
 		}
 		c.awaitingMut.Unlock()
 
-		go c.receiver.Close(c.id, err)
+		c.receiver.Closed(c, err)
 	})
 }
 


### PR DESCRIPTION
### Purpose

So there were some issues here. The main problem was that model.Close(deviceID) was overloaded to mean "the connection was closed by the protocol layer" and "i want to close this connection". That meant it could get called twice - once *to* close the connection and then once more when the connection *was* closed.

After this refactor there is instead a Closed(conn) method that is the callback. I didn't need to change the parameter in the end, but I think it's clearer what it means when it takes the connection that was closed instead of a device ID. To close a connection, the new close(deviceID) method is used instead, which only closes the underlying connection and leaves the cleanup to the Closed() callback.

I also changed how we do connection switching. Instead of the connection service calling close and then adding the connection, it just adds the new connection. The model knows that it already has a connection and makes sure to close and clean out that one before adding the new connection.

To make sure to sequence this properly I added a new map of channels that get created on connection add and closed by Closed(), so that AddConnection() can do the close and wait for the cleanup to happen before proceeding.

### Testing

Our testing capabilities here really suck and we should work on that.

What I did was remove all of the already-connected and priority checks in the connection service, so that the connection loop ran continuously and every new connection became a connection switch. This crashed instantly on the old code, but runs for at least a few minutes with a connection switch every five seconds on the new code. I also run the TestRestart* integration things and they still work.

I might have missed a possible deadlock somewhere, but hey... :/