### PR TITLE
lib/model: Add initial noop watch cancel func (fixes #4464)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -40,6 +40,7 @@ func newFolder(model *Model, cfg config.FolderConfiguration) folder {
 		cancel:              cancel,
 		model:               model,
 		initialScanFinished: make(chan struct{}),
+		watchCancel:         func() {},
 	}
 }
 

--- a/lib/model/rofolder.go
+++ b/lib/model/rofolder.go
@@ -34,7 +34,7 @@ func (f *sendOnlyFolder) Serve() {
 		f.scan.timer.Stop()
 	}()
 
-	if f.FSWatcherEnabled {
+	if f.FSWatcherEnabled && f.CheckHealth() == nil {
 		f.startWatch()
 	}
 

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -164,7 +164,7 @@ func (f *sendReceiveFolder) Serve() {
 	var prevSec int64
 	var prevIgnoreHash string
 
-	if f.FSWatcherEnabled {
+	if f.FSWatcherEnabled && f.CheckHealth() == nil {
 		f.startWatch()
 	}
 


### PR DESCRIPTION
I think this is neater then check whether `cancelWatch` is nil every time before calling it. Also I sneaked a health check in before the initial start of the fs watch - I hope that will be permitted? :)