### PR TITLE
cmd/syncthing: Make the default folder default again

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -955,9 +955,8 @@ func defaultConfig(myName string) config.Configuration {
 
 	if !noDefaultFolder {
 		l.Infoln("Default folder created and/or linked to new config")
-		folderID := strings.ToLower(rand.String(5) + "-" + rand.String(5))
-		defaultFolder = config.NewFolderConfiguration(folderID, locations[locDefFolder])
-		defaultFolder.Label = "Default Folder (" + folderID + ")"
+		defaultFolder = config.NewFolderConfiguration("default", locations[locDefFolder])
+		defaultFolder.Label = "Default Folder"
 		defaultFolder.RescanIntervalS = 60
 		defaultFolder.MinDiskFreePct = 1
 		defaultFolder.Devices = []config.FolderDeviceConfiguration{{DeviceID: myID}}


### PR DESCRIPTION
The current way is quite confusing for new users - we create a default folder, but it's not usable with the default folder created somewhere else. Instead, when setting up for the first time with two devices, the default folder must be removed and recreated on one of them. This comes up on IRC and the forum now and then.

I think this matches expectactions better.

Another alternative would be to remove it entirely (not create a default folder), but then we should also add some guidance in the UI on how to proceed.

Relates to, for example, https://github.com/syncthing/docs/pull/250