### PR TITLE
gui: show remaining bytes in remote devices panel (#4227)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -564,7 +564,7 @@
                 <span ng-switch="deviceStatus(deviceCfg)" class="pull-right text-{{deviceClass(deviceCfg)}}">
                   <span ng-switch-when="insync"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="syncing">
-                    <span class="hidden-xs" translate>Syncing</span>({{completion[deviceCfg.deviceID]._total | number:0}}%, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
+                    <span class="hidden-xs" translate>Syncing</span> ({{completion[deviceCfg.deviceID]._total | number:0}}%, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
                   </span>
                   <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="disconnected"><span class="hidden-xs" translate>Disconnected</span><span class="visible-xs">&#9724;</span></span>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -564,7 +564,7 @@
                 <span ng-switch="deviceStatus(deviceCfg)" class="pull-right text-{{deviceClass(deviceCfg)}}">
                   <span ng-switch-when="insync"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="syncing">
-                    <span class="hidden-xs" translate>Syncing</span> ({{completion[deviceCfg.deviceID]._total | number:0}}%)
+                    <span class="hidden-xs" translate>Syncing</span>({{completion[deviceCfg.deviceID]._total | number:0}}%, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
                   </span>
                   <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="disconnected"><span class="hidden-xs" translate>Disconnected</span><span class="visible-xs">&#9724;</span></span>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -232,7 +232,8 @@ angular.module('syncthing.core')
                     address: arg.data.addr
                 };
                 $scope.completion[arg.data.id] = {
-                    _total: 100
+                    _total: 100,
+                    _needBytes: 0
                 };
             }
         });
@@ -378,7 +379,8 @@ angular.module('syncthing.core')
             $scope.devices = $scope.config.devices;
             $scope.devices.forEach(function (deviceCfg) {
                 $scope.completion[deviceCfg.deviceID] = {
-                    _total: 100
+                    _total: 100,
+                    _needBytes: 0
                 };
             });
             $scope.devices.sort(deviceCompare);
@@ -463,7 +465,7 @@ angular.module('syncthing.core')
         function recalcCompletion(device) {
             var total = 0, needed = 0, deletes = 0;
             for (var folder in $scope.completion[device]) {
-                if (folder === "_total") {
+                if (folder === "_total" || folder === '_needBytes') {
                     continue;
                 }
                 total += $scope.completion[device][folder].globalBytes;
@@ -472,8 +474,10 @@ angular.module('syncthing.core')
             }
             if (total == 0) {
                 $scope.completion[device]._total = 100;
+                $scope.completion[device]._needBytes = 0;
             } else {
                 $scope.completion[device]._total = 100 * (1 - needed / total);
+                $scope.completion[device]._needBytes = needed
             }
 
             if (needed == 0 && deletes > 0) {
@@ -481,6 +485,7 @@ angular.module('syncthing.core')
                 // to do. Drop down the completion percentage to indicate
                 // that we have stuff to do.
                 $scope.completion[device]._total = 95;
+                $scope.completion[device]._needBytes = 0;
             }
 
             console.log("recalcCompletion", device, $scope.completion[device]);


### PR DESCRIPTION
### Purpose

Show remaining bytes in remote devices panel (#4227)

### Testing

When 2 devices are in syncing state, the remote devices panel should show "Syncing (`X`%, `Y` MiB)" Where `X` is the completion percentage and `Y` is the remaining bytes to be synced on that remote device.

### Screenshots


<img width="720" alt="sync" src="https://user-images.githubusercontent.com/3293332/27855317-9d04eaaa-619c-11e7-9495-e66167738579.png">


