### PR TITLE
gui: Reset warnings about nested folder roots (fixes #3433)

### DIFF
--- a/gui/default/syncthing/core/pathIsSubDirDirective.js
+++ b/gui/default/syncthing/core/pathIsSubDirDirective.js
@@ -20,22 +20,22 @@ angular.module('syncthing.core')
                         }).every(function(e) { return e });
                     }
 
-                    scope.pathIsSubFolder = false;
-                    scope.pathIsParentFolder = false;
-                    scope.otherFolder = "";
-                    scope.otherFolderLabel = "";
+                    scope.folderPathErrors.isSub = false;
+                    scope.folderPathErrors.isParent = false;
+                    scope.folderPathErrors.otherID = "";
+                    scope.folderPathErrors.otherLabel = "";
                     for (var folderID in scope.folders) {
                         if (isSubDir(scope.folders[folderID].path, viewValue)) {
-                            scope.otherFolder = folderID;
-                            scope.otherFolderLabel = scope.folders[folderID].label;
-                            scope.pathIsSubFolder = true;
+                            scope.folderPathErrors.otherID = folderID;
+                            scope.folderPathErrors.otherLabel = scope.folders[folderID].label;
+                            scope.folderPathErrors.isSub = true;
                             break;
                         }
                         if (viewValue !== "" &&
                             isSubDir(viewValue, scope.folders[folderID].path)) {
-                            scope.otherFolder = folderID;
-                            scope.otherFolderLabel = scope.folders[folderID].label;
-                            scope.pathIsParentFolder = true;
+                            scope.folderPathErrors.otherID = folderID;
+                            scope.folderPathErrors.otherLabel = scope.folders[folderID].label;
+                            scope.folderPathErrors.isParent = true;
                             break;
                         }
                     }

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -53,27 +53,30 @@ angular.module('syncthing.core')
         $scope.themes = [];
         $scope.globalChangeEvents = {};
         $scope.metricRates = false;
+        $scope.folderPathErrors = {};
 
         try {
             $scope.metricRates = (window.localStorage["metricRates"] == "true");
         } catch (exception) { }
 
         $scope.folderDefaults = {
-                selectedDevices: {},
-                type: "readwrite",
-                rescanIntervalS: 60,
-                minDiskFree: {value: 1, unit: "%"},
-                maxConflicts: 10,
-                fsync: true,
-                order: "random",
-                fileVersioningSelector: "none",
-                trashcanClean: 0,
-                simpleKeep: 5,
-                staggeredMaxAge: 365,
-                staggeredCleanInterval: 3600,
-                staggeredVersionsPath: "",
-                externalCommand: "",
-                autoNormalize: true
+            selectedDevices: {},
+            type: "readwrite",
+            rescanIntervalS: 60,
+            fsNotifications: $scope.fsNotificationsAvailable,
+            notifyDelayS: 10,
+            minDiskFree: {value: 1, unit: "%"},
+            maxConflicts: 10,
+            fsync: true,
+            order: "random",
+            fileVersioningSelector: "none",
+            trashcanClean: 0,
+            simpleKeep: 5,
+            staggeredMaxAge: 365,
+            staggeredCleanInterval: 3600,
+            staggeredVersionsPath: "",
+            externalCommand: "",
+            autoNormalize: true,
         };
 
         $scope.localStateTotal = {
@@ -1409,6 +1412,7 @@ angular.module('syncthing.core')
             $scope.currentFolder.externalCommand = $scope.currentFolder.externalCommand || "";
 
             $scope.editingExisting = true;
+            $scope.folderPathErrors = {};
             $scope.folderEditor.$setPristine();
             $('#editFolder').modal();
         };
@@ -1417,6 +1421,7 @@ angular.module('syncthing.core')
             $scope.currentFolder = angular.copy($scope.folderDefaults);
             $scope.editingExisting = false;
             $('#editIgnores textarea').val("");
+            $scope.folderPathErrors = {};
             $scope.folderEditor.$setPristine();
             $http.get(urlbase + '/svc/random/string?length=10').success(function (data) {
                 $scope.currentFolder.id = (data.random.substr(0, 5) + '-' + data.random.substr(5, 5)).toLowerCase();
@@ -1435,6 +1440,7 @@ angular.module('syncthing.core')
             $scope.currentFolder.selectedDevices[device] = true;
 
             $scope.editingExisting = false;
+            $scope.folderPathErrors = {};
             $scope.folderEditor.$setPristine();
             $('#editFolder').modal();
         };

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -63,8 +63,6 @@ angular.module('syncthing.core')
             selectedDevices: {},
             type: "readwrite",
             rescanIntervalS: 60,
-            fsNotifications: $scope.fsNotificationsAvailable,
-            notifyDelayS: 10,
             minDiskFree: {value: 1, unit: "%"},
             maxConflicts: 10,
             fsync: true,
@@ -76,7 +74,7 @@ angular.module('syncthing.core')
             staggeredCleanInterval: 3600,
             staggeredVersionsPath: "",
             externalCommand: "",
-            autoNormalize: true,
+            autoNormalize: true
         };
 
         $scope.localStateTotal = {

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -26,12 +26,12 @@
               <option ng-repeat="directory in directoryList" value="{{ directory }}" />
             </datalist>
             <p class="help-block">
-              <span translate ng-if="folderEditor.folderPath.$valid || folderEditor.folderPath.$pristine">Path to the folder on the local computer. Will be created if it does not exist. The tilde character (~) can be used as a shortcut for</span> <code>{{system.tilde}}</code>.
+              <span ng-if="folderEditor.folderPath.$valid || folderEditor.folderPath.$pristine"><span translate>Path to the folder on the local computer. Will be created if it does not exist. The tilde character (~) can be used as a shortcut for</span> <code>{{system.tilde}}</code>.</br></span>
               <span translate ng-if="folderEditor.folderPath.$error.required && folderEditor.folderPath.$dirty">The folder path cannot be blank.</span>
-              <span class="text-danger" translate translate-value-other-folder="{{otherFolder}}" ng-if="pathIsSubFolder && otherFolderLabel.length == 0">Warning, this path is a subdirectory of an existing folder "{%otherFolder%}".</span>
-              <span class="text-danger" translate translate-value-other-folder="{{otherFolder}}" translate-value-other-folder-label="{{otherFolderLabel}}" ng-if="pathIsSubFolder && otherFolderLabel.length != 0">Warning, this path is a subdirectory of an existing folder "{%otherFolderLabel%}" ({%otherFolder%}).</span>
-              <span class="text-danger" translate translate-value-other-folder="{{otherFolder}}" ng-if="pathIsParentFolder && otherFolderLabel.length == 0">Warning, this path is a parent directory of an existing folder "{%otherFolder%}".</span>
-              <span class="text-danger" translate translate-value-other-folder="{{otherFolder}}" translate-value-other-folder-label="{{otherFolderLabel}}" ng-if="pathIsParentFolder && otherFolderLabel.length != 0">Warning, this path is a parent directory of an existing folder "{%otherFolderLabel%}" ({%otherFolder%}).</span>
+              <span class="text-danger" translate translate-value-other-folder="{{folderPathErrors.otherID}}" ng-if="folderPathErrors.isSub && folderPathErrors.otherLabel.length == 0">Warning, this path is a subdirectory of an existing folder "{%otherFolder%}".</span>
+              <span class="text-danger" translate translate-value-other-folder="{{folderPathErrors.otherID}}" translate-value-other-folder-label="{{folderPathErrors.otherLabel}}" ng-if="folderPathErrors.isSub && folderPathErrors.otherLabel.length != 0">Warning, this path is a subdirectory of an existing folder "{%otherFolderLabel%}" ({%otherFolder%}).</span>
+              <span class="text-danger" translate translate-value-other-folder="{{folderPathErrors.otherID}}" ng-if="folderPathErrors.isParent && folderPathErrors.otherLabel.length == 0">Warning, this path is a parent directory of an existing folder "{%otherFolder%}".</span>
+              <span class="text-danger" translate translate-value-other-folder="{{folderPathErrors.otherID}}" translate-value-other-folder-label="{{folderPathErrors.otherLabel}}" ng-if="folderPathErrors.isParent && folderPathErrors.otherLabel.length != 0">Warning, this path is a parent directory of an existing folder "{%otherFolderLabel%}" ({%otherFolder%}).</span>
             </p>
           </div>
         </div>


### PR DESCRIPTION
Refer to #3433 for a description of the problem.

To reset the warning on modal open the variables set in the `pathIsSubDir`-directive need to be reset. To make this easier I collected them in one object called `folderPathErrors`.

I also found one small mistake in the help text about tilde expansion (path wasn't included in the ng-if condition). And indentation polish.