### PR TITLE
cmd/syncthing, lib/logger: Set debug flags on SetDebug instead of main for tests

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -269,7 +269,7 @@ func defaultRuntimeOptions() RuntimeOptions {
 	}
 
 	if os.Getenv("STTRACE") != "" {
-		options.logFlags = log.Ltime | log.Ldate | log.Lmicroseconds | log.Lshortfile
+		options.logFlags = log.debugFlags
 	}
 
 	if runtime.GOOS != "windows" {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -269,7 +269,7 @@ func defaultRuntimeOptions() RuntimeOptions {
 	}
 
 	if os.Getenv("STTRACE") != "" {
-		options.logFlags = log.debugFlags
+		options.logFlags = logger.DebugFlags
 	}
 
 	if runtime.GOOS != "windows" {

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -28,6 +28,8 @@ const (
 	NumLevels
 )
 
+const debugFlags = log.Ltime | log.Ldate | log.Lmicroseconds | log.Lshortfile
+
 // A MessageHandler is called with the log level and message text.
 type MessageHandler func(l LogLevel, msg string)
 
@@ -215,6 +217,7 @@ func (l *logger) SetDebug(facility string, enabled bool) {
 	l.mut.Lock()
 	l.debug[facility] = enabled
 	l.mut.Unlock()
+	l.SetFlags(debugFlags)
 }
 
 // FacilityDebugging returns the set of facilities that have debugging

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -28,7 +28,7 @@ const (
 	NumLevels
 )
 
-const debugFlags = log.Ltime | log.Ldate | log.Lmicroseconds | log.Lshortfile
+const DebugFlags = log.Ltime | log.Ldate | log.Lmicroseconds | log.Lshortfile
 
 // A MessageHandler is called with the log level and message text.
 type MessageHandler func(l LogLevel, msg string)
@@ -217,7 +217,7 @@ func (l *logger) SetDebug(facility string, enabled bool) {
 	l.mut.Lock()
 	l.debug[facility] = enabled
 	l.mut.Unlock()
-	l.SetFlags(debugFlags)
+	l.SetFlags(DebugFlags)
 }
 
 // FacilityDebugging returns the set of facilities that have debugging


### PR DESCRIPTION
### Purpose

If you currently run tests with STTRACE set the flags for filenames/precise timestamps/... are not activated, as these get set in cmd/syncthing. Now those flags get set as well when SetDebug is called. This results in flags being set redundantly, if multiple facilities are activated, but I think this is a non-issue and cleaner than e.g. checking for the length of l.debug.

### Testing

Tests still passing and tests now display the additional info.