### PR TITLE
Added ufw firewall application preset (again)

### DIFF
--- a/build.go
+++ b/build.go
@@ -95,6 +95,7 @@ var targets = map[string]target{
 			{src: "etc/linux-systemd/system/syncthing@.service", dst: "deb/lib/systemd/system/syncthing@.service", perm: 0644},
 			{src: "etc/linux-systemd/system/syncthing-resume.service", dst: "deb/lib/systemd/system/syncthing-resume.service", perm: 0644},
 			{src: "etc/linux-systemd/user/syncthing.service", dst: "deb/usr/lib/systemd/user/syncthing.service", perm: 0644},
+			{src: "etc/firewall-ufw/syncthing", dst: "deb/etc/ufw/applications.d/syncthing", perm: 0644},
 		},
 	},
 	"stdiscosrv": {

--- a/etc/firewall-ufw/README.md
+++ b/etc/firewall-ufw/README.md
@@ -1,0 +1,22 @@
+Uncomplicated FireWall application preset
+===================
+Installation
+-----------
+**Please note:** When you installed syncthing using the official deb package, you can skip the copying.
+
+Copy the file `syncthing` to your ufw applications directory usually located at `/etc/ufw/applications.d/`. (root permissions required).
+
+In a terminal run
+```
+sudo ufw app update syncthing
+```
+to load the preset.
+To allow the syncthing ports, run
+```
+sudo ufw allow syncthing
+```
+You can then verify the opened ports
+```
+sudo ufw status verbose
+```
+

--- a/etc/firewall-ufw/syncthing
+++ b/etc/firewall-ufw/syncthing
@@ -1,0 +1,4 @@
+[syncthing]
+title=Syncthing
+description=Syncthing file synchronisation
+ports=22000/tcp|21027/udp


### PR DESCRIPTION
This adds the firewall preset that was removed in 19bf51cefb2e2add0fc32952faf77a7c54d11bc3 due to [problems with the upgrade system](https://github.com/syncthing/syncthing/issues/2446). 
See Pull request #2440 and issue #2435 for more details.
As stated [here](https://github.com/syncthing/syncthing/pull/2440#issuecomment-188584542) by @calmh this should be safe to re-add now.