### PR TITLE
Diskchange api

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -232,7 +232,7 @@ func (s *apiService) Serve() {
 	getRestMux.HandleFunc("/rest/db/status", s.getDBStatus)                      // folder
 	getRestMux.HandleFunc("/rest/db/browse", s.getDBBrowse)                      // folder [prefix] [dirsonly] [levels]
 	getRestMux.HandleFunc("/rest/events", s.getEvents)                           // since [limit]
-	getRestMux.HandleFunc("/rest/diskevents", s.getDiskEvents)                   // since [limit]
+	getRestMux.HandleFunc("/rest/events/disk", s.getDiskEvents)                  // since [limit]
 	getRestMux.HandleFunc("/rest/stats/device", s.getDeviceStats)                // -
 	getRestMux.HandleFunc("/rest/stats/folder", s.getFolderStats)                // -
 	getRestMux.HandleFunc("/rest/svc/deviceid", s.getDeviceID)                   // id

--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -70,7 +70,7 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 	}
 	w := config.Wrap("/dev/null", cfg)
 
-	srv := newAPIService(protocol.LocalDeviceID, w, "../../test/h1/https-cert.pem", "../../test/h1/https-key.pem", "", nil, nil, nil, nil, nil, nil)
+	srv := newAPIService(protocol.LocalDeviceID, w, "../../test/h1/https-cert.pem", "../../test/h1/https-key.pem", "", nil, nil, nil, nil, nil, nil, nil)
 	srv.started = make(chan string)
 
 	sup := suture.NewSimple("test")
@@ -469,6 +469,7 @@ func startHTTP(cfg *mockedConfig) (string, error) {
 	httpsKeyFile := "../../test/h1/https-key.pem"
 	assetDir := "../../gui"
 	eventSub := new(mockedEventSub)
+	diskEventSub := new(mockedEventSub)
 	discoverer := new(mockedCachingMux)
 	connections := new(mockedConnections)
 	errorLog := new(mockedLoggerRecorder)
@@ -477,7 +478,7 @@ func startHTTP(cfg *mockedConfig) (string, error) {
 
 	// Instantiate the API service
 	svc := newAPIService(protocol.LocalDeviceID, cfg, httpsCertFile, httpsKeyFile, assetDir, model,
-		eventSub, discoverer, connections, errorLog, systemLog)
+		eventSub, diskEventSub, discoverer, connections, errorLog, systemLog)
 	svc.started = addrChan
 
 	// Actually start the API service

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1469,8 +1469,10 @@ func (m *Model) updateLocalsFromScanning(folder string, fs []protocol.FileInfo) 
 	// updates.
 	m.fmut.RLock()
 	path := m.folderCfgs[folder].Path()
+	folderID := m.folderCfgs[folder].ID
+	folderLabel := m.folderCfgs[folder].Label
 	m.fmut.RUnlock()
-	m.localChangeDetected(folder, path, fs)
+	m.localChangeDetected(folderID, folderLabel, path, fs)
 }
 
 func (m *Model) updateLocalsFromPulling(folder string, fs []protocol.FileInfo) {
@@ -1500,7 +1502,7 @@ func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 	})
 }
 
-func (m *Model) localChangeDetected(folder, path string, files []protocol.FileInfo) {
+func (m *Model) localChangeDetected(folderID string, folderLabel string, path string, files []protocol.FileInfo) {
 	// For windows paths, strip unwanted chars from the front
 	path = strings.Replace(path, `\\?\`, "", 1)
 
@@ -1530,7 +1532,8 @@ func (m *Model) localChangeDetected(folder, path string, files []protocol.FileIn
 		path := filepath.Join(path, filepath.FromSlash(file.Name))
 
 		events.Default.Log(events.LocalChangeDetected, map[string]string{
-			"folder": folder,
+			"folderID": folderID,
+			"label":  folderLabel,
 			"action": action,
 			"type":   objType,
 			"path":   path,

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1465,9 +1465,10 @@ func sendIndexTo(minSequence int64, conn protocol.Connection, folder string, fs 
 func (m *Model) updateLocalsFromScanning(folder string, fs []protocol.FileInfo) {
 	m.updateLocals(folder, fs)
 
-	// Fire the LocalChangeDetected event to notify listeners about local
-	// updates.
+	// Fire the LocalChangeDetected event to notify listeners about local updates.
+	m.fmut.RLock()
 	m.localChangeDetected(m.folderCfgs[folder], fs)
+	m.fmut.RUnlock()
 }
 
 func (m *Model) updateLocalsFromPulling(folder string, fs []protocol.FileInfo) {
@@ -1499,9 +1500,7 @@ func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 
 func (m *Model) localChangeDetected(folder config.FolderConfiguration, files []protocol.FileInfo) {
 	// For windows paths, strip unwanted chars from the front
-	m.fmut.RLock()
 	path := strings.Replace(folder.Path(), `\\?\`, "", 1)
-	m.fmut.RUnlock()
 
 	for _, file := range files {
 		objType := "file"

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1501,6 +1501,8 @@ func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 }
 
 func (m *Model) localChangeDetected(folderCfg config.FolderConfiguration, files []protocol.FileInfo) {
+	path := strings.Replace(folderCfg.Path(), `\\?\`, "", 1)
+
 	for _, file := range files {
 		objType := "file"
 		action := "modified"
@@ -1525,7 +1527,7 @@ func (m *Model) localChangeDetected(folderCfg config.FolderConfiguration, files 
 
 		// The full file path, adjusted to the local path separator character.  Also
 		// for windows paths, strip unwanted chars from the front.
-		path := filepath.Join(strings.Replace(folderCfg.Path(), `\\?\`, "", 1), filepath.FromSlash(file.Name))
+		path := filepath.Join(path, filepath.FromSlash(file.Name))
 
 		events.Default.Log(events.LocalChangeDetected, map[string]string{
 			"folderID": folderCfg.ID,

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1467,12 +1467,7 @@ func (m *Model) updateLocalsFromScanning(folder string, fs []protocol.FileInfo) 
 
 	// Fire the LocalChangeDetected event to notify listeners about local
 	// updates.
-	m.fmut.RLock()
-	path := m.folderCfgs[folder].Path()
-	folderID := m.folderCfgs[folder].ID
-	folderLabel := m.folderCfgs[folder].Label
-	m.fmut.RUnlock()
-	m.localChangeDetected(folderID, folderLabel, path, fs)
+	m.localChangeDetected(m.folderCfgs[folder], fs)
 }
 
 func (m *Model) updateLocalsFromPulling(folder string, fs []protocol.FileInfo) {
@@ -1502,9 +1497,9 @@ func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 	})
 }
 
-func (m *Model) localChangeDetected(folderID string, folderLabel string, path string, files []protocol.FileInfo) {
+func (m *Model) localChangeDetected(folder config.FolderConfiguration, files []protocol.FileInfo) {
 	// For windows paths, strip unwanted chars from the front
-	path = strings.Replace(path, `\\?\`, "", 1)
+	path := strings.Replace(folder.Path(), `\\?\`, "", 1)
 
 	for _, file := range files {
 		objType := "file"
@@ -1532,8 +1527,8 @@ func (m *Model) localChangeDetected(folderID string, folderLabel string, path st
 		path := filepath.Join(path, filepath.FromSlash(file.Name))
 
 		events.Default.Log(events.LocalChangeDetected, map[string]string{
-			"folderID": folderID,
-			"label":  folderLabel,
+			"folderID": folder.ID,
+			"label":  folder.Label,
 			"action": action,
 			"type":   objType,
 			"path":   path,

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1499,7 +1499,9 @@ func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 
 func (m *Model) localChangeDetected(folder config.FolderConfiguration, files []protocol.FileInfo) {
 	// For windows paths, strip unwanted chars from the front
+	m.fmut.RLock()
 	path := strings.Replace(folder.Path(), `\\?\`, "", 1)
+	m.fmut.RUnlock()
 
 	for _, file := range files {
 		objType := "file"

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1528,10 +1528,10 @@ func (m *Model) localChangeDetected(folder config.FolderConfiguration, files []p
 
 		events.Default.Log(events.LocalChangeDetected, map[string]string{
 			"folderID": folder.ID,
-			"label":  folder.Label,
-			"action": action,
-			"type":   objType,
-			"path":   path,
+			"label":    folder.Label,
+			"action":   action,
+			"type":     objType,
+			"path":     path,
 		})
 	}
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1466,13 +1466,11 @@ func (m *Model) updateLocalsFromScanning(folder string, fs []protocol.FileInfo) 
 	m.updateLocals(folder, fs)
 
 	m.fmut.RLock()
-	folderPath := m.folderCfgs[folder].Path()
-	folderID := m.folderCfgs[folder].ID
-	folderLabel := m.folderCfgs[folder].Label
+	folderCfg := m.folderCfgs[folder]
 	m.fmut.RUnlock()
 
 	// Fire the LocalChangeDetected event to notify listeners about local updates.
-	m.localChangeDetected(folderPath, folderID, folderLabel, fs)
+	m.localChangeDetected(folderCfg, fs)
 }
 
 func (m *Model) updateLocalsFromPulling(folder string, fs []protocol.FileInfo) {
@@ -1502,7 +1500,7 @@ func (m *Model) updateLocals(folder string, fs []protocol.FileInfo) {
 	})
 }
 
-func (m *Model) localChangeDetected(folderPath string, folderID string, folderLabel string, files []protocol.FileInfo) {
+func (m *Model) localChangeDetected(folderCfg config.FolderConfiguration, files []protocol.FileInfo) {
 	for _, file := range files {
 		objType := "file"
 		action := "modified"
@@ -1527,11 +1525,11 @@ func (m *Model) localChangeDetected(folderPath string, folderID string, folderLa
 
 		// The full file path, adjusted to the local path separator character.  Also
 		// for windows paths, strip unwanted chars from the front.
-		path := filepath.Join(strings.Replace(folderPath, `\\?\`, "", 1), filepath.FromSlash(file.Name))
+		path := filepath.Join(strings.Replace(folderCfg.Path(), `\\?\`, "", 1), filepath.FromSlash(file.Name))
 
 		events.Default.Log(events.LocalChangeDetected, map[string]string{
-			"folderID": folderID,
-			"label":    folderLabel,
+			"folderID": folderCfg.ID,
+			"label":    folderCfg.Label,
 			"action":   action,
 			"type":     objType,
 			"path":     path,

--- a/test/http_test.go
+++ b/test/http_test.go
@@ -27,6 +27,7 @@ var jsonEndpoints = []string{
 	"/rest/db/status?folder=default",
 	"/rest/db/browse?folder=default",
 	"/rest/events?since=-1&limit=5",
+	"/rest/events/disk?since=-1&limit=5",
 	"/rest/stats/device",
 	"/rest/stats/folder",
 	"/rest/svc/deviceid?id=I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU",


### PR DESCRIPTION
### Purpose

Adds a URL handler for the 'LocalDiskChange' events, so it has it's own buffered subscription.

### Testing

curl -H "X-API-Key: Z0mgS3cr3tAPIkey" http://localhost:8384/rest/events/disk | yourfavjsonprettyprinter

### Documentation

This should keep the main events sub from getting polluted with local disk change events and vice versa.  Also it gives people a programmatic way to view what files were modified on what server by polling each nodes API service (Of course they would need to set nodes to listen on 0.0.0.0 instead of 127.0.0.1 first and prob would then want to set SSL as well).  So if someone were to create a program that gathered all that data to create a global log, they could.

### Authorship

Nate Morrison (nrm21)