### PR TITLE
lib/model: Minor cleanup to not fondle cfg.Raw things in handleDeintroductions

### DIFF
--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -209,6 +209,27 @@ func (w *Wrapper) SetDevice(dev DeviceConfiguration) error {
 	return w.replaceLocked(newCfg)
 }
 
+// RemoveDevice removes the device from the configuration
+func (w *Wrapper) RemoveDevice(id protocol.DeviceID) error {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+
+	newCfg := w.cfg.Copy()
+	removed := false
+	for i := range newCfg.Devices {
+		if newCfg.Devices[i].DeviceID == id {
+			newCfg.Devices = append(newCfg.Devices[:i], newCfg.Devices[i+1:]...)
+			removed = true
+			break
+		}
+	}
+	if !removed {
+		return nil
+	}
+
+	return w.replaceLocked(newCfg)
+}
+
 // Folders returns a map of folders. Folder structures should not be changed,
 // other than for the purpose of updating via SetFolder().
 func (w *Wrapper) Folders() map[string]FolderConfiguration {


### PR DESCRIPTION
### Purpose

This is a bit cleaner in my opinion as it avoid pulling in a RawCopy and uses the existing methods to iterate over devices. Adds a new `RemoveDevice` on the config wrapper, similar to `SetDevice`, which abstracts away the copying and replacing stuff.

### Testing

Same as always...