### PR TITLE
lib/config: Ignored folders that are added to the config should not remain ignored (fixes #4219)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -268,6 +268,14 @@ func (cfg *Configuration) clean() error {
 		seenFolders[folder.ID] = struct{}{}
 	}
 
+	// Remove ignored folders that are anyway part of the configuration.
+	for i := 0; i < len(cfg.IgnoredFolders); i++ {
+		if _, ok := seenFolders[cfg.IgnoredFolders[i]]; ok {
+			cfg.IgnoredFolders = append(cfg.IgnoredFolders[:i], cfg.IgnoredFolders[i+1:]...)
+			i-- // IgnoredFolders[i] now points to something else, so needs to be rechecked
+		}
+	}
+
 	cfg.Options.ListenAddresses = util.UniqueStrings(cfg.Options.ListenAddresses)
 	cfg.Options.GlobalAnnServers = util.UniqueStrings(cfg.Options.GlobalAnnServers)
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -807,3 +807,34 @@ func TestSharesRemovedOnDeviceRemoval(t *testing.T) {
 		t.Error("Unexpected extra device")
 	}
 }
+
+func TestIssue4219(t *testing.T) {
+	// Adding a folder that was previously ignored should make it unignored.
+
+	r := bytes.NewReader([]byte(`{
+		"folders": [
+			{"id": "abcd123"}
+		],
+		"ignoredFolders": ["t1", "abcd123", "t2"]
+	}`))
+
+	cfg, err := ReadJSON(r, protocol.LocalDeviceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.IgnoredFolders) != 2 {
+		t.Errorf("There should be two ignored folders, not %d", len(cfg.IgnoredFolders))
+	}
+
+	w := Wrap("/tmp/cfg", cfg)
+	if !w.IgnoredFolder("t1") {
+		t.Error("Folder t1 should be ignored")
+	}
+	if !w.IgnoredFolder("t2") {
+		t.Error("Folder t2 should be ignored")
+	}
+	if w.IgnoredFolder("abcd123") {
+		t.Error("Folder abcd123 should not be ignored")
+	}
+}


### PR DESCRIPTION
### Purpose

Manually adding a folder that was ignored should work.

### Testing

Unit test.
