### PR TITLE
build: Warn when being executed outside of gopath

### DIFF
--- a/build.go
+++ b/build.go
@@ -45,7 +45,7 @@ var (
 	noBuildGopath bool
 	extraTags     string
 	installSuffix string
-	pkgdir	      string
+	pkgdir        string
 )
 
 type target struct {
@@ -204,14 +204,16 @@ func main() {
 		}()
 	}
 
-	if gopath() == "" {
-		gopath, err := temporaryBuildDir()
+	gopath := gopath()
+	if gopath == "" {
+		var err error
+		gopath, err = temporaryBuildDir()
 		if err != nil {
 			log.Fatal(err)
 		}
 		if !noBuildGopath {
 			lazyRebuildAssets()
-			if err := buildGOPATH(gopath); err != nil {
+			if err = buildGOPATH(gopath); err != nil {
 				log.Fatal(err)
 			}
 		}
@@ -221,7 +223,11 @@ func main() {
 
 	// Set path to $GOPATH/bin:$PATH so that we can for sure find tools we
 	// might have installed during "build.go setup".
-	os.Setenv("PATH", fmt.Sprintf("%s%cbin%c%s", os.Getenv("GOPATH"), os.PathSeparator, os.PathListSeparator, os.Getenv("PATH")))
+	os.Setenv("PATH", fmt.Sprintf("%s%cbin%c%s", gopath, os.PathSeparator, os.PathListSeparator, os.Getenv("PATH")))
+
+	if wd, _ := os.Getwd(); !strings.HasPrefix(wd, gopath) {
+		os.Chdir(filepath.Join(gopath, "src/github.com/syncthing/syncthing"))
+	}
 
 	checkArchitecture()
 


### PR DESCRIPTION
Currently if you have Syncthing checked out in two directories, once at the proper place in the gopath, once somewhere outside. If you then run e.g. `go run build.go build` in the source dir outside of gopath, assets will be generated in the local working dir (i.e. outside of gopath) while building happens within gopath. This can then lead to the build failing, due to missing assets. This is due to commands from the go toolchain operating within gopath and generating assets within the current working directory.

This patch removes this inconsistency by moving the working directory into the gopath. I am not entirely convinced, this is the cleanest way to go, but I couldn't think of anything else that is really consistent. It also means that the `install` operations cannot install to `./bin` anymore, but always to `gopath/bin`.