### PR TITLE
lib/db: Don't panic

### DIFF
--- a/lib/db/leveldb.go
+++ b/lib/db/leveldb.go
@@ -69,13 +69,15 @@ func getFile(db dbReader, key []byte) (protocol.FileInfo, bool) {
 		return protocol.FileInfo{}, false
 	}
 	if err != nil {
-		panic(err)
+		l.Debugln("surprise error:", err)
+		return protocol.FileInfo{}, false
 	}
 
 	var f protocol.FileInfo
 	err = f.Unmarshal(bs)
 	if err != nil {
-		panic(err)
+		l.Debugln("unmarshal error:", err)
+		return protocol.FileInfo{}, false
 	}
 	return f, true
 }


### PR DESCRIPTION
### Purpose

So, when first implementing the database layer I added panics on every
unexpected error condition mostly to be sure to flush out bugs and
inconsistencies. Then it became sort of standard, and we don't seem to
have many bugs here any more so the panics are usually caused by things
like checksum errors on read. But it's not an optimal user experience to
crash all the time.

Here I've weeded out most of the panics, while retaining a few "can't
happen" ones like errors on marshalling and write that we really can't
recover from.

For the rest, I'm mostly treating any read error as "entry didn't
exist". This should mean we'll rescan the file and correct the info (if
scanning) or treat it as a new file and do conflict handling (when
pulling). In some cases things like our global stats may be slightly
incorrect until a restart, if a database entry goes suddenly missing
during runtime.

All in all, I think this makes us a bit more robust and friendly without
introducing too many risks for the user. If the database is truly toast,
probably many other things on the system will be toast as well...

### Testing

asdfasdfasdf?