### PR TITLE
systemd: use sleep.target in syncthing-resume.service

### DIFF
--- a/etc/linux-systemd/system/syncthing-resume.service
+++ b/etc/linux-systemd/system/syncthing-resume.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Restart Syncthing after resume
 Documentation=man:syncthing(1)
-After=suspend.target
+After=sleep.target
 
 [Service]
 Type=oneshot
 ExecStart=-/usr/bin/pkill -HUP -x syncthing
 
 [Install]
-WantedBy=suspend.target
+WantedBy=sleep.target


### PR DESCRIPTION
### Purpose

Make sure that syncthing is also restarted when waking up from hibernate and hybrid-sleep, not just from suspend.

According to systemd.special(7):

    sleep.target
        A special target unit that is pulled in by suspend.target, hibernate.target and
        hybrid-sleep.target and may be used to hook units into the sleep state logic.

### Testing

Put a system into hibernation or hybrid-sleep and notice how `syncthing-resume.service` is not started once it resumes. Using `sleep.target` it works for all three sleep types.

### Documentation

As far as I can see `syncthing-resume.service` isn't specifically documented anywhere, so no changes should be needed.