### PR TITLE
gui: Display file timestamps in 24h format

### DIFF
--- a/gui/default/syncthing/device/globalChangesModalView.html
+++ b/gui/default/syncthing/device/globalChangesModalView.html
@@ -15,7 +15,7 @@
             <td>{{changeEvent.data.action}}</td>
             <td>{{changeEvent.data.type}}</td>
             <td>{{changeEvent.data.path}}</td>
-            <td>{{changeEvent.time | date:'medium'}}</td>
+            <td>{{changeEvent.time | date:"yyyy-MM-dd HH:mm:ss"}}</td>
           </tr>
         </table>
     </div>
@@ -24,4 +24,4 @@
         <span class="fa fa-times"></span>&nbsp;<span translate>Close</span>
         </button>
     </div>
-</model>
+</modal>


### PR DESCRIPTION
in regular folder view tooltips on "latest change" are in 24h format, in global changes modal timestamps are in 12h format

