### PR TITLE
there is no network.target for user instances

### DIFF
--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Syncthing - Open Source Continuous File Synchronization
 Documentation=man:syncthing(1)
-After=network.target
 Wants=syncthing-inotify.service
 
 [Service]


### PR DESCRIPTION
### Purpose

network.target is only available to system services and not user services so there is no point specifying a dependency.

Further to: https://github.com/syncthing/syncthing-inotify/pull/130

### Testing

The previous depedency never worked - it was silently dropped. It runs fine here with and without.

### Screenshots

n/a

### Documentation

n/a
