### PR TITLE
main: Improve logging for initial config loading (ref #4431)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -982,7 +982,7 @@ func loadConfigAtStartup() *config.Wrapper {
 		cfg.Save()
 		l.Infof("Default config saved. Edit %s to taste or use the GUI\n", cfg.ConfigPath())
 	} else if err == io.EOF {
-		l.Fatalln("Config file is corrupt")
+		l.Fatalln("Failed to load config: unexpected end of file. Truncated or empty configuration?")
 	} else if err != nil {
 		l.Fatalln("Failed to load config:", err)
 	}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -449,7 +449,7 @@ func main() {
 }
 
 func openGUI() {
-	cfg, _ := loadConfig()
+	cfg, _ := loadOrDefaultConfig()
 	if cfg.GUI().Enabled {
 		openURL(cfg.GUI().URL())
 	} else {
@@ -488,9 +488,7 @@ func generate(generateDir string) {
 		l.Warnln("Config exists; will not overwrite.")
 		return
 	}
-	var myName, _ = os.Hostname()
-	var newCfg = defaultConfig(myName)
-	var cfg = config.Wrap(cfgFile, newCfg)
+	var cfg = defaultConfig(cfgFile)
 	err = cfg.Save()
 	if err != nil {
 		l.Warnln("Failed to save config", err)
@@ -520,7 +518,7 @@ func debugFacilities() string {
 }
 
 func checkUpgrade() upgrade.Release {
-	cfg, _ := loadConfig()
+	cfg, _ := loadOrDefaultConfig()
 	opts := cfg.Options()
 	release, err := upgrade.LatestRelease(opts.ReleasesURL, Version, opts.UpgradeToPreReleases)
 	if err != nil {
@@ -558,7 +556,7 @@ func performUpgrade(release upgrade.Release) {
 }
 
 func upgradeViaRest() error {
-	cfg, _ := loadConfig()
+	cfg, _ := loadOrDefaultConfig()
 	u, err := url.Parse(cfg.GUI().URL())
 	if err != nil {
 		return err
@@ -663,7 +661,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		"myID": myID.String(),
 	})
 
-	cfg := loadOrCreateConfig()
+	cfg := loadConfigAtStartup()
 
 	if err := checkShortIDs(cfg); err != nil {
 		l.Fatalln("Short device IDs are in conflict. Unlucky!\n  Regenerate the device ID of one of the following:\n  ", err)
@@ -965,26 +963,26 @@ func setupSignalHandling() {
 	}()
 }
 
-func loadConfig() (*config.Wrapper, error) {
+func loadOrDefaultConfig() (*config.Wrapper, error) {
 	cfgFile := locations[locConfigFile]
 	cfg, err := config.Load(cfgFile, myID)
 
 	if err != nil {
-		myName, _ := os.Hostname()
-		newCfg := defaultConfig(myName)
-		cfg = config.Wrap(cfgFile, newCfg)
+		cfg = defaultConfig(cfgFile)
 	}
 
 	return cfg, err
 }
 
-func loadOrCreateConfig() *config.Wrapper {
-	cfg, err := loadConfig()
+func loadConfigAtStartup() *config.Wrapper {
+	cfgFile := locations[locConfigFile]
+	cfg, err := config.Load(cfgFile, myID)
 	if os.IsNotExist(err) {
+		cfg := defaultConfig(cfgFile)
 		cfg.Save()
-		l.Infof("Defaults saved. Edit %s to taste or use the GUI\n", cfg.ConfigPath())
+		l.Infof("Default config saved. Edit %s to taste or use the GUI\n", cfg.ConfigPath())
 	} else if err != nil {
-		l.Fatalln("Config:", err)
+		l.Fatalln("Failed to load config:", err)
 	}
 
 	if cfg.RawCopy().OriginalVersion != config.CurrentVersion {
@@ -1087,7 +1085,9 @@ func setupGUI(mainService *suture.Supervisor, cfg *config.Wrapper, m *model.Mode
 	}
 }
 
-func defaultConfig(myName string) config.Configuration {
+func defaultConfig(cfgFile string) *config.Wrapper {
+	myName, _ := os.Hostname()
+
 	var defaultFolder config.FolderConfiguration
 
 	if !noDefaultFolder {
@@ -1131,7 +1131,7 @@ func defaultConfig(myName string) config.Configuration {
 		}
 	}
 
-	return newCfg
+	return config.Wrap(cfgFile, newCfg)
 }
 
 func resetDB() error {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -981,6 +981,8 @@ func loadConfigAtStartup() *config.Wrapper {
 		cfg := defaultConfig(cfgFile)
 		cfg.Save()
 		l.Infof("Default config saved. Edit %s to taste or use the GUI\n", cfg.ConfigPath())
+	} else if err == io.EOF {
+		l.Fatalln("Config file is corrupt")
 	} else if err != nil {
 		l.Fatalln("Failed to load config:", err)
 	}


### PR DESCRIPTION
### Purpose

As shown in #4431 the logging isn't super clear when we fail to parse the logging file.

In addition the default configuration was already created before even checking why loading failed, which results in a useless and potentially confusing line before the failure:

```
INFO: Default folder created and/or linked to new config
```

So I slightly refactored those convenience function, such that this only gets invoked if really needed (no functional change).