### PR TITLE
Home page: Домашная страница → Сайт

### DIFF
--- a/gui/default/assets/lang/lang-ru.json
+++ b/gui/default/assets/lang/lang-ru.json
@@ -102,7 +102,7 @@
     "Global Discovery Servers": "Серверы глобального обнаружения",
     "Global State": "Глобальное состояние",
     "Help": "Помощь",
-    "Home page": "Домашная страница",
+    "Home page": "Сайт",
     "Ignore": "Игнорировать",
     "Ignore Patterns": "Шаблоны игнорирования",
     "Ignore Permissions": "Игнорировать файловые права доступа",


### PR DESCRIPTION
1. `Домашная` is a typo. Correct is `Домашняя`.

2. `Домашняя страница` is a bit verbose and causes the footer to be placed in two text rows instead of one (on maximum page width):

![image](https://user-images.githubusercontent.com/980679/27642866-bad45e68-5c28-11e7-8d74-7b9a3cafa464.png)
↓
![image](https://user-images.githubusercontent.com/980679/27642887-ca0ed84a-5c28-11e7-964e-0184c7873ea7.png)
