### PR TITLE
cmd/syncthing: Accept pre-hashed password in config POST (fixes #4458)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -44,6 +44,9 @@ import (
 
 var (
 	startTime = time.Now()
+
+	// matches a bcrypt hash and not too much else
+	bcryptExpr = regexp.MustCompile(`^\$2[aby]\$\d+\$.{50,}`)
 )
 
 const (
@@ -791,7 +794,6 @@ func (s *apiService) postSystemConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if to.GUI.Password != s.cfg.GUI().Password {
-		bcryptExpr := regexp.MustCompile(`^\$2[aby]\$\d+\$.{50,}`)
 		if to.GUI.Password != "" && !bcryptExpr.MatchString(to.GUI.Password) {
 			hash, err := bcrypt.GenerateFromPassword([]byte(to.GUI.Password), 0)
 			if err != nil {

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"runtime/pprof"
 	"sort"
@@ -790,7 +791,8 @@ func (s *apiService) postSystemConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if to.GUI.Password != s.cfg.GUI().Password {
-		if to.GUI.Password != "" {
+		bcryptExpr := regexp.MustCompile(`^\$2[aby]\$\d+\$.+`)
+		if to.GUI.Password != "" && !bcryptExpr.MatchString(to.GUI.Password) {
 			hash, err := bcrypt.GenerateFromPassword([]byte(to.GUI.Password), 0)
 			if err != nil {
 				l.Warnln("bcrypting password:", err)

--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -791,7 +791,7 @@ func (s *apiService) postSystemConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if to.GUI.Password != s.cfg.GUI().Password {
-		bcryptExpr := regexp.MustCompile(`^\$2[aby]\$\d+\$.+`)
+		bcryptExpr := regexp.MustCompile(`^\$2[aby]\$\d+\$.{50,}`)
 		if to.GUI.Password != "" && !bcryptExpr.MatchString(to.GUI.Password) {
 			hash, err := bcrypt.GenerateFromPassword([]byte(to.GUI.Password), 0)
 			if err != nil {


### PR DESCRIPTION
It must be a bcrypt hash.

Tested manually to change password to and from stuff and pasting in a hash in the password field in the GUI.

If your actual password looks like `$2a$10$(50 characters or more)` you're going to have a bad day. I'd wager that doesn't happen very often.