### PR TITLE
gui: Added a CSS rule for out of sync items modal

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -100,9 +100,11 @@ ul+h5 {
     white-space: nowrap;
 }
 
+/* Removing text decoration on anchor link hover pull request: #4135 */
 .table td.small-data span a:hover {
     text-decoration: none;
 }
+
 table.table-condensed {
     table-layout: fixed;
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -100,6 +100,9 @@ ul+h5 {
     white-space: nowrap;
 }
 
+.table td.small-data span a:hover {
+    text-decoration: none;
+}
 table.table-condensed {
     table-layout: fixed;
 }


### PR DESCRIPTION
### Purpose

Removed text decoration on hover which was shown while hovering on span with eject icon which is "Move to top of queue" in Out of sync items modal

### Testing

Tested on Firefox Browser and works as fixed. CSS change is really minor and will be the same across other Browsers. No tests needed.

### Screenshots

Two screenshots below for before and after
![Before](https://cloud.githubusercontent.com/assets/5254217/25775271/eea3386a-32be-11e7-8b91-dc7ee9045a26.png)
![After](https://cloud.githubusercontent.com/assets/5254217/25775274/0ae22360-32bf-11e7-95e9-f92858ec2e36.png)


### Documentation

No documentation change.

### Authorship

Every author of a code contribution (Go, Javascript, HTML, CSS etc, with the
possible exception of minor typo corrections and similar) is recorded in the
AUTHORS and NICKS files and the in-GUI credits. If this is your first
contribution, a maintainer will add you properly before accepting the
contribution. You need not do so yourself or worry about the fact that the
"authors" automated test fails. However, if your name (such as you want it
presented in the credits) is not visible on your Github profile or in your
commit messages, please assist by providing it here.
