### PR TITLE
lib/config: Subscribers get a copy of the config

### DIFF
--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -159,7 +159,7 @@ func (w *Wrapper) replaceLocked(to Configuration) error {
 
 func (w *Wrapper) notifyListeners(from, to Configuration) {
 	for _, sub := range w.subs {
-		go w.notifyListener(sub, from, to)
+		go w.notifyListener(sub, from.Copy(), to.Copy())
 	}
 }
 


### PR DESCRIPTION
As notifications are not under a lock, and the config might be modified as subscribers access it.
Plus, from the API perspective people might modify it locally for some reason, affecting the value others get.


I believe this solves the race in de-introduction stuff, so we can revert the revert.