### PR TITLE
lib/model: Create root directory for paused folders (fixes #4094)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -812,6 +812,16 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		setPauseState(cfg, true)
 	}
 
+	// Add and start folders
+	for _, folderCfg := range cfg.Folders() {
+		if folderCfg.Paused {
+			folderCfg.CreateRoot()
+			continue
+		}
+		m.AddFolder(folderCfg)
+		m.StartFolder(folderCfg.ID)
+	}
+
 	mainService.Add(m)
 
 	// Start discovery
@@ -856,8 +866,6 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 			cachedDiscovery.Add(mcd, 0, 0, ipv6LocalDiscoveryPriority)
 		}
 	}
-
-	cfg.Replace(cfg.RawCopy())
 
 	// GUI
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -812,15 +812,6 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		setPauseState(cfg, true)
 	}
 
-	// Add and start folders
-	for _, folderCfg := range cfg.Folders() {
-		if folderCfg.Paused {
-			continue
-		}
-		m.AddFolder(folderCfg)
-		m.StartFolder(folderCfg.ID)
-	}
-
 	mainService.Add(m)
 
 	// Start discovery
@@ -865,6 +856,8 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 			cachedDiscovery.Add(mcd, 0, 0, ipv6LocalDiscoveryPriority)
 		}
 	}
+
+	cfg.Replace(cfg.RawCopy())
 
 	// GUI
 

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -104,6 +104,26 @@ func (f *FolderConfiguration) HasMarker() bool {
 	return err == nil
 }
 
+func (f *FolderConfiguration) CreateRoot() (err error) {
+	// Directory permission bits. Will be filtered down to something
+	// sane by umask on Unixes.
+	permBits := os.FileMode(0777)
+	if runtime.GOOS == "windows" {
+		// Windows has no umask so we must chose a safer set of bits to
+		// begin with.
+		permBits = 0700
+	}
+
+	if _, err = os.Stat(f.Path()); os.IsNotExist(err) {
+		if err = osutil.MkdirAll(f.Path(), permBits); err != nil {
+			l.Warnf("Creating directory for %v: %v",
+				f.Description(), err)
+		}
+	}
+
+	return err
+}
+
 func (f FolderConfiguration) Description() string {
 	if f.Label == "" {
 		return f.ID

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -232,7 +232,7 @@ func (m *Model) startFolderLocked(folder string) config.FolderType {
 		// Directory permission bits. Will be filtered down to something
 		// sane by umask on Unixes.
 
-		createRootFolder(cfg)
+		createFolderRoot(cfg)
 
 		if err := cfg.CreateMarker(); err != nil {
 			l.Warnln("Creating folder marker:", err)
@@ -2372,7 +2372,7 @@ func (m *Model) CommitConfiguration(from, to config.Configuration) bool {
 			// A folder was added.
 			if cfg.Paused {
 				l.Infoln(m, "Paused folder", cfg.Description())
-				createRootFolder(cfg)
+				createFolderRoot(cfg)
 			} else {
 				l.Infoln(m, "Adding folder", cfg.Description())
 				m.AddFolder(cfg)
@@ -2715,7 +2715,7 @@ func rootedJoinedPath(root, rel string) (string, error) {
 	return joined, nil
 }
 
-func createRootFolder(cfg config.FolderConfiguration) {
+func createFolderRoot(cfg config.FolderConfiguration) {
 	// Directory permission bits. Will be filtered down to something
 	// sane by umask on Unixes.
 	permBits := os.FileMode(0777)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -232,7 +232,7 @@ func (m *Model) startFolderLocked(folder string) config.FolderType {
 		// Directory permission bits. Will be filtered down to something
 		// sane by umask on Unixes.
 
-		createFolderRoot(cfg)
+		cfg.CreateRoot()
 
 		if err := cfg.CreateMarker(); err != nil {
 			l.Warnln("Creating folder marker:", err)
@@ -2372,7 +2372,7 @@ func (m *Model) CommitConfiguration(from, to config.Configuration) bool {
 			// A folder was added.
 			if cfg.Paused {
 				l.Infoln(m, "Paused folder", cfg.Description())
-				createFolderRoot(cfg)
+				cfg.CreateRoot()
 			} else {
 				l.Infoln(m, "Adding folder", cfg.Description())
 				m.AddFolder(cfg)
@@ -2713,22 +2713,4 @@ func rootedJoinedPath(root, rel string) (string, error) {
 	}
 
 	return joined, nil
-}
-
-func createFolderRoot(cfg config.FolderConfiguration) {
-	// Directory permission bits. Will be filtered down to something
-	// sane by umask on Unixes.
-	permBits := os.FileMode(0777)
-	if runtime.GOOS == "windows" {
-		// Windows has no umask so we must chose a safer set of bits to
-		// begin with.
-		permBits = 0700
-	}
-
-	if _, err := os.Stat(cfg.Path()); os.IsNotExist(err) {
-		if err := osutil.MkdirAll(cfg.Path(), permBits); err != nil {
-			l.Warnf("Creating directory for %v: %v",
-				cfg.Description(), err)
-		}
-	}
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -231,18 +231,9 @@ func (m *Model) startFolderLocked(folder string) config.FolderType {
 
 		// Directory permission bits. Will be filtered down to something
 		// sane by umask on Unixes.
-		permBits := os.FileMode(0777)
-		if runtime.GOOS == "windows" {
-			// Windows has no umask so we must chose a safer set of bits to
-			// begin with.
-			permBits = 0700
-		}
 
-		if _, err := os.Stat(cfg.Path()); os.IsNotExist(err) {
-			if err := osutil.MkdirAll(cfg.Path(), permBits); err != nil {
-				l.Warnln("Creating folder:", err)
-			}
-		}
+		createRootFolder(cfg)
+
 		if err := cfg.CreateMarker(); err != nil {
 			l.Warnln("Creating folder marker:", err)
 		}
@@ -2381,6 +2372,7 @@ func (m *Model) CommitConfiguration(from, to config.Configuration) bool {
 			// A folder was added.
 			if cfg.Paused {
 				l.Infoln(m, "Paused folder", cfg.Description())
+				createRootFolder(cfg)
 			} else {
 				l.Infoln(m, "Adding folder", cfg.Description())
 				m.AddFolder(cfg)
@@ -2721,4 +2713,22 @@ func rootedJoinedPath(root, rel string) (string, error) {
 	}
 
 	return joined, nil
+}
+
+func createRootFolder(cfg config.FolderConfiguration) {
+	// Directory permission bits. Will be filtered down to something
+	// sane by umask on Unixes.
+	permBits := os.FileMode(0777)
+	if runtime.GOOS == "windows" {
+		// Windows has no umask so we must chose a safer set of bits to
+		// begin with.
+		permBits = 0700
+	}
+
+	if _, err := os.Stat(cfg.Path()); os.IsNotExist(err) {
+		if err := osutil.MkdirAll(cfg.Path(), permBits); err != nil {
+			l.Warnf("Creating directory for %v: %v",
+				cfg.Description(), err)
+		}
+	}
 }


### PR DESCRIPTION
see #4094

One possible caveat: Paused folders in config.xml are not handled (e.g. https://github.com/syncthing/syncthing/blob/master/cmd/syncthing/main.go#L817), but possibly other places too (?).