### PR TITLE
lib/model: Create folders via newFolder

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -9,10 +9,13 @@ package model
 import (
 	"context"
 	"time"
+
+	"github.com/syncthing/syncthing/lib/config"
 )
 
 type folder struct {
 	stateTracker
+	config.FolderConfiguration
 
 	scan                folderScanner
 	model               *Model
@@ -21,9 +24,23 @@ type folder struct {
 	initialScanFinished chan struct{}
 }
 
-func (f *folder) IndexUpdated() {
+func newFolder(model *Model, cfg config.FolderConfiguration) folder {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	return folder{
+		stateTracker:        newStateTracker(cfg.ID),
+		FolderConfiguration: cfg,
+
+		scan:                newFolderScanner(cfg),
+		ctx:                 ctx,
+		cancel:              cancel,
+		model:               model,
+		initialScanFinished: make(chan struct{}),
+	}
 }
 
+func (f *folder) IndexUpdated() {
+}
 func (f *folder) DelayScan(next time.Duration) {
 	f.scan.Delay(next)
 }

--- a/lib/model/rofolder.go
+++ b/lib/model/rofolder.go
@@ -7,7 +7,6 @@
 package model
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/syncthing/syncthing/lib/config"
@@ -21,23 +20,10 @@ func init() {
 
 type sendOnlyFolder struct {
 	folder
-	config.FolderConfiguration
 }
 
 func newSendOnlyFolder(model *Model, cfg config.FolderConfiguration, _ versioner.Versioner, _ fs.Filesystem) service {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	return &sendOnlyFolder{
-		folder: folder{
-			stateTracker:        newStateTracker(cfg.ID),
-			scan:                newFolderScanner(cfg),
-			ctx:                 ctx,
-			cancel:              cancel,
-			model:               model,
-			initialScanFinished: make(chan struct{}),
-		},
-		FolderConfiguration: cfg,
-	}
+	return &sendOnlyFolder{folder: newFolder(model, cfg)}
 }
 
 func (f *sendOnlyFolder) Serve() {

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -7,7 +7,6 @@
 package model
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -81,7 +80,6 @@ type dbUpdateJob struct {
 
 type sendReceiveFolder struct {
 	folder
-	config.FolderConfiguration
 
 	fs        fs.Filesystem
 	versioner versioner.Versioner
@@ -98,18 +96,8 @@ type sendReceiveFolder struct {
 }
 
 func newSendReceiveFolder(model *Model, cfg config.FolderConfiguration, ver versioner.Versioner, fs fs.Filesystem) service {
-	ctx, cancel := context.WithCancel(context.Background())
-
 	f := &sendReceiveFolder{
-		folder: folder{
-			stateTracker:        newStateTracker(cfg.ID),
-			scan:                newFolderScanner(cfg),
-			ctx:                 ctx,
-			cancel:              cancel,
-			model:               model,
-			initialScanFinished: make(chan struct{}),
-		},
-		FolderConfiguration: cfg,
+		folder: newFolder(model, cfg),
 
 		fs:        fs,
 		versioner: ver,


### PR DESCRIPTION
This is a part of the notifications PR, but not really related to notifications. It removes some code-duplication and potentially simplifies keeping said PR up-to-date with master.