### PR TITLE
lib/connections, lib/model: Connection service should expose a single interface

### DIFF
--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -30,7 +30,7 @@ type relayListener struct {
 
 	uri     *url.URL
 	tlsCfg  *tls.Config
-	conns   chan IntermediateConnection
+	conns   chan internalConn
 	factory listenerFactory
 
 	err    error
@@ -93,7 +93,7 @@ func (t *relayListener) Serve() {
 				continue
 			}
 
-			t.conns <- IntermediateConnection{tc, "Relay (Server)", relayPriority}
+			t.conns <- internalConn{tc, connTypeRelayServer, relayPriority}
 
 		// Poor mans notifier that informs the connection service that the
 		// relay URI has changed. This can only happen when we connect to a
@@ -167,7 +167,7 @@ func (t *relayListener) String() string {
 
 type relayListenerFactory struct{}
 
-func (f *relayListenerFactory) New(uri *url.URL, cfg *config.Wrapper, tlsCfg *tls.Config, conns chan IntermediateConnection, natService *nat.Service) genericListener {
+func (f *relayListenerFactory) New(uri *url.URL, cfg *config.Wrapper, tlsCfg *tls.Config, conns chan internalConn, natService *nat.Service) genericListener {
 	return &relayListener{
 		uri:     uri,
 		tlsCfg:  tlsCfg,

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -9,6 +9,7 @@ package connections
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/url"
 	"time"
@@ -18,19 +19,61 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
-type IntermediateConnection struct {
-	*tls.Conn
-	Type     string
-	Priority int
+// Connection is what we expose to the outside. It is a protocol.Connection
+// that can be closed and has some metadata.
+type Connection interface {
+	protocol.Connection
+	io.Closer
+	Type() string
+	RemoteAddr() net.Addr
 }
 
-type Connection struct {
-	IntermediateConnection
+// completeConn is the aggregation of an internalConn and the
+// protocol.Connection running on top of it. It implements the Connection
+// interface.
+type completeConn struct {
+	internalConn
 	protocol.Connection
 }
 
-func (c Connection) String() string {
-	return fmt.Sprintf("%s-%s/%s", c.LocalAddr(), c.RemoteAddr(), c.Type)
+// internalConn is the raw TLS connection plus some metadata on where it
+// came from (type, priority).
+type internalConn struct {
+	*tls.Conn
+	connType connType
+	priority int
+}
+
+type connType int
+
+const (
+	connTypeRelayClient connType = iota
+	connTypeRelayServer
+	connTypeTCPClient
+	connTypeTCPServer
+)
+
+func (t connType) String() string {
+	switch t {
+	case connTypeRelayClient:
+		return "relay-client"
+	case connTypeRelayServer:
+		return "relay-server"
+	case connTypeTCPClient:
+		return "tcp-client"
+	case connTypeTCPServer:
+		return "tcp-server"
+	default:
+		return "unknown-type"
+	}
+}
+
+func (c internalConn) Type() string {
+	return c.connType.String()
+}
+
+func (c internalConn) String() string {
+	return fmt.Sprintf("%s-%s/%s", c.LocalAddr(), c.RemoteAddr(), c.connType.String())
 }
 
 type dialerFactory interface {
@@ -41,12 +84,12 @@ type dialerFactory interface {
 }
 
 type genericDialer interface {
-	Dial(protocol.DeviceID, *url.URL) (IntermediateConnection, error)
+	Dial(protocol.DeviceID, *url.URL) (internalConn, error)
 	RedialFrequency() time.Duration
 }
 
 type listenerFactory interface {
-	New(*url.URL, *config.Wrapper, *tls.Config, chan IntermediateConnection, *nat.Service) genericListener
+	New(*url.URL, *config.Wrapper, *tls.Config, chan internalConn, *nat.Service) genericListener
 	Enabled(config.Configuration) bool
 }
 

--- a/lib/connections/tcp_dial.go
+++ b/lib/connections/tcp_dial.go
@@ -30,23 +30,23 @@ type tcpDialer struct {
 	tlsCfg *tls.Config
 }
 
-func (d *tcpDialer) Dial(id protocol.DeviceID, uri *url.URL) (IntermediateConnection, error) {
+func (d *tcpDialer) Dial(id protocol.DeviceID, uri *url.URL) (internalConn, error) {
 	uri = fixupPort(uri)
 
 	conn, err := dialer.DialTimeout(uri.Scheme, uri.Host, 10*time.Second)
 	if err != nil {
 		l.Debugln(err)
-		return IntermediateConnection{}, err
+		return internalConn{}, err
 	}
 
 	tc := tls.Client(conn, d.tlsCfg)
 	err = tlsTimedHandshake(tc)
 	if err != nil {
 		tc.Close()
-		return IntermediateConnection{}, err
+		return internalConn{}, err
 	}
 
-	return IntermediateConnection{tc, "TCP (Client)", tcpPriority}, nil
+	return internalConn{tc, connTypeTCPClient, tcpPriority}, nil
 }
 
 func (d *tcpDialer) RedialFrequency() time.Duration {

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -32,7 +32,7 @@ type tcpListener struct {
 	uri     *url.URL
 	tlsCfg  *tls.Config
 	stop    chan struct{}
-	conns   chan IntermediateConnection
+	conns   chan internalConn
 	factory listenerFactory
 
 	natService *nat.Service
@@ -115,7 +115,7 @@ func (t *tcpListener) Serve() {
 			continue
 		}
 
-		t.conns <- IntermediateConnection{tc, "TCP (Server)", tcpPriority}
+		t.conns <- internalConn{tc, connTypeTCPServer, tcpPriority}
 	}
 }
 
@@ -173,7 +173,7 @@ func (t *tcpListener) Factory() listenerFactory {
 
 type tcpListenerFactory struct{}
 
-func (f *tcpListenerFactory) New(uri *url.URL, cfg *config.Wrapper, tlsCfg *tls.Config, conns chan IntermediateConnection, natService *nat.Service) genericListener {
+func (f *tcpListenerFactory) New(uri *url.URL, cfg *config.Wrapper, tlsCfg *tls.Config, conns chan internalConn, natService *nat.Service) genericListener {
 	return &tcpListener{
 		uri:        fixupPort(uri),
 		tlsCfg:     tlsCfg,

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -412,7 +412,7 @@ func (m *Model) ConnectionStats() map[string]interface{} {
 			Paused:        m.devicePaused[device],
 		}
 		if conn, ok := m.conn[device]; ok {
-			ci.Type = conn.Type
+			ci.Type = conn.Type()
 			ci.Connected = ok
 			ci.Statistics = conn.Statistics()
 			if addr := conn.RemoteAddr(); addr != nil {
@@ -1334,7 +1334,7 @@ func (m *Model) AddConnection(conn connections.Connection, hello protocol.HelloR
 		"deviceName":    hello.DeviceName,
 		"clientName":    hello.ClientName,
 		"clientVersion": hello.ClientVersion,
-		"type":          conn.Type,
+		"type":          conn.Type(),
 	}
 
 	addr := conn.RemoteAddr()

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -107,7 +107,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 		TempIndexMinBlocks:      10,
 	})
 
-	fc := &FakeConnection{}
+	fc := &fakeConnection{}
 
 	p := NewProgressEmitter(c)
 	p.temporaryIndexSubscribe(fc, []string{"folder", "folder2"})


### PR DESCRIPTION
### Purpose

Makes testing easier, which we'll need.