### PR TITLE
lib/model: Double check results in filepath.Join where needed

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -119,6 +119,7 @@ var (
 	errDeviceUnknown       = errors.New("unknown device")
 	errDevicePaused        = errors.New("device is paused")
 	errDeviceIgnored       = errors.New("device is ignored")
+	errNotRelative         = errors.New("not a relative path")
 )
 
 // NewModel creates and starts a new model. The model starts in read-only mode,
@@ -1105,12 +1106,15 @@ func (m *Model) Request(deviceID protocol.DeviceID, folder, name string, offset 
 	//     4. Eliminate .. elements that begin a rooted path:
 	//        that is, replace "/.." by "/" at the beginning of a path,
 	//        assuming Separator is '/'.
-	fn := filepath.Join(folderPath, name)
-
-	if !strings.HasPrefix(fn, folderPath) {
+	fn, err := rootedJoinedPath(folderPath, name)
+	if err != nil {
 		// Request tries to escape!
 		l.Debugf("%v Invalid REQ(in) tries to escape: %s: %q / %q o=%d s=%d", m, deviceID, folder, name, offset, len(buf))
 		return protocol.ErrInvalid
+	}
+
+	if isInternal(name) {
+		return protocol.ErrNoSuchFile
 	}
 
 	if folderIgnores != nil {
@@ -1152,7 +1156,7 @@ func (m *Model) Request(deviceID protocol.DeviceID, folder, name string, offset 
 		// file has finished downloading.
 	}
 
-	err := readOffsetIntoBuf(fn, offset, buf)
+	err = readOffsetIntoBuf(fn, offset, buf)
 	if os.IsNotExist(err) {
 		return protocol.ErrNoSuchFile
 	} else if err != nil {
@@ -1700,7 +1704,9 @@ func (m *Model) ScanFolderSubdirs(folder string, subs []string) error {
 func (m *Model) internalScanFolderSubdirs(folder string, subDirs []string) error {
 	for i, sub := range subDirs {
 		sub = osutil.NativeFilename(sub)
-		if p := filepath.Clean(filepath.Join(folder, sub)); !strings.HasPrefix(p, folder) {
+		// We test each path by joining with "root". What we join with is
+		// not relevant, we just want the dotdot escape detection here.
+		if _, err := rootedJoinedPath("root", sub); err != nil {
 			return errors.New("invalid subpath")
 		}
 		subDirs[i] = sub
@@ -2550,8 +2556,6 @@ func makeForgetUpdate(files []protocol.FileInfo) []protocol.FileDownloadProgress
 
 // shouldIgnore returns true when a file should be excluded from processing
 func shouldIgnore(file db.FileIntf, matcher *ignore.Matcher, ignoreDelete bool) bool {
-	// We check things in a certain order here...
-
 	switch {
 	case ignoreDelete && file.IsDeleted():
 		// ignoreDelete first because it's a very cheap test so a win if it
@@ -2559,12 +2563,29 @@ func shouldIgnore(file db.FileIntf, matcher *ignore.Matcher, ignoreDelete bool) 
 		// deleted files.
 		return true
 
+	case isInternal(file.FileName()):
+		return true
+
 	case matcher.Match(file.FileName()).IsIgnored():
-		// ignore patterns second because ignoring them is a valid way to
-		// silence warnings about them being invalid and so on.
 		return true
 	}
 
+	return false
+}
+
+func isInternal(name string) bool {
+	for _, internal := range []string{".stfolder", ".stignore", ".stversions"} {
+		// The internal always-ignored file names should never be
+		// transferred. It is however valid for them to appear in some
+		// deeper place in the hierarchy (i.e. someOtherFolder/.stignore is
+		// just a file as far as we're concerned.)
+		if name == internal {
+			return true
+		}
+		if strings.HasPrefix(name, internal+string(os.PathSeparator)) {
+			return true
+		}
+	}
 	return false
 }
 
@@ -2605,4 +2626,38 @@ func (s folderDeviceSet) sortedDevices(folder string) []protocol.DeviceID {
 	}
 	sort.Sort(protocol.DeviceIDs(devs))
 	return devs
+}
+
+// rootedJoinedPath takes a root and a supposedly relative path inside that
+// root and returns the joined path. An error is returned if the joined path
+// is not in fact inside the root.
+func rootedJoinedPath(root, rel string) (string, error) {
+	// The expected prefix for the resulting path is the root, with a path
+	// separator at the end.
+	expectedPrefix := filepath.FromSlash(root)
+	if !strings.HasSuffix(expectedPrefix, string(os.PathSeparator)) {
+		expectedPrefix += string(os.PathSeparator)
+	}
+
+	// The relative path should be clean from internal dotdots and similar
+	// funkyness.
+	rel = filepath.FromSlash(rel)
+	if filepath.Clean(rel) != rel {
+		return "", errInvalidFilename
+	}
+
+	// It is not acceptable to attempt to traverse upwards.
+	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", errNotRelative
+	}
+
+	// The supposedly correct path is the one filepath.Join will return, as
+	// it does cleaning and so on. Check that one first to make sure no
+	// obvious escape attempts have been made.
+	joined := filepath.Join(root, rel)
+	if !strings.HasPrefix(joined, expectedPrefix) {
+		return "", errNotRelative
+	}
+
+	return joined, nil
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2595,6 +2595,11 @@ func (s folderDeviceSet) sortedDevices(folder string) []protocol.DeviceID {
 // root and returns the joined path. An error is returned if the joined path
 // is not in fact inside the root.
 func rootedJoinedPath(root, rel string) (string, error) {
+	// The root must not be empty.
+	if root == "" {
+		return "", errInvalidFilename
+	}
+
 	// The expected prefix for the resulting path is the root, with a path
 	// separator at the end.
 	expectedPrefix := filepath.FromSlash(root)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2614,7 +2614,12 @@ func rootedJoinedPath(root, rel string) (string, error) {
 		return "", errInvalidFilename
 	}
 
-	// It is not acceptable to attempt to traverse upwards.
+	// It is not acceptable to attempt to traverse upwards or refer to the
+	// root itself.
+	switch rel {
+	case ".", "..", string(os.PathSeparator):
+		return "", errNotRelative
+	}
 	if strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 		return "", errNotRelative
 	}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2207,17 +2207,20 @@ func TestRootedJoinedPath(t *testing.T) {
 		extraCases := []testcase{
 			{`c:\`, `foo`, `c:\foo`, true},
 			{`\\?\c:\`, `foo`, `\\?\c:\foo`, true},
+			{`c:\`, `\foo`, `c:\foo`, true},
+			{`\\?\c:\`, `\foo`, `\\?\c:\foo`, true},
 
 			{`c:\`, `\\foo`, ``, false},
-			{`c:\`, `\foo`, ``, false},
 			{`c:\`, ``, ``, false},
 			{`c:\`, `.`, ``, false},
 			{`c:\`, `\`, ``, false},
 			{`\\?\c:\`, `\\foo`, ``, false},
-			{`\\?\c:\`, `\foo`, ``, false},
 			{`\\?\c:\`, ``, ``, false},
 			{`\\?\c:\`, `.`, ``, false},
 			{`\\?\c:\`, `\`, ``, false},
+
+			// makes no sense, but will be treated simply as a bad filename
+			{`c:\foo`, `d:\bar`, `c:\foo\d:\bar`, true},
 		}
 
 		for _, tc := range cases {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2170,6 +2170,8 @@ func TestRootedJoinedPath(t *testing.T) {
 		{"baz/foo", "bar/../../../baz/foo/bar", "", false},
 
 		// Escape attempts.
+		{"foo", "", "", false},
+		{"foo", "/", "", false},
 		{"foo", "..", "", false},
 		{"foo", "/..", "", false},
 		{"foo", "../", "", false},
@@ -2188,17 +2190,34 @@ func TestRootedJoinedPath(t *testing.T) {
 		{"", "foo", "", false},
 		{"", ".", "", false},
 		{"", "..", "", false},
+		{"", "/", "", false},
 		{"", "", "", false},
+
+		// Root=/ is valid, and things should be verified as usual.
+		{"/", "foo", "/foo", true},
+		{"/", "/foo", "/foo", true},
+		{"/", "../foo", "", false},
+		{"/", ".", "", false},
+		{"/", "..", "", false},
+		{"/", "/", "", false},
+		{"/", "", "", false},
 	}
 
 	if runtime.GOOS == "windows" {
 		extraCases := []testcase{
+			{`c:\`, `foo`, `c:\foo`, true},
+			{`\\?\c:\`, `foo`, `\\?\c:\foo`, true},
+
 			{`c:\`, `\\foo`, ``, false},
 			{`c:\`, `\foo`, ``, false},
-			{`c:\`, `foo`, `c:\foo`, true},
+			{`c:\`, ``, ``, false},
+			{`c:\`, `.`, ``, false},
+			{`c:\`, `\`, ``, false},
 			{`\\?\c:\`, `\\foo`, ``, false},
 			{`\\?\c:\`, `\foo`, ``, false},
-			{`\\?\c:\`, `foo`, `\\?\c:\foo`, true},
+			{`\\?\c:\`, ``, ``, false},
+			{`\\?\c:\`, `.`, ``, false},
+			{`\\?\c:\`, `\`, ``, false},
 		}
 
 		for _, tc := range cases {


### PR DESCRIPTION
### Purpose

Wherever we have untrusted relative paths, make sure they are not escaping their folder root.

### Testing

Unit tests on the new functions.

@Unrud to review.