### PR TITLE
Add arm64 deb build to jenkins/build-linux.bash (fixes #3894)

### DIFF
--- a/jenkins/build-linux.bash
+++ b/jenkins/build-linux.bash
@@ -47,6 +47,7 @@ go run build.go -goarch amd64 deb
 go run build.go -goarch i386 deb
 go run build.go -goarch armel deb
 go run build.go -goarch armhf deb
+go run build.go -goarch arm64 deb
 
 mv *.deb "$WORKSPACE"
 


### PR DESCRIPTION
### Purpose

This change adds a DEB package build for the arm64 architecture. I'm not entirely sure if this change is enough for the apt repository to contain this build. If not, please let me know.

### Testing

I tested running `go run build.go -goarch arm64 deb` on xenial amd64 with go 1.7.5 and it worked fine.