### PR TITLE
Add folder list to table cell title

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -394,7 +394,7 @@
                     </tr>
                     <tr>
                       <th><span class="fa fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span></th>
-                      <td class="text-right">{{sharesFolder(folder)}}</td>
+                      <td class="text-right" title="{{sharesFolder(folder)}}">{{sharesFolder(folder)}}</td>
                     </tr>
                     <tr>
                       <th><span class="fa fa-fw fa-clock-o"></span>&nbsp;<span translate>Last Scan</span></th>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -645,7 +645,7 @@
                     </tr>
                     <tr ng-if="deviceFolders(deviceCfg).length > 0">
                       <th><span class="fa fa-fw fa-folder"></span>&nbsp;<span translate>Folders</span></th>
-                      <td class="text-right">{{deviceFolders(deviceCfg).map(folderLabel).join(", ")}}</td>
+                      <td class="text-right" title="{{deviceFolders(deviceCfg).map(folderLabel).join(", ")}}">{{deviceFolders(deviceCfg).map(folderLabel).join(", ")}}</td>
                     </tr>
                   </tbody>
                 </table>


### PR DESCRIPTION
This is useful when you wanna view all folder names but their list is truncated by ￼`overflow: hidden; text-overflow: ellipsis;`.