### PR TITLE
cmd/syncthing: Add some common security releated HTTP headers (fixes #4360)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -332,7 +332,7 @@ func (s *apiService) Serve() {
 	}
 
 	// Add the CORS handling
-	handler = corsMiddleware(handler)
+	handler = corsMiddleware(handler, guiCfg.InsecureAllowFrameLoading)
 
 	if addressIsLocalhost(guiCfg.Address()) && !guiCfg.InsecureSkipHostCheck {
 		// Verify source host
@@ -459,7 +459,7 @@ func debugMiddleware(h http.Handler) http.Handler {
 	})
 }
 
-func corsMiddleware(next http.Handler) http.Handler {
+func corsMiddleware(next http.Handler, allowFrameLoading bool) http.Handler {
 	// Handle CORS headers and CORS OPTIONS request.
 	// CORS OPTIONS request are typically sent by browser during AJAX preflight
 	// when the browser initiate a POST request.
@@ -489,9 +489,11 @@ func corsMiddleware(next http.Handler) http.Handler {
 		// Other security related headers that can always be present.
 		// https://www.owasp.org/index.php/Security_Headers
 
-		// We don't want to be rendered in an <iframe>, <frame> or
-		// <object>.
-		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		if !allowFrameLoading {
+			// We don't want to be rendered in an <iframe>, <frame> or
+			// <object>.
+			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+		}
 
 		// If the browser senses an XSS attack it's allowed to take
 		// action. (How this would not alwayss be the default I

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -486,6 +486,21 @@ func corsMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
+		// Other security related headers that can always be present.
+		// https://www.owasp.org/index.php/Security_Headers
+
+		// We don't want to be rendered in an <iframe>, <frame> or
+		// <object>.
+		w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+
+		// If the browser senses an XSS attack it's allowed to take
+		// action. (How this would not alwayss be the default I
+		// don't fully understand.)
+		w.Header().Set("X-XSS-Protection", "1; mode=block")
+
+		// Our content type headers are correct. Don't guess.
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+
 		// For everything else, pass to the next handler
 		next.ServeHTTP(w, r)
 		return

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -486,17 +486,21 @@ func corsMiddleware(next http.Handler, allowFrameLoading bool) http.Handler {
 			return
 		}
 
-		// Other security related headers that can always be present.
+		// Other security related headers that should be present.
 		// https://www.owasp.org/index.php/Security_Headers
 
 		if !allowFrameLoading {
-			// We don't want to be rendered in an <iframe>, <frame> or
-			// <object>.
+			// We don't want to be rendered in an <iframe>,
+			// <frame> or <object>. (Unless we do it ourselves.
+			// This is also an escape hatch for people who serve
+			// Syncthing GUI as part of their own website
+			// through a proxy, so they don't need to set the
+			// allowFrameLoading bool.)
 			w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 		}
 
 		// If the browser senses an XSS attack it's allowed to take
-		// action. (How this would not alwayss be the default I
+		// action. (How this would not always be the default I
 		// don't fully understand.)
 		w.Header().Set("X-XSS-Protection", "1; mode=block")
 

--- a/cmd/syncthing/gui_statics.go
+++ b/cmd/syncthing/gui_statics.go
@@ -141,17 +141,17 @@ func (s *staticsServer) serveThemes(w http.ResponseWriter, r *http.Request) {
 func (s *staticsServer) mimeTypeForFile(file string) string {
 	// We use a built in table of the common types since the system
 	// TypeByExtension might be unreliable. But if we don't know, we delegate
-	// to the system.
+	// to the system. All our files are UTF-8.
 	ext := filepath.Ext(file)
 	switch ext {
 	case ".htm", ".html":
-		return "text/html"
+		return "text/html; charset=utf-8"
 	case ".css":
-		return "text/css"
+		return "text/css; charset=utf-8"
 	case ".js":
-		return "application/javascript"
+		return "application/javascript; charset=utf-8"
 	case ".json":
-		return "application/json"
+		return "application/json; charset=utf-8"
 	case ".png":
 		return "image/png"
 	case ".ttf":
@@ -159,7 +159,7 @@ func (s *staticsServer) mimeTypeForFile(file string) string {
 	case ".woff":
 		return "application/x-font-woff"
 	case ".svg":
-		return "image/svg+xml"
+		return "image/svg+xml; charset=utf-8"
 	default:
 		return mime.TypeByExtension(ext)
 	}

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -13,16 +13,17 @@ import (
 )
 
 type GUIConfiguration struct {
-	Enabled               bool   `xml:"enabled,attr" json:"enabled" default:"true"`
-	RawAddress            string `xml:"address" json:"address" default:"127.0.0.1:8384"`
-	User                  string `xml:"user,omitempty" json:"user"`
-	Password              string `xml:"password,omitempty" json:"password"`
-	RawUseTLS             bool   `xml:"tls,attr" json:"useTLS"`
-	APIKey                string `xml:"apikey,omitempty" json:"apiKey"`
-	InsecureAdminAccess   bool   `xml:"insecureAdminAccess,omitempty" json:"insecureAdminAccess"`
-	Theme                 string `xml:"theme" json:"theme" default:"default"`
-	Debugging             bool   `xml:"debugging,attr" json:"debugging"`
-	InsecureSkipHostCheck bool   `xml:"insecureSkipHostcheck,omitempty" json:"insecureSkipHostcheck"`
+	Enabled                   bool   `xml:"enabled,attr" json:"enabled" default:"true"`
+	RawAddress                string `xml:"address" json:"address" default:"127.0.0.1:8384"`
+	User                      string `xml:"user,omitempty" json:"user"`
+	Password                  string `xml:"password,omitempty" json:"password"`
+	RawUseTLS                 bool   `xml:"tls,attr" json:"useTLS"`
+	APIKey                    string `xml:"apikey,omitempty" json:"apiKey"`
+	InsecureAdminAccess       bool   `xml:"insecureAdminAccess,omitempty" json:"insecureAdminAccess"`
+	Theme                     string `xml:"theme" json:"theme" default:"default"`
+	Debugging                 bool   `xml:"debugging,attr" json:"debugging"`
+	InsecureSkipHostCheck     bool   `xml:"insecureSkipHostcheck,omitempty" json:"insecureSkipHostcheck"`
+	InsecureAllowFrameLoading bool   `xml:"insecureAllowFrameLoading,omitempty" json:"insecureAllowFrameLoading"`
 }
 
 func (c GUIConfiguration) Address() string {


### PR DESCRIPTION
These:

1. X-Frame-Options: SAMEORIGIN
2. X-XSS-Protection: 1; mode=block
3. X-Content-Type-Options: nosniff
4. Content-Type: text/html; charset=utf-8

Number 4 we already do of course, but I sprinkled some utf-8 where appropriate.

Numbers 2-3 are uncontroversial and shouldn't do any harm.

Number 1 might be an issue. Potentially for apps that wrap Syncthing (@nutomic, @kozec, @canton7), also I recall from forums that there are people who have their own web pages that load the Syncthing UI in a part of them. I added a new GUI config option `InsecureAllowFrameLoading` to turn off this header.