### PR TITLE
chore: gnome-shell autostart

### DIFF
--- a/etc/linux-gnome-shell/README.md
+++ b/etc/linux-gnome-shell/README.md
@@ -1,0 +1,5 @@
+This directory contains a configuration for running syncthing as user startup application in the gnome-shell Linux environment.
+ 1. Copy the file `synthing.desktop` to `$HOME/.config/autostart/syncthing.desktop`
+
+Log output is sent to syslogd.
+

--- a/etc/linux-gnome-shell/syncthing.desktop
+++ b/etc/linux-gnome-shell/syncthing.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Name=syncthing
+GenericName=syncthing
+Comment=syncthing
+Exec=/usr/bin/syncthing -no-browser -no-restart -logflags=0
+Terminal=false
+Type=Application
+X-Desktop-File-Install-Version=0.22


### PR DESCRIPTION
### Purpose

Provides sample for gnome-shell startup integration

### Testing

Has been tested on RHEL 7.4 with Gnome shell.
