### PR TITLE
gui: Ensure failed items folder path contains separator (fixes #4143)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1651,6 +1651,9 @@ angular.module('syncthing.core')
         $scope.showFailed = function (folder) {
             $scope.failedCurrent = $scope.failed[folder];
             $scope.failedFolderPath = $scope.folders[folder].path;
+            if ($scope.failedFolderPath[$scope.failedFolderPath.length - 1] !== $scope.system.pathSeparator) {
+                $scope.failedFolderPath += $scope.system.pathSeparator;
+            }
             $('#failed').modal().on('hidden.bs.modal', function () {
                 $scope.failedCurrent = undefined;
             });


### PR DESCRIPTION
Windows specific, due to how we handle folder paths. Tested manually.