### PR TITLE
Mark initial scan as finished even if failed and refactor (fixes #4103)

### DIFF
--- a/lib/model/rwfolder_test.go
+++ b/lib/model/rwfolder_test.go
@@ -80,9 +80,9 @@ func setUpModel(file protocol.FileInfo) *Model {
 func setUpSendReceiveFolder(model *Model) *sendReceiveFolder {
 	f := &sendReceiveFolder{
 		folder: folder{
-			stateTracker:         newStateTracker("default"),
-			model:                model,
-			initialScanCompleted: make(chan struct{}),
+			stateTracker:        newStateTracker("default"),
+			model:               model,
+			initialScanFinished: make(chan struct{}),
 		},
 
 		mtimeFS:   fs.NewMtimeFS(fs.DefaultFilesystem, db.NewNamespacedKV(model.db, "mtime")),
@@ -93,7 +93,7 @@ func setUpSendReceiveFolder(model *Model) *sendReceiveFolder {
 	}
 
 	// Folders are never actually started, so no initial scan will be done
-	close(f.initialScanCompleted)
+	close(f.initialScanFinished)
 
 	return f
 }


### PR DESCRIPTION
The mechanism to disallow manual scans before the initial scan completed (#3996) , had the side effect, that if the initial scan failed, no further scans are allowed. So this marks the initial scan as finished regardless of whether it succeeded or not.

There was also redundant code in rofolder and a pointless check for folder health in `scanSubsIfHealthy` (happens in `internalScanFolderSubdirs` as well). This also moves logging from folder.go to ro/rw-folder.go to include the information about whether it is send-only or send-receive.