### PR TITLE
lib/sync: Fix a race in unlocker logging (fixes #3884)

### DIFF
--- a/lib/sync/sync.go
+++ b/lib/sync/sync.go
@@ -123,7 +123,7 @@ func (m *loggedRWMutex) Lock() {
 
 	atomic.StoreInt32(&m.logUnlockers, 1)
 	m.RWMutex.Lock()
-	m.logUnlockers = 0
+	atomic.StoreInt32(&m.logUnlockers, 0)
 
 	holder := getHolder()
 	m.holder.Store(holder)


### PR DESCRIPTION
Other routines use atomics, hence even if we are under a lock, we should
too.
