### PR TITLE
lib/model: Correct virtual mtime handling (fixes #3516)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1245,9 +1245,6 @@ func (f *rwFolder) performFinish(state *sharedPullerState) error {
 		}
 	}
 
-	// Set the correct timestamp on the new file
-	f.mtimeFS.Chtimes(state.tempName, state.file.ModTime(), state.file.ModTime()) // never fails
-
 	if stat, err := f.mtimeFS.Lstat(state.realName); err == nil {
 		// There is an old file or directory already in place. We need to
 		// handle that.
@@ -1293,6 +1290,9 @@ func (f *rwFolder) performFinish(state *sharedPullerState) error {
 	if err := osutil.TryRename(state.tempName, state.realName); err != nil {
 		return err
 	}
+
+	// Set the correct timestamp on the new file
+	f.mtimeFS.Chtimes(state.realName, state.file.ModTime(), state.file.ModTime()) // never fails
 
 	// If it's a symlink, the target of the symlink is inside the file.
 	if state.file.IsSymlink() {


### PR DESCRIPTION
### Purpose

We previously set the mtime on the temp file, and then renamed it to the real path. Unfortunately that means we'd save the real timestamp under the under the temp name ".syncthing.foo.tmp" when the actual file that we will look up on the next scan is "foo". This moves the Chtimes later, ensuring that it gets recorded correctly under the right name.

### Testing

Verified in my FreeBSD + Mac setup. Unfortunately we don't have a good way to test the puller, especially not cross platform... :/