### PR TITLE
cmd/syncthing: Fix rescan delay in /rest/db/scan

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -1131,14 +1131,8 @@ func (s *apiService) postDBScan(w http.ResponseWriter, r *http.Request) {
 	qs := r.URL.Query()
 	folder := qs.Get("folder")
 	if folder != "" {
-		nextStr := qs.Get("next")
-		next, err := strconv.Atoi(nextStr)
-		if err == nil {
-			s.model.DelayScan(folder, time.Duration(next)*time.Second)
-		}
-
 		subs := qs["sub"]
-		err = s.model.ScanFolderSubdirs(folder, subs)
+		err := s.model.ScanFolderSubdirs(folder, subs)
 		if err != nil {
 			http.Error(w, err.Error(), 500)
 			return
@@ -1150,6 +1144,11 @@ func (s *apiService) postDBScan(w http.ResponseWriter, r *http.Request) {
 			sendJSON(w, errors)
 			return
 		}
+	}
+	nextStr := qs.Get("next")
+	next, err := strconv.Atoi(nextStr)
+	if err == nil {
+		s.model.DelayScan(folder, time.Duration(next)*time.Second)
 	}
 }
 

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -1137,6 +1137,11 @@ func (s *apiService) postDBScan(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), 500)
 			return
 		}
+		nextStr := qs.Get("next")
+		next, err := strconv.Atoi(nextStr)
+		if err == nil {
+			s.model.DelayScan(folder, time.Duration(next)*time.Second)
+		}
 	} else {
 		errors := s.model.ScanFolders()
 		if len(errors) > 0 {
@@ -1144,11 +1149,6 @@ func (s *apiService) postDBScan(w http.ResponseWriter, r *http.Request) {
 			sendJSON(w, errors)
 			return
 		}
-	}
-	nextStr := qs.Get("next")
-	next, err := strconv.Atoi(nextStr)
-	if err == nil {
-		s.model.DelayScan(folder, time.Duration(next)*time.Second)
 	}
 }
 


### PR DESCRIPTION
### Purpose

Currently scanning is delayed even when the scan fails but never when all folders are scanned (i.e. no folder keyword given). This changes the behaviour such that the next scan is only delayed when the scan is successful, but regardless whether a specific folder or all folders were scanned.

### Testing

Nothing new.

### Documentation

This brings the actual behaviour closer to the docs. Related: syncthing/docs#283