### PR TITLE
gui: Icons and directory information in "This Device" summary consistent with folders (fixes #4100)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -496,7 +496,12 @@
                   </tr>
                   <tr>
                     <th><span class="fa fa-fw fa-home"></span>&nbsp;<span translate>Local State (Total)</span></th>
-                    <td class="text-right">{{localStateTotal.files | alwaysNumber}} <span translate>items</span>, ~{{localStateTotal.bytes | binary}}B</td>
+                    <td class="text-right">
+                        <span tooltip data-original-title="{{localStateTotal.files | alwaysNumber}} {{'files' | translate}}, {{ localStateTotal.directories | alwaysNumber}} {{'directories' | translate}}, ~{{ localStateTotal.bytes | binary}}B">
+                        <span class="fa fa-files-o"></span>&nbsp;{{localStateTotal.files | alwaysNumber}}&ensp;
+                        <span class="fa fa-folder-o"></span>&nbsp;{{localStateTotal.directories| alwaysNumber}}&ensp;
+                        <span class="fa fa-hdd-o"></span>&nbsp;~{{localStateTotal.bytes | binary}}B
+                    </td>
                   </tr>
                   <tr>
                     <th><span class="fa fa-fw fa-th"></span>&nbsp;<span translate>RAM Utilization</span></th>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -79,6 +79,7 @@ angular.module('syncthing.core')
 
         $scope.localStateTotal = {
             bytes: 0,
+            directories: 0,
             files: 0
         };
 
@@ -448,12 +449,14 @@ angular.module('syncthing.core')
         function recalcLocalStateTotal () {
             $scope.localStateTotal = {
                 bytes: 0,
+                directories: 0,
                 files: 0
             };
 
             for (var f in $scope.model) {
                $scope.localStateTotal.bytes += $scope.model[f].localBytes;
                $scope.localStateTotal.files += $scope.model[f].localFiles;
+               $scope.localStateTotal.directories += $scope.model[f].localDirectories;
             }
         }
 


### PR DESCRIPTION
Resolves #4100.

### Summary
Changes [index.html](https://github.com/syncthing/syncthing/blob/master/gui/default/index.html) so that the `<td>` element is consistent with per-folder's HTML. Adds a tooltip, similar to folder. 

Adds `directories` attribute to the `localStateTotal` in [syncthingController.js](https://github.com/syncthing/syncthing/blob/master/gui/default/syncthing/syncthingController.js) which populates the template engine's variables. This value is obtained from `$scope.model[f].localDirectories`, which has the correct value. This is the same method as used for other attributes, thus requiring no further changes.

### Screenshots
Preliminary test of generated web UI:
![syncthing issue 4100](https://user-images.githubusercontent.com/4134288/26873349-0b94d498-4b69-11e7-9a2e-51cd67cec50e.png)

### Documentation

Can remain the same, UX is more intuitive now.