### PR TITLE
lib/upnp: Disable confusing messages

### DIFF
--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -168,7 +168,9 @@ USER-AGENT: syncthing/1.0
 
 	_, err = socket.WriteTo(search, ssdp)
 	if err != nil {
-		l.Infoln(err)
+		if e, ok := err.(net.Error); !ok || !e.Timeout() {
+			l.Infoln(err)
+		}
 		return
 	}
 
@@ -226,11 +228,6 @@ func parseResponse(deviceType string, resp []byte) (IGD, error) {
 	}
 
 	deviceUUID := strings.TrimPrefix(strings.Split(deviceUSN, "::")[0], "uuid:")
-	matched, _ := regexp.MatchString("[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}", deviceUUID)
-	if !matched {
-		l.Infoln("Invalid IGD response: invalid device UUID", deviceUUID, "(continuing anyway)")
-	}
-
 	response, err = http.Get(deviceDescriptionLocation)
 	if err != nil {
 		return IGD{}, err


### PR DESCRIPTION
The Write on Windows to some virtual adapters always times out.
And the invalid ID makes people think something is wrong.