### PR TITLE
lib/beacon: Don't exit after a single write failure (fixes #4414)

### DIFF
--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -137,17 +137,11 @@ func (w *broadcastWriter) Serve() {
 				return
 			}
 
-			if err, ok := err.(net.Error); ok && err.Temporary() {
-				// A transient error. Lets hope for better luck in the future.
-				l.Debugln(err)
-				continue
-			}
-
 			if err != nil {
-				// Some other error that we don't expect. Bail and retry.
+				// Some other error that we don't expect. Debug and continue.
 				l.Debugln(err)
 				w.setError(err)
-				return
+				continue
 			}
 
 			l.Debugf("sent %d bytes to %s", len(bs), dst)


### PR DESCRIPTION
### Purpose

Actually send IPv4 broadcasts.

### Testing

❓ 