### PR TITLE
Remove focus outline on active panel header (fixes #3684)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -50,6 +50,10 @@ ul+h5 {
     word-wrap:break-word;
 }
 
+.btn:focus {
+    outline: 0;
+}
+
 .text-monospace {
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }


### PR DESCRIPTION
Remove focus outline on active panel header (webkit browsers, e.g. Chrome)