### PR TITLE
Add "Next Scan" timestamp to folder view #3586

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -390,13 +390,12 @@
                       <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Last Scan</span></th>
                       <td translate ng-if="folderStats[folder.id].lastScanDays >= 365" class="text-right">Never</td>
                       <td ng-if="folderStats[folder.id].lastScanDays < 365" class="text-right">
-                        <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
-                      </td>
-                    </tr>
-                    <tr ng-if="folderStats[folder.id].nextScanDelta > 0">
-                      <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Next Scan</span></th>
-                      <td class="text-right">
-                        <span>{{folderStats[folder.id].nextScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
+                        <span tooltip ng-if="folderStats[folder.id].nextScanDelta > 0" data-original-title="<strong><span class='fa fa-fw fa-angle-double-right'></span><span translate>Next scan</span></strong><br> {{folderStats[folder.id].nextScan | date:'yyyy-MM-dd HH:mm:ss'}}">
+                          <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
+                        </span>
+                        <span ng-if="folderStats[folder.id].nextScanDelta <= 0">
+                          <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
+                        </span>
                       </td>
                     </tr>
                     <tr ng-if="folder.type != 'readonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -393,6 +393,12 @@
                         <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
                       </td>
                     </tr>
+                    <tr>
+                      <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Next Scan</span></th>
+                      <td class="text-right">
+                        <span>{{folderStats[folder.id].nextScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
+                      </td>
+                    </tr>
                     <tr ng-if="folder.type != 'readonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">
                       <th><span class="fa fa-fw fa-exchange"></span>&nbsp;<span translate>Last File Received</span></th>
                       <td class="text-right">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -393,7 +393,7 @@
                         <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
                       </td>
                     </tr>
-                    <tr>
+                    <tr ng-if="folderStats[folder.id].nextScanDelta > 0">
                       <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Next Scan</span></th>
                       <td class="text-right">
                         <span>{{folderStats[folder.id].nextScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -618,6 +618,7 @@ angular.module('syncthing.core')
 
                     $scope.folderStats[folder].lastScan = new Date($scope.folderStats[folder].lastScan);
                     $scope.folderStats[folder].lastScanDays = (new Date() - $scope.folderStats[folder].lastScan) / 1000 / 86400;
+                    $scope.folderStats[folder].nextScan = new Date($scope.folderStats[folder].nextScan);
                 }
                 console.log("refreshfolderStats", data);
             }).error($scope.emitHTTPError);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -619,6 +619,7 @@ angular.module('syncthing.core')
                     $scope.folderStats[folder].lastScan = new Date($scope.folderStats[folder].lastScan);
                     $scope.folderStats[folder].lastScanDays = (new Date() - $scope.folderStats[folder].lastScan) / 1000 / 86400;
                     $scope.folderStats[folder].nextScan = new Date($scope.folderStats[folder].nextScan);
+                    $scope.folderStats[folder].nextScanDelta = $scope.folderStats[folder].nextScan - $scope.folderStats[folder].lastScanDays;
                 }
                 console.log("refreshfolderStats", data);
             }).error($scope.emitHTTPError);

--- a/lib/model/folderscanner.go
+++ b/lib/model/folderscanner.go
@@ -34,15 +34,16 @@ func newFolderScanner(config config.FolderConfiguration) folderScanner {
 	}
 }
 
-func (f *folderScanner) Reschedule() {
+func (f *folderScanner) Reschedule() time.Time {
 	if f.interval == 0 {
-		return
+		return time.Time{}
 	}
 	// Sleep a random time between 3/4 and 5/4 of the configured interval.
 	sleepNanos := (f.interval.Nanoseconds()*3 + rand.Int63n(2*f.interval.Nanoseconds())) / 4
 	interval := time.Duration(sleepNanos) * time.Nanosecond
 	l.Debugln(f, "next rescan in", interval)
 	f.timer.Reset(interval)
+	return time.Now().Add(interval)
 }
 
 func (f *folderScanner) Scan(subdirs []string) error {

--- a/lib/model/rofolder.go
+++ b/lib/model/rofolder.go
@@ -50,7 +50,8 @@ func (f *roFolder) Serve() {
 		case <-f.scan.timer.C:
 			if err := f.model.CheckFolderHealth(f.folderID); err != nil {
 				l.Infoln("Skipping folder", f.folderID, "scan due to folder error:", err)
-				f.scan.Reschedule()
+				nextScanTime := f.scan.Reschedule()
+				f.model.folderStatRef(f.folderID).ScanScheduled(nextScanTime)
 				continue
 			}
 
@@ -62,7 +63,8 @@ func (f *roFolder) Serve() {
 				// the same one as returned by CheckFolderHealth, though
 				// duplicate set is handled by setError.
 				f.setError(err)
-				f.scan.Reschedule()
+				nextScanTime := f.scan.Reschedule()
+				f.model.folderStatRef(f.folderID).ScanScheduled(nextScanTime)
 				continue
 			}
 
@@ -75,7 +77,8 @@ func (f *roFolder) Serve() {
 				continue
 			}
 
-			f.scan.Reschedule()
+			nextScanTime := f.scan.Reschedule()
+			f.model.folderStatRef(f.folderID).ScanScheduled(nextScanTime)
 
 		case req := <-f.scan.now:
 			req.err <- f.scanSubdirsIfHealthy(req.subdirs)

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -292,7 +292,8 @@ func (f *rwFolder) Serve() {
 		// same time.
 		case <-f.scan.timer.C:
 			err := f.scanSubdirsIfHealthy(nil)
-			f.scan.Reschedule()
+			nextScanTime := f.scan.Reschedule()
+			f.model.folderStatRef(f.folderID).ScanScheduled(nextScanTime)
 			if err != nil {
 				continue
 			}

--- a/lib/stats/folder.go
+++ b/lib/stats/folder.go
@@ -15,6 +15,7 @@ import (
 type FolderStatistics struct {
 	LastFile LastFile  `json:"lastFile"`
 	LastScan time.Time `json:"lastScan"`
+	NextScan time.Time `json:"nextScan"`
 }
 
 type FolderStatisticsReference struct {
@@ -64,6 +65,10 @@ func (s *FolderStatisticsReference) ScanCompleted() {
 	s.ns.PutTime("lastScan", time.Now())
 }
 
+func (s *FolderStatisticsReference) ScanScheduled(time time.Time) {
+	s.ns.PutTime("nextScan", time)
+}
+
 func (s *FolderStatisticsReference) GetLastScanTime() time.Time {
 	lastScan, ok := s.ns.Time("lastScan")
 	if !ok {
@@ -72,9 +77,18 @@ func (s *FolderStatisticsReference) GetLastScanTime() time.Time {
 	return lastScan
 }
 
+func (s *FolderStatisticsReference) GetNextScanTime() time.Time {
+	nextScan, ok := s.ns.Time("nextScan")
+	if !ok {
+		return time.Time{}
+	}
+	return nextScan
+}
+
 func (s *FolderStatisticsReference) GetStatistics() FolderStatistics {
 	return FolderStatistics{
 		LastFile: s.GetLastFile(),
 		LastScan: s.GetLastScanTime(),
+		NextScan: s.GetNextScanTime(),
 	}
 }

--- a/lib/stats/folder.go
+++ b/lib/stats/folder.go
@@ -65,8 +65,8 @@ func (s *FolderStatisticsReference) ScanCompleted() {
 	s.ns.PutTime("lastScan", time.Now())
 }
 
-func (s *FolderStatisticsReference) ScanScheduled(time time.Time) {
-	s.ns.PutTime("nextScan", time)
+func (s *FolderStatisticsReference) ScanScheduled(when time.Time) {
+	s.ns.PutTime("nextScan", when)
 }
 
 func (s *FolderStatisticsReference) GetLastScanTime() time.Time {


### PR DESCRIPTION
### Purpose

Adds an entry _Next Scan_ to each folder in the GUI that shows when the next scan will happen (similar to the _Last Scan_ entry) as requested by #3586.
### Testing

I didn't find any tests I could hook into. Currently, I don't think I can write a test in the way I should to test this feature from scratch (i.e., set up the environment, create a dummy share and check whether the time shows right) because I'm just starting to read the syncthing code. I checked that the next scan is correct on my installation manually. I also checked that if the timestamp is not greater than the last scan's timestamp the entry is hidden.

However, it seems to me that `func (f *folderScanner) Reschedule() time.Time` is called just after the StateChange event in `func (m *Model) internalScanFolderSubdirs(folder string, subDirs []string) error` is fired. I think that, in theory, the GUI could query the new folder state just before the next scan timestamp is updated. I would suggest to fire another StateChanged event right after updating the next scan timestamp in the folderState object. It seems to me that there is no intended way to do this without actually changing the state to another value (see `func (s *stateTracker) setState(newState folderState)`). What would be the right way to do this?
### Screenshots

![firefox_2016-09-27_22-29-32](https://cloud.githubusercontent.com/assets/12752324/18890733/b84e3b76-8502-11e6-828f-1dcfc21b574c.png)
### Documentation

A new screenshot of the GUI may be added to docs/intro/gui.rst (the current one seems to be outdated anyway).
