### PR TITLE
At rest file encryption

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -26,6 +26,7 @@ type FolderConfiguration struct {
 	RescanIntervalS       int                         `xml:"rescanIntervalS,attr" json:"rescanIntervalS"`
 	IgnorePerms           bool                        `xml:"ignorePerms,attr" json:"ignorePerms"`
 	AutoNormalize         bool                        `xml:"autoNormalize,attr" json:"autoNormalize"`
+	EncryptionKey         string                      `xml:"encryptionKey" json:"encryptionKey"`
 	MinDiskFree           Size                        `xml:"minDiskFree" json:"minDiskFree"`
 	Versioning            VersioningConfiguration     `xml:"versioning" json:"versioning"`
 	Copiers               int                         `xml:"copiers" json:"copiers"` // This defines how many files are handled concurrently.

--- a/lib/config/foldertype.go
+++ b/lib/config/foldertype.go
@@ -11,6 +11,7 @@ type FolderType int
 const (
 	FolderTypeSendReceive FolderType = iota // default is sendreceive
 	FolderTypeSendOnly
+	FolderTypeEncrypted
 )
 
 func (t FolderType) String() string {
@@ -19,6 +20,8 @@ func (t FolderType) String() string {
 		return "readwrite"
 	case FolderTypeSendOnly:
 		return "readonly"
+	case FolderTypeEncrypted:
+		return "encrypted"
 	default:
 		return "unknown"
 	}
@@ -34,6 +37,8 @@ func (t *FolderType) UnmarshalText(bs []byte) error {
 		*t = FolderTypeSendReceive
 	case "readonly", "sendonly":
 		*t = FolderTypeSendOnly
+	case "encrypted":
+		*t = FolderTypeEncrypted
 	default:
 		*t = FolderTypeSendReceive
 	}

--- a/lib/model/fileencryption.go
+++ b/lib/model/fileencryption.go
@@ -1,0 +1,181 @@
+package model
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+// This function is used to encrypt or decrypt the file based on existance of the right file signature
+func EncOrDecFiles(rootDir string, files []protocol.FileInfo) {
+	for _, file := range files {
+		if !file.IsDeleted() && !file.IsDirectory() { // non deleted files only
+			l.Infoln("file:", file.Name, file.IsDeleted())
+
+			if file.Type == 0 || file.Type == 4 { // files and symlinks only (ignore dirs and all the other bs for now)
+				// some key for testing (32 bytes exactly, otherwise we need to truncate/pad to length)
+				key := checkKeyLength([]byte("ThisiswaytoolongakeyforSyncthing"))
+				aesblock, err := aes.NewCipher(key)
+				if err != nil {
+					l.Infoln(err)
+				}
+				pathToFile := rootDir + string(os.PathSeparator) + filepath.FromSlash(file.Name)
+
+				plainOrCiphertext, err := ioutil.ReadFile(pathToFile)
+				if err != nil {
+					l.Infoln(err)
+				}
+
+				// if file sig exists we should decrypt instead
+				if string(plainOrCiphertext[:5]) == "stenc" {
+					if !strings.HasSuffix(rootDir, ".ENC") { // make sure we're not running decryption dir created to hold the enc files
+						decryptFile(rootDir, pathToFile, key, aesblock, plainOrCiphertext)
+					}
+				} else {
+					encryptFile(rootDir, pathToFile, key, aesblock, plainOrCiphertext)
+				}
+			}
+		}
+	}
+}
+
+func decryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.Block, ciphertext []byte) {
+	ciphertext = ciphertext[5:] // strip file sig
+
+	iv := ciphertext[:16]             // extract IV from next 16 bytes
+	ciphertext = ciphertext[len(iv):] // and strip it
+
+	plaintext := make([]byte, len(ciphertext))
+	stream := cipher.NewCFBDecrypter(aesblock, iv)
+	stream.XORKeyStream(plaintext, ciphertext)
+
+	filepathNull := bytes.IndexByte(plaintext, 0) // find first null char (end of filename)
+	if filepathNull == -1 {
+		l.Infoln("Cannot find null byte, we may have the wrong key or a corrupt file")
+	}
+	newfilepath := string(plaintext[:filepathNull]) // extract filepath
+	newfilepath = filepath.Base(newfilepath)
+	plaintext = plaintext[filepathNull+1:] // remove filepath from file contents
+	plaintext = plaintext[32:]             // strip off sha256 plaintext hash (since we're not using them right now)
+	plaintext = plaintext[(8 * 3):]        // strip off file access times (since we're not using them right now)
+
+	f, err := os.Create(rootDir + string(os.PathSeparator) + newfilepath)
+	if err != nil {
+		l.Infoln(err)
+	}
+	_, err = io.Copy(f, bytes.NewReader(plaintext))
+	if err != nil {
+		l.Infoln(err)
+	}
+}
+
+func encryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.Block, plaintext []byte) {
+	// Get file MAC times and make byte arrays out of them
+	mtime, atime, ctime, err := fileStatTimes(pathToFile)
+	bmtime, batime, bctime := make([]byte, 8), make([]byte, 8), make([]byte, 8)
+	binary.LittleEndian.PutUint64(bmtime, uint64(mtime))
+	binary.LittleEndian.PutUint64(batime, uint64(atime))
+	binary.LittleEndian.PutUint64(bctime, uint64(ctime))
+	// To revert to int again ==>     i = int64(binary.LittleEndian.Uint64(b))
+
+	// The IV needs to be unique but not secure, so put it at beginning of ciphertext
+	h := sha256.New()
+	h.Write([]byte(pathToFile))
+	var iv []byte
+	iv = append(iv, h.Sum(nil)...)
+
+	if _, err := io.Copy(h, bytes.NewReader(plaintext)); err != nil {
+		log.Fatal(err)
+	}
+	sha256HashBytes := h.Sum(nil) // sha256 of just the filedata by itself
+
+	var fileHeader []byte
+	fileHeader = append([]byte(pathToFile), 0)          // null byte terminated
+	fileHeader = append(fileHeader, sha256HashBytes...) // plaintext hash
+	fileHeader = append(fileHeader, bmtime...)          // mod time
+	fileHeader = append(fileHeader, batime...)          // access time
+	fileHeader = append(fileHeader, bctime...)          // created time
+
+	plaintext = append(fileHeader, plaintext...) // prepend fileheader to contents
+	ciphertext := make([]byte, len(plaintext))
+
+	iv = iv[:16] // make iv the first half of the sha256 hash
+	stream := cipher.NewCFBEncrypter(aesblock, iv)
+	stream.XORKeyStream(ciphertext, plaintext)
+
+	filesig := []byte{115, 116, 101, 110, 99}   // "stenc" file sig
+	ciphertext = append(iv, ciphertext...)      // prepend unencrypted file IV
+	ciphertext = append(filesig, ciphertext...) // prepend file sig
+
+	// make dir if not existing
+	err = os.MkdirAll(rootDir+".ENC", os.ModeDir)
+	if err != nil {
+		l.Infoln(err)
+	}
+	// create blank file
+	f, err := os.Create(rootDir + ".ENC" + string(os.PathSeparator) + hex.EncodeToString(iv[:8]))
+	if err != nil {
+		l.Infoln(err)
+	}
+	// fill file with data
+	_, err = io.Copy(f, bytes.NewReader(ciphertext))
+	if err != nil {
+		l.Infoln(err)
+	}
+	f.Close()
+}
+
+// Enforce exactly 32 bytes long for the key
+func checkKeyLength(key []byte) []byte {
+	// Check if key too short, if so pad with 0's
+	if len(key) < 32 {
+		for i := 0; i < (aes.BlockSize); i++ {
+			if i >= len(key) {
+				key = append(key, '0')
+			}
+		}
+	}
+	// Check if key too long, if so crop it
+	if len(key) > 32 {
+		key = key[:32]
+	}
+
+	return key
+}
+
+// This function should get the MAC times of any file (in unixtimestamp format)
+func fileStatTimes(name string) (mtime, atime, ctime int64, err error) {
+	fi, err := os.Stat(name)
+	if err != nil {
+		return
+	}
+	mtime = fi.ModTime().Unix()
+
+	if runtime.GOOS == "windows" {
+		stat := fi.Sys().(*syscall.Win32FileAttributeData)
+		atime = stat.LastAccessTime.Nanoseconds() / int64(time.Second)
+		ctime = stat.CreationTime.Nanoseconds() / int64(time.Second)
+	}
+
+	// if runtime.GOOS == "Linux" {
+	//     stat := fi.Sys().(*syscall.Stat_t)
+	//     atime = time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec))
+	//     ctime = time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec))
+	// }
+
+	return
+}

--- a/lib/model/fileencryption.go
+++ b/lib/model/fileencryption.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"crypto/rand"
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
@@ -20,43 +21,56 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
-// This function is used to encrypt or decrypt the file based on existance of the right file signature
-func EncOrDecFiles(rootDir string, key []byte, files []protocol.FileInfo) {
+// This function is used as wrapper to encrypt or decrypt the file based on
+// existance of the file signature and do some other setup first as well
+func (m *Model) EncOrDecFiles(folder string, files []protocol.FileInfo) {
+	rootDir := m.folderCfgs[folder].Path()
+
 	for _, file := range files {
 		if !file.IsDeleted() && !file.IsDirectory() { // non deleted files only
 			if file.Type == 0 || file.Type == 4 { // files and symlinks only (ignore dirs and all the other bs for now)
-				// some key for testing (32 bytes exactly, otherwise we need to truncate/pad to length)
+				key := m.getKeyFromConfig(folder)
 				key = stripOrPadKeyLength(key, 32)
-				l.Infoln("------------------------------------------------------------ key is:", key, len(key))
 				aesblock, err := aes.NewCipher(key)
 				if err != nil {
 					l.Infoln(err)
 				}
-				pathToFile := rootDir + string(os.PathSeparator) + filepath.FromSlash(file.Name)
 
+				pathToFile := rootDir + string(os.PathSeparator) + filepath.FromSlash(file.Name)
 				plainOrCiphertext, err := ioutil.ReadFile(pathToFile)
 				if err != nil {
 					l.Infoln(err)
 				}
 
-				// if file sig exists we should decrypt instead
-				if string(plainOrCiphertext[:5]) == "stenc" {
-					if !strings.HasSuffix(rootDir, ".ENC") { // make sure we're not running decryption dir created to hold the enc files
-						decryptFile(rootDir, pathToFile, key, aesblock, plainOrCiphertext)
+				if strings.HasSuffix(rootDir, ".ENC") { // make sure we're not running decryption in regular dir (only enc dir)
+					rootDir = rootDir[:len(rootDir)-4]
+					// now strip ".ENC" from folder path and find the folder ID for that path so we use the same key of the
+					// folder that encrypted the file.  This avoids an error where using 2 different keys causes either
+					// decyrption to fail or produce further gibberish which can be somewhat hard/confusing to debug
+					for id, fldrCfg := range m.folderCfgs {
+						if rootDir == fldrCfg.Path() { // rootDir now without the ".ENC"
+							folder = id
+							key = []byte(m.folderCfgs[folder].EncryptionKey)
+						}
 					}
-				} else {
-					encryptFile(rootDir, pathToFile, key, aesblock, plainOrCiphertext)
+
+					if string(plainOrCiphertext[:5]) == "stenc" { // if file sig exists we should decrypt
+						decryptFile(rootDir, pathToFile, aesblock, plainOrCiphertext)
+					}
+				} else { // otherwise we're in normal dir
+					encryptFile(rootDir, pathToFile, aesblock, plainOrCiphertext)
 				}
 			}
 		}
 	}
 }
 
-func decryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.Block, ciphertext []byte) {
+// Perform file decryption on ciphertext
+func decryptFile(rootDir string, pathToFile string, aesblock cipher.Block, ciphertext []byte) {
 	ciphertext = ciphertext[5:] // strip file sig
 
 	iv := ciphertext[:16]             // extract IV from next 16 bytes
-	ciphertext = ciphertext[len(iv):] // and strip it
+	ciphertext = ciphertext[len(iv):] // and strip IV
 
 	plaintext := make([]byte, len(ciphertext))
 	stream := cipher.NewCFBDecrypter(aesblock, iv)
@@ -66,23 +80,28 @@ func decryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.
 	if filepathNull == -1 {
 		l.Infoln("Cannot find null byte, we may have the wrong key or a corrupt file")
 	}
-	newfilepath := string(plaintext[:filepathNull]) // extract filepath
-	newfilepath = filepath.Base(newfilepath)
+	newFilepath := string(plaintext[:filepathNull]) // extract filepath
+	newFilepath = filepath.Base(newFilepath)
 	plaintext = plaintext[filepathNull+1:] // remove filepath from file contents
 	plaintext = plaintext[32:]             // strip off sha256 plaintext hash (since we're not using them right now)
 	plaintext = plaintext[(8 * 3):]        // strip off file access times (since we're not using them right now)
 
-	f, err := os.Create(rootDir + string(os.PathSeparator) + newfilepath)
-	if err != nil {
-		l.Infoln(err)
-	}
-	_, err = io.Copy(f, bytes.NewReader(plaintext))
-	if err != nil {
-		l.Infoln(err)
+	if _, err := os.Stat(rootDir + string(os.PathSeparator) + newFilepath); os.IsNotExist(err) {
+		f, err := os.Create(rootDir + string(os.PathSeparator) + newFilepath)
+		if err != nil {
+			l.Infoln(err)
+		}
+		_, err = io.Copy(f, bytes.NewReader(plaintext))
+		if err != nil {
+			l.Infoln(err)
+		}
+	} else {
+		l.Debugln("File already exists... ignoring decryption of file")
 	}
 }
 
-func encryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.Block, plaintext []byte) {
+// Perform file encryption on plaintext
+func encryptFile(rootDir string, pathToFile string, aesblock cipher.Block, plaintext []byte) {
 	// Get file MAC times and make byte arrays out of them
 	mtime, atime, ctime, err := fileStatTimes(pathToFile)
 	bmtime, batime, bctime := make([]byte, 8), make([]byte, 8), make([]byte, 8)
@@ -93,17 +112,23 @@ func encryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.
 
 	// The IV needs to be unique but not secure, so put it at beginning of ciphertext
 	h := sha256.New()
-	h.Write([]byte(pathToFile))
-	var iv []byte
-	iv = append(iv, h.Sum(nil)...)
+
+	// Never use more than 2^32 random nonces with given key because of risk of repeat
+	iv := make([]byte, 16)
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		panic(err.Error())
+	}
+	// h.Write([]byte(pathToFile))
+	// var iv []byte
+	// iv = append(iv, h.Sum(nil)...)
 
 	if _, err := io.Copy(h, bytes.NewReader(plaintext)); err != nil {
 		log.Fatal(err)
 	}
+
 	sha256HashBytes := h.Sum(nil) // sha256 of just the filedata by itself
 
-	var fileHeader []byte
-	fileHeader = append([]byte(pathToFile), 0)          // null byte terminated
+	fileHeader := append([]byte(pathToFile), 0)         // null byte terminated
 	fileHeader = append(fileHeader, sha256HashBytes...) // plaintext hash
 	fileHeader = append(fileHeader, bmtime...)          // mod time
 	fileHeader = append(fileHeader, batime...)          // access time
@@ -112,7 +137,7 @@ func encryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.
 	plaintext = append(fileHeader, plaintext...) // prepend fileheader to contents
 	ciphertext := make([]byte, len(plaintext))
 
-	iv = iv[:16] // make iv the first half of the sha256 hash
+	iv = iv[:16] // make sure we're using only the first 16 bytes of iv (if there happen to be more)
 	stream := cipher.NewCFBEncrypter(aesblock, iv)
 	stream.XORKeyStream(ciphertext, plaintext)
 
@@ -136,6 +161,26 @@ func encryptFile(rootDir string, pathToFile string, key []byte, aesblock cipher.
 		l.Infoln(err)
 	}
 	f.Close()
+}
+
+// This function should ensure we get the key from the same folderCfg despite working with 2 different folders
+func (m *Model) getKeyFromConfig(folder string) []byte {
+	rootDir := m.folderCfgs[folder].Path()
+	key := []byte(m.folderCfgs[folder].EncryptionKey)
+
+	if strings.HasSuffix(rootDir, ".ENC") { // make sure we're not running decryption in regular dir (only enc dir)
+		// now strip ".ENC" from folder path and find the folder ID for that path so we use the same key of the
+		// folder that encrypted the file.  This avoids an error where using 2 different keys causes either
+		// decyrption to fail or produce further gibberish which can be somewhat hard/confusing to debug
+		for id, fldrCfg := range m.folderCfgs {
+			if rootDir[:len(rootDir)-4] == fldrCfg.Path() { // rootDir without the ".ENC"
+				folder = id
+				key = []byte(m.folderCfgs[folder].EncryptionKey)
+			}
+		}
+	}
+
+	return key
 }
 
 // Enforce exactly 32 bytes long for the key

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1856,7 +1856,7 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 
 	// This needs to run before deleted so 'batch' contains list of added not deleted files
 	//if folderCfg.Type == config.FolderTypeEncrypted {		// Cant get foldertype working without panic on startup
-	EncOrDecFiles(m.folderCfgs[folder].Path(), batch)
+	EncOrDecFiles(m.folderCfgs[folder].Path(), []byte(m.folderCfgs[folder].EncryptionKey), batch)
 	//}
 
 	// Do a scan of the database for each prefix, to check for deleted and

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1856,7 +1856,7 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 
 	// This needs to run before deleted so 'batch' contains list of added not deleted files
 	//if folderCfg.Type == config.FolderTypeEncrypted {		// Cant get foldertype working without panic on startup
-	EncOrDecFiles(m.folderCfgs[folder].Path(), []byte(m.folderCfgs[folder].EncryptionKey), batch)
+	m.EncOrDecFiles(folder, batch)
 	//}
 
 	// Do a scan of the database for each prefix, to check for deleted and

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1854,6 +1854,11 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 		subDirs = []string{""}
 	}
 
+	// This needs to run before deleted so 'batch' contains list of added not deleted files
+	//if folderCfg.Type == config.FolderTypeEncrypted {		// Cant get foldertype working without panic on startup
+	EncOrDecFiles(m.folderCfgs[folder].Path(), batch)
+	//}
+
 	// Do a scan of the database for each prefix, to check for deleted and
 	// ignored files.
 	batch = batch[:0]


### PR DESCRIPTION
### Purpose

At rest file encryption.  Shouldn't need explanation why, its the most requested feature we get pretty much. 
 This is just a preliminary alpha to receive comments (and if necessary help).  It's very much not ready for PR yet.

Fulfills most of #109 I think
Also semi-related to this forum thread: https://forum.syncthing.net/t/encrypted-nodes-please-test/5295/42

### Testing

Ok so far it works like this (and I realize this is not in some finished usable state yet, it's mostly PoC for now):
* You setup a directory that you leave unsynced w/ anyone (let's call it 'Sync')
* You put files and folders in it, and wait for a scan
* After scan it will create a Sync.ENC dir in a lateral dir to it in the same root (that is the dir you setup sync pair with your untrusted client)
* It will place a file in that dir for every file you have in your 'Sync' dir (it will traverse sub folders since it's using the standard scanner but ignore creation of encrypted objects for folders, yet it WILL save the full file path inside the encrypted portion of the file)
* All those files will be placed in the Sync.ENC dir at top level, there will be no depth and the filename of each will be some fraction (prob first quarter) of the sha256 hash of file.
* Decryption happens pretty much on the very next scan of that Sync.ENC folder, where it tries to recreate the path back in the non .ENC folder (at least that's the idea, I haven't yet gotten it working for multiple files at a time yet).
* On decryption, if file exists it should ignore and not rewrite back to disk

### Notes
* Filenames can be changed for now and it should have no bearing on the decryption capability since all relevant info needed for it is stored inside the file (possibly subject to change).
* Determination to encrypt/decrypt is made based on location of file (is it in rootdir or rootdir.ENC) AND existence of the file sig (aka magic numbers) we attach to it after encryption.
* Puts file MAC times in the file but currently ignore this on decrypt (possibly we do something in future with this)
* Currently the engine decrypts a file and finds out of it is needed or the file already exists.  We might need to explore ways to decide if we need a file enc/dec operation or not BEFORE we perform it (hash comparisons here might be better)
* Giving strong consideration to JUST doing encryption and putting the decryption code in a separate executable for now as a first round.  The logic here is that it avoids quite a few problems and MOST of the time people probably just want an encrypted backup of their stuff on an untrusted client (that's always updated older file version with newer file versions/modification) and the ONE time they need backup from catastrophe, they can use the decryption executable


Here's a general idea of encrypted file structure (picture since I can't get this post to format as fixed length font):
http://imgur.com/a2V8In3


### Authorship

nrm21
