### PR TITLE
Minor bugfix of GlobalLog

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -92,6 +92,7 @@ angular.module('syncthing.core')
             refreshConnectionStats();
             refreshDeviceStats();
             refreshFolderStats();
+            refreshGlobalChanges();
             refreshThemes();
 
             $http.get(urlbase + '/system/version').success(function (data) {
@@ -624,7 +625,7 @@ angular.module('syncthing.core')
         }, 2500);
 
         var refreshGlobalChanges = debounce(function () {
-            $http.get(urlbase + "/events/disk?limit=15").success(function (data) {
+            $http.get(urlbase + "/events/disk?limit=25").success(function (data) {
                 data = data.reverse();
                 $scope.globalChangeEvents = data;
 


### PR DESCRIPTION
Very minor bugfix.  I forgot to Refresh the GlobalLog on page load so I fixed that (one line).  Also upped the event limit from 15 to 25 once I saw that Angular handles vertical scrolling of large windows anyway.
