### PR TITLE
lib/model, lib/scanner: Properly ignore symlinks on Windows (fixes #4035)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -53,8 +53,9 @@ type copyBlocksState struct {
 const retainBits = os.ModeSetgid | os.ModeSetuid | os.ModeSticky
 
 var (
-	activity    = newDeviceActivity()
-	errNoDevice = errors.New("peers who had this file went away, or the file has changed while syncing. will retry later")
+	activity               = newDeviceActivity()
+	errNoDevice            = errors.New("peers who had this file went away, or the file has changed while syncing. will retry later")
+	errSymlinksUnsupported = errors.New("symlinks not supported")
 )
 
 const (
@@ -1758,6 +1759,9 @@ func fileValid(file db.FileIntf) error {
 	case file.IsDeleted():
 		// We don't care about file validity if we're not supposed to have it
 		return nil
+
+	case runtime.GOOS == "windows" && file.IsSymlink():
+		return errSymlinksUnsupported
 
 	case runtime.GOOS == "windows" && windowsInvalidFilename(file.FileName()):
 		return errInvalidFilename

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -373,6 +373,12 @@ func (w *walker) walkDir(relPath string, info os.FileInfo, dchan chan protocol.F
 // walkSymlink returns nil or an error, if the error is of the nature that
 // it should stop the entire walk.
 func (w *walker) walkSymlink(absPath, relPath string, dchan chan protocol.FileInfo) error {
+	// Symlinks are not supported on Windows. We ignore instead of returning
+	// an error.
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
 	// We always rehash symlinks as they have no modtime or
 	// permissions. We check if they point to the old target by
 	// checking that their existing blocks match with the blocks in


### PR DESCRIPTION
Adds a unit test to ensure we don't scan symlinks on Windows. For the
rwfolder, trusts that the logic in the invalid check is correct and that
the check is actually called from the need loop.

(Need to make the build server able to run the symlink test, but it works on my Windows 10 as admin)