### PR TITLE
lib/model,lib/ignores: Fix fs regressions (fixes #4313, fixes #4314)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2304,7 +2304,7 @@ func (m *Model) checkFreeSpace(req config.Size, fs fs.Filesystem) error {
 	}
 
 	if req.Percentage() {
-		freePct := (1 - float64(usage.Free)/float64(usage.Total)) * 100
+		freePct := (float64(usage.Free)/float64(usage.Total)) * 100
 		if err == nil && freePct < val {
 			return fmt.Errorf("insufficient space in %v %v: %f %% < %v", fs.Type(), fs.URI(), freePct, req)
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2304,7 +2304,7 @@ func (m *Model) checkFreeSpace(req config.Size, fs fs.Filesystem) error {
 	}
 
 	if req.Percentage() {
-		freePct := (float64(usage.Free)/float64(usage.Total)) * 100
+		freePct := (float64(usage.Free) / float64(usage.Total)) * 100
 		if err == nil && freePct < val {
 			return fmt.Errorf("insufficient space in %v %v: %f %% < %v", fs.Type(), fs.URI(), freePct, req)
 		}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2382,27 +2382,32 @@ func (fakeAddr) String() string {
 	return "address"
 }
 
+type alwaysChangedKey struct {
+	fs   fs.Filesystem
+	name string
+}
+
 // alwaysChanges is an ignore.ChangeDetector that always returns true on Changed()
 type alwaysChanged struct {
-	seen map[string]struct{}
+	seen map[alwaysChangedKey]struct{}
 }
 
 func newAlwaysChanged() *alwaysChanged {
 	return &alwaysChanged{
-		seen: make(map[string]struct{}),
+		seen: make(map[alwaysChangedKey]struct{}),
 	}
 }
 
-func (c *alwaysChanged) Remember(name string, _ time.Time) {
-	c.seen[name] = struct{}{}
+func (c *alwaysChanged) Remember(fs fs.Filesystem, name string, _ time.Time) {
+	c.seen[alwaysChangedKey{fs, name}] = struct{}{}
 }
 
 func (c *alwaysChanged) Reset() {
-	c.seen = make(map[string]struct{})
+	c.seen = make(map[alwaysChangedKey]struct{})
 }
 
-func (c *alwaysChanged) Seen(name string) bool {
-	_, ok := c.seen[name]
+func (c *alwaysChanged) Seen(fs fs.Filesystem, name string) bool {
+	_, ok := c.seen[alwaysChangedKey{fs, name}]
 	return ok
 }
 


### PR DESCRIPTION
We should probably deprecate escaping filesystems for ignores.