### PR TITLE
lib/fs: make watcher tests even more darwin slowness resistant

### DIFF
--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -201,7 +201,7 @@ func testScenario(t *testing.T, name string, testCase func(), expectedEvents []E
 	// they get flushed to disk with a delay.
 	initDelayMs := 500
 	if runtime.GOOS == "darwin" {
-		initDelayMs = 900
+		initDelayMs = 2000
 	}
 	sleepMs(initDelayMs)
 


### PR DESCRIPTION
Apparently I can't push to master, so lets go via PR.

```
$ git push upstream master 
Counting objects: 5, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 468 bytes | 468.00 KiB/s, done.
Total 5 (delta 4), reused 0 (delta 0)
remote: Resolving deltas: 100% (4/4), completed with 4 local objects.
remote: error: GH006: Protected branch update failed for refs/heads/master.
remote: error: You're not authorized to push to this branch. Visit https://help.github.com/articles/about-protected-branches/ for more information.
To github.com:syncthing/syncthing.git
 ! [remote rejected]   master -> master (protected branch hook declined)
error: failed to push some refs to 'git@github.com:syncthing/syncthing.git'
```