### PR TITLE
lib/db, lib/model: Always use reasonable sized batches (fixes #2250, fixes #4112)

### DIFF
--- a/lib/db/blockmap.go
+++ b/lib/db/blockmap.go
@@ -19,7 +19,7 @@ import (
 
 var blockFinder *BlockFinder
 
-const maxBatchSize = 256 << 10
+const maxBatchSize = 1000
 
 type BlockMap struct {
 	db     *Instance


### PR DESCRIPTION
### Purpose

Harmonize how we use batches in the model, using ProtoSize() to judge the actual weight of the entire batch instead of estimating. Use smaller batches in the block map - I think we might have though that batch.Len() in the leveldb was the batch size in bytes, but it's actually number of operations.

### Testing

Tried both the override and remove operations on my collection of sample data. With the old version memory usage ballooned ~80 -> ~390 MB. With this change, it stays at ~100 MB instead.

There could conceivably be a performance impact from the smaller batches. I didn't see any statistically relevant change on the ManyFiles benchmark though, and if it's small it's probably worth it anyway.
