### PR TITLE
Check file names for conflicts on Windows

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -721,6 +721,12 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		ldb.DropDeltaIndexIDs()
 	}
 
+	if cfg.RawCopy().OriginalVersion <= 17 {
+		// The config version 17->18 migration is about tracking folder versions
+		// in the database
+		ldb.AddFolderVersions()
+	}
+
 	m := model.NewModel(cfg, myID, myDeviceName(cfg), "syncthing", Version, ldb, protectedFiles)
 
 	if t := os.Getenv("STDEADLOCKTIMEOUT"); len(t) > 0 {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	OldestHandledVersion = 10
-	CurrentVersion       = 17
+	CurrentVersion       = 18
 	MaxRescanIntervalS   = 365 * 24 * 60 * 60
 )
 
@@ -257,6 +257,9 @@ func (cfg *Configuration) clean() error {
 	if cfg.Version == 16 {
 		convertV16V17(cfg)
 	}
+	if cfg.Version == 17 {
+		convertV17V18(cfg)
+	}
 
 	// Build a list of available devices
 	existingDevices := make(map[protocol.DeviceID]bool)
@@ -336,6 +339,11 @@ func convertV16V17(cfg *Configuration) {
 	}
 
 	cfg.Version = 17
+}
+
+func convertV17V18(cfg *Configuration) {
+	// Triggers a database tweak
+	cfg.Version = 18
 }
 
 func convertV13V14(cfg *Configuration) {

--- a/lib/config/testdata/v18.xml
+++ b/lib/config/testdata/v18.xml
@@ -1,0 +1,15 @@
+<configuration version="18">
+    <folder id="test" path="testdata" type="readonly" ignorePerms="false" rescanIntervalS="600" autoNormalize="true">
+        <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR"></device>
+        <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2"></device>
+        <minDiskFreePct>1</minDiskFreePct>
+        <maxConflicts>-1</maxConflicts>
+        <fsync>true</fsync>
+    </folder>
+    <device id="AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR" name="node one" compression="metadata">
+        <address>tcp://a</address>
+    </device>
+    <device id="P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2" name="node two" compression="metadata">
+        <address>tcp://b</address>
+    </device>
+</configuration>

--- a/lib/db/leveldb.go
+++ b/lib/db/leveldb.go
@@ -25,6 +25,7 @@ const (
 	KeyTypeFolderIdx
 	KeyTypeDeviceIdx
 	KeyTypeIndexID
+	KeyTypeFolderVersion
 )
 
 func (l VersionList) String() string {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1789,6 +1789,15 @@ func (m *Model) internalScanFolderSubdirs(folder string, subDirs []string) error
 		return err
 	}
 
+	if err := fs.UpdateFolderVersion(func() error {
+		return m.CheckFolderHealth(folder)
+	}, func(name string) bool {
+		return osutil.CheckNameConflict(folderCfg.Path(), name)
+	}); err != nil {
+		l.Infof("Stopping folder %s mid-update due to folder error: %s", folderCfg.Description(), err)
+		return err
+	}
+
 	// Clean the list of subitems to ensure that we start at a known
 	// directory, and don't scan subdirectories of things we've already
 	// scanned.

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1792,9 +1792,16 @@ func (m *Model) internalScanFolderSubdirs(folder string, subDirs []string) error
 	// Clean the list of subitems to ensure that we start at a known
 	// directory, and don't scan subdirectories of things we've already
 	// scanned.
-	subDirs = unifySubs(subDirs, func(f string) bool {
-		_, ok := fs.Get(protocol.LocalDeviceID, f)
-		return ok
+	subDirs = unifySubs(subDirs, func(dir string) bool {
+		if _, ok := fs.Get(protocol.LocalDeviceID, dir); !ok {
+			return false
+		}
+		if !osutil.IsDir(folderCfg.Path(), dir) {
+			return false
+		}
+		return true
+	}, func(name string) bool {
+		return osutil.CheckNameConflict(folderCfg.Path(), name)
 	})
 
 	// The cancel channel is closed whenever we return (such as from an error),
@@ -2567,19 +2574,21 @@ func readOffsetIntoBuf(file string, offset int64, buf []byte) error {
 
 // The exists function is expected to return true for all known paths
 // (excluding "" and ".")
-func unifySubs(dirs []string, exists func(dir string) bool) []string {
-	subs := trimUntilParentKnown(dirs, exists)
+func unifySubs(dirs []string, exists func(dir string) bool,
+	isSafe func(name string) bool) []string {
+	subs := trimUntilParentKnownAndSafe(dirs, exists, isSafe)
 	sort.Strings(subs)
 	return simplifySortedPaths(subs)
 }
 
-func trimUntilParentKnown(dirs []string, exists func(dir string) bool) []string {
+func trimUntilParentKnownAndSafe(dirs []string, exists func(dir string) bool,
+	isSafe func(name string) bool) []string {
 	var subs []string
 	for _, sub := range dirs {
 		for sub != "" && !ignore.IsInternal(sub) {
 			sub = filepath.Clean(sub)
 			parent := filepath.Dir(sub)
-			if parent == "." || exists(parent) {
+			if (parent == "." || exists(parent)) && isSafe(sub) {
 				break
 			}
 			sub = parent

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -121,6 +121,7 @@ var (
 	errDevicePaused        = errors.New("device is paused")
 	errDeviceIgnored       = errors.New("device is ignored")
 	errNotRelative         = errors.New("not a relative path")
+	errNameConflict        = errors.New("filename collides with existing file")
 )
 
 // NewModel creates and starts a new model. The model starts in read-only mode,
@@ -1160,6 +1161,11 @@ func (m *Model) Request(deviceID protocol.DeviceID, folder, name string, offset 
 
 	if err := osutil.TraversesSymlink(folderPath, filepath.Dir(name)); err != nil {
 		l.Debugf("%v REQ(in) traversal check: %s - %s: %q / %q o=%d s=%d", m, err, deviceID, folder, name, offset, len(buf))
+		return protocol.ErrNoSuchFile
+	}
+
+	if !osutil.CheckNameConflict(folderPath, name) {
+		l.Debugf("%v REQ(in) for file not in dir: %s: %q / %q o=%d s=%d", m, deviceID, folder, name, offset, len(buf))
 		return protocol.ErrNoSuchFile
 	}
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1641,21 +1641,18 @@ func TestUnifySubs(t *testing.T) {
 	cases := []struct {
 		in     []string // input to unifySubs
 		exists []string // paths that exist in the database
-		unsafe []string // paths that are not safe (e.g. name conflict)
 		out    []string // expected output
 	}{
 		{
 			// 0. trailing slashes are cleaned, known paths are just passed on
 			[]string{"foo/", "bar//"},
 			[]string{"foo", "bar"},
-			nil,
 			[]string{"bar", "foo"}, // the output is sorted
 		},
 		{
 			// 1. "foo/bar" gets trimmed as it's covered by foo
 			[]string{"foo", "bar/", "foo/bar/"},
 			[]string{"foo", "bar"},
-			nil,
 			[]string{"bar", "foo"},
 		},
 		{
@@ -1663,14 +1660,12 @@ func TestUnifySubs(t *testing.T) {
 			[]string{"foo", ""},
 			[]string{"foo"},
 			nil,
-			nil,
 		},
 		{
 			// 3. "foo/bar" is unknown, but it's kept
 			// because its parent is known
 			[]string{"foo/bar"},
 			[]string{"foo"},
-			nil,
 			[]string{"foo/bar"},
 		},
 		{
@@ -1678,14 +1673,12 @@ func TestUnifySubs(t *testing.T) {
 			// "usr/lib" is not a prefix of "usr/libexec"
 			[]string{"usr/lib", "usr/libexec"},
 			[]string{"usr", "usr/lib", "usr/libexec"},
-			nil,
 			[]string{"usr/lib", "usr/libexec"},
 		},
 		{
 			// 5. "usr/lib" is a prefix of "usr/lib/exec"
 			[]string{"usr/lib", "usr/lib/exec"},
 			[]string{"usr", "usr/lib", "usr/libexec"},
-			nil,
 			[]string{"usr/lib"},
 		},
 		{
@@ -1693,7 +1686,6 @@ func TestUnifySubs(t *testing.T) {
 			// verbatim even though they are unknown
 			[]string{".stfolder", ".stignore"},
 			[]string{},
-			nil,
 			[]string{".stfolder", ".stignore"},
 		},
 		{
@@ -1701,7 +1693,6 @@ func TestUnifySubs(t *testing.T) {
 			// scan
 			[]string{".stfolder", ".stignore", "foo/bar"},
 			[]string{},
-			nil,
 			[]string{".stfolder", ".stignore", "foo"},
 		},
 		{
@@ -1709,35 +1700,12 @@ func TestUnifySubs(t *testing.T) {
 			nil,
 			[]string{"foo"},
 			nil,
-			nil,
 		},
 		{
 			// 9. empty list of subs
 			[]string{},
 			[]string{"foo"},
 			nil,
-			nil,
-		},
-		{
-			// 10. name conflict
-			[]string{"FOO"},
-			nil,
-			[]string{"FOO"},
-			nil,
-		},
-		{
-			// 11. name conflict in first component
-			[]string{"FOO/bar"},
-			[]string{"FOO", "FOO/bar"},
-			[]string{"FOO", "FOO/bar"},
-			nil,
-		},
-		{
-			// 12. name conflict in last component
-			[]string{"foo/BAR"},
-			[]string{"foo", "foo/BAR"},
-			[]string{"foo/BAR"},
-			[]string{"foo"},
 		},
 	}
 
@@ -1749,9 +1717,6 @@ func TestUnifySubs(t *testing.T) {
 			}
 			for j, p := range cases[i].exists {
 				cases[i].exists[j] = filepath.FromSlash(p)
-			}
-			for j, p := range cases[i].unsafe {
-				cases[i].unsafe[j] = filepath.FromSlash(p)
 			}
 			for j, p := range cases[i].out {
 				cases[i].out[j] = filepath.FromSlash(p)
@@ -1768,16 +1733,8 @@ func TestUnifySubs(t *testing.T) {
 			}
 			return false
 		}
-		isSafe := func(f string) bool {
-			for _, e := range tc.unsafe {
-				if f == e {
-					return false
-				}
-			}
-			return true
-		}
 
-		out := unifySubs(tc.in, exists, isSafe)
+		out := unifySubs(tc.in, exists)
 		if diff, equal := messagediff.PrettyDiff(tc.out, out); !equal {
 			t.Errorf("Case %d failed; got %v, expected %v, diff:\n%s", i, out, tc.out, diff)
 		}

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1297,6 +1297,16 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 					if err != nil {
 						return false
 					}
+					// The following checks are racy
+					if err := osutil.TraversesSymlink(folderRoots[folder], filepath.Dir(file)); err != nil {
+						return false
+					}
+					if !osutil.CheckNameConflict(folderRoots[folder], file) {
+						return false
+					}
+					if info, err := osutil.Lstat(inFile); err != nil || !info.Mode().IsRegular() {
+						return false
+					}
 					fd, err := os.Open(inFile)
 					if err != nil {
 						return false

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -429,17 +429,29 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher) int {
 	buckets := map[string][]protocol.FileInfo{}
 
 	for _, fi := range processDirectly {
+		handlePathError := func(err error) {
+			if fi.IsDeleted() {
+				if fi.IsDirectory() {
+					f.dbUpdates <- dbUpdateJob{fi, dbUpdateDeleteDir}
+				} else {
+					f.dbUpdates <- dbUpdateJob{fi, dbUpdateDeleteFile}
+				}
+			} else {
+				f.newError(fi.Name, err)
+			}
+		}
+
 		// Verify that the thing we are handling lives inside a directory,
 		// and not a symlink or empty space.
 		if err := osutil.TraversesSymlink(f.dir, filepath.Dir(fi.Name)); err != nil {
-			f.newError(fi.Name, err)
+			handlePathError(err)
 			continue
 		}
 
 		// Verify that we handle the right thing and not something whose name
 		// collides.
 		if !osutil.CheckNameConflict(f.dir, fi.Name) {
-			f.newError(fi.Name, errNameConflict)
+			handlePathError(errNameConflict)
 			continue
 		}
 
@@ -1588,7 +1600,10 @@ func (f *sendReceiveFolder) dbUpdaterRoutine() {
 					// fsyncing symlinks is only supported by MacOS, ignore
 				}
 				if job.jobType != dbUpdateShortcutFile {
-					changedDirs = append(changedDirs, filepath.Dir(filepath.Join(f.dir, job.file.Name)))
+					err := osutil.TraversesSymlink(f.dir, filepath.Dir(job.file.Name))
+					if err == nil && osutil.CheckNameConflict(f.dir, job.file.Name) {
+						changedDirs = append(changedDirs, filepath.Dir(filepath.Join(f.dir, job.file.Name)))
+					}
 				}
 			}
 			if job.file.IsInvalid() || (job.file.IsDirectory() && !job.file.IsSymlink()) {

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -436,6 +436,13 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher) int {
 			continue
 		}
 
+		// Verify that we handle the right thing and not something whose name
+		// collides.
+		if !osutil.CheckNameConflict(f.dir, fi.Name) {
+			f.newError(fi.Name, errNameConflict)
+			continue
+		}
+
 		switch {
 		case fi.IsDeleted():
 			// A deleted file, directory or symlink
@@ -522,6 +529,13 @@ nextFile:
 		// and not a symlink or empty space.
 		if err := osutil.TraversesSymlink(f.dir, filepath.Dir(fi.Name)); err != nil {
 			f.newError(fi.Name, err)
+			continue
+		}
+
+		// Verify that we handle the right thing and not something whose name
+		// collides.
+		if !osutil.CheckNameConflict(f.dir, fi.Name) {
+			f.newError(fi.Name, errNameConflict)
 			continue
 		}
 

--- a/lib/osutil/name_conflict.go
+++ b/lib/osutil/name_conflict.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !windows
+
+package osutil
+
+// CheckNameConflict returns true if every path component of name up to and
+// including filepath.Join(base, name) doesn't conflict with any existing
+// files or folders with different names.
+func CheckNameConflict(base, name string) bool {
+	return true
+}

--- a/lib/osutil/name_conflict.go
+++ b/lib/osutil/name_conflict.go
@@ -10,7 +10,8 @@ package osutil
 
 // CheckNameConflict returns true if every path component of name up to and
 // including filepath.Join(base, name) doesn't conflict with any existing
-// files or folders with different names.
+// files or folders with different names. Base and name must both be clean and
+// name must be relative to base.
 func CheckNameConflict(base, name string) bool {
 	return true
 }

--- a/lib/osutil/name_conflict.go
+++ b/lib/osutil/name_conflict.go
@@ -4,14 +4,36 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build !windows
-
 package osutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
 
 // CheckNameConflict returns true if every path component of name up to and
 // including filepath.Join(base, name) doesn't conflict with any existing
 // files or folders with different names. Base and name must both be clean and
 // name must be relative to base.
 func CheckNameConflict(base, name string) bool {
+	// Conflicts depend on the OS and file system.
+	subname := "."
+	parts := strings.Split(name, string(os.PathSeparator))
+	for _, part := range parts {
+		subname = filepath.Join(subname, part)
+		fileName, err := FindRealFileName(base, subname)
+		if err != nil {
+			return false
+		}
+		if fileName == "" {
+			// doesn't exist
+			return true
+		}
+		if fileName != part {
+			// conflict
+			return false
+		}
+	}
 	return true
 }

--- a/lib/osutil/name_conflict_test.go
+++ b/lib/osutil/name_conflict_test.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+package osutil_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/osutil"
+)
+
+func TestCheckNameConflict(t *testing.T) {
+	os.RemoveAll("testdata")
+	defer os.RemoveAll("testdata")
+	os.MkdirAll("testdata/Foo/BAR", 0755)
+
+	cases := []struct {
+		name         string
+		conflictFree bool
+	}{
+		// Exists
+		{"Foo", true},
+		{"Foo/BAR", true},
+		{"Foo/BAR/baz", true},
+		// Doesn't exist
+		{"bar", true},
+		{"Foo/baz", true},
+	}
+
+	for _, tc := range cases {
+		nativeName := filepath.FromSlash(tc.name)
+		if res := osutil.CheckNameConflict("testdata", nativeName); res != tc.conflictFree {
+			t.Errorf("CheckNameConflict(%q) = %v, should be %v", tc.name, res, tc.conflictFree)
+		}
+	}
+}
+
+func TestCheckNameConflictCasing(t *testing.T) {
+	os.RemoveAll("testdata")
+	defer os.RemoveAll("testdata")
+	os.MkdirAll("testdata/Foo/BAR/baz", 0755)
+	// check if the file system is case-sensitive
+	if _, err := os.Lstat("testdata/foo"); err != nil {
+		t.Skip("pointless test")
+		return
+	}
+
+	cases := []struct {
+		name         string
+		conflictFree bool
+	}{
+		// Conflicts
+		{"foo", false},
+		{"foo/BAR", false},
+		{"Foo/bar", false},
+		{"Foo/BAR/BAZ", false},
+	}
+
+	for _, tc := range cases {
+		nativeName := filepath.FromSlash(tc.name)
+		if res := osutil.CheckNameConflict("testdata", nativeName); res != tc.conflictFree {
+			t.Errorf("CheckNameConflict(%q) = %v, should be %v", tc.name, res, tc.conflictFree)
+		}
+	}
+}

--- a/lib/osutil/name_conflict_unix.go
+++ b/lib/osutil/name_conflict_unix.go
@@ -1,0 +1,57 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build !windows
+
+package osutil
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// FindRealFileName returns the real name of the last path component of name.
+// Base and name must both be clean and name must be relative to base.
+// If the last path component of name doesn't exist "" is returned.
+func FindRealFileName(base, name string) (string, error) {
+	// Conflicts can be caused by different casing (e.g. foo and FOO).
+	info, err := os.Lstat(filepath.Join(base, name))
+	if os.IsNotExist(err) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return "", errors.New("Not a syscall.Stat_t")
+	}
+	targetIno := stat.Ino
+	fd, err := os.Open(filepath.Join(base, filepath.Dir(name)))
+	if err != nil {
+		// possible race condition
+		return "", err
+	}
+	defer fd.Close()
+	for {
+		infos, err := fd.Readdir(256)
+		if err != nil {
+			// possible race condition
+			return "", err
+		}
+		for _, info := range infos {
+			stat, ok := info.Sys().(*syscall.Stat_t)
+			if !ok {
+				return "", errors.New("Not a syscall.Stat_t")
+			}
+			if stat.Ino == targetIno {
+				return info.Name(), nil
+			}
+		}
+	}
+}

--- a/lib/osutil/name_conflict_windows.go
+++ b/lib/osutil/name_conflict_windows.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build windows
+
+package osutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// CheckNameConflict returns true if every path component of name up to and
+// including filepath.Join(base, name) doesn't conflict with any existing
+// files or folders with different names. Base and name must both be clean and
+// name must be relative to base.
+func CheckNameConflict(base, name string) bool {
+	// Conflicts can be caused by different casing (e.g. foo and FOO) or
+	// by the use of short names (e.g. foo.barbaz and FOO~1.BAR).
+	path := base
+	parts := strings.Split(name, string(os.PathSeparator))
+	for _, part := range parts {
+		path = filepath.Join(path, part)
+		pathp, err := syscall.UTF16PtrFromString(path)
+		if err != nil {
+			return false
+		}
+		var data syscall.Win32finddata
+		handle, err := syscall.FindFirstFile(pathp, &data)
+		if err == syscall.ERROR_FILE_NOT_FOUND {
+			return true
+		}
+		if err != nil {
+			return false
+		}
+		syscall.Close(handle)
+		fileName := syscall.UTF16ToString(data.FileName[:])
+		if part != fileName {
+			return false
+		}
+	}
+	return true
+}

--- a/lib/osutil/name_conflict_windows.go
+++ b/lib/osutil/name_conflict_windows.go
@@ -38,7 +38,7 @@ func CheckNameConflict(base, name string) bool {
 		if err != nil {
 			return false
 		}
-		syscall.Close(handle)
+		syscall.FindClose(handle)
 		fileName := syscall.UTF16ToString(data.FileName[:])
 		if part != fileName {
 			return false

--- a/lib/osutil/name_conflict_windows.go
+++ b/lib/osutil/name_conflict_windows.go
@@ -9,40 +9,29 @@
 package osutil
 
 import (
-	"os"
 	"path/filepath"
-	"strings"
 	"syscall"
 )
 
-// CheckNameConflict returns true if every path component of name up to and
-// including filepath.Join(base, name) doesn't conflict with any existing
-// files or folders with different names. Base and name must both be clean and
-// name must be relative to base.
-func CheckNameConflict(base, name string) bool {
+// FindRealFileName returns the real name of the last path component of name.
+// Base and name must both be clean and name must be relative to base.
+// If the last path component of name doesn't exist "" is returned.
+func FindRealFileName(base, name string) (string, error) {
 	// Conflicts can be caused by different casing (e.g. foo and FOO) or
 	// by the use of short names (e.g. foo.barbaz and FOO~1.BAR).
-	path := base
-	parts := strings.Split(name, string(os.PathSeparator))
-	for _, part := range parts {
-		path = filepath.Join(path, part)
-		pathp, err := syscall.UTF16PtrFromString(path)
-		if err != nil {
-			return false
-		}
-		var data syscall.Win32finddata
-		handle, err := syscall.FindFirstFile(pathp, &data)
-		if err == syscall.ERROR_FILE_NOT_FOUND {
-			return true
-		}
-		if err != nil {
-			return false
-		}
-		syscall.FindClose(handle)
-		fileName := syscall.UTF16ToString(data.FileName[:])
-		if part != fileName {
-			return false
-		}
+	path := filepath.Join(base, name)
+	pathp, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
+		return "", err
 	}
-	return true
+	var data syscall.Win32finddata
+	handle, err := syscall.FindFirstFile(pathp, &data)
+	if err == syscall.ERROR_FILE_NOT_FOUND {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	syscall.FindClose(handle)
+	return syscall.UTF16ToString(data.FileName[:]), nil
 }

--- a/lib/osutil/name_conflict_windows_test.go
+++ b/lib/osutil/name_conflict_windows_test.go
@@ -19,42 +19,6 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 )
 
-func TestCheckNameConflictCasing(t *testing.T) {
-	os.RemoveAll("testdata")
-	defer os.RemoveAll("testdata")
-	os.MkdirAll("testdata/Foo/BAR/baz", 0755)
-	// check if the file system is case-sensitive
-	if _, err := os.Lstat("testdata/foo"); err != nil {
-		t.Skip("pointless test")
-		return
-	}
-
-	cases := []struct {
-		name         string
-		conflictFree bool
-	}{
-		// Exists
-		{"Foo", true},
-		{"Foo/BAR", true},
-		{"Foo/BAR/baz", true},
-		// Doesn't exist
-		{"bar", true},
-		{"Foo/baz", true},
-		// Conflicts
-		{"foo", false},
-		{"foo/BAR", false},
-		{"Foo/bar", false},
-		{"Foo/BAR/BAZ", false},
-	}
-
-	for _, tc := range cases {
-		nativeName := filepath.FromSlash(tc.name)
-		if res := osutil.CheckNameConflict("testdata", nativeName); res != tc.conflictFree {
-			t.Errorf("CheckNameConflict(%q) = %v, should be %v", tc.name, res, tc.conflictFree)
-		}
-	}
-}
-
 func TestCheckNameConflictShortName(t *testing.T) {
 	os.RemoveAll("testdata")
 	defer os.RemoveAll("testdata")
@@ -91,7 +55,6 @@ func TestCheckNameConflictShortName(t *testing.T) {
 		{"foobarbaz", true},
 		{"foobarbaz/qux", true},
 		// Doesn't exist
-		{"foo", true},
 		{"foobarbaz/quux", true},
 		// Conflicts
 		{shortName, false},

--- a/lib/osutil/name_conflict_windows_test.go
+++ b/lib/osutil/name_conflict_windows_test.go
@@ -1,0 +1,108 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build windows
+
+package osutil_test
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"unsafe"
+
+	"github.com/syncthing/syncthing/lib/osutil"
+)
+
+func TestCheckNameConflictCasing(t *testing.T) {
+	os.RemoveAll("testdata")
+	defer os.RemoveAll("testdata")
+	os.MkdirAll("testdata/Foo/BAR/baz", 0755)
+	// check if the file system is case-sensitive
+	if _, err := os.Lstat("testdata/foo"); err != nil {
+		t.Skip("pointless test")
+		return
+	}
+
+	cases := []struct {
+		name         string
+		conflictFree bool
+	}{
+		// Exists
+		{"Foo", true},
+		{"Foo/BAR", true},
+		{"Foo/BAR/baz", true},
+		// Doesn't exist
+		{"bar", true},
+		{"Foo/baz", true},
+		// Conflicts
+		{"foo", false},
+		{"foo/BAR", false},
+		{"Foo/bar", false},
+		{"Foo/BAR/BAZ", false},
+	}
+
+	for _, tc := range cases {
+		nativeName := filepath.FromSlash(tc.name)
+		if res := osutil.CheckNameConflict("testdata", nativeName); res != tc.conflictFree {
+			t.Errorf("CheckNameConflict(%q) = %v, should be %v", tc.name, res, tc.conflictFree)
+		}
+	}
+}
+
+func TestCheckNameConflictShortName(t *testing.T) {
+	os.RemoveAll("testdata")
+	defer os.RemoveAll("testdata")
+	os.MkdirAll("testdata/foobarbaz/qux", 0755)
+	ppath, err := syscall.UTF16PtrFromString("testdata/foobarbaz")
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	// check if the file system supports short names
+	bufferSize, err := syscall.GetShortPathName(ppath, nil, 0)
+	if err != nil {
+		t.Skip("pointless test")
+		return
+	}
+
+	// get the short name
+	buffer := make([]uint16, bufferSize)
+	length, err := syscall.GetShortPathName(ppath,
+		(*uint16)(unsafe.Pointer(&buffer[0])), bufferSize)
+	if err != nil {
+		t.Fatal("unexpected error", err)
+	}
+	// on success length doesn't contain the terminating null character
+	if bufferSize != length+1 {
+		t.Fatal("length of short name changed")
+	}
+	shortName := filepath.Base(syscall.UTF16ToString(buffer))
+
+	cases := []struct {
+		name         string
+		conflictFree bool
+	}{
+		// Exists
+		{"foobarbaz", true},
+		{"foobarbaz/qux", true},
+		// Doesn't exist
+		{"foo", true},
+		{"foobarbaz/quux", true},
+		// Conflicts
+		{shortName, false},
+		{path.Join(shortName, "qux"), false},
+		{path.Join(shortName, "quux"), false},
+	}
+
+	for _, tc := range cases {
+		nativeName := filepath.FromSlash(tc.name)
+		if res := osutil.CheckNameConflict("testdata", nativeName); res != tc.conflictFree {
+			t.Errorf("CheckNameConflict(%q) = %v, should be %v", tc.name, res, tc.conflictFree)
+		}
+	}
+}

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -120,6 +120,14 @@ func (w *walker) walk() (chan protocol.FileInfo, error) {
 			filepath.Walk(w.Dir, hashFiles)
 		} else {
 			for _, sub := range w.Subs {
+				if err := osutil.TraversesSymlink(w.Dir, filepath.Dir(sub)); err != nil {
+					l.Infoln("Skipping sub path that traverses symlink", w.Dir, sub)
+					continue
+				}
+				if !osutil.CheckNameConflict(w.Dir, sub) {
+					l.Infoln("Skipping sub path that collides", w.Dir, sub)
+					continue
+				}
 				filepath.Walk(filepath.Join(w.Dir, sub), hashFiles)
 			}
 		}


### PR DESCRIPTION
### Purpose

On Windows different paths can point to the same file. This is the case for paths with different casing (e.g. foo and FOO) or short names (e.g. foo.barbaz and FOO~1.BAR).
This causes unexpected complications when syncing with non-Windows systems and can lead to inadvertently deleted files.
Furthermore it causes security issues.

External tools like syncthing-inotiify can wreak havoc by passing conflicting names to syncthing.

This PR adds checks to avoid this conflicts.