### PR TITLE
model: consistently use cfg when referring to config instance and not…

### DIFF
--- a/lib/model/rofolder.go
+++ b/lib/model/rofolder.go
@@ -22,11 +22,11 @@ type roFolder struct {
 	folder
 }
 
-func newROFolder(model *Model, config config.FolderConfiguration, _ versioner.Versioner, _ *fs.MtimeFS) service {
+func newROFolder(model *Model, cfg config.FolderConfiguration, _ versioner.Versioner, _ *fs.MtimeFS) service {
 	return &roFolder{
 		folder: folder{
-			stateTracker: newStateTracker(config.ID),
-			scan:         newFolderScanner(config),
+			stateTracker: newStateTracker(cfg.ID),
+			scan:         newFolderScanner(cfg),
 			stop:         make(chan struct{}),
 			model:        model,
 		},

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -143,7 +143,7 @@ func newRWFolder(model *Model, cfg config.FolderConfiguration, ver versioner.Ver
 	return f
 }
 
-func (f *rwFolder) configureCopiersAndPullers(config config.FolderConfiguration) {
+func (f *rwFolder) configureCopiersAndPullers(cfg config.FolderConfiguration) {
 	if f.copiers == 0 {
 		f.copiers = defaultCopiers
 	}
@@ -151,16 +151,16 @@ func (f *rwFolder) configureCopiersAndPullers(config config.FolderConfiguration)
 		f.pullers = defaultPullers
 	}
 
-	if config.PullerPauseS == 0 {
+	if cfg.PullerPauseS == 0 {
 		f.pause = defaultPullerPause
 	} else {
-		f.pause = time.Duration(config.PullerPauseS) * time.Second
+		f.pause = time.Duration(cfg.PullerPauseS) * time.Second
 	}
 
-	if config.PullerSleepS == 0 {
+	if cfg.PullerSleepS == 0 {
 		f.sleep = defaultPullerSleep
 	} else {
-		f.sleep = time.Duration(config.PullerSleepS) * time.Second
+		f.sleep = time.Duration(cfg.PullerSleepS) * time.Second
 	}
 }
 


### PR DESCRIPTION
This is just minor polish:
I noticed that both  `cfg` and `config` are used as variable names for config.*** instances in rofolder.go and rwfolder.go. This PR makes the naming consistent by always using `cfg`.