### PR TITLE
Update version regex to support non-prefixed version

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -63,7 +63,7 @@ var (
 	IsCandidate       bool
 	IsBeta            bool
 	LongVersion       string
-	allowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-[^\s]+)?$`)
+	allowedVersionExp = regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-[^\s]+)?$`)
 )
 
 const (


### PR DESCRIPTION
Otherwise the check can fail with things like:
```
$ /usr/bin/syncthing
19:06:55 FATAL: Invalid version string "0.14.23";
        does not match regexp ^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-[^\s]+)?$
```

We are [hit by this issue in Mageia](https://bugs.mageia.org/show_bug.cgi?id=20445) and [had a patch for it for a few releases](http://svnweb.mageia.org/packages/cauldron/syncthing/current/SOURCES/syncthing-0.14.0-version.patch?view=markup&pathrev=1089104), which was apparently never contributed back upstream yet, so here it is.

Note: I don't particularly require attribution in your AUTHORS file for such a small patch (which was not originally written by myself).