### PR TITLE
lib/protocol: Apply input filtering on file names

### DIFF
--- a/lib/protocol/nativemodel_windows.go
+++ b/lib/protocol/nativemodel_windows.go
@@ -6,29 +6,64 @@ package protocol
 
 // Windows uses backslashes as file separator
 
-import "path/filepath"
+import (
+	"path/filepath"
+	"strings"
+)
 
 type nativeModel struct {
 	Model
 }
 
 func (m nativeModel) Index(deviceID DeviceID, folder string, files []FileInfo) {
-	fixupFiles(folder, files)
+	files = fixupFiles(files)
 	m.Model.Index(deviceID, folder, files)
 }
 
 func (m nativeModel) IndexUpdate(deviceID DeviceID, folder string, files []FileInfo) {
-	fixupFiles(folder, files)
+	files = fixupFiles(files)
 	m.Model.IndexUpdate(deviceID, folder, files)
 }
 
 func (m nativeModel) Request(deviceID DeviceID, folder string, name string, offset int64, hash []byte, fromTemporary bool, buf []byte) error {
+	if strings.Contains(name, `\`) {
+		l.Warnln("Dropping request for %s, contains invalid path separator", name)
+		return ErrNoSuchFile
+	}
+
 	name = filepath.FromSlash(name)
 	return m.Model.Request(deviceID, folder, name, offset, hash, fromTemporary, buf)
 }
 
-func fixupFiles(folder string, files []FileInfo) {
+func fixupFiles(files []FileInfo) []FileInfo {
+	var out []FileInfo
 	for i := range files {
+		if strings.Contains(files[i].Name, `\`) {
+			l.Warnln("Dropping index entry for %s, contains invalid path separator", files[i].Name)
+			if out == nil {
+				// Most incoming updates won't contain anything invalid, so
+				// we delay the allocation and copy to output slice until we
+				// really need to do it, then copy all the so-far valid
+				// files to it.
+				out = make([]FileInfo, i, len(files)-1)
+				copy(out, files)
+			}
+			continue
+		}
+
+		// Fixup the path separators
 		files[i].Name = filepath.FromSlash(files[i].Name)
+
+		if out != nil {
+			out = append(out, files[i])
+		}
 	}
+
+	if out != nil {
+		// We did some filtering
+		return out
+	}
+
+	// Unchanged
+	return files
 }

--- a/lib/protocol/nativemodel_windows_test.go
+++ b/lib/protocol/nativemodel_windows_test.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2016 The Protocol Authors.
+
+package protocol
+
+import "testing"
+import "reflect"
+
+func TestFixupFiles(t *testing.T) {
+	files := []FileInfo{
+		{Name: "foo/bar"},
+		{Name: `foo\bar`},
+		{Name: "foo/baz"},
+		{Name: "foo/quux"},
+		{Name: `foo\fail`},
+	}
+
+	// Filenames should be slash converted, except files which already have
+	// backslashes in them which are instead filtered out.
+	expected := []FileInfo{
+		{Name: `foo\bar`},
+		{Name: `foo\baz`},
+		{Name: `foo\quux`},
+	}
+
+	fixed := fixupFiles(files)
+	if !reflect.DeepEqual(fixed, expected) {
+		t.Errorf("Got %v, expected %v", fixed, expected)
+	}
+}

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -59,7 +59,6 @@ var (
 	errUnknownMessage       = errors.New("unknown message")
 	errInvalidFilename      = errors.New("filename is invalid")
 	errUncleanFilename      = errors.New("filename not in canonical format")
-	errInternalFilename     = errors.New("filename is internal")
 )
 
 type Model interface {


### PR DESCRIPTION
### Purpose

Stricter filtering of incoming filenames. Essentially, names on the wire should be in canonical shortest possible form -- no internal `.` or `..` components, no double slashes, not be one of `.` or `..`, not be absolute (start with `/`), not end with `/`, not start with `../`, and not be empty.

(.stignore and similar special files should not be served, but it is not a *protocol* error to talk about them, it's a Syncthing specific limitation that we will not serve them. Coming in another PR.)

On Windows, files in index messages containing backslashes are filtered out with a warning. Requests for such files get an error return and a warning logged.

### Testing

The filter methods have some unit tests on them.

### Documentation

Requires additions to the spec to explain the restrictions we apply here.

@Unrud for review.
