### PR TITLE
Nodename in conflictfile

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1692,7 +1692,7 @@ func (f *sendReceiveFolder) moveForConflict(name string) error {
 		err = nil
 	}
 	if f.MaxConflicts > -1 {
-		matches, gerr := osutil.Glob(withoutExt + ".sync-conflict-????????-??????" + ext)
+		matches, gerr := osutil.Glob(withoutExt + ".sync-conflict-????????-??????-???????" + ext)
 		if gerr == nil && len(matches) > f.MaxConflicts {
 			sort.Sort(sort.Reverse(sort.StringSlice(matches)))
 			for _, match := range matches[f.MaxConflicts:] {

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1694,7 +1694,7 @@ func (f *sendReceiveFolder) moveForConflict(name string, lastModBy string) error
 		err = nil
 	}
 	if f.MaxConflicts > -1 {
-		matches, gerr := osutil.Glob(withoutExt + ".sync-conflict-????????-??????.*" + ext)
+		matches, gerr := osutil.Glob(withoutExt + ".sync-conflict-????????-??????*" + ext)
 		if gerr == nil && len(matches) > f.MaxConflicts {
 			sort.Sort(sort.Reverse(sort.StringSlice(matches)))
 			for _, match := range matches[f.MaxConflicts:] {


### PR DESCRIPTION
### Purpose

Fulfills issue #3524 request

### Testing

Changed a file on 3 different (ntp synced) computers at a 2 second internal difference.  Client A, B, C in that order.  Client C's file remained the master, the other 2 reacted accordingly.

All 3 had different info thus 2 conflicts were created (in addition to master).
If only 2 computers have conflict then only one conflict will be produced.

### Screenshots

After 2 pull intervals (so all clients could receive all copies):
[http://i.imgur.com/m3TkNog.png](http://i.imgur.com/m3TkNog.png)

### Authorship

Nate Morrison (nrm21)
