### PR TITLE
Update syncthing.plist

### DIFF
--- a/etc/macosx-launchd/syncthing.plist
+++ b/etc/macosx-launchd/syncthing.plist
@@ -25,7 +25,10 @@
 		</dict>
 
 		<key>KeepAlive</key>
-		<true/>
+		<dict>
+			<key>SuccessfulExit</key>
+			<true/>
+		</dict>
 
 		<key>LowPriorityIO</key>
 		<true/>

--- a/etc/macosx-launchd/syncthing.plist
+++ b/etc/macosx-launchd/syncthing.plist
@@ -23,7 +23,10 @@
 			<key>STNORESTART</key>
 			<string>1</string>
 		</dict>
-
+		
+		<key>RunAtLoad</key>
+		<true/>
+		
 		<key>KeepAlive</key>
 		<dict>
 			<key>SuccessfulExit</key>


### PR DESCRIPTION
### Purpose

I was looking into how to make Syncthing run on login and came across this plist from Syncthing's documentation. After reading Apple's own documentation on plists and trying it out, I believe that adding the SuccessfulExit subkey would be a great addition. 

If the user exits Syncthing, launchd won't forcibly try to restart it which can be useful if the user doesn't want Syncthing to be constantly running. This saves the user from having to manually unload Syncthing. Upon next login though, Syncthing will start up on login as usual. Let me know what you think, thanks!

For reference:
http://launchd.info/
https://developer.apple.com/legacy/library/documentation/Darwin/Reference/ManPages/man5/launchd.plist.5.html#//apple_ref/doc/man/5/launchd.plist
### Testing

All manually by loading and unloading via the launchctl command. Also logged in and out to test.
### Screenshots

None
### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.
### Authorship

Every author of a code contribution (Go, Javascript, HTML, CSS etc, with the
possible exception of minor typo corrections and similar) is recorded in the
AUTHORS and NICKS files and the in-GUI credits. If this is your first
contribution, a maintainer will add you properly before accepting the
contribution. You need not do so yourself or worry about the fact that the
"authors" automated test fails. However, if your name (such as you want it
presented in the credits) is not visible on your Github profile or in your
commit messages, please assist by providing it here.
