### PR TITLE
lib/model: TestIgnores: Add ms sleep on all platforms (ref #3986 #3996)

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -957,6 +957,8 @@ func changeIgnores(t *testing.T, m *Model, expected []string) {
 		// system into thinking the file has not changed. Work around it in
 		// an ugly way...
 		time.Sleep(time.Second)
+	} else {
+		time.Sleep(time.Millisecond)
 	}
 	err = m.SetIgnores("default", ignores)
 	if err != nil {
@@ -975,6 +977,8 @@ func changeIgnores(t *testing.T, m *Model, expected []string) {
 	if runtime.GOOS == "darwin" {
 		// see above
 		time.Sleep(time.Second)
+	} else {
+		time.Sleep(time.Millisecond)
 	}
 	err = m.SetIgnores("default", expected)
 	if err != nil {


### PR DESCRIPTION
Apparently no sleep at all between changes to ".stignore" is potentially too fast even for non-darwin systems.
https://build.syncthing.net/job/syncthing-pr/3605/console
Unfortunately it isn't reproducible as with the mac builds, but hopefully a tiny 1ms sleep will fix it.
This PR exists primarily to get rid of unrelated test failures in #3986.