### PR TITLE
lib/config, lib/model: Make sure to hide our special files (fixes #4382)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -392,6 +392,7 @@ func convertV22V23(cfg *Configuration) {
 			err = fs.Remove(".stfolder")
 			if err == nil {
 				err = fs.Mkdir(".stfolder", permBits)
+				fs.Hide(".stfolder") // ignore error
 			}
 			if err != nil {
 				l.Fatalln("failed to upgrade folder marker:", err)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -253,7 +253,14 @@ func (m *Model) startFolderLocked(folder string) config.FolderType {
 		}
 	}
 
-	p := folderFactory(m, cfg, ver, fs.MtimeFS())
+	ffs := fs.MtimeFS()
+
+	// These are our metadata files, and they should always be hidden.
+	ffs.Hide(".stfolder")
+	ffs.Hide(".stversions")
+	ffs.Hide(".stignore")
+
+	p := folderFactory(m, cfg, ver, ffs)
 	m.folderRunners[folder] = p
 
 	m.warnAboutOverwritingProtectedFiles(folder)


### PR DESCRIPTION
### Purpose

The folder marker conversion forgot to hide the .stfolder. This adds
that, for those who have not yet been converted.

Also adds Hide() calls to the folder start, to mend historical
unhidedness. (I'm sure this will upset someone who is manually managing
their .stignores in the other direction...)

### Testing

Tested manually on a Windows VM.