### PR TITLE
lib/model: Correct lock taking order in ConnectionStats (fixes #3596)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -396,8 +396,8 @@ func (info ConnectionInfo) MarshalJSON() ([]byte, error) {
 
 // ConnectionStats returns a map with connection statistics for each device.
 func (m *Model) ConnectionStats() map[string]interface{} {
-	m.pmut.RLock()
 	m.fmut.RLock()
+	m.pmut.RLock()
 
 	res := make(map[string]interface{})
 	devs := m.cfg.Devices()
@@ -426,8 +426,8 @@ func (m *Model) ConnectionStats() map[string]interface{} {
 
 	res["connections"] = conns
 
-	m.fmut.RUnlock()
 	m.pmut.RUnlock()
+	m.fmut.RUnlock()
 
 	in, out := protocol.TotalInOut()
 	res["total"] = ConnectionInfo{


### PR DESCRIPTION
### Purpose

ConnectionStats took the locks in the wrong order, and gets called due to the config refresh in the same time window as folders are being restarted. High probability of deadlock.

### Testing

Hammered it a bit manually.