### PR TITLE
lib/ignore: Don't match root (".")

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -163,7 +163,7 @@ func (m *Matcher) patternsUnchanged(file string) bool {
 }
 
 func (m *Matcher) Match(file string) (result Result) {
-	if m == nil {
+	if m == nil || file == "." {
 		return resultNotMatched
 	}
 

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -843,3 +843,32 @@ func TestIsInternal(t *testing.T) {
 		}
 	}
 }
+
+func TestRoot(t *testing.T) {
+	stignore := `
+	!/a
+	/*
+	`
+
+	testcases := []struct {
+		file    string
+		matches bool
+	}{
+		{".", false},
+		{"a", false},
+		{"b", true},
+	}
+
+	pats := New(true)
+	err := pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range testcases {
+		res := pats.Match(tc.file).IsIgnored()
+		if res != tc.matches {
+			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
+		}
+	}
+}


### PR DESCRIPTION
When the line "/*" or "*" is present in ".stignore", the folder root (i.e. ".") is ignored. This is a problem when files are explicitly included (e.g. "!/a*") and it generally doesn't make sense to ignore the entire folder.

This surfaced in syncthing/syncthing/inotify#161 and wasn't a problem for Syncthing, as the root folder case was already handled in walk.go.