### PR TITLE
cmd/syncthing: Trigger usage message on extra CLI parameters

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -278,6 +278,11 @@ func parseCommandLineOptions() RuntimeOptions {
 	flag.Usage = usageFor(flag.CommandLine, usage, longUsage)
 	flag.Parse()
 
+	if len(flag.Args()) > 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
 	return options
 }
 


### PR DESCRIPTION
fixes: #3690