### PR TITLE
cmd/syncthing, lib/sha256: Skip CPU benchmarks when user decided (fixes #4348)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -638,12 +638,10 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	l.Infoln(LongVersion)
 	l.Infoln("My ID:", myID)
 
+	// Select SHA256 implementation and report. Affected by the
+	// STHASHING environment variable.
 	sha256.SelectAlgo()
 	sha256.Report()
-	perfWithWeakHash := cpuBench(3, 150*time.Millisecond, true)
-	l.Infof("Hashing performance with weak hash is %.02f MB/s", perfWithWeakHash)
-	perfWithoutWeakHash := cpuBench(3, 150*time.Millisecond, false)
-	l.Infof("Hashing performance without weak hash is %.02f MB/s", perfWithoutWeakHash)
 
 	// Emit the Starting event, now that we know who we are.
 
@@ -696,6 +694,11 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	opts := cfg.Options()
 
 	if opts.WeakHashSelectionMethod == config.WeakHashAuto {
+		perfWithWeakHash := cpuBench(3, 150*time.Millisecond, true)
+		l.Infof("Hashing performance with weak hash is %.02f MB/s", perfWithWeakHash)
+		perfWithoutWeakHash := cpuBench(3, 150*time.Millisecond, false)
+		l.Infof("Hashing performance without weak hash is %.02f MB/s", perfWithoutWeakHash)
+
 		if perfWithoutWeakHash*0.8 > perfWithWeakHash {
 			l.Infof("Weak hash disabled, as it has an unacceptable performance impact.")
 			weakhash.Enabled = false

--- a/lib/sha256/sha256.go
+++ b/lib/sha256/sha256.go
@@ -55,17 +55,13 @@ func SelectAlgo() {
 		}
 
 	case "minio":
-		// When set to "minio", use that. Benchmark anyway to be able to
-		// present the difference.
-		benchmark()
+		// When set to "minio", use that.
 		selectMinio()
 
 	default:
 		// When set to anything else, such as "standard", use the default Go
-		// implementation. Benchmark that anyway, so we can report something
-		// useful in Report(). Make sure not to touch the minio
+		// implementation. Make sure not to touch the minio
 		// implementation as it may be disabled for incompatibility reasons.
-		cryptoPerf = cpuBenchOnce(benchmarkingIterations*benchmarkingDuration, cryptoSha256.New)
 	}
 
 	verifyCorrectness()
@@ -87,6 +83,10 @@ func Report() {
 		selectedRate = minioPerf
 		otherRate = cryptoPerf
 		otherImpl = defaultImpl
+	}
+
+	if selectedRate == 0 {
+		return
 	}
 
 	l.Infof("Single thread SHA256 performance is %s using %s (%s using %s).", formatRate(selectedRate), selectedImpl, formatRate(otherRate), otherImpl)


### PR DESCRIPTION
### Purpose

When STHASHING is set, don't benchmark as it's already decided. If weak
hashing isn't set to "auto", don't benchmark that either.

### Testing

I haven't even had coffee yet.