### PR TITLE
gui: Round down in devices completion (consistent with folders)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -477,7 +477,7 @@ angular.module('syncthing.core')
                 $scope.completion[device]._total = 100;
                 $scope.completion[device]._needBytes = 0;
             } else {
-                $scope.completion[device]._total = 100 * (1 - needed / total);
+                $scope.completion[device]._total = Math.floor(100 * (1 - needed / total));
                 $scope.completion[device]._needBytes = needed
             }
 


### PR DESCRIPTION
The completion percentage is already rounded down to avoid the potentially confusing situation where the status is "Syncing" but the completion 100%. This PR does the same for the devices.