### PR TITLE
gui: fix path breaking out of global changes modal (fixes #3895)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -266,6 +266,21 @@ ul.three-columns li, ul.two-columns li {
     z-index: 980;
 }
 
+.globalChanges-path-col {
+  /* These are technically the same, but use both */
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+
+  -ms-word-break: break-all;
+  /* This is the dangerous one in WebKit, as it breaks things wherever */
+  word-break: break-all;
+  /* Instead use this non-standard one: */
+  word-break: break-word;
+}
+.globalChanges-time-col {
+    width: 100px;
+}
+
 /** Footer nav on small devices **/
 @media (max-width: 1199px) {
     /* Stay at the end of the page, with space reserved for the footer

--- a/gui/default/syncthing/device/globalChangesModalView.html
+++ b/gui/default/syncthing/device/globalChangesModalView.html
@@ -14,8 +14,8 @@
             <td ng-if="!changeEvent.data.modifiedBy"><span translate>Unknown</span></td>
             <td>{{changeEvent.data.action}}</td>
             <td>{{changeEvent.data.type}}</td>
-            <td>{{changeEvent.data.path}}</td>
-            <td>{{changeEvent.time | date:"yyyy-MM-dd HH:mm:ss"}}</td>
+            <td class="globalChanges-path-col">{{changeEvent.data.path}}</td>
+            <td class="globalChanges-time-col">{{changeEvent.time | date:"yyyy-MM-dd HH:mm:ss"}}</td>
           </tr>
         </table>
     </div>


### PR DESCRIPTION
### Purpose

Break long paths in global changes modal regardless of breakable characters.
Also, as the time is now fixed in ISO format, the time col is not fixed at 100px width, so the date doesn't break into two rows.

### Testing

Manually tested in current Firefox and Chrome on Linux and in current Firefox, Forefox Dev Edition, Chrome, Opera and IE11 on Win7.

### Screenshots

#### Before
![before](https://cloud.githubusercontent.com/assets/1026763/26024646/1414d088-37d6-11e7-9c62-19d5b9670380.png)

#### After
on Desktop:
![after-on-desktop](https://cloud.githubusercontent.com/assets/1026763/26024655/2918618e-37d6-11e7-9a91-4653a1d45735.png)

on Mobile:
![after-on-mobile-portrait](https://cloud.githubusercontent.com/assets/1026763/26024657/38708d8c-37d6-11e7-8ff9-a7d040948517.png)

![after-on-mobile-landscape](https://cloud.githubusercontent.com/assets/1026763/26024659/497a0716-37d6-11e7-887f-77a218edd3db.png)
