### PR TITLE
Fix a bug on windows when using external versioner

### DIFF
--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -65,7 +65,7 @@ func (v External) Archive(filePath string) error {
 
 	// Windows Go has a bug where it won't properly run the external versioner
 	// if there is a space in the filename.  This code fixes that bug.
-    if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" {
 		filenameparts := strings.Split(inFolderPath, " ")
 		// Remove the last element
 		cmd.Args = cmd.Args[:len(cmd.Args)-1]

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/syncthing/syncthing/lib/osutil"
@@ -61,6 +62,19 @@ func (v External) Archive(filePath string) error {
 	}
 
 	cmd := exec.Command(v.command, v.folderPath, inFolderPath)
+
+	// Windows Go has a bug where it won't properly run the external versioner
+	// if there is a space in the filename.  This code fixes that bug.
+    if runtime.GOOS == "windows" {
+		filenameparts := strings.Split(inFolderPath, " ")
+		// Remove the last element
+		cmd.Args = cmd.Args[:len(cmd.Args)-1]
+		// And reappend all filename parts as seperate args
+		for _, v := range filenameparts {
+			cmd.Args = append(cmd.Args, v)
+		}
+	}
+
 	env := os.Environ()
 	// filter STGUIAUTH and STGUIAPIKEY from environment variables
 	filteredEnv := []string{}


### PR DESCRIPTION
### Purpose

Fixes a bug on windows where, when using an external versioner (such as a batch file), filenames that contain spaces are simply ignored because the cmd.run() command errors out silently and won't call the batch script.

### Testing

To test simply setup a folder on windows with external versioning and call a batch file.  Place two files (one containing space and the other without space in the filename) into the dir and sync to another.  Then delete the files one by one (on another machine) and sync between each.  You should observe the batch script runs for the one file and not the other.  The batch file doesn't have to delete, it can do anything (like echo hello world to a file on the desktop just as an example).  You will see the batch file fire for one and not the other.


### Documentation

This MIGHT be just a Windows 10 issue since I didn't test with Windows 7 but I imagine it is for both.  Also I didn't test with Linux (since I don't use ST on that OS) and if the issue exists for Linux this might also fix for that as well by removing the if runtime.GOOS == "windows" check.

If the pull req is accepted I can provide the batch script I use as an example of how to delete to recycle bin that I use by modifying this document: https://docs.syncthing.net/users/versioning.html


### Authorship

Nate Morrison
