### PR TITLE
gui: Fix discovered devices list (follow-up to #4186)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1186,13 +1186,17 @@ angular.module('syncthing.core')
             return $http.get(urlbase + '/system/discovery')
                 .success(function (registry) {
                     $scope.discovery = [];
+                    outer:
                     for (var id in registry) {
                         if ($scope.discovery.length === 5) {
                             break;
                         }
-                        if (!(id in $scope.devices)) {
-                            $scope.discovery.push(id);
+                        for (var i = 0; i < $scope.devices.length; i++) {
+                            if ($scope.devices[i].deviceID === id) {
+                                continue outer;
+                            }
                         }
+                        $scope.discovery.push(id);
                     }
                 })
                 .then(function () {

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -3,24 +3,26 @@
     <form role="form" name="deviceEditor">
       <div class="form-group" ng-class="{'has-error': deviceEditor.deviceID.$invalid && deviceEditor.deviceID.$dirty}" ng-init="loadFormIntoScope(deviceEditor)">
         <label translate for="deviceID">Device ID</label>
-        <input ng-if="!editingExisting" name="deviceID" id="deviceID" class="form-control text-monospace" type="text" ng-model="currentDevice.deviceID" required valid-deviceid list="discovery-list" />
-        <datalist id="discovery-list" ng-if="!editingExisting">
-          <option ng-repeat="id in discovery" value="{{id}}" />
-        </datalist>
+        <div ng-if="!editingExisting">
+          <input name="deviceID" id="deviceID" class="form-control text-monospace" type="text" ng-model="currentDevice.deviceID" required valid-deviceid list="discovery-list" />
+          <datalist id="discovery-list">
+            <option ng-repeat="id in discovery" value="{{id}}" />
+          </datalist>
+          <p class="help-block" ng-if="discovery">
+            <span translate>You can also select one of these nearby devices:</span>
+            <ul>
+              <li ng-repeat="id in discovery"><a ng-click="currentDevice.deviceID = id">{{id}}</a></li>
+            </ul>
+          </p>
+          <p class="help-block">
+            <span translate ng-if="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">The device ID to enter here can be found in the "Actions > Show ID" dialog on the other device. Spaces and dashes are optional (ignored).</span>
+            <span translate ng-show="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">When adding a new device, keep in mind that this device must be added on the other side too.</span>
+            <span translate ng-if="deviceEditor.deviceID.$error.required && deviceEditor.deviceID.$dirty">The device ID cannot be blank.</span>
+            <span translate ng-if="deviceEditor.deviceID.$error.validDeviceid && deviceEditor.deviceID.$dirty">The entered device ID does not look valid. It should be a 52 or 56 character string consisting of letters and numbers, with spaces and dashes being optional.</span>
+            <span translate ng-if="deviceEditor.deviceID.$error.unique && deviceEditor.deviceID.$dirty">A device with that ID is already added.</span>
+          </p>
+        </div>
         <div ng-if="editingExisting" class="well well-sm text-monospace" select-on-click>{{currentDevice.deviceID}}</div>
-        <p class="help-block" ng-if="!editingExisting && discovery">
-          <span translate>You can also select one of these nearby devices:</span>
-          <ul>
-            <li ng-repeat="id in discovery"><a ng-click="currentDevice.deviceID = id">{{id}}</a>
-          </ul>
-        </p>
-        <p class="help-block">
-          <span translate ng-if="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">The device ID to enter here can be found in the "Actions > Show ID" dialog on the other device. Spaces and dashes are optional (ignored).</span>
-          <span translate ng-show="!editingExisting && (deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine)">When adding a new device, keep in mind that this device must be added on the other side too.</span>
-          <span translate ng-if="deviceEditor.deviceID.$error.required && deviceEditor.deviceID.$dirty">The device ID cannot be blank.</span>
-          <span translate ng-if="deviceEditor.deviceID.$error.validDeviceid && deviceEditor.deviceID.$dirty">The entered device ID does not look valid. It should be a 52 or 56 character string consisting of letters and numbers, with spaces and dashes being optional.</span>
-          <span translate ng-if="deviceEditor.deviceID.$error.unique && deviceEditor.deviceID.$dirty">A device with that ID is already added.</span>
-        </p>
       </div>
       <div class="form-group">
         <label translate for="name">Device Name</label>


### PR DESCRIPTION
Thanks @dinosore for discovering the problem. Filtering devices didn't work (`in` is unfortunately not the same in JS as in python...). Also the list of device ids was shown when editing an existing device - no idea why, but cleaning up the html structure also got rid of that glitch.