### PR TITLE
gui: update translation

### DIFF
--- a/gui/default/assets/lang/lang-zh-CN.json
+++ b/gui/default/assets/lang/lang-zh-CN.json
@@ -122,7 +122,7 @@
     "Out of Sync": "未同步",
     "Out of Sync Items": "未同步的项目",
     "Outgoing Rate Limit (KiB/s)": "上传速度限制 (KiB/s)",
-    "Override Changes": "撤销改变",
+    "Override Changes": "接受其他设备的修改",
     "Path to the folder on the local computer. Will be created if it does not exist. The tilde character (~) can be used as a shortcut for": "文件夹在本地的路径。如果不存在，则会被创建。波浪线符号（~）是如下路径的缩略符：",
     "Path where versions should be stored (leave empty for the default .stversions folder in the folder).": "用来存储历史版本的文件夹（留空则将默认会存储在.stversions文件夹中）",
     "Pause": "暂停",


### PR DESCRIPTION
### Purpose

With reference to the context and translation in other languages,
"Override changes"  means the folder changed on other device(s),
user choose to accept the changes,
and override to the local master folder.
"撤销改变" means "Revert changes",
is not a proper translation.
So I modify the translation,
"接受其他设备的修改" means
"accept changes from other devices",
which I think most close to the original meaning.

### Testing

gui : translation change only.