### PR TITLE
build: Snap versions should not have initial "v"

### DIFF
--- a/build.go
+++ b/build.go
@@ -527,7 +527,7 @@ func buildDeb(target target) {
 
 func buildSnap(target target) {
 	os.RemoveAll("snap")
-	
+
 	tmpl, err := template.ParseFiles("snapcraft.yaml.template")
 	if err != nil {
 		log.Fatal(err)
@@ -541,9 +541,13 @@ func buildSnap(target target) {
 	snaparch := goarch
 	if snaparch == "armhf" {
 		goarch = "arm"
-	}	
+	}
+	snapver := version
+	if strings.HasPrefix(snapver, "v") {
+		snapver = snapver[1:]
+	}
 	err = tmpl.Execute(f, map[string]string{
-		"Version": version,
+		"Version":      snapver,
 		"Architecture": snaparch})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
To get a build server build of this... Also build.go is apparently not covered by gofmt guarantee, will fix that.