### PR TITLE
Add support to TLS renegotiation

### DIFF
--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -89,6 +89,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister) (Fin
 			Proxy: http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: opts.insecure,
+				Renegotiation: tls.RenegotiateFreelyAsClient,
 				Certificates:       []tls.Certificate{cert},
 			},
 		},


### PR DESCRIPTION
I have the discovery server running in http mode behind SSL-secured apache.
Configuration as:
```
        <Location /v2>
                SSLVerifyClient optional_no_ca
        </Location>
        RequestHeader set X-SSL-Cert "%{SSL_CLIENT_CERT}s"
        ProxyPass /ping http://127.0.0.1:8484/ping
        ProxyPass /v2 http://127.0.0.1:8484/v2
```
This case cause tls renegotiation, and announceClient will failed with "tls: no renegotiation"

The change require Go 1.7.1 or higher to compile. Refer to [crypto/tls: does not support renegotiation #5742](https://github.com/golang/go/issues/5742)
