### PR TITLE
gui: Don't reload concurrently with saving config when changing theme (fixes #4127)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1101,14 +1101,14 @@ angular.module('syncthing.core')
                     });
                 });
 
-                $scope.saveConfig();
+                $scope.saveConfig(function () {
+                    if (themeChanged) {
+                        document.location.reload(true);
+                    }
+                });
             }
 
             $('#settings').modal("hide");
-
-            if (themeChanged) {
-              document.location.reload(true);
-            }
         };
 
         $scope.saveAdvanced = function () {


### PR DESCRIPTION
### Purpose

Avoid the error saving config that happens when the POST gets cancelled due to reload.

### Testing

Changed theme a few times...

There is another problem though related to caching that is not fixed by this PR. The reload done by the UI didn't actually *change* the theme for me. I needed a manual, cache-clearing, shift-reload for that to happen...