### PR TITLE
Update to accept relay clients listening on all interfaces

### DIFF
--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -326,7 +326,7 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ip = net.ParseIP(host)
+	ip := net.ParseIP(host)
 	// The client did not provide an IP address, use the IP address of the client.
 	if ip == nil || ip.IsUnspecified() {
 		uri.Host = net.JoinHostPort(rhost, port)

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -287,6 +287,7 @@ func handleGetRequest(w http.ResponseWriter, r *http.Request) {
 
 func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	var newRelay relay
+	var ip net.IP
 	err := json.NewDecoder(r.Body).Decode(&newRelay)
 	r.Body.Close()
 
@@ -326,8 +327,9 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	ip = net.ParseIP(host)
 	// The client did not provide an IP address, use the IP address of the client.
-	if host == "" || host == "0.0.0.0" {
+	if host == "" || ip.IsUnspecified() {
 		uri.Host = net.JoinHostPort(rhost, port)
 		newRelay.URL = uri.String()
 	} else if host != rhost {

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -327,7 +327,7 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The client did not provide an IP address, use the IP address of the client.
-	if host == "" {
+	if host == "" && host == "0.0.0.0" {
 		uri.Host = net.JoinHostPort(rhost, port)
 		newRelay.URL = uri.String()
 	} else if host != rhost {

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -327,7 +327,7 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// The client did not provide an IP address, use the IP address of the client.
-	if host == "" && host == "0.0.0.0" {
+	if host == "" || host == "0.0.0.0" {
 		uri.Host = net.JoinHostPort(rhost, port)
 		newRelay.URL = uri.String()
 	} else if host != rhost {

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -287,7 +287,6 @@ func handleGetRequest(w http.ResponseWriter, r *http.Request) {
 
 func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	var newRelay relay
-	var ip net.IP
 	err := json.NewDecoder(r.Body).Decode(&newRelay)
 	r.Body.Close()
 
@@ -329,7 +328,7 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 
 	ip = net.ParseIP(host)
 	// The client did not provide an IP address, use the IP address of the client.
-	if host == "" || ip.IsUnspecified() {
+	if ip == nil || ip.IsUnspecified() {
 		uri.Host = net.JoinHostPort(rhost, port)
 		newRelay.URL = uri.String()
 	} else if host != rhost {


### PR DESCRIPTION
Update to accept relay clients listening on all interfaces  …

Listening on all interfaces is the default behavior of running the relay server without any parameters.
This commit will allow those clients to connect instead of rejecting them with a HTTP-401.