### PR TITLE
lib: Remove osutil.Remove & osutil.RemoveAll (fixes #3513)

### DIFF
--- a/lib/fs/mtimefs_test.go
+++ b/lib/fs/mtimefs_test.go
@@ -12,13 +12,11 @@ import (
 	"os"
 	"testing"
 	"time"
-
-	"github.com/syncthing/syncthing/lib/osutil"
 )
 
 func TestMtimeFS(t *testing.T) {
-	osutil.RemoveAll("testdata")
-	defer osutil.RemoveAll("testdata")
+	os.RemoveAll("testdata")
+	defer os.RemoveAll("testdata")
 	os.Mkdir("testdata", 0755)
 	ioutil.WriteFile("testdata/exists0", []byte("hello"), 0644)
 	ioutil.WriteFile("testdata/exists1", []byte("hello"), 0644)

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1343,8 +1343,8 @@ func TestIssue3028(t *testing.T) {
 }
 
 func TestIssue3164(t *testing.T) {
-	osutil.RemoveAll("testdata/issue3164")
-	defer osutil.RemoveAll("testdata/issue3164")
+	os.RemoveAll("testdata/issue3164")
+	defer os.RemoveAll("testdata/issue3164")
 
 	if err := os.MkdirAll("testdata/issue3164/oktodelete/foobar", 0777); err != nil {
 		t.Fatal(err)
@@ -1445,7 +1445,7 @@ func TestIssue2782(t *testing.T) {
 
 	testName := ".syncthing-test." + srand.String(16)
 	testDir := filepath.Join(home, testName)
-	if err := osutil.RemoveAll(testDir); err != nil {
+	if err := os.RemoveAll(testDir); err != nil {
 		t.Skip(err)
 	}
 	if err := osutil.MkdirAll(testDir+"/syncdir", 0755); err != nil {
@@ -1457,7 +1457,7 @@ func TestIssue2782(t *testing.T) {
 	if err := os.Symlink("syncdir", testDir+"/synclink"); err != nil {
 		t.Skip(err)
 	}
-	defer osutil.RemoveAll(testDir)
+	defer os.RemoveAll(testDir)
 
 	db := db.OpenMemory()
 	m := NewModel(defaultConfig, protocol.LocalDeviceID, "device", "syncthing", "dev", db, nil)

--- a/lib/model/sorter.go
+++ b/lib/model/sorter.go
@@ -9,9 +9,9 @@ package model
 import (
 	"encoding/binary"
 	"io/ioutil"
+	"os"
 	"sort"
 
-	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/opt"
@@ -186,7 +186,7 @@ func (s *onDiskIndexSorter) Sorted(fn func(protocol.FileInfo) bool) {
 func (s *onDiskIndexSorter) Close() {
 	l.Debugf("onDiskIndexSorter %p closes", s)
 	s.db.Close()
-	osutil.RemoveAll(s.dir)
+	os.RemoveAll(s.dir)
 }
 
 func (s *onDiskIndexSorter) full() bool {

--- a/lib/osutil/osutil_test.go
+++ b/lib/osutil/osutil_test.go
@@ -71,6 +71,8 @@ func TestInWriteableDir(t *testing.T) {
 }
 
 func TestInWritableDirWindowsRemove(t *testing.T) {
+	// os.Remove should remove read only things on windows
+
 	if runtime.GOOS != "windows" {
 		t.Skipf("Tests not required")
 		return
@@ -104,6 +106,42 @@ func TestInWritableDirWindowsRemove(t *testing.T) {
 		if err != nil {
 			t.Errorf("Unexpected error %s: %s", path, err)
 		}
+	}
+}
+
+func TestInWritableDirWindowsRemoveAll(t *testing.T) {
+	// os.RemoveAll should remove read only things on windows
+
+	if runtime.GOOS != "windows" {
+		t.Skipf("Tests not required")
+		return
+	}
+
+	err := os.RemoveAll("testdata")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod("testdata/windows/ro/readonlynew", 0700)
+	defer os.RemoveAll("testdata")
+
+	create := func(name string) error {
+		fd, err := os.Create(name)
+		if err != nil {
+			return err
+		}
+		fd.Close()
+		return nil
+	}
+
+	os.Mkdir("testdata", 0700)
+
+	os.Mkdir("testdata/windows", 0500)
+	os.Mkdir("testdata/windows/ro", 0500)
+	create("testdata/windows/ro/readonly")
+	os.Chmod("testdata/windows/ro/readonly", 0500)
+
+	if err := os.RemoveAll("testdata/windows"); err != nil {
+		t.Errorf("Unexpected error: %s", err)
 	}
 }
 

--- a/lib/osutil/osutil_test.go
+++ b/lib/osutil/osutil_test.go
@@ -70,50 +70,6 @@ func TestInWriteableDir(t *testing.T) {
 	}
 }
 
-func TestInWritableDirWindowsRemove(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skipf("Tests not required")
-		return
-	}
-
-	err := os.RemoveAll("testdata")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.Chmod("testdata/windows/ro/readonlynew", 0700)
-	defer os.RemoveAll("testdata")
-
-	create := func(name string) error {
-		fd, err := os.Create(name)
-		if err != nil {
-			return err
-		}
-		fd.Close()
-		return nil
-	}
-
-	os.Mkdir("testdata", 0700)
-
-	os.Mkdir("testdata/windows", 0500)
-	os.Mkdir("testdata/windows/ro", 0500)
-	create("testdata/windows/ro/readonly")
-	os.Chmod("testdata/windows/ro/readonly", 0500)
-
-	for _, path := range []string{"testdata/windows/ro/readonly", "testdata/windows/ro", "testdata/windows"} {
-		err := os.Remove(path)
-		if err == nil {
-			t.Errorf("Expected error %s", path)
-		}
-	}
-
-	for _, path := range []string{"testdata/windows/ro/readonly", "testdata/windows/ro", "testdata/windows"} {
-		err := osutil.InWritableDir(osutil.Remove, path)
-		if err != nil {
-			t.Errorf("Unexpected error %s: %s", path, err)
-		}
-	}
-}
-
 func TestInWritableDirWindowsRename(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skipf("Tests not required")

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -289,8 +289,8 @@ func TestWalkSymlink(t *testing.T) {
 
 	// Create a folder with a symlink in it
 
-	osutil.RemoveAll("_symlinks")
-	defer osutil.RemoveAll("_symlinks")
+	os.RemoveAll("_symlinks")
+	defer os.RemoveAll("_symlinks")
 
 	os.Mkdir("_symlinks", 0755)
 	symlinks.Create("_symlinks/link", "destination", symlinks.TargetUnknown)

--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -165,7 +165,7 @@ func (v Staggered) expire(versions []string) {
 			continue
 		}
 
-		if err := osutil.Remove(file); err != nil {
+		if err := os.Remove(file); err != nil {
 			l.Warnf("Versioner: can't remove %q: %v", file, err)
 		}
 	}

--- a/lib/versioner/trashcan.go
+++ b/lib/versioner/trashcan.go
@@ -144,7 +144,7 @@ func (t *Trashcan) cleanoutArchive() error {
 			// directory was empty and try to remove it. We ignore failure for
 			// the time being.
 			if currentDir != "" && filesInDir == 0 {
-				osutil.Remove(currentDir)
+				os.Remove(currentDir)
 			}
 			currentDir = path
 			filesInDir = 0
@@ -153,7 +153,7 @@ func (t *Trashcan) cleanoutArchive() error {
 
 		if info.ModTime().Before(cutoff) {
 			// The file is too old; remove it.
-			osutil.Remove(path)
+			os.Remove(path)
 		} else {
 			// Keep this file, and remember it so we don't unnecessarily try
 			// to remove this directory.
@@ -169,7 +169,7 @@ func (t *Trashcan) cleanoutArchive() error {
 	// The last directory seen by the walkFn may not have been removed as it
 	// should be.
 	if currentDir != "" && filesInDir == 0 {
-		osutil.Remove(currentDir)
+		os.Remove(currentDir)
 	}
 	return nil
 }

--- a/test/util.go
+++ b/test/util.go
@@ -208,7 +208,7 @@ func alterFiles(dir string) error {
 							return err
 						}
 					} else {
-						err := osutil.Remove(path)
+						err := os.Remove(path)
 						if err != nil {
 							return err
 						}


### PR DESCRIPTION
### Purpose

These are no longer required with Go 1.7. Change made by removing the
functions, doing a global s/osutil.Remove/os.Remove/.

### Testing

Lets see what happens on the Windows build server...