### PR TITLE
lib/model: Hide temporary files on Windows while they are in use (fixes #4382)

### DIFF
--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -164,6 +164,9 @@ func (s *sharedPullerState) tempFile() (io.WriterAt, error) {
 		return nil, err
 	}
 
+	// Hide the temporary file
+	s.fs.Hide(s.tempName)
+
 	// Don't truncate symlink files, as that will mean that the path will
 	// contain a bunch of nulls.
 	if s.sparse && !s.file.IsSymlink() {
@@ -306,6 +309,12 @@ func (s *sharedPullerState) finalClose() (bool, error) {
 	}
 
 	s.closed = true
+
+	// Unhide the temporary file when we close it, as it's likely to
+	// immediately be renamed to the final name. If this is a failed temp
+	// file we will also unhide it, but I'm fine with that as we're now
+	// leaving it around for potentially quite a while.
+	s.fs.Unhide(s.tempName)
 
 	return true, s.err
 }


### PR DESCRIPTION
### Purpose

Hide the temp files while we are using them.

### Testing

None whatsoever. I'm just assuming that the Hide() call works and that it's valid to call Hide() on an open file. If someone on Windows could confirm that it would be lovely.

I don't think there are any ways out of a temp file other than via sharedPullerState.finalClose - if there are this would result in files becoming permanently hidden which would be bad.