### PR TITLE
 lib/osutil: Prevent infinite Glob recursion (fixes #3577)

### DIFF
--- a/lib/osutil/glob_windows.go
+++ b/lib/osutil/glob_windows.go
@@ -26,7 +26,7 @@ func Glob(pattern string) (matches []string, err error) {
 		return []string{pattern}, nil
 	}
 
-	dir, file := filepath.Split(pattern)
+	dir, file := filepath.Split(filepath.Clean(pattern))
 	switch dir {
 	case "":
 		dir = "."

--- a/lib/osutil/glob_windows_test.go
+++ b/lib/osutil/glob_windows_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build windows
+
+package osutil_test
+
+import (
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/osutil"
+)
+
+func TestGlob(t *testing.T) {
+	testcases := []string{
+		`C:\*`,
+		`\\?\C:\*`,
+		`\\?\C:\Users`,
+		`\\?\\\?\C:\Users`,
+	}
+	for _, tc := range testcases {
+		if _, err := osutil.Glob(tc); err != nil {
+			t.Fatalf("pattern %s failed: %v", tc, err)
+		}
+	}
+}


### PR DESCRIPTION
This prevents filepath.Split(pattern) from returning the same `dir` value as `pattern` which cause infinite recursion on bad input.

### Testing

In GUI, click "Add folder".
In folder path type: \\\\?\C:\Users
