### PR TITLE
lib/events: Add timeout to events API, remove Ping (fixes #3933)

### DIFF
--- a/cmd/syncthing/auditservice_test.go
+++ b/cmd/syncthing/auditservice_test.go
@@ -20,13 +20,13 @@ func TestAuditService(t *testing.T) {
 	service := newAuditService(buf)
 
 	// Event sent before start, will not be logged
-	events.Default.Log(events.Ping, "the first event")
+	events.Default.Log(events.ConfigSaved, "the first event")
 
 	go service.Serve()
 	service.WaitForStart()
 
 	// Event that should end up in the audit log
-	events.Default.Log(events.Ping, "the second event")
+	events.Default.Log(events.ConfigSaved, "the second event")
 
 	// We need to give the events time to arrive, since the channels are buffered etc.
 	time.Sleep(10 * time.Millisecond)
@@ -35,7 +35,7 @@ func TestAuditService(t *testing.T) {
 	service.WaitForStop()
 
 	// This event should not be logged, since we have stopped.
-	events.Default.Log(events.Ping, "the third event")
+	events.Default.Log(events.ConfigSaved, "the third event")
 
 	result := string(buf.Bytes())
 	t.Log(result)

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -233,8 +233,8 @@ func (s *apiService) Serve() {
 	getRestMux.HandleFunc("/rest/db/need", s.getDBNeed)                          // folder [perpage] [page]
 	getRestMux.HandleFunc("/rest/db/status", s.getDBStatus)                      // folder
 	getRestMux.HandleFunc("/rest/db/browse", s.getDBBrowse)                      // folder [prefix] [dirsonly] [levels]
-	getRestMux.HandleFunc("/rest/events", s.getIndexEvents)                      // since [limit]
-	getRestMux.HandleFunc("/rest/events/disk", s.getDiskEvents)                  // since [limit]
+	getRestMux.HandleFunc("/rest/events", s.getIndexEvents)                      // since [limit] [timeout]
+	getRestMux.HandleFunc("/rest/events/disk", s.getDiskEvents)                  // since [limit] [timeout]
 	getRestMux.HandleFunc("/rest/stats/device", s.getDeviceStats)                // -
 	getRestMux.HandleFunc("/rest/stats/folder", s.getFolderStats)                // -
 	getRestMux.HandleFunc("/rest/svc/deviceid", s.getDeviceID)                   // id
@@ -1019,8 +1019,14 @@ func (s *apiService) getEvents(w http.ResponseWriter, r *http.Request, eventSub 
 	qs := r.URL.Query()
 	sinceStr := qs.Get("since")
 	limitStr := qs.Get("limit")
+	timeoutStr := qs.Get("timeout")
 	since, _ := strconv.Atoi(sinceStr)
 	limit, _ := strconv.Atoi(limitStr)
+
+	timeout := defaultEventTimeout
+	if timeoutSec, timeoutErr := strconv.Atoi(timeoutStr); timeoutErr == nil && timeoutSec >= 0 { // 0 is a valid timeout
+		timeout = time.Duration(timeoutSec) * time.Second
+	}
 
 	// Flush before blocking, to indicate that we've received the request and
 	// that it should not be retried. Must set Content-Type header before
@@ -1029,7 +1035,8 @@ func (s *apiService) getEvents(w http.ResponseWriter, r *http.Request, eventSub 
 	f := w.(http.Flusher)
 	f.Flush()
 
-	evs := eventSub.Since(since, nil)
+	// If there are no events available return an empty slice, as this gets serialized as `[]`
+	evs := eventSub.Since(since, []events.Event{}, timeout)
 	if 0 < limit && limit < len(evs) {
 		evs = evs[len(evs)-limit:]
 	}

--- a/cmd/syncthing/mocked_events_test.go
+++ b/cmd/syncthing/mocked_events_test.go
@@ -6,10 +6,14 @@
 
 package main
 
-import "github.com/syncthing/syncthing/lib/events"
+import (
+	"time"
+
+	"github.com/syncthing/syncthing/lib/events"
+)
 
 type mockedEventSub struct{}
 
-func (s *mockedEventSub) Since(id int, into []events.Event) []events.Event {
+func (s *mockedEventSub) Since(id int, into []events.Event, timeout time.Duration) []events.Event {
 	select {}
 }

--- a/cmd/syncthing/summaryservice.go
+++ b/cmd/syncthing/summaryservice.go
@@ -169,7 +169,7 @@ func (c *folderSummaryService) foldersToHandle() []string {
 	c.lastEventReqMut.Lock()
 	last := c.lastEventReq
 	c.lastEventReqMut.Unlock()
-	if time.Since(last) > pingEventInterval {
+	if time.Since(last) > defaultEventTimeout {
 		return nil
 	}
 

--- a/cmd/syncthing/verboseservice.go
+++ b/cmd/syncthing/verboseservice.go
@@ -66,7 +66,7 @@ func (s *verboseService) WaitForStart() {
 
 func (s *verboseService) formatEvent(ev events.Event) string {
 	switch ev.Type {
-	case events.Ping, events.DownloadProgress, events.LocalIndexUpdated:
+	case events.DownloadProgress, events.LocalIndexUpdated:
 		// Skip
 		return ""
 

--- a/gui/default/syncthing/core/eventService.js
+++ b/gui/default/syncthing/core/eventService.js
@@ -70,7 +70,6 @@ angular.module('syncthing.core')
             ITEM_FINISHED:        'ItemFinished',   // Generated when Syncthing ends synchronizing a file to a newer version
             ITEM_STARTED:         'ItemStarted',   // Generated when Syncthing begins synchronizing a file to a newer version
             LOCAL_INDEX_UPDATED:  'LocalIndexUpdated',   // Generated when the local index information has changed, due to synchronizing one or more items from the cluster or discovering local changes during a scan
-            PING:                 'Ping',   // Generated automatically every 60 seconds
             REMOTE_INDEX_UPDATED: 'RemoteIndexUpdated',   // Generated each time new index information is received from a device
             STARTING:             'Starting',   // Emitted exactly once, when Syncthing starts, before parsing configuration etc
             STARTUP_COMPLETED:    'StartupCompleted',   // Emitted exactly once, when initialization is complete and Syncthing is ready to start exchanging data with other devices

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -10,7 +10,6 @@ package events
 import (
 	"errors"
 	"runtime"
-	stdsync "sync"
 	"time"
 
 	"github.com/syncthing/syncthing/lib/sync"
@@ -19,8 +18,7 @@ import (
 type EventType int
 
 const (
-	Ping EventType = 1 << iota
-	Starting
+	Starting EventType = 1 << iota
 	StartupComplete
 	DeviceDiscovered
 	DeviceConnected
@@ -55,8 +53,6 @@ var runningTests = false
 
 func (t EventType) String() string {
 	switch t {
-	case Ping:
-		return "Ping"
 	case Starting:
 		return "Starting"
 	case StartupComplete:
@@ -274,16 +270,16 @@ func (s *Subscription) C() <-chan Event {
 }
 
 type bufferedSubscription struct {
-	sub  *Subscription
-	buf  []Event
-	next int
-	cur  int // Current SubscriptionID
-	mut  sync.Mutex
-	cond *stdsync.Cond
+	sub                  *Subscription
+	buf                  []Event
+	next                 int
+	cur                  int // Current SubscriptionID
+	mut                  sync.Mutex
+	newEventNotification chan struct{} // If non-nil, this is closed when a new event becomes available. It is lazily created when needed.
 }
 
 type BufferedSubscription interface {
-	Since(id int, into []Event) []Event
+	Since(id int, into []Event, timeout time.Duration) []Event
 }
 
 func NewBufferedSubscription(s *Subscription, size int) BufferedSubscription {
@@ -292,7 +288,6 @@ func NewBufferedSubscription(s *Subscription, size int) BufferedSubscription {
 		buf: make([]Event, size),
 		mut: sync.NewMutex(),
 	}
-	bs.cond = stdsync.NewCond(bs.mut)
 	go bs.pollingLoop()
 	return bs
 }
@@ -314,18 +309,21 @@ func (s *bufferedSubscription) pollingLoop() {
 		s.buf[s.next] = ev
 		s.next = (s.next + 1) % len(s.buf)
 		s.cur = ev.SubscriptionID
-		s.cond.Broadcast()
+		if s.newEventNotification != nil {
+			close(s.newEventNotification)
+			s.newEventNotification = nil
+		}
 		s.mut.Unlock()
 	}
 }
 
-func (s *bufferedSubscription) Since(id int, into []Event) []Event {
+func (s *bufferedSubscription) Since(id int, into []Event, timeout time.Duration) []Event {
+	if eventAvailable := s.waitForNewEventWithTimeout(id, timeout); !eventAvailable {
+		return into
+	}
+
 	s.mut.Lock()
 	defer s.mut.Unlock()
-
-	for id >= s.cur {
-		s.cond.Wait()
-	}
 
 	for i := s.next; i < len(s.buf); i++ {
 		if s.buf[i].SubscriptionID > id {
@@ -350,4 +348,57 @@ func Error(err error) *string {
 	}
 	str := err.Error()
 	return &str
+}
+
+// Wait for the given event to become available, or for a timeout, whichever is sooner.
+// Returns true if the event became available, or false if we timed out.
+func (s *bufferedSubscription) waitForNewEventWithTimeout(id int, timeout time.Duration) bool {
+	// Checks whether 'id' is available. If it is, returns nil. If it isn't, returns newEventNotification (constructing it if necessary)
+	checkIDAndConstructNotificationIfNecessary := func() <-chan struct{} {
+		s.mut.Lock()
+		defer s.mut.Unlock()
+
+		if id < s.cur {
+			return nil
+		}
+		if s.newEventNotification == nil {
+			s.newEventNotification = make(chan struct{})
+		}
+		return s.newEventNotification
+	}
+
+	// Early exit, in the case where events are already available - saves creating the timer
+	newEventNotification := checkIDAndConstructNotificationIfNecessary()
+	if newEventNotification == nil {
+		return true
+	}
+	if timeout <= 0 {
+		return false
+	}
+
+	// From the point on, we know we're going to have to wait.
+
+	// Don't use time.After, as that (temporarily) leaks the timer if we don't timeout, and that might
+	// make a difference when there's a large volume of events.
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		// If the timer fires, then we've definitely timed out.
+		// If the newEventNotification channel is closed, then the event we want may or may not be present.
+		// It's likely that it will be, because people don't tend to ask for events in the future,
+		// but check anyway. If it isn't, we'll need to make sure that a new newEventNotification has been
+		// created.
+
+		select {
+		case <-timer.C:
+			return false
+		case <-newEventNotification:
+		}
+
+		newEventNotification = checkIDAndConstructNotificationIfNecessary()
+		if newEventNotification == nil {
+			return true
+		}
+	}
 }

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -219,7 +219,7 @@ func TestBufferedSub(t *testing.T) {
 
 	recv := 0
 	for recv < 10*BufferSize {
-		evs := bs.Since(recv, nil)
+		evs := bs.Since(recv, nil, time.Minute)
 		for _, ev := range evs {
 			if ev.GlobalID != recv+1 {
 				t.Fatalf("Incorrect ID; %d != %d", ev.GlobalID, recv+1)
@@ -252,7 +252,7 @@ func BenchmarkBufferedSub(b *testing.B) {
 		recv := 0
 		var evs []Event
 		for i := 0; i < b.N; {
-			evs = bs.Since(recv, evs[:0])
+			evs = bs.Since(recv, evs[:0], time.Minute)
 			for _, ev := range evs {
 				if ev.GlobalID != recv+1 {
 					done <- fmt.Errorf("skipped event %v %v", ev.GlobalID, recv)
@@ -299,7 +299,7 @@ func TestSinceUsesSubscriptionId(t *testing.T) {
 	// delivered to the buffered subscription when we get here.
 	t0 := time.Now()
 	for time.Since(t0) < time.Second {
-		events := bs.Since(0, nil)
+		events := bs.Since(0, nil, time.Minute)
 		if len(events) == 2 {
 			break
 		}
@@ -308,7 +308,7 @@ func TestSinceUsesSubscriptionId(t *testing.T) {
 		}
 	}
 
-	events := bs.Since(1, nil)
+	events := bs.Since(1, nil, time.Minute)
 	if len(events) != 1 {
 		t.Fatal("Incorrect number of events:", len(events))
 	}

--- a/lib/sync/sync_test.go
+++ b/lib/sync/sync_test.go
@@ -226,3 +226,89 @@ func TestWaitGroup(t *testing.T) {
 	debug = false
 	l.SetDebug("sync", false)
 }
+
+func TestTimeoutCond(t *testing.T) {
+	const (
+		// Low values to avoid being intrusive in continous testing. Can be
+		// increased significantly for stress testing.
+		iterations = 100
+		routines   = 10
+
+		timeMult = 2
+	)
+
+	c := NewTimeoutCond(NewMutex())
+
+	// Start a routine to periodically broadcast on the cond.
+
+	go func() {
+		d := time.Duration(routines) * timeMult * time.Millisecond / 2
+		t.Log("Broadcasting every", d)
+		for i := 0; i < iterations; i++ {
+			time.Sleep(d)
+
+			c.L.Lock()
+			c.Broadcast()
+			c.L.Unlock()
+		}
+	}()
+
+	// Start several routines that wait on it with different timeouts.
+
+	var results [routines][2]int
+	var wg sync.WaitGroup
+	for i := 0; i < routines; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			d := time.Duration(i) * timeMult * time.Millisecond
+			t.Logf("Routine %d waits for %v\n", i, d)
+			succ, fail := runLocks(t, iterations, c, d)
+			results[i][0] = succ
+			results[i][1] = fail
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	// Print a table of routine number: successes, failures.
+
+	for i, v := range results {
+		t.Logf("%4d: %4d %4d\n", i, v[0], v[1])
+	}
+}
+
+func runLocks(t *testing.T, iterations int, c *TimeoutCond, d time.Duration) (succ, fail int) {
+	for i := 0; i < iterations; i++ {
+		c.L.Lock()
+		w := c.SetupWait(d)
+
+		t0 := time.Now()
+		res := w.Wait()
+		waited := time.Since(t0)
+
+		// Allow 20% slide in either direction, and a five milliseconds of
+		// scheduling delay... In tweaking these it was clear that things
+		// worked like the should, so if this becomes a spurious failure
+		// kind of thing feel free to remove or give significantly more
+		// slack.
+
+		if !res && waited < d*8/10 {
+			t.Errorf("Wait failed early, %v < %v", waited, d)
+		}
+		if res && waited > d*11/10+5*time.Millisecond {
+			t.Errorf("Wait succeeded late, %v > %v", waited, d)
+		}
+
+		w.Stop()
+
+		if res {
+			succ++
+		} else {
+			fail++
+		}
+		c.L.Unlock()
+	}
+	return
+}


### PR DESCRIPTION
Previously, the Ping event was used to ensure that something appered on the events API at least every minute, so that requests to the events API would take at most a minute. However this is less than ideal in some cases. If there are very few events, then ping events can dominate, meaning it's hard to find other events. Filtering out ping events from the disk events API also makes consumers more complex.

Instead, allow a timeout to be specified when requesting events. If no events are found within this timeout, then an empty array is returned. The timeout defaults to 60 seconds (for backwards compatibility), and any invalid value (<0, non-numeric) is also treated as 60 seconds. A timeout of zero is allowed, in which case the events API because request-response instead of long-polling, returning immediately if no events are available.

In order to facilitate this, a new structure in lib/sync, TimeoutCond, was created. This behaves similarly to Cond, except that it allows the user to specify a timeout. One timeout will span multiple calls to .Wait().