### PR TITLE
gui: bottom nav always behind dropdown (fixes #3758)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -249,6 +249,10 @@ ul.three-columns li, ul.two-columns li {
     text-indent: -0.5em;
 }
 
+.navbar-fixed-bottom {
+    z-index: 980;
+}
+
 /** Footer nav on small devices **/
 @media (max-width: 1199px) {
     /* Stay at the end of the page, with space reserved for the footer


### PR DESCRIPTION
### Purpose

Lower the z-index of `.navbar-fixed-bottom` to be behind menu dropdowns.

`.dropdown-menu` has `z-index 1000` and `.dropdown-backdrop` has `z-index: 990`. There is no `z-index` between `2` and `990`, to setting it to `980` for `.navbar-fixed-bottom` doesn't change anything else.