### PR TITLE
cmd/syncthing: Remove old temp index dbs on startup (fixes #3529)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -1124,15 +1124,16 @@ func autoUpgrade(cfg *config.Wrapper) {
 // suitable time after they have gone out of fashion.
 func cleanConfigDirectory() {
 	patterns := map[string]time.Duration{
-		"panic-*.log":      7 * 24 * time.Hour,  // keep panic logs for a week
-		"audit-*.log":      7 * 24 * time.Hour,  // keep audit logs for a week
-		"index":            14 * 24 * time.Hour, // keep old index format for two weeks
-		"index-v0.11.0.db": 14 * 24 * time.Hour, // keep old index format for two weeks
-		"index-v0.13.0.db": 14 * 24 * time.Hour, // keep old index format for two weeks
-		"index*.converted": 14 * 24 * time.Hour, // keep old converted indexes for two weeks
-		"config.xml.v*":    30 * 24 * time.Hour, // old config versions for a month
-		"*.idx.gz":         30 * 24 * time.Hour, // these should for sure no longer exist
-		"backup-of-v0.8":   30 * 24 * time.Hour, // these neither
+		"panic-*.log":        7 * 24 * time.Hour,  // keep panic logs for a week
+		"audit-*.log":        7 * 24 * time.Hour,  // keep audit logs for a week
+		"index":              14 * 24 * time.Hour, // keep old index format for two weeks
+		"index-v0.11.0.db":   14 * 24 * time.Hour, // keep old index format for two weeks
+		"index-v0.13.0.db":   14 * 24 * time.Hour, // keep old index format for two weeks
+		"index*.converted":   14 * 24 * time.Hour, // keep old converted indexes for two weeks
+		"config.xml.v*":      30 * 24 * time.Hour, // old config versions for a month
+		"*.idx.gz":           30 * 24 * time.Hour, // these should for sure no longer exist
+		"backup-of-v0.8":     30 * 24 * time.Hour, // these neither
+		"tmp-index-sorter.*": 0,                   // these should never exist on startup
 	}
 
 	for pat, dur := range patterns {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -1133,7 +1133,7 @@ func cleanConfigDirectory() {
 		"config.xml.v*":      30 * 24 * time.Hour, // old config versions for a month
 		"*.idx.gz":           30 * 24 * time.Hour, // these should for sure no longer exist
 		"backup-of-v0.8":     30 * 24 * time.Hour, // these neither
-		"tmp-index-sorter.*": 0,                   // these should never exist on startup
+		"tmp-index-sorter.*": time.Minute,         // these should never exist on startup
 	}
 
 	for pat, dur := range patterns {


### PR DESCRIPTION
### Purpose

Remove temp index databases left over after a crash or similar incident.

### Testing

I ran it, and it removed an old index db I had lying around.