### PR TITLE
lib/fs, lib/model, lib/scanner: Make scans cancellable (fixes #3965)

### DIFF
--- a/cmd/stfileinfo/main.go
+++ b/cmd/stfileinfo/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"os"
@@ -70,7 +71,7 @@ func main() {
 		if *standardBlocks || blockSize < protocol.BlockSize {
 			blockSize = protocol.BlockSize
 		}
-		bs, err := scanner.Blocks(fd, blockSize, fi.Size(), nil, true)
+		bs, err := scanner.Blocks(context.TODO(), fd, blockSize, fi.Size(), nil, true)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/tls"
 	"encoding/json"
@@ -309,7 +310,7 @@ func cpuBenchOnce(duration time.Duration, useWeakHash bool, bs []byte) float64 {
 	b := 0
 	for time.Since(t0) < duration {
 		r := bytes.NewReader(bs)
-		blocksResult, _ = scanner.Blocks(r, protocol.BlockSize, int64(len(bs)), nil, useWeakHash)
+		blocksResult, _ = scanner.Blocks(context.TODO(), r, protocol.BlockSize, int64(len(bs)), nil, useWeakHash)
 		b += len(bs)
 	}
 	d := time.Since(t0)

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -7,6 +7,7 @@
 package fs
 
 import (
+	"errors"
 	"os"
 	"time"
 )
@@ -84,6 +85,11 @@ func (f *BasicFilesystem) Create(name string) (File, error) {
 		return nil, err
 	}
 	return fsFile{fd}, err
+}
+
+func (f *BasicFilesystem) Walk(root string, walkFn WalkFunc) error {
+	// implemented in WalkFS
+	return errors.New("not implemented")
 }
 
 // fsFile implements the fs.File interface on top of an os.File

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -88,7 +88,7 @@ func (f *BasicFilesystem) Create(name string) (File, error) {
 }
 
 func (f *BasicFilesystem) Walk(root string, walkFn WalkFunc) error {
-	// implemented in WalkFS
+	// implemented in WalkFilesystem
 	return errors.New("not implemented")
 }
 

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -64,7 +64,7 @@ const ModePerm = FileMode(os.ModePerm)
 
 // DefaultFilesystem is the fallback to use when nothing explicitly has
 // been passed.
-var DefaultFilesystem Filesystem = NewBasicFilesystem()
+var DefaultFilesystem Filesystem = NewWalkFilesystem(NewBasicFilesystem())
 
 // SkipDir is used as a return value from WalkFuncs to indicate that
 // the directory named in the call is to be skipped. It is not returned

--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -28,8 +28,16 @@ import "path/filepath"
 // Walk skips the remaining files in the containing directory.
 type WalkFunc func(path string, info FileInfo, err error) error
 
+type WalkFilesystem struct {
+	Filesystem
+}
+
+func NewWalkFilesystem(next Filesystem) *WalkFilesystem {
+	return &WalkFilesystem{next}
+}
+
 // walk recursively descends path, calling walkFn.
-func (f *BasicFilesystem) walk(path string, info FileInfo, walkFn WalkFunc) error {
+func (f *WalkFilesystem) walk(path string, info FileInfo, walkFn WalkFunc) error {
 	err := walkFn(path, info, nil)
 	if err != nil {
 		if info.IsDir() && err == SkipDir {
@@ -72,7 +80,7 @@ func (f *BasicFilesystem) walk(path string, info FileInfo, walkFn WalkFunc) erro
 // order, which makes the output deterministic but means that for very
 // large directories Walk can be inefficient.
 // Walk does not follow symbolic links.
-func (f *BasicFilesystem) Walk(root string, walkFn WalkFunc) error {
+func (f *WalkFilesystem) Walk(root string, walkFn WalkFunc) error {
 	info, err := f.Lstat(root)
 	if err != nil {
 		return walkFn(root, nil, err)

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -17,7 +17,7 @@ type folder struct {
 	scan                folderScanner
 	model               *Model
 	ctx                 context.Context
-	cancel              func()
+	cancel              context.CancelFunc
 	initialScanFinished chan struct{}
 }
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -6,14 +6,18 @@
 
 package model
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type folder struct {
 	stateTracker
 
 	scan                folderScanner
 	model               *Model
-	stop                chan struct{}
+	ctx                 context.Context
+	cancel              func()
 	initialScanFinished chan struct{}
 }
 
@@ -28,8 +32,9 @@ func (f *folder) Scan(subdirs []string) error {
 	<-f.initialScanFinished
 	return f.scan.Scan(subdirs)
 }
+
 func (f *folder) Stop() {
-	close(f.stop)
+	f.cancel()
 }
 
 func (f *folder) Jobs() ([]string, []string) {
@@ -39,7 +44,7 @@ func (f *folder) Jobs() ([]string, []string) {
 func (f *folder) BringToFront(string) {}
 
 func (f *folder) scanSubdirs(subDirs []string) error {
-	if err := f.model.internalScanFolderSubdirs(f.folderID, subDirs); err != nil {
+	if err := f.model.internalScanFolderSubdirs(f.ctx, f.folderID, subDirs); err != nil {
 		// Potentially sets the error twice, once in the scanner just
 		// by doing a check, and once here, if the error returned is
 		// the same one as returned by CheckFolderHealth, though

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -8,6 +8,7 @@ package model
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -317,7 +318,7 @@ func (f *fakeConnection) addFile(name string, flags uint32, ftype protocol.FileI
 	f.mut.Lock()
 	defer f.mut.Unlock()
 
-	blocks, _ := scanner.Blocks(bytes.NewReader(data), protocol.BlockSize, int64(len(data)), nil, true)
+	blocks, _ := scanner.Blocks(context.TODO(), bytes.NewReader(data), protocol.BlockSize, int64(len(data)), nil, true)
 	var version protocol.Vector
 	version = version.Update(f.id.Short())
 

--- a/lib/model/rwfolder_test.go
+++ b/lib/model/rwfolder_test.go
@@ -7,6 +7,7 @@
 package model
 
 import (
+	"context"
 	"crypto/rand"
 	"io"
 	"os"
@@ -83,6 +84,7 @@ func setUpSendReceiveFolder(model *Model) *sendReceiveFolder {
 			stateTracker:        newStateTracker("default"),
 			model:               model,
 			initialScanFinished: make(chan struct{}),
+			ctx:                 context.TODO(),
 		},
 
 		mtimeFS:   fs.NewMtimeFS(fs.DefaultFilesystem, db.NewNamespacedKV(model.db, "mtime")),
@@ -244,7 +246,7 @@ func TestCopierFinder(t *testing.T) {
 	}
 
 	// Verify that the fetched blocks have actually been written to the temp file
-	blks, err := scanner.HashFile(fs.DefaultFilesystem, tempFile, protocol.BlockSize, nil, false)
+	blks, err := scanner.HashFile(context.TODO(), fs.DefaultFilesystem, tempFile, protocol.BlockSize, nil, false)
 	if err != nil {
 		t.Log(err)
 	}
@@ -297,7 +299,7 @@ func TestWeakHash(t *testing.T) {
 	// File 1: abcdefgh
 	// File 2: xyabcdef
 	f.Seek(0, os.SEEK_SET)
-	existing, err := scanner.Blocks(f, protocol.BlockSize, size, nil, true)
+	existing, err := scanner.Blocks(context.TODO(), f, protocol.BlockSize, size, nil, true)
 	if err != nil {
 		t.Error(err)
 	}
@@ -306,7 +308,7 @@ func TestWeakHash(t *testing.T) {
 	remainder := io.LimitReader(f, size-shift)
 	prefix := io.LimitReader(rand.Reader, shift)
 	nf := io.MultiReader(prefix, remainder)
-	desired, err := scanner.Blocks(nf, protocol.BlockSize, size, nil, true)
+	desired, err := scanner.Blocks(context.TODO(), nf, protocol.BlockSize, size, nil, true)
 	if err != nil {
 		t.Error(err)
 	}

--- a/lib/scanner/blocks_test.go
+++ b/lib/scanner/blocks_test.go
@@ -8,6 +8,7 @@ package scanner
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"fmt"
 	origAdler32 "hash/adler32"
@@ -68,7 +69,7 @@ var blocksTestData = []struct {
 func TestBlocks(t *testing.T) {
 	for testNo, test := range blocksTestData {
 		buf := bytes.NewBuffer(test.data)
-		blocks, err := Blocks(buf, test.blocksize, -1, nil, true)
+		blocks, err := Blocks(context.TODO(), buf, test.blocksize, -1, nil, true)
 
 		if err != nil {
 			t.Fatal(err)
@@ -125,8 +126,8 @@ var diffTestData = []struct {
 
 func TestDiff(t *testing.T) {
 	for i, test := range diffTestData {
-		a, _ := Blocks(bytes.NewBufferString(test.a), test.s, -1, nil, false)
-		b, _ := Blocks(bytes.NewBufferString(test.b), test.s, -1, nil, false)
+		a, _ := Blocks(context.TODO(), bytes.NewBufferString(test.a), test.s, -1, nil, false)
+		b, _ := Blocks(context.TODO(), bytes.NewBufferString(test.b), test.s, -1, nil, false)
 		_, d := BlockDiff(a, b)
 		if len(d) != len(test.d) {
 			t.Fatalf("Incorrect length for diff %d; %d != %d", i, len(d), len(test.d))

--- a/lib/scanner/infinitefs_test.go
+++ b/lib/scanner/infinitefs_test.go
@@ -1,0 +1,100 @@
+// Copyright (C) 2017 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package scanner
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/syncthing/syncthing/lib/fs"
+)
+
+type infiniteFS struct {
+	width    int   // number of files and directories per level
+	depth    int   // number of tree levels to simulate
+	filesize int64 // size of each file in bytes
+}
+
+var errNotSupp = errors.New("not supported")
+
+func (i infiniteFS) Lstat(name string) (fs.FileInfo, error) {
+	return fakeInfo{name, i.filesize}, nil
+}
+
+func (i infiniteFS) DirNames(name string) ([]string, error) {
+	var names []string
+	for j := 0; j < i.width; j++ {
+		names = append(names, fmt.Sprintf("file%d", j))
+	}
+	if len(strings.Split(name, string(os.PathSeparator))) < i.depth {
+		for j := 0; j < i.width; j++ {
+			names = append(names, fmt.Sprintf("dir%d", j))
+		}
+	}
+	return names, nil
+}
+
+func (i infiniteFS) Open(name string) (fs.File, error) {
+	return &fakeFile{name, i.filesize, 0}, nil
+}
+
+func (infiniteFS) Chmod(name string, mode fs.FileMode) error                   { return errNotSupp }
+func (infiniteFS) Chtimes(name string, atime time.Time, mtime time.Time) error { return errNotSupp }
+func (infiniteFS) Create(name string) (fs.File, error)                         { return nil, errNotSupp }
+func (infiniteFS) CreateSymlink(name, target string) error                     { return errNotSupp }
+func (infiniteFS) Mkdir(name string, perm fs.FileMode) error                   { return errNotSupp }
+func (infiniteFS) ReadSymlink(name string) (string, error)                     { return "", errNotSupp }
+func (infiniteFS) Remove(name string) error                                    { return errNotSupp }
+func (infiniteFS) Rename(oldname, newname string) error                        { return errNotSupp }
+func (infiniteFS) Stat(name string) (fs.FileInfo, error)                       { return nil, errNotSupp }
+func (infiniteFS) SymlinksSupported() bool                                     { return false }
+func (infiniteFS) Walk(root string, walkFn fs.WalkFunc) error                  { return errNotSupp }
+
+type fakeInfo struct {
+	name string
+	size int64
+}
+
+func (f fakeInfo) Name() string       { return f.name }
+func (f fakeInfo) Mode() fs.FileMode  { return 0755 }
+func (f fakeInfo) Size() int64        { return f.size }
+func (f fakeInfo) ModTime() time.Time { return time.Now() }
+func (f fakeInfo) IsDir() bool        { return strings.Contains(filepath.Base(f.name), "dir") }
+func (f fakeInfo) IsRegular() bool    { return !f.IsDir() }
+func (f fakeInfo) IsSymlink() bool    { return false }
+
+type fakeFile struct {
+	name       string
+	size       int64
+	readOffset int64
+}
+
+func (f *fakeFile) Read(bs []byte) (int, error) {
+	remaining := f.size - f.readOffset
+	if remaining == 0 {
+		return 0, io.EOF
+	}
+	if remaining < int64(len(bs)) {
+		f.readOffset = f.size
+		return int(remaining), nil
+	}
+	f.readOffset += int64(len(bs))
+	return len(bs), nil
+}
+
+func (f *fakeFile) Stat() (fs.FileInfo, error) {
+	return fakeInfo{f.name, f.size}, nil
+}
+
+func (f *fakeFile) WriteAt(bs []byte, offs int64) (int, error) { return 0, errNotSupp }
+func (f *fakeFile) Close() error                               { return nil }
+func (f *fakeFile) Truncate(size int64) error                  { return errNotSupp }

--- a/lib/scanner/infinitefs_test.go
+++ b/lib/scanner/infinitefs_test.go
@@ -31,13 +31,16 @@ func (i infiniteFS) Lstat(name string) (fs.FileInfo, error) {
 }
 
 func (i infiniteFS) DirNames(name string) ([]string, error) {
+	// Returns a list of fake files and directories. Names are such that
+	// files appear before directories - this makes it so the scanner will
+	// actually see a few files without having to reach the max depth.
 	var names []string
 	for j := 0; j < i.width; j++ {
-		names = append(names, fmt.Sprintf("file%d", j))
+		names = append(names, fmt.Sprintf("aa-file-%d", j))
 	}
 	if len(strings.Split(name, string(os.PathSeparator))) < i.depth {
 		for j := 0; j < i.width; j++ {
-			names = append(names, fmt.Sprintf("dir%d", j))
+			names = append(names, fmt.Sprintf("zz-dir-%d", j))
 		}
 	}
 	return names, nil
@@ -67,7 +70,7 @@ type fakeInfo struct {
 func (f fakeInfo) Name() string       { return f.name }
 func (f fakeInfo) Mode() fs.FileMode  { return 0755 }
 func (f fakeInfo) Size() int64        { return f.size }
-func (f fakeInfo) ModTime() time.Time { return time.Now() }
+func (f fakeInfo) ModTime() time.Time { return time.Unix(1234567890, 0) }
 func (f fakeInfo) IsDir() bool        { return strings.Contains(filepath.Base(f.name), "dir") }
 func (f fakeInfo) IsRegular() bool    { return !f.IsDir() }
 func (f fakeInfo) IsSymlink() bool    { return false }

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -467,10 +467,7 @@ func TestStopWalk(t *testing.T) {
 	// 100^100 files and 100^100 directories. It'll take a while to scan,
 	// unless the cancel works.
 
-	fs := fs.NewWalkFilesystem(&infiniteFS{
-		width: 100,
-		depth: 100,
-	})
+	fs := fs.NewWalkFilesystem(&infiniteFS{100, 100, 1e6})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	fchan, err := Walk(ctx, Config{


### PR DESCRIPTION
### Purpose

The folder already knew how to stop properly, but the fs.Walk() didn't
and can potentially take a very long time. This adds context support to
Walk and the underlying scanning stuff, and passes in an appropriate
context from above. The stop channel in model.folder is replaced with a
context for this purpose.

### Testing

To test I added an infiniteFS that represents a large amount of data
(not actually infinite, but close) and verify that walking it is
properly stopped. For that to be implemented smoothly I moved out the
Walk function to it's own type, as typically the implementer of a new
filesystem type might not need or want to reimplement Walk.

It's somewhat tricky to test that this actually works properly on the
actual sendReceiveFolder and so on, as those are started from inside the
model and the filesystem isn't easily pluggable etc. Instead I've tested
that part manually by adding a huge folder and verifying that pause,
resume and reconfig do the right things by looking at debug output.
