### PR TITLE
lib/model: Remove syncthing-specific files (fixes #3819)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -330,6 +330,9 @@ func (m *Model) RemoveFolder(folder string) {
 	m.fmut.Lock()
 	m.pmut.Lock()
 
+	// Delete syncthing specific files
+	os.Remove(filepath.Join(cfg.Path(), ".stfolder"))
+
 	m.tearDownFolderLocked(folder)
 	// Remove it from the database
 	db.DropFolder(m.db, folder)
@@ -362,10 +365,6 @@ func (m *Model) tearDownFolderLocked(folder string) {
 	for dev, folders := range m.deviceFolders {
 		m.deviceFolders[dev] = stringSliceWithout(folders, folder)
 	}
-
-	// Delete syncthing specific files
-	os.Remove(filepath.Join(cfg.Path(), ".stfolder"))
-	os.Remove(filepath.Join(cfg.Path(), ".stignore"))
 }
 
 func (m *Model) RestartFolder(cfg config.FolderConfiguration) {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -331,7 +331,9 @@ func (m *Model) RemoveFolder(folder string) {
 	m.pmut.Lock()
 
 	// Delete syncthing specific files
-	os.Remove(filepath.Join(cfg.Path(), ".stfolder"))
+	folderCfg := m.folderCfgs[folder]
+	folderPath := folderCfg.Path()
+	os.Remove(filepath.Join(folderPath, ".stfolder"))
 
 	m.tearDownFolderLocked(folder)
 	// Remove it from the database

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -362,6 +362,10 @@ func (m *Model) tearDownFolderLocked(folder string) {
 	for dev, folders := range m.deviceFolders {
 		m.deviceFolders[dev] = stringSliceWithout(folders, folder)
 	}
+
+	// Delete syncthing specific files
+	os.Remove(filepath.Join(cfg.Path(), ".stfolder"))
+	os.Remove(filepath.Join(cfg.Path(), ".stignore"))
 }
 
 func (m *Model) RestartFolder(cfg config.FolderConfiguration) {


### PR DESCRIPTION
Syncthing adds some hidden files when a folder is added, but there is currently
no equivalent cleanup procedure. This change is conservative as not to
accidentally cause data loss.
