### PR TITLE
lib/events, cmd/syncthing: Correct GlobalID in debug and make since arameter optional

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -233,8 +233,8 @@ func (s *apiService) Serve() {
 	getRestMux.HandleFunc("/rest/db/need", s.getDBNeed)                          // folder [perpage] [page]
 	getRestMux.HandleFunc("/rest/db/status", s.getDBStatus)                      // folder
 	getRestMux.HandleFunc("/rest/db/browse", s.getDBBrowse)                      // folder [prefix] [dirsonly] [levels]
-	getRestMux.HandleFunc("/rest/events", s.getIndexEvents)                      // since [limit] [timeout]
-	getRestMux.HandleFunc("/rest/events/disk", s.getDiskEvents)                  // since [limit] [timeout]
+	getRestMux.HandleFunc("/rest/events", s.getIndexEvents)                      // [since] [limit] [timeout]
+	getRestMux.HandleFunc("/rest/events/disk", s.getDiskEvents)                  // [since] [limit] [timeout]
 	getRestMux.HandleFunc("/rest/stats/device", s.getDeviceStats)                // -
 	getRestMux.HandleFunc("/rest/stats/folder", s.getFolderStats)                // -
 	getRestMux.HandleFunc("/rest/svc/deviceid", s.getDeviceID)                   // id

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -166,8 +166,8 @@ func NewLogger() *Logger {
 
 func (l *Logger) Log(t EventType, data interface{}) {
 	l.mutex.Lock()
-	dl.Debugln("log", l.nextGlobalID, t, data)
 	l.nextGlobalID++
+	dl.Debugln("log", l.nextGlobalID, t, data)
 
 	e := Event{
 		GlobalID: l.nextGlobalID,


### PR DESCRIPTION
These are minor fixes as a side product of writing documentation.
The since parameter is not actually required for /rest/events and this is already used in the gui code.
The debug log is simply offset by one compared to /rest/events due to first logging then incrementing GlobalID, 
