### PR TITLE
core/languageSelectdirective: Sorted languages alphabetically (fixes …

### DIFF
--- a/gui/default/syncthing/core/languageSelectDirective.js
+++ b/gui/default/syncthing/core/languageSelectDirective.js
@@ -6,8 +6,8 @@ angular.module('syncthing.core')
             template:
                     '<a ng-if="visible" href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false"><span class="fa fa-globe"></span><span class="hidden-xs">&nbsp;{{localesNames[currentLocale] || "English"}}</span> <span class="caret"></span></a>'+
                     '<ul ng-if="visible" class="dropdown-menu">'+
-                        '<li ng-repeat="(i,name) in localesNames" ng-class="{active: i==currentLocale}">'+
-                            '<a href="#" data-ng-click="changeLanguage(i)">{{name}}</a>'+
+                        '<li ng-repeat="name in localesNamesInvKeys" ng-class="{active: localesNamesInv[name]==currentLocale}">'+
+                            '<a href="#" data-ng-click="changeLanguage(localesNamesInv[name])">{{name}}</a>'+
                         '</li>'+
                     '</ul>',
 
@@ -26,8 +26,22 @@ angular.module('syncthing.core')
                         availableLocaleNames[a] = '[' + a + ']';
                     }
                 }
-
                 $scope.localesNames = availableLocaleNames;
+                
+                var invert = function (obj) {
+                    var new_obj = {};
+
+                    for (var prop in obj) {
+                        if(obj.hasOwnProperty(prop)) {
+                            new_obj[obj[prop]] = prop;
+                        }
+                    }
+                    return new_obj;
+                };
+                $scope.localesNamesInv = invert($scope.localesNames)
+                $scope.localesNamesInvKeys = Object.keys($scope.localesNamesInv).sort()
+                
+                $scope.localesLanguageNames = 
                 $scope.visible = $scope.localesNames && $scope.localesNames['en'];
 
                 // using $watch cause LocaleService.currentLocale will be change after receive async query accepted-languages

--- a/gui/default/syncthing/core/languageSelectDirective.js
+++ b/gui/default/syncthing/core/languageSelectDirective.js
@@ -38,10 +38,9 @@ angular.module('syncthing.core')
                     }
                     return new_obj;
                 };
-                $scope.localesNamesInv = invert($scope.localesNames)
-                $scope.localesNamesInvKeys = Object.keys($scope.localesNamesInv).sort()
+                $scope.localesNamesInv = invert($scope.localesNames);
+                $scope.localesNamesInvKeys = Object.keys($scope.localesNamesInv).sort();
                 
-                $scope.localesLanguageNames = 
                 $scope.visible = $scope.localesNames && $scope.localesNames['en'];
 
                 // using $watch cause LocaleService.currentLocale will be change after receive async query accepted-languages


### PR DESCRIPTION
…3813)

### Purpose

This change sorts the language selection menu in Syncthing's home page so that the languages are displayed alphabetically. The issue was discussed in #3813. 
There were few ways of doing this. Sorting the language names in transifix file did not work due to access control. So I sorted the languages directly in languageSelectdirective.js by inverting and sorting the language info retrieved from localeService.js. 

### Testing

The changes could be seen in the GUI homepage as shown in the screenshot bleow. The translations works as expected. 

### Screenshots
![image](https://cloud.githubusercontent.com/assets/23461501/24109903/5f3804ea-0d92-11e7-94b1-10749d5ed84a.png)




