### PR TITLE
gui: Don't set default path editing existing folders without label (fixes #4297)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -622,8 +622,8 @@ angular.module('syncthing.core')
             return path;
         }
 
-        function shouldNotSetDefaultPath() {
-            return !$scope.config.options || !$scope.config.options.defaultFolderPath || $scope.editingExisting || !$scope.folderEditor.folderPath.$pristine
+        function shouldSetDefaultFolderPath() {
+            return $scope.config.options && $scope.config.options.defaultFolderPath && !$scope.editingExisting && $scope.folderEditor.folderPath.$pristine
         }
 
         $scope.neededPageChanged = function (page) {
@@ -1392,14 +1392,14 @@ angular.module('syncthing.core')
         });
 
         $scope.$watch('currentFolder.label', function (newvalue) {
-            if (!newvalue || shouldNotSetDefaultPath) {
+            if (!newvalue || !shouldSetDefaultFolderPath()) {
                 return;
             }
             $scope.currentFolder.path = pathJoin($scope.config.options.defaultFolderPath, newvalue);
         });
 
         $scope.$watch('currentFolder.id', function (newvalue) {
-            if (!newvalue || shouldNotSetDefaultPath || $scope.currentFolder.label) {
+            if (!newvalue || !shouldSetDefaultFolderPath() || $scope.currentFolder.label) {
                 return;
             }
             $scope.currentFolder.path = pathJoin($scope.config.options.defaultFolderPath, newvalue);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -622,6 +622,10 @@ angular.module('syncthing.core')
             return path;
         }
 
+        function shouldNotSetDefaultPath() {
+            return !$scope.config.options || !$scope.config.options.defaultFolderPath || $scope.editingExisting || !$scope.folderEditor.folderPath.$pristine
+        }
+
         $scope.neededPageChanged = function (page) {
             $scope.neededCurrentPage = page;
             refreshNeed($scope.neededFolder);
@@ -1388,14 +1392,14 @@ angular.module('syncthing.core')
         });
 
         $scope.$watch('currentFolder.label', function (newvalue) {
-            if (!$scope.config.options || !$scope.config.options.defaultFolderPath || $scope.editingExisting || !$scope.folderEditor.folderPath.$pristine || !newvalue) {
+            if (!newvalue || shouldNotSetDefaultPath) {
                 return;
             }
             $scope.currentFolder.path = pathJoin($scope.config.options.defaultFolderPath, newvalue);
         });
 
         $scope.$watch('currentFolder.id', function (newvalue) {
-            if (!$scope.config.options || !$scope.config.options.defaultFolderPath || !$scope.folderEditor.folderPath.$pristine || !newvalue || $scope.currentFolder.label) {
+            if (!newvalue || shouldNotSetDefaultPath || $scope.currentFolder.label) {
                 return;
             }
             $scope.currentFolder.path = pathJoin($scope.config.options.defaultFolderPath, newvalue);


### PR DESCRIPTION
I put the condition about  whether the path should be changed in the watch into a separate function to make them consistent. This is not yet tested, that's up next.