### PR TITLE
Set the sync home to SNAP_USER_COMMON

### DIFF
--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -13,7 +13,7 @@ confinement: strict
 
 apps:
   syncthing:
-    command: syncthing
+    command: syncthing -home $SNAP_USER_COMMON
     plugs: [home, network, network-bind]
 
 parts:

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -13,7 +13,7 @@ confinement: strict
 
 apps:
   syncthing:
-    command: syncthing -home $SNAP_USER_COMMON
+    command: env HOME=$SNAP_USER_COMMON $SNAP/syncthing
     plugs: [home, network, network-bind]
 
 parts:


### PR DESCRIPTION
### Purpose

Set the home to a path that's not versioned with snap updates.

### Testing

Installed in a kvm, and confirm that the sync path is now in $HOME/snap/syncthing/common

### Documentation

When we document the snap, we need to mention the sync path. I prefer to give a little testing on edge before documenting, because things are likely to change.

