### PR TITLE
Ignore pkill error on resume

### DIFF
--- a/etc/linux-systemd/system/syncthing-resume.service
+++ b/etc/linux-systemd/system/syncthing-resume.service
@@ -5,7 +5,7 @@ After=suspend.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/pkill -HUP -x syncthing
+ExecStart=-/usr/bin/pkill -HUP -x syncthing
 
 [Install]
 WantedBy=suspend.target


### PR DESCRIPTION
### Purpose

The ```syncthing-resume.service``` will show as a failed service in case
there are no syncthing processes running after resume but it can be
safely ignored because it makes no difference.

### Testing

1. On a Linux distribution with systemd
2. Make sure all syncthing processes are stopped
3. Suspend
4. Resume
5. ```systemctl status syncthing-resume```

You will see an error.

With this patch applied, the service is no longer in a failed state.
