### PR TITLE
cmd/syncthing: Avoid HTTP Keepalive/GUI refresh race

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -326,8 +326,10 @@ func (s *apiService) Serve() {
 	handler = debugMiddleware(handler)
 
 	srv := http.Server{
-		Handler:     handler,
-		ReadTimeout: 10 * time.Second,
+		Handler: handler,
+		// ReadTimeout must be longer than SyncthingController $scope.refresh
+		// interval to avoid HTTP keepalive/GUI refresh race.
+		ReadTimeout: 15 * time.Second,
 	}
 
 	s.fss = newFolderSummaryService(s.cfg, s.model)


### PR DESCRIPTION
Set GUI server ReadTimeout to support reliable HTTP persistent connections and avoid unnecessary browser request failures and retries. Eg:
- Browser reuses existing HTTP connection for GUI refresh request
- Server closes connection with request in flight
- Browser retries GET request.

Corresponding client side refresh interval can be found in: github.com/syncthing/syncthing/gui/default/syncthing/core/syncthingController.js:17 

Discovered since httputil.ReverseProxy does not retry failed GET requests (golang/go #16036, partially fixed in Go1.8) which causes the Syncthing GUI to fail after a single 502 Bad Gateway response.

### Testing

Rebuilt binary and confirmed:
- Persistent connections stay open for 15s (instead of 10s)
- GUI refreshes at 10s (unchanged)
- GUI no longer fails behind httputil.ReverseProxy