### PR TITLE
Build the snaps for armhf and arm64

### DIFF
--- a/build.go
+++ b/build.go
@@ -539,8 +539,8 @@ func buildSnap(target target) {
 	}
 
 	snaparch := goarch
-	if goarch == "arm" {
-		snaparch = "armhf"
+	if snaparch == "armhf" {
+		goarch = "arm"
 	}	
 	err = tmpl.Execute(f, map[string]string{
 		"Version": version,

--- a/build.go
+++ b/build.go
@@ -526,6 +526,8 @@ func buildDeb(target target) {
 }
 
 func buildSnap(target target) {
+	os.RemoveAll("snap")
+	
 	tmpl, err := template.ParseFiles("snapcraft.yaml.template")
 	if err != nil {
 		log.Fatal(err)
@@ -535,7 +537,12 @@ func buildSnap(target target) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	err = tmpl.Execute(f, map[string]string{"Version": version})
+	err = tmpl.Execute(f, map[string]string{
+		"Version": version,
+		"Architecture": goarch})
+	if err != nil {
+		log.Fatal(err)
+	}
 	runPrint("snapcraft", "clean")
 	build(target, []string{"noupgrade"})
 	runPrint("snapcraft")

--- a/build.go
+++ b/build.go
@@ -537,9 +537,14 @@ func buildSnap(target target) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	snaparch := goarch
+	if goarch == "arm" {
+		snaparch = "armhf"
+	}	
 	err = tmpl.Execute(f, map[string]string{
 		"Version": version,
-		"Architecture": goarch})
+		"Architecture": snaparch})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/jenkins/build-linux.bash
+++ b/jenkins/build-linux.bash
@@ -51,6 +51,7 @@ go run build.go -goarch armhf deb
 mv *.deb "$WORKSPACE"
 
 go run build.go -goarch amd64 snap
+go run build.go -goarch armhf snap
+go run build.go -goarch arm64 snap
 
 mv *.snap "$WORKSPACE"
-

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -6,6 +6,7 @@ description: |
   trustworthy and decentralized. Your data is your data alone and you deserve
   to choose where it is stored, if it is shared with some third party and how
   it's transmitted over the Internet.
+architectures: [{{.Architecture}}]
 
 grade: devel
 confinement: strict


### PR DESCRIPTION
### Purpose

Support building snaps for armhf and arm64.

### Testing

I built the snaps in a xenial lxc with:
go run build.go -goarch armhf snap
go run build.go -goarch arm64 snap
 
Then tested the armhf in an raspberrypi2 and arm64 in a dragonboard 410c, both with ubuntu core snappy images.

### Documentation

There are no docs for building debs, so I haven't written anything yet about building snaps. However, I think a new section should be added for this. I can do it in a follow up branch.

