### PR TITLE
Add FreeBSD rc.d script

### DIFF
--- a/etc/freebsd-rc/README.md
+++ b/etc/freebsd-rc/README.md
@@ -1,0 +1,16 @@
+This directory contains an example for running Syncthing with a `rc.d` script in FreeBSD.
+
+* Install `syncthing` in `/usr/local/bin/syncthing`.
+* Copy the `syncthing` rc.d script in `/usr/local/etc/rc.d/syncthing`.
+* To automatically start `syncthing` at boot time, add the following line to `/etc/rc.conf`:
+```
+syncthing_enable=YES
+```
+* Optional configuration options are:
+```
+syncthing_home=</path/to/syncthing/config/dir>
+syncthing_log_file=</path/to/syncthing/log/file>
+syncthing_user=<syncthing_user>
+syncthing_group=<syncthing_group>
+```
+See the rc.d script for more informations.

--- a/etc/freebsd-rc/syncthing
+++ b/etc/freebsd-rc/syncthing
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+#
+# PROVIDE: syncthing
+# REQUIRE: DAEMON
+# KEYWORD: shutdown
+#
+# Add the following lines to /etc/rc.conf to enable this service:
+#
+# syncthing_enable:       Set to NO by default. Set it to YES to enable it.
+# syncthing_home:         Directory where syncthing configuration
+#                         data is stored.
+#                         Default: /usr/local/etc/syncthing
+# syncthing_log_file:     Syncthing log file
+#                         Default: /var/log/syncthing.log
+# syncthing_user:         The user account syncthing daemon runs as what
+#                         you want it to be.
+#                         Default: syncthing
+# syncthing_group:        The group account syncthing daemon runs as what
+#                         you want it to be.
+#                         Default: syncthing
+
+. /etc/rc.subr
+
+name=syncthing
+rcvar=syncthing_enable
+
+start_cmd="${name}_start"
+
+load_rc_config $name
+
+: ${syncthing_enable:=NO}
+: ${syncthing_home=/usr/local/etc/syncthing}
+: ${syncthing_log_file=/var/log/syncthing.log}
+: ${syncthing_user:=syncthing}
+syncthing_group=${syncthing_group:-$syncthing_user}
+
+
+command=/usr/local/bin/syncthing
+pidfile=/var/run/syncthing.pid
+syncthing_flags=" \
+    ${syncthing_home:+-home=${syncthing_home}} \
+    ${syncthing_log_file:+--logfile=${syncthing_log_file}}"
+
+syncthing_start() {
+    echo "Starting syncthing"
+    touch ${pidfile} && chown ${syncthing_user} ${pidfile}
+    touch ${syncthing_log_file} && chown ${syncthing_user} ${syncthing_log_file}
+    /usr/sbin/daemon -cf -p ${pidfile} -u ${syncthing_user} ${command} ${syncthing_flags}
+}
+
+syncthing_cleanup() {
+    [ -f ${pidfile} ] && rm ${pidfile}
+}
+
+run_rc_command $1

--- a/etc/freebsd-rc/syncthing
+++ b/etc/freebsd-rc/syncthing
@@ -38,9 +38,7 @@ syncthing_group=${syncthing_group:-$syncthing_user}
 
 command=/usr/local/bin/syncthing
 pidfile=/var/run/syncthing.pid
-syncthing_flags=" \
-    ${syncthing_home:+-home=${syncthing_home}} \
-    ${syncthing_log_file:+--logfile=${syncthing_log_file}}"
+syncthing_flags="${syncthing_home:+-home=${syncthing_home}} ${syncthing_log_file:+-logfile=${syncthing_log_file}}"
 
 syncthing_start() {
     echo "Starting syncthing"


### PR DESCRIPTION
### Purpose
This PR adds a `rc.d` script for FreeBSD, to manage Syncthing like a service.

### Testing
Tested on FreeBSD 10.3.

### Documentation
A `README.md` file is present in `etc/freebsd-rc`.
