### PR TITLE
lib/model: GetIgnores: Don't return error for no .stignore file

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1250,25 +1250,28 @@ func (m *Model) GetIgnores(folder string) ([]string, []string, error) {
 	defer m.fmut.RUnlock()
 
 	cfg, ok := m.folderCfgs[folder]
-	if ok {
-		if !cfg.HasMarker() {
-			return nil, nil, fmt.Errorf("Folder %s stopped", folder)
+	if !ok {
+		cfg, ok = m.cfg.Folders()[folder]
+		if !ok {
+			return nil, nil, fmt.Errorf("Folder %s does not exist", folder)
 		}
+	}
 
-		ignores := m.folderIgnores[folder]
+	if err := m.checkFolderPath(cfg); err != nil {
+		return nil, nil, err
+	}
 
+	ignores, ok := m.folderIgnores[folder]
+	if ok {
 		return ignores.Lines(), ignores.Patterns(), nil
 	}
 
-	if cfg, ok := m.cfg.Folders()[folder]; ok {
-		matcher := ignore.New(cfg.Filesystem())
-		if err := matcher.Load(".stignore"); err != nil {
-			return nil, nil, err
-		}
-		return matcher.Lines(), matcher.Patterns(), nil
+	ignores = ignore.New(fs.NewFilesystem(cfg.FilesystemType, cfg.Path))
+	if err := ignores.Load(".stignore"); err != nil && !fs.IsNotExist(err) {
+		return nil, nil, err
 	}
 
-	return nil, nil, fmt.Errorf("Folder %s does not exist", folder)
+	return ignores.Lines(), ignores.Patterns(), nil
 }
 
 func (m *Model) SetIgnores(folder string, content []string) error {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1083,6 +1083,11 @@ func TestIgnores(t *testing.T) {
 	// added to the model and thus there is no initial scan happening.
 
 	changeIgnores(t, m, expected)
+
+	// Make sure no .stignore file is considered valid
+	os.Rename("testdata/.stignore", "testdata/.stignore.bak")
+	changeIgnores(t, m, []string{})
+	os.Rename("testdata/.stignore.bak", "testdata/.stignore")
 }
 
 func TestROScanRecovery(t *testing.T) {


### PR DESCRIPTION
GetIgnores returned an error if the folder is not currently in model and there is no ".stignore" file, while this is valid. 