### PR TITLE
Set the secure flag to true for the session cookie

### DIFF
--- a/cmd/syncthing/gui_auth.go
+++ b/cmd/syncthing/gui_auth.go
@@ -117,13 +117,13 @@ func basicAuthAndSessionMiddleware(cookieName string, cfg config.GUIConfiguratio
 		sessionsMut.Lock()
 		sessions[sessionid] = struct{}{}
 		sessionsMut.Unlock()
-		cookie := &http.Cookie{
+		outCookie := &http.Cookie{
 			Name:   cookieName,
 			Value:  sessionid,
 			MaxAge: 0,
 		}
-		setCookieSecure(r, cookie)
-		http.SetCookie(w, cookie)
+		setCookieSecure(r, outCookie)
+		http.SetCookie(w, outCookie)
 
 		emitLoginAttempt(true, username)
 		next.ServeHTTP(w, r)

--- a/cmd/syncthing/gui_csrf.go
+++ b/cmd/syncthing/gui_csrf.go
@@ -156,4 +156,5 @@ func getForwardedProto(r *http.Request) string {
 			return proto[len(proto)-1]
 		}
 	}
+	return ""
 }


### PR DESCRIPTION
If the HTTP proto used is HTTPS, then the secure flag must be set on the session cookie.  Not using secure could allow the cookie to be sent over an unencrypted connection which would allow a malicious actor to steal the session information.

This also removes a trivial memory allocation in the session map.

### Purpose

Fixes a potential session leak vulnerability by enabling the secure flag for session cookies over HTTPS connections or when behind a reverse proxy that is presenting HTTPS connections to the internet.

### Testing

Tested behind an HTTP reverse proxy that sets the "X-FORWARDED-PROTO" header to "https".  To test, run syncthing with HTTPS enabled or behind an HTTPS enabled reverse proxy that uses one of the supported headers.

### Authorship

Every author of a code contribution (Go, Javascript, HTML, CSS etc, with the
possible exception of minor typo corrections and similar) is recorded in the
AUTHORS and NICKS files and the in-GUI credits. If this is your first
contribution, a maintainer will add you properly before accepting the
contribution. You need not do so yourself or worry about the fact that the
"authors" automated test fails. However, if your name (such as you want it
presented in the credits) is not visible on your Github profile or in your
commit messages, please assist by providing it here.
