### PR TITLE
lib/ignores: Don't add text from includes to lines

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -77,8 +77,8 @@ type ChangeDetector interface {
 }
 
 type Matcher struct {
-	lines          []string
-	patterns       []Pattern
+	lines          []string  // exact lines read from .stignore
+	patterns       []Pattern // patterns including those from included files
 	withCache      bool
 	matches        *cache
 	curHash        string
@@ -386,11 +386,10 @@ func parseIgnoreFile(fd io.Reader, currentFile string, cd ChangeDetector) ([]str
 		} else if strings.HasPrefix(line, "#include ") {
 			includeRel := line[len("#include "):]
 			includeFile := filepath.Join(filepath.Dir(currentFile), includeRel)
-			includeLines, includePatterns, err := loadIgnoreFile(includeFile, cd)
+			_, includePatterns, err := loadIgnoreFile(includeFile, cd)
 			if err != nil {
 				return fmt.Errorf("include of %q: %v", includeRel, err)
 			}
-			lines = append(lines, includeLines...)
 			patterns = append(patterns, includePatterns...)
 		} else {
 			// Path name or pattern, add it so it matches files both in

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -872,3 +872,38 @@ func TestRoot(t *testing.T) {
 		}
 	}
 }
+
+func TestLines(t *testing.T) {
+	stignore := `
+	#include testdata/excludes
+	
+	!/a
+	/*
+	`
+
+	pats := New(WithCache(true))
+	err := pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedLines := []string{
+		"",
+		"#include testdata/excludes",
+		"",
+		"!/a",
+		"/*",
+		"",
+	}
+
+	lines := pats.Lines()
+	if len(lines) != len(expectedLines) {
+		t.Fatalf("len(Lines()) == %d, expected %d", len(lines), len(expectedLines))
+	}
+	for i := range lines {
+		if lines[i] != expectedLines[i] {
+			t.Fatalf("Lines()[%d] == %s, expected %s", i, lines[i], expectedLines[i])
+		}
+	}
+
+}


### PR DESCRIPTION
Otherwise all the lines from includes are present in the web UI instead of
just the #include ... line. This problem was introduced in #3996.