### PR TITLE
cmd/syncthing: Handle -logfile again (fixes #3931)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -401,7 +401,7 @@ func main() {
 		return
 	}
 
-	if options.noRestart {
+	if innerProcess || options.noRestart {
 		syncthingMain(options)
 	} else {
 		monitorMain(options)

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -35,7 +35,6 @@ const (
 )
 
 func monitorMain(runtimeOptions RuntimeOptions) {
-	os.Setenv("STNORESTART", "yes")
 	os.Setenv("STMONITORED", "yes")
 	l.SetPrefix("[monitor] ")
 


### PR DESCRIPTION
The monitor process should not set STNORESTART as this indicates the intention from the user. Setting STMONITORED is enough, as this tells the next Syncthing instance that it is running under the monitor process.

### Testing

I ran it manually in the various scenarios, on Mac and Windows.