### PR TITLE
build: moves test-coverage from build.sh to jenkins/common-bash.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -93,40 +93,6 @@ case "${1:-default}" in
 		done
 		;;
 
-	test-cov)
-		ulimit -t 600 &>/dev/null || true
-		ulimit -d 512000 &>/dev/null || true
-		ulimit -m 512000 &>/dev/null || true
-
-		echo "mode: set" > coverage.out
-		fail=0
-
-		# For every package in the repo
-		for dir in $(go list ./lib/... ./cmd/...) ; do
-			# run the tests
-			GOPATH="$(pwd)/Godeps/_workspace:$GOPATH" go test -coverprofile=profile.out $dir
-			if [ -f profile.out ] ; then
-				# and if there was test output, append it to coverage.out
-				grep -v "mode: " profile.out >> coverage.out
-				rm profile.out
-			fi
-		done
-
-		notCovered=$(egrep -c '\s0$' coverage.out)
-		total=$(wc -l coverage.out | awk '{print $1}')
-		coverPct=$(awk "BEGIN{print (1 - $notCovered / $total) * 100}")
-		echo "Total coverage is $coverPct%"
-
-		gocov convert coverage.out | gocov-xml > coverage.xml
-
-		# This is usually run from within Jenkins. If it is, we need to
-		# tweak the paths in coverage.xml so cobertura finds the
-		# source.
-		if [[ "${WORKSPACE:-default}" != "default" ]] ; then
-			sed "s#$WORKSPACE##g" < coverage.xml > coverage.xml.new && mv coverage.xml.new coverage.xml
-		fi
-		;;
-
 	test-xunit)
 		ulimit -t 600 &>/dev/null || true
 		ulimit -d 512000 &>/dev/null || true


### PR DESCRIPTION
### Purpose

Tried to run tests and struggled with using `build.sh` or `build.go`. 

Searched for usage and only found `testCoverage` in `jenkins/common-bash.sh`and
this https://docs.syncthing.net/dev/release-creation.html (through https://www.google.de/search?q=site%3Ahttps%3A%2F%2Fdocs.syncthing.net%2F+%22build.sh%22)

So I moved the `testCoverage`.

Seems `build.sh` has a lot of dead code, am I right?
### Testing

do the jenkins build
