### PR TITLE
lib/model: Fix minor logging regression and inconsistency of #4338 (ref #4375)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -245,8 +245,8 @@ func (f *sendReceiveFolder) Serve() {
 					// errors preventing us. Flag this with a warning and
 					// wait a bit longer before retrying.
 					if folderErrors := f.currentErrors(); len(folderErrors) > 0 {
-						for path, err := range folderErrors {
-							l.Infof("Puller (folder %v, dir %q): %v", f.Description(), path, err)
+						for _, fileError := range folderErrors {
+							l.Infof("Puller (folder %v, dir %q): %v", f.Description(), fileError.Path, fileError.Err)
 						}
 						events.Default.Log(events.FolderErrors, map[string]interface{}{
 							"folder": f.folderID,

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -246,7 +246,7 @@ func (f *sendReceiveFolder) Serve() {
 					// wait a bit longer before retrying.
 					if folderErrors := f.currentErrors(); len(folderErrors) > 0 {
 						for path, err := range folderErrors {
-							l.Infof("Puller (folder %q, dir %q): %v", f.Description(), path, err)
+							l.Infof("Puller (folder %v, dir %q): %v", f.Description(), path, err)
 						}
 						events.Default.Log(events.FolderErrors, map[string]interface{}{
 							"folder": f.folderID,
@@ -254,7 +254,7 @@ func (f *sendReceiveFolder) Serve() {
 						})
 					}
 
-					l.Infof("Folder %q isn't making progress. Pausing puller for %v.", f.folderID, f.pause)
+					l.Infof("Folder %v isn't making progress. Pausing puller for %v.", f.Description(), f.pause)
 					l.Debugln(f, "next pull in", f.pause)
 
 					f.pullTimer.Reset(f.pause)


### PR DESCRIPTION
In #4338, the added line logged to info level used `%q` instead of `%v` and the existing line wasn't changed to use `f.Description()` for consistency.