### PR TITLE
lib/model: Deduplicate folder loops

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -71,3 +71,20 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 	}
 	return nil
 }
+
+func (f *folder) scanTimerFired() {
+	err := f.scanSubdirs(nil)
+
+	select {
+	case <-f.initialScanFinished:
+	default:
+		status := "Completed"
+		if err != nil {
+			status = "Failed"
+		}
+		l.Infoln(status, "initial scan of", f.Type.String(), "folder", f.Description())
+		close(f.initialScanFinished)
+	}
+
+	f.scan.Reschedule()
+}

--- a/lib/model/folderscanner.go
+++ b/lib/model/folderscanner.go
@@ -57,7 +57,3 @@ func (f *folderScanner) Scan(subdirs []string) error {
 func (f *folderScanner) Delay(next time.Duration) {
 	f.delay <- next
 }
-
-func (f *folderScanner) HasNoInterval() bool {
-	return f.interval == 0
-}

--- a/lib/model/rofolder.go
+++ b/lib/model/rofolder.go
@@ -41,24 +41,7 @@ func (f *sendOnlyFolder) Serve() {
 
 		case <-f.scan.timer.C:
 			l.Debugln(f, "Scanning subdirectories")
-			err := f.scanSubdirs(nil)
-
-			select {
-			case <-f.initialScanFinished:
-			default:
-				status := "Completed"
-				if err != nil {
-					status = "Failed"
-				}
-				l.Infoln(status, "initial scan (ro) of", f.Description())
-				close(f.initialScanFinished)
-			}
-
-			if f.scan.HasNoInterval() {
-				continue
-			}
-
-			f.scan.Reschedule()
+			f.scanTimerFired()
 
 		case req := <-f.scan.now:
 			req.err <- f.scanSubdirs(req.subdirs)

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -268,18 +268,7 @@ func (f *sendReceiveFolder) Serve() {
 		// same time.
 		case <-f.scan.timer.C:
 			l.Debugln(f, "Scanning subdirectories")
-			err := f.scanSubdirs(nil)
-			f.scan.Reschedule()
-			select {
-			case <-f.initialScanFinished:
-			default:
-				close(f.initialScanFinished)
-				status := "Completed"
-				if err != nil {
-					status = "Failed"
-				}
-				l.Infoln(status, "initial scan (rw) of", f.Description())
-			}
+			f.scanTimerFired()
 
 		case req := <-f.scan.now:
 			req.err <- f.scanSubdirs(req.subdirs)


### PR DESCRIPTION
Purely (almost) cosmetic to reduce code duplication, remove unnecessary code, handle scanning the same for both folder types and use new terminology (ro/rw -> sendonly/sendreceive) for info logging.
The only difference was that `sendOnlyFolder` called `Reschedule` after the initial scan finished, `sendReceiveFolder` before. Now both do it after.