### PR TITLE
lib/versioner: base versions path to working dir (#4188)

### DIFF
--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -51,11 +51,14 @@ func NewStaggered(folderID, folderPath string, params map[string]string) Version
 	// Use custom path if set, otherwise .stversions in folderPath
 	var versionsDir string
 	if params["versionsPath"] == "" {
-		l.Debugln("using default dir .stversions")
 		versionsDir = filepath.Join(folderPath, ".stversions")
-	} else {
+		l.Debugln("using default dir .stversions")
+	} else if filepath.IsAbs(params["versionsPath"]) {
 		l.Debugln("using dir", params["versionsPath"])
 		versionsDir = params["versionsPath"]
+	} else {
+		versionsDir = filepath.Join(folderPath, params["versionsPath"])
+		l.Debugln("using dir", versionsDir)
 	}
 
 	s := &Staggered{


### PR DESCRIPTION
### Purpose

base versions path to working dir (#4188)

### Testing

__base settings__: In folder, advanced settings, "File Versioning" dropdown, choose "Stagger file versioning" option.

#### - Scenario 1:
Leave field "Versions Path" empty and save.

Expect staggered files to be synced to `<<Folder Path>>/.stversions` folder where `<<Folder Path>>` is the "Folder Path" value displayed in the same dialog.

#### - Scenario 2:

Give a absolute path in "Versions Path" field, E.g. "`/tmp/testpath`" and save.

Expect staggered files to be synced to the given path. E.g. "`/tmp/testpath`"


#### - Scenario 3:

Give a relative path in "Versions Path" field, E.g. "`testpath`" and save.

Expect staggered files to be synced to the path relative to "Folder Path", E.g. `<<Folder Path>>/testpath`




