### PR TITLE
Webui unix socket support

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -173,7 +173,8 @@ func (s *apiService) getListener(guiCfg config.GUIConfiguration) (net.Listener, 
 		},
 	}
 
-	rawListener, err := net.Listen("tcp", guiCfg.Address())
+	var rawListener net.Listener
+	rawListener, err = net.Listen(guiCfg.AddressFamily(), guiCfg.Address())
 	if err != nil {
 		return nil, err
 	}
@@ -223,6 +224,11 @@ func (s *apiService) Serve() {
 		return
 	}
 
+	if s.cfg.GUI().AddressFamily() == "unix" {
+		defer func() {
+			os.Remove(s.cfg.GUI().Address())
+		}()
+	}
 	defer listener.Close()
 
 	// The GET handlers
@@ -374,6 +380,9 @@ func (s *apiService) Serve() {
 }
 
 func (s *apiService) Stop() {
+	if s.cfg.GUI().AddressFamily() == "unix" {
+		os.Remove(s.cfg.GUI().Address())
+	}
 	close(s.stop)
 }
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -1081,7 +1081,9 @@ func setupGUI(mainService *suture.Supervisor, cfg *config.Wrapper, m *model.Mode
 	cfg.Subscribe(api)
 	mainService.Add(api)
 
-	if cfg.Options().StartBrowser && !runtimeOptions.noBrowser && !runtimeOptions.stRestarting {
+	// Browser generally do not support UNIX socket connection.
+	if cfg.GUI().AddressFamily() == "tcp" &&
+		cfg.Options().StartBrowser && !runtimeOptions.noBrowser && !runtimeOptions.stRestarting {
 		// Can potentially block if the utility we are invoking doesn't
 		// fork, and just execs, hence keep it in it's own routine.
 		<-api.startedOnce

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -127,7 +127,7 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 		select {
 		case s := <-stopSign:
 			l.Infof("Signal %d received; exiting", s)
-			cmd.Process.Kill()
+			cmd.Process.Signal(sigTerm)
 			<-exit
 			return
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -365,12 +365,13 @@ angular.module('syncthing.core')
                 });
             });
 
-            // If we're not listening on localhost, and there is no
-            // authentication configured, and the magic setting to silence the
-            // warning isn't set, then yell at the user.
+            // If we're not listening on localhost or a local UNIX socket, and
+            // there is no authentication configured, and the magic setting to
+            // silence the warning isn't set, then yell at the user.
             var guiCfg = $scope.config.gui;
             $scope.openNoAuth = guiCfg.address.substr(0, 4) !== "127."
                 && guiCfg.address.substr(0, 6) !== "[::1]:"
+	        && guiCfg.address.substr(0, 7) !== "unix://"
                 && (!guiCfg.user || !guiCfg.password)
                 && !guiCfg.insecureAdminAccess;
 


### PR DESCRIPTION
### Purpose

The purpose of these patches is to allow the Web GUI to listen on an UNIX socket. This is useful when the Web GUI is proxified and the proxifier sits on the same host than the Syncthing instance. This way, one can avoid to waste a local TCP port for such purpose.

An UNIX socket can now be requested by specifying in the `<gui><address>` field an absolute pathname prefixed with `unix://`.
Example: `<gui><address> unix:///tmp/syncthing-webui.sock </address></gui>`.

Note that implementing such support required an additional patch to fix the way the core process is signaled to exit by the monitor process (patch on the same branch). This is necessary as my patch hooks in the GUI closing callback to remove the UNIX pathname.

### Testing

I have performed a simple test by specifying an arbitrary UNIX socket pathname in the configuration file.
When Syncthing starts, I correctly notice the creation of the UNIX socket (and in the same time that no more TCP socket are opened for the GUI);
Using `socat(1)` to relay this UNIX socket to a local TCP socket, I have tested that my Web browser accesses the Syncthing UI in the same way than with a classical TCP Socket; also, this socket is well interpreted as a localhost-one so no warning popup related to authentication is raised;
When Syncthing exits (both with and without monitor mode), I correctly notice that the UNIX socket pathname is removed.

### Documentation

The documentation should be updated to reflect this new support. I currently did not provide any patch at this level. I will be enthusiast to provide one as soon as my current patches will be accepted.
