### PR TITLE
lib/ignore: Add directory separator to glob.Compile call

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -279,14 +279,14 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 		var err error
 		if strings.HasPrefix(line, "/") {
 			// Pattern is rooted in the current dir only
-			pattern.match, err = glob.Compile(line[1:])
+			pattern.match, err = glob.Compile(line[1:], '/')
 			if err != nil {
 				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
 			}
 			patterns = append(patterns, pattern)
 		} else if strings.HasPrefix(line, "**/") {
 			// Add the pattern as is, and without **/ so it matches in current dir
-			pattern.match, err = glob.Compile(line)
+			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
 				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
 			}
@@ -294,7 +294,7 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 
 			line = line[3:]
 			pattern.pattern = line
-			pattern.match, err = glob.Compile(line)
+			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
 				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
 			}
@@ -310,7 +310,7 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 		} else {
 			// Path name or pattern, add it so it matches files both in
 			// current directory and subdirs.
-			pattern.match, err = glob.Compile(line)
+			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
 				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
 			}
@@ -318,7 +318,7 @@ func parseIgnoreFile(fd io.Reader, currentFile string, seen map[string]bool) ([]
 
 			line := "**/" + line
 			pattern.pattern = line
-			pattern.match, err = glob.Compile(line)
+			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
 				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
 			}

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -737,3 +737,35 @@ func TestIssue3639(t *testing.T) {
 		t.Error("Should not match 'foo'")
 	}
 }
+
+func TestIssue3674(t *testing.T) {
+	stignore := `
+	a*b
+	a**c
+	`
+
+	testcases := []struct {
+		file    string
+		matches bool
+	}{
+		{"ab", true},
+		{"asdfb", true},
+		{"ac", true},
+		{"asdfc", true},
+		{"as/db", false},
+		{"as/dc", true},
+	}
+
+	pats := New(true)
+	err := pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testcases {
+		res := pats.Match(tc.file).IsIgnored()
+		if res != tc.matches {
+			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
+		}
+	}
+}


### PR DESCRIPTION
The current implementation of [gobwas/glob](https://github.com/gobwas/glob) in lib/ignore does not account for directory separators ('/'). Thus the distinction between '\*' and '\*\*' is meaningless. Currently both the patterns 'a\*b' and 'a\*\*b' match the path 'a/b'.

I confirmed the current behavior looking at the last file received entry in the GUI. But as I am only familiar with syncthing-inotify and it uses lib/ignore for its filtering as well, I tested this PR with debug information from syncthing-inotify. The test setup is trivial, just put something like the strings mentioned into .stignore.