### PR TITLE
directoy is a misspelling of directory

### DIFF
--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -71,7 +71,7 @@ func newBasicFilesystem(root string) *BasicFilesystem {
 
 // rooted expands the relative path to the full path that is then used with os
 // package. If the relative path somehow causes the final path to escape the root
-// directoy, this returns an error, to prevent accessing files that are not in the
+// directory, this returns an error, to prevent accessing files that are not in the
 // shared directory.
 func (f *BasicFilesystem) rooted(rel string) (string, error) {
 	// The root must not be empty.


### PR DESCRIPTION
Signed-off-by: wgliang <liangcszzu@163.com>

### Purpose

directoy is a misspelling of directory

### Testing

NONE

### Screenshots

NONE
### Documentation

NONE

### Authorship

NONE