### PR TITLE
meta: Move metadata checks into meta directory, make them tests

### DIFF
--- a/meta/README.txt
+++ b/meta/README.txt
@@ -1,0 +1,3 @@
+The files in this directory contain metadata tests - that is, tests on the
+shape and colour of the code in the rest of the repository. This code is not
+compiled into the final product.

--- a/meta/copyright_test.go
+++ b/meta/copyright_test.go
@@ -4,25 +4,26 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// +build ignore
-
 // Checks for files missing copyright notice
-package main
+package meta
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"testing"
 )
 
 // File extensions to check
-var checkExts = map[string]bool{
+var copyrightCheckExts = map[string]bool{
 	".go": true,
 }
+
+// Directories to search
+var copyrightCheckDirs = []string{".", "../cmd", "../lib", "../test", "../script"}
 
 // Valid copyright headers, searched for in the top five lines in each file.
 var copyrightRegexps = []string{
@@ -34,13 +35,11 @@ var copyrightRegexps = []string{
 
 var copyrightRe = regexp.MustCompile(strings.Join(copyrightRegexps, "|"))
 
-func main() {
-	flag.Parse()
-	for _, dir := range flag.Args() {
+func TestCheckCopyright(t *testing.T) {
+	for _, dir := range copyrightCheckDirs {
 		err := filepath.Walk(dir, checkCopyright)
 		if err != nil {
-			fmt.Println(err)
-			os.Exit(1)
+			t.Error(err)
 		}
 	}
 }
@@ -52,7 +51,7 @@ func checkCopyright(path string, info os.FileInfo, err error) error {
 	if !info.Mode().IsRegular() {
 		return nil
 	}
-	if !checkExts[filepath.Ext(path)] {
+	if !copyrightCheckExts[filepath.Ext(path)] {
 		return nil
 	}
 

--- a/meta/gofmt_test.go
+++ b/meta/gofmt_test.go
@@ -1,0 +1,45 @@
+// Copyright (C) 2015 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Checks for authors that are not mentioned in AUTHORS
+package meta
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+var gofmtCheckDirs = []string{".", "../cmd", "../lib", "../test", "../script"}
+
+func TestCheckGoFmt(t *testing.T) {
+	for _, dir := range gofmtCheckDirs {
+		err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if path == ".git" {
+				return filepath.SkipDir
+			}
+			if filepath.Ext(path) != ".go" {
+				return nil
+			}
+			cmd := exec.Command("gofmt", "-s", "-d", path)
+			bs, err := cmd.CombinedOutput()
+			if err != nil {
+				return err
+			}
+			if len(bs) != 0 {
+				t.Errorf("File %s is not formatted correctly:\n\n%s", path, string(bs))
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/meta/metalint_test.go
+++ b/meta/metalint_test.go
@@ -1,0 +1,113 @@
+// Copyright (C) 2017 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package meta
+
+import (
+	"bytes"
+	"log"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+var (
+	// fast linters complete in a fraction of a second and might as well be
+	// run always as part of the build
+	fastLinters = []string{
+		"deadcode",
+		"golint",
+		"ineffassign",
+		"vet",
+	}
+
+	// slow linters take several seconds and are run only as part of the
+	// "metalint" command.
+	slowLinters = []string{
+		"gosimple",
+		"staticcheck",
+		"structcheck",
+		"unused",
+		"varcheck",
+	}
+
+	// Which parts of the tree to lint
+	lintDirs = []string{".", "../script/...", "../lib/...", "../cmd/..."}
+
+	// Messages to ignore
+	lintExcludes = []string{
+		".pb.go",
+		"should have comment",
+		"protocol.Vector composite literal uses unkeyed fields",
+		"cli.Requires composite literal uses unkeyed fields",
+		"Use DialContext instead",   // Go 1.7
+		"os.SEEK_SET is deprecated", // Go 1.7
+		"SA4017",                    // staticcheck "is a pure function but its return value is ignored"
+	}
+)
+
+func TestCheckMetalint(t *testing.T) {
+	if !isGometalinterInstalled() {
+		return
+	}
+
+	gometalinter(t, lintDirs, lintExcludes...)
+}
+
+func isGometalinterInstalled() bool {
+	if _, err := runError("gometalinter", "--disable-all"); err != nil {
+		log.Println("gometalinter is not installed")
+		return false
+	}
+	return true
+}
+
+func gometalinter(t *testing.T, dirs []string, excludes ...string) bool {
+	params := []string{"--disable-all", "--concurrency=2", "--deadline=300s"}
+
+	for _, linter := range fastLinters {
+		params = append(params, "--enable="+linter)
+	}
+
+	if !testing.Short() {
+		for _, linter := range slowLinters {
+			params = append(params, "--enable="+linter)
+		}
+	}
+
+	for _, exclude := range excludes {
+		params = append(params, "--exclude="+exclude)
+	}
+
+	params = append(params, dirs...)
+
+	bs, _ := runError("gometalinter", params...)
+
+	nerr := 0
+	lines := make(map[string]struct{})
+	for _, line := range strings.Split(string(bs), "\n") {
+		if line == "" {
+			continue
+		}
+		if _, ok := lines[line]; ok {
+			continue
+		}
+		log.Println(line)
+		if strings.Contains(line, "executable file not found") {
+			log.Println(` - Try "go run build.go setup" to install missing tools`)
+		}
+		lines[line] = struct{}{}
+		nerr++
+	}
+
+	return nerr == 0
+}
+
+func runError(cmd string, args ...string) ([]byte, error) {
+	ecmd := exec.Command(cmd, args...)
+	bs, err := ecmd.CombinedOutput()
+	return bytes.TrimSpace(bs), err
+}


### PR DESCRIPTION
This moves a few things from script/ to a new directory meta/, and makes
them real Go tests. These are the authors, copyright, metalint and gofmt
checks. That means that they can now be run by

go test -v ./meta

and optionally filtered by the usual -run thing to go test. Also -short
will cut down on the metalint stuff and exclude the authors check (which
is slow because it runs git lots of times).

Mainly this makes everything easier on things like build servers where
we can now just run tests instead of do a bunch of scripting.
