### PR TITLE
script, gui: Silence useless warnings in translation script

### DIFF
--- a/gui/default/syncthing/core/aboutModalView.html
+++ b/gui/default/syncthing/core/aboutModalView.html
@@ -18,7 +18,7 @@ Jakob Borg, Audrius Butkevicius, Alexander Graf, Anderson Mesquita, Antony Male,
     <hr/>
 
     <p translate>Syncthing includes the following software or portions thereof:</p>
-    <ul class="list-unstyled two-columns">
+    <ul class="list-unstyled two-columns" id="copyright-notices">
       <li><a href="http://getbootstrap.com/">Bootstrap</a>, Copyright &copy; 2011-2016 Twitter, Inc.</li>
       <li><a href="https://angularjs.org/">AngularJS</a>, Copyright &copy; 2010-2016 Google, Inc.</li>
       <li><a href="https://github.com/bkaradzic/go-lz4">bkaradzic/go-lz4</a>, Copyright &copy; 2011-2012 Branimir Karadzic, 2013 Damian Gryski.</li>


### PR DESCRIPTION
When I ran `go run build.go translate` I was irritated at first about all the output and then just ignored it and looked at the actual effect it has.
This adds rules to silence untranslated strings warnings related to strings, that are not to be translated, such that in the future relevant warnings about untranslated strings don't go unnoticed.

I decided to ignore the "errors" and "warn" strings in the yellow top bar in case of javascript errors instead of translate them, as they are part of a kind of warning symbol, not really a textual information.