### PR TITLE
cmd/syncthing: Add fswatcher and remove useAPIKey stats

### DIFF
--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -208,9 +208,11 @@ func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf,
 			"disableTempIndexes":      0,
 			"alwaysWeakHash":          0,
 			"customWeakHashThreshold": 0,
+			"fsWatcherEnabled":        0,
 		}
 		pullOrder := make(map[string]int)
 		filesystemType := make(map[string]int)
+		var fsWatcherDelays []int
 		for _, cfg := range cfg.Folders() {
 			if cfg.ScanProgressIntervalS < 0 {
 				folderUsesV3["scanProgressDisabled"]++
@@ -233,12 +235,18 @@ func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf,
 			} else if cfg.WeakHashThresholdPct != 25 {
 				folderUsesV3["customWeakHashThreshold"]++
 			}
+			if cfg.FSWatcherEnabled {
+				folderUsesV3["fsWatcherEnabled"]++
+			}
 			pullOrder[cfg.Order.String()]++
 			filesystemType[cfg.FilesystemType.String()]++
+			fsWatcherDelays = append(fsWatcherDelays, cfg.FSWatcherDelayS)
 		}
+		sort.Ints(fsWatcherDelays)
 		folderUsesV3Interface := map[string]interface{}{
-			"pullOrder":      pullOrder,
-			"filesystemType": filesystemType,
+			"pullOrder":       pullOrder,
+			"filesystemType":  filesystemType,
+			"fsWatcherDelays": fsWatcherDelays,
 		}
 		for key, value := range folderUsesV3 {
 			folderUsesV3Interface[key] = value
@@ -251,7 +259,6 @@ func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf,
 			"enabled":                   0,
 			"useTLS":                    0,
 			"useAuth":                   0,
-			"useAPIKey":                 0,
 			"insecureAdminAccess":       0,
 			"debugging":                 0,
 			"insecureSkipHostCheck":     0,
@@ -267,9 +274,6 @@ func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf,
 			}
 			if len(guiCfg.User) > 0 && len(guiCfg.Password) > 0 {
 				guiStats["useAuth"]++
-			}
-			if len(guiCfg.APIKey) > 0 {
-				guiStats["useAPIKey"]++
 			}
 			if guiCfg.InsecureAdminAccess {
 				guiStats["insecureAdminAccess"]++


### PR DESCRIPTION
This adds usage reporting for the filesystem notification feature and removes the useAPIKey field as requested by @AudriusButkevicius.