### PR TITLE
gui, script: Translate discovery popover and detect it in translate script

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -30,6 +30,7 @@
    "CPU Utilization": "CPU Utilization",
    "Changelog": "Changelog",
    "Clean out after": "Clean out after",
+   "Click to see discovery failures": "Click to see discovery failures",
    "Close": "Close",
    "Command": "Command",
    "Comment, when used at the start of a line": "Comment, when used at the start of a line",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -511,7 +511,7 @@
                         <span>{{discoveryTotal}}/{{discoveryTotal}}</span>
                       </span>
                       <span ng-if="discoveryFailed.length != 0" class="data" ng-class="{'text-danger': discoveryFailed.length == discoveryTotal}">
-                        <span popover data-trigger="hover" data-placement="bottom" data-content="Click to see discovery failures.">
+                        <span popover data-trigger="hover" data-placement="bottom" data-content="{{'Click to see discovery failures' | translate}}.">
                           <a href="" style="color:inherit" ng-click="showDiscoveryFailures()">{{discoveryTotal-discoveryFailed.length}}/{{discoveryTotal}}</a>
                         </span>
                       </span>

--- a/script/translate.go
+++ b/script/translate.go
@@ -50,6 +50,11 @@ func generalNode(n *html.Node, filename string) {
 					if matches := attrRe.FindStringSubmatch(a.Val); len(matches) == 2 {
 						translation(matches[1])
 					}
+					if a.Key == "data-content" &&
+						!noStringRe.MatchString(a.Val) {
+						log.Println("Untranslated data-content string (" + filename + "):")
+						log.Print("\t" + a.Val)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
The popover text for discovery failures wasn't translated. Thanks @bugith for noticing and [notifying about this](https://github.com/syncthing/syncthing/issues/2344#issuecomment-289193071).
The translate.go script did not pick these up as untranslated, so I added this case such that one gets notified if this happens again in the future.