### PR TITLE
Reducing height of textarea in editIgnoresModalView modal

### DIFF
--- a/gui/default/syncthing/folder/editIgnoresModalView.html
+++ b/gui/default/syncthing/folder/editIgnoresModalView.html
@@ -1,7 +1,7 @@
 <modal id="editIgnores" status="default" heading="{{'Ignore Patterns' | translate}}" large="yes" closeable="yes">
   <div class="modal-body">
     <p translate>Enter ignore patterns, one per line.</p>
-    <textarea class="form-control" rows="15"></textarea>
+    <textarea class="form-control" rows="5"></textarea>
 
     <hr/>
 


### PR DESCRIPTION
### Purpose

The height of the 'ignore patterns' modal is excessively large and can cause unnecessary display issues on smaller screens.  Important items like the *Save* button get pushed below the bottom of the screen.  The screen confusion is amplified by the fact that this is a modal inside another modal.

All of this is unnecessary because an HTML `textarea` element will scroll if the user adds more than the 5 lines.  Additionally, in modern browsers like Chrome, user can also grab the bottom-right corner and drag to make the textarea larger in case that is desirable.

### Testing

Tested in all major browsers. A very simple change to standard HTML attribute.
I experimented with several heights, 5 lines was chosen because it clearly indicates multiple lines are possible and will be plenty to get any user started.

### Screenshots

![syncthing-modal](https://cloud.githubusercontent.com/assets/5115470/25054232/3d29298c-215c-11e7-957b-9ffd25aafcfa.jpg)

### Documentation

Documentation is not necessary.

### Authorship

Every author of a code contribution (Go, Javascript, HTML, CSS etc, with the
possible exception of minor typo corrections and similar) is recorded in the
AUTHORS and NICKS files and the in-GUI credits. If this is your first
contribution, a maintainer will add you properly before accepting the
contribution. You need not do so yourself or worry about the fact that the
"authors" automated test fails. However, if your name (such as you want it
presented in the credits) is not visible on your Github profile or in your
commit messages, please assist by providing it here.

**I agree to the above.**