### PR TITLE
lib/scanner: Stopped outputting rescan debug message if file doesn't …

### DIFF
--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -311,7 +311,9 @@ func (w *walker) walkRegular(relPath string, info os.FileInfo, fchan chan protoc
 		return nil
 	}
 
-	l.Debugln("rescan:", cf, info.ModTime().Unix(), info.Mode()&os.ModePerm)
+	if ok {
+		l.Debugln("rescan:", cf, info.ModTime().Unix(), info.Mode()&os.ModePerm)
+	}
 
 	f := protocol.FileInfo{
 		Name:          relPath,


### PR DESCRIPTION
…exist locally (fixes #1350)

### Purpose

To stop logging 'rescan' debug messages on files that don't exist locally.

### Testing

I ran the scanner test suite to make sure every still functioned as normal.
