### PR TITLE
Remove arbitrary fsync

### DIFF
--- a/lib/osutil/osutil.go
+++ b/lib/osutil/osutil.go
@@ -172,10 +172,7 @@ func copyFileContents(src, dst string) (err error) {
 			err = cerr
 		}
 	}()
-	if _, err = io.Copy(out, in); err != nil {
-		return
-	}
-	err = out.Sync()
+	_, err = io.Copy(out, in)
 	return
 }
 


### PR DESCRIPTION
Fsyncing the file has a small performance penalty and seems unnecessary.
The file will be fsynced anyway, when the changes are commited to the database.