### PR TITLE
lib/model: resolve file conflicts for new file (#3742)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1450,7 +1450,7 @@ func (f *sendReceiveFolder) performFinish(state *sharedPullerState) error {
 			if err = osutil.InWritableDir(os.Remove, state.realName); err != nil {
 				return err
 			}
-		case !state.info.ModTime().Equal(stat.ModTime()) || state.info.Size() != stat.Size() ||
+		case state.info == nil || !state.info.ModTime().Equal(stat.ModTime()) || state.info.Size() != stat.Size() ||
 			f.inConflict(state.version, state.file.Version):
 			// The new file has been changed in conflict with the existing one. We
 			// should file it away as a conflict instead of just removing or

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
 )
@@ -27,6 +28,7 @@ type sharedPullerState struct {
 	reused      int // Number of blocks reused from temporary file
 	ignorePerms bool
 	version     protocol.Vector // The current (old) version
+	info        fs.FileInfo
 	sparse      bool
 	created     time.Time
 


### PR DESCRIPTION


### Purpose

Always use `currentFolderFile()`'s version which is more up-to-date than
cached version in `sendReceiveFolder` struct.
Fixes  #3742

### Testing

Tested with steps described in the mentioned issue and it worked properly with `xxx-conflict-xxx` file generated.

