### PR TITLE
script: Ignore units and allow translated strings as translate-values

### DIFF
--- a/script/translate.go
+++ b/script/translate.go
@@ -24,7 +24,7 @@ var attrRe = regexp.MustCompile(`\{\{'([^']+)'\s+\|\s+translate\}\}`)
 
 // exceptions to the untranslated text warning
 var noStringRe = regexp.MustCompile(
-	`^((\W*\{\{.*?\}\} ?.?\/?.?(bps)?\W*)+(\.stignore)?|[^a-zA-Z]+.?[^a-zA-Z]*|(k|M|G|T)B|Twitter|JS\W?|DEV|https?://\S+)$`)
+	`^((\W*\{\{.*?\}\} ?.?\/?.?(bps)?\W*)+(\.stignore)?|[^a-zA-Z]+.?[^a-zA-Z]*|[kMGT]?B|Twitter|JS\W?|DEV|https?://\S+)$`)
 
 // exceptions to the untranslated text warning specific to aboutModalView.html
 var aboutRe = regexp.MustCompile(`^([^/]+/[^/]+|(The Go Pro|Font Awesome ).+)$`)

--- a/script/translate.go
+++ b/script/translate.go
@@ -24,7 +24,7 @@ var attrRe = regexp.MustCompile(`\{\{'([^']+)'\s+\|\s+translate\}\}`)
 
 // exceptions to the untranslated text warning
 var noStringRe = regexp.MustCompile(
-	`^((\W*\{\{.*?\}\} ?.?\W*)+(\.stignore)?|[^a-zA-Z]+.?[^a-zA-Z]*|Twitter|JS\W?|DEV|https?://\S+)$`)
+	`^((\W*\{\{.*?\}\} ?.?\/?.?(bps)?\W*)+(\.stignore)?|[^a-zA-Z]+.?[^a-zA-Z]*|(k|M|G|T)B|Twitter|JS\W?|DEV|https?://\S+)$`)
 
 // exceptions to the untranslated text warning specific to aboutModalView.html
 var aboutRe = regexp.MustCompile(`^([^/]+/[^/]+|(The Go Pro|Font Awesome ).+)$`)
@@ -40,7 +40,6 @@ func generalNode(n *html.Node, filename string) {
 			for _, a := range n.Attr {
 				if a.Key == "translate" {
 					translate = true
-					break
 				} else if a.Key == "id" && (a.Val == "contributor-list" ||
 					a.Val == "copyright-notices") {
 					// Don't translate a list of names and


### PR DESCRIPTION
This extends the regex of ignored strings (i.e. no warning about being untranslated). This regex gets increasingly sillyish, maybe at some point it would be worth to switch to something like the earlier proposed `data-translatable="no"` attribute.

Also I removed a break statement to also check translate-values for translated strings. This allows to separate terms that are "names" and should be consistent in all translations. An example can be seen in #4119 where I added each occurrence of "filesystem notifications" as a translate-value. This could also be used for "Folder ID" and similar terms.
Doing this is a trade-off between simplicity and consistent translations. I think it is worth doing. Opinions?