### PR TITLE
lib/model: Start/stop fs watch when folder error is cleared/set (fixes #4445)

### DIFF
--- a/lib/model/rofolder.go
+++ b/lib/model/rofolder.go
@@ -43,7 +43,7 @@ func (f *sendOnlyFolder) Serve() {
 		case <-f.ctx.Done():
 			return
 
-		case <-f.ignoresUpdated:
+		case <-f.restartWatch:
 			if f.FSWatcherEnabled {
 				f.restartWatcher()
 			}

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -178,11 +178,10 @@ func (f *sendReceiveFolder) Serve() {
 			f.pullTimer.Reset(0)
 			l.Debugln(f, "remote index updated, rescheduling pull")
 
-		case <-f.ignoresUpdated:
+		case <-f.restartWatch:
 			if f.FSWatcherEnabled {
 				f.restartWatcher()
 			}
-			f.IndexUpdated()
 
 		case <-f.pullTimer.C:
 			select {
@@ -1694,6 +1693,11 @@ func (f *sendReceiveFolder) currentErrors() []fileError {
 	sort.Sort(fileErrorList(errors))
 	f.errorsMut.Unlock()
 	return errors
+}
+
+func (f *sendReceiveFolder) IgnoresUpdated() {
+	f.folder.IgnoresUpdated()
+	f.IndexUpdated()
 }
 
 // A []fileError is sent as part of an event and will be JSON serialized.


### PR DESCRIPTION
The approach seems a bit hackish, but the only alternative I see is in my opinion worse: Subscribe to folder state events in the folder itself (which are generated by an embedded type).