### PR TITLE
cmd/syncthing: Handle XML format configs over the API

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -7,8 +7,10 @@
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -198,6 +200,22 @@ func sendJSON(w http.ResponseWriter, jsonObject interface{}) {
 		return
 	}
 	w.Write(bs)
+}
+
+func sendXML(w http.ResponseWriter, xmlObject interface{}) {
+	buf := new(bytes.Buffer)
+	e := xml.NewEncoder(buf)
+	e.Indent("", "    ")
+	if err := e.Encode(xmlObject); err != nil {
+		bs, _ := json.Marshal(map[string]string{"error": err.Error()})
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		http.Error(w, string(bs), http.StatusInternalServerError)
+		return
+	}
+	buf.WriteByte('\n')
+
+	w.Header().Set("Content-Type", "application/xml; charset=utf-8")
+	w.Write(buf.Bytes())
 }
 
 func (s *apiService) Serve() {
@@ -736,6 +754,11 @@ func (s *apiService) getDBFile(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *apiService) getSystemConfig(w http.ResponseWriter, r *http.Request) {
+	if strings.Contains(r.Header.Get("Accept"), "application/xml") {
+		sendXML(w, s.cfg.RawCopy())
+		return
+	}
+
 	sendJSON(w, s.cfg.RawCopy())
 }
 
@@ -743,6 +766,15 @@ func (s *apiService) postSystemConfig(w http.ResponseWriter, r *http.Request) {
 	s.systemConfigMut.Lock()
 	defer s.systemConfigMut.Unlock()
 
+	if strings.Contains(r.Header.Get("Content-Type"), "application/xml") {
+		s.postSystemConfigXML(w, r)
+		return
+	}
+
+	s.postSystemConfigJSON(w, r)
+}
+
+func (s *apiService) postSystemConfigJSON(w http.ResponseWriter, r *http.Request) {
 	to, err := config.ReadJSON(r.Body, myID)
 	r.Body.Close()
 	if err != nil {
@@ -777,6 +809,28 @@ func (s *apiService) postSystemConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Activate and save
+
+	if err := s.cfg.Replace(to); err != nil {
+		l.Warnln("Replacing config:", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := s.cfg.Save(); err != nil {
+		l.Warnln("Saving config:", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (s *apiService) postSystemConfigXML(w http.ResponseWriter, r *http.Request) {
+	to, err := config.ReadXML(r.Body, myID)
+	r.Body.Close()
+	if err != nil {
+		l.Warnln("Decoding posted config:", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if err := s.cfg.Replace(to); err != nil {
 		l.Warnln("Replacing config:", err)


### PR DESCRIPTION
### Purpose

This simplifies backing up and restoring config remotely. By setting "Accept: application/xml" when GETing the config we get the config in the same format as on disk. Conversely, we can clone a device config to a remote device by POSTing an existing config from disk using "Content-Type: application/xml".

When accepting an XML format config we take it as-is: no funny business about the password etc, it should already be in hashed format.

### Testing

Works for me

### Documentation

Needs adding to the API docs