### PR TITLE
cmd/syncthing: Append build tags used to the long version string

### DIFF
--- a/cmd/syncthing/buildtag_noupgrade.go
+++ b/cmd/syncthing/buildtag_noupgrade.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2017 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//+build noupgrade
+
+package main
+
+func init() {
+	BuildTags = append(BuildTags, "noupgrade")
+}

--- a/cmd/syncthing/buildtag_race.go
+++ b/cmd/syncthing/buildtag_race.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2017 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//+build race
+
+package main
+
+func init() {
+	BuildTags = append(BuildTags, "race")
+}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -63,6 +63,7 @@ var (
 	IsCandidate       bool
 	IsBeta            bool
 	LongVersion       string
+	BuildTags         []string
 	allowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-[^\s]+)?$`)
 )
 
@@ -99,7 +100,9 @@ func init() {
 			l.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", Version, allowedVersionExp)
 		}
 	}
+}
 
+func setBuildMetadata() {
 	// Check for a clean release build. A release is something like
 	// "v0.1.2", with an optional suffix of letters and dot separated
 	// numbers like "-beta3.47". If there's more stuff, like a plus sign and
@@ -124,6 +127,10 @@ func init() {
 
 	date := BuildDate.UTC().Format("2006-01-02 15:04:05 MST")
 	LongVersion = fmt.Sprintf(`syncthing %s "%s" (%s %s-%s) %s@%s %s`, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, BuildUser, BuildHost, date)
+
+	if len(BuildTags) > 0 {
+		LongVersion = fmt.Sprintf("%s [%s]", LongVersion, strings.Join(BuildTags, ", "))
+	}
 }
 
 var (
@@ -318,6 +325,8 @@ func parseCommandLineOptions() RuntimeOptions {
 }
 
 func main() {
+	setBuildMetadata()
+
 	options := parseCommandLineOptions()
 	l.SetFlags(options.logFlags)
 


### PR DESCRIPTION
Because I'm a fanatic about the binary showing what sort of creature it is.

    $ go run build.go -race -no-upgrade
    $ syncthing -version
    syncthing v0.14.25-rc.2 "Dysprosium Dragonfly" (go1.8 darwin-amd64)
      jb@unu.kastelo.net 2017-03-16 23:06:21 UTC [noupgrade, race]
