### PR TITLE
modified web gui to show' recent changes' and info icon (fixes #4326)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -676,7 +676,7 @@
         <div class="form-group">
           <span class="pull-right">
             <button type="button" class="btn btn-sm btn-default" ng-click="globalChanges()">
-              <span class="fa fa-fw fa-history"></span>&nbsp;<span translate>Global Changes</span>
+              <span class="fa fa-fw fa-info-circle"></span>&nbsp;<span translate>Recent Changes</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addDevice()">
               <span class="fa fa-plus"></span>&nbsp;<span translate>Add Remote Device</span>

--- a/gui/default/syncthing/device/globalChangesModalView.html
+++ b/gui/default/syncthing/device/globalChangesModalView.html
@@ -1,5 +1,5 @@
 <style> th, td { padding: 6px; } </style>
-<modal id="globalChanges" status="default" icon="{{'history'}}" heading="{{'Global Changes' | translate}}" large="yes" closeable="yes">
+<modal id="globalChanges" status="default" icon="{{'info-circle'}}" heading="{{'Recent Changes' | translate}}" large="yes" closeable="yes">
     <div class="modal-body">
         <table>
           <thead>          


### PR DESCRIPTION
### Purpose

@HaleTom pointed out that the 'Global changes' button is ambiguous and a bit intimidating:
[https://github.com/syncthing/syncthing/issues/4326](https://github.com/syncthing/syncthing/issues/4326)

> 
> I have no idea what this button does, but I'm too scared to press it as:
> 
> - I don't know what it does
> - It may may be irreversible

This commit implements the sugestions of @Ferroin and @Moonbase59 to rename the button and modal heading to 'Recent Changes' and to use an info icon instead of the history icon.

### Testing

No tests should be needed as this is a minor change to a few html files.

### Screenshots

Before (button)
![global-changes-btn](https://user-images.githubusercontent.com/4805611/32358253-48c16d3e-c00a-11e7-8edc-1d7fb22a6eee.png)

After (button)
![recent-changes-btn](https://user-images.githubusercontent.com/4805611/32358265-57f3630c-c00a-11e7-8a99-ced3450650af.png)

Before (modal)
![global-changes-modal](https://user-images.githubusercontent.com/4805611/32358271-61f34aac-c00a-11e7-9b16-d2bb738e0ef3.png)

After (modal)
![recent-changes-modal](https://user-images.githubusercontent.com/4805611/32358282-6b33966c-c00a-11e7-980d-02689ebf984e.png)

### Documentation

I believe there was some complaint in the issue that there was no reference to this button in the docs. It appears to display the 25 most recent changes to the filesystem. If this hasn't already been covered, it may need to be done. If it has, the docs should refer to the new name on the next update. 

Though having used it on my machine, the button already feel more self-explanatory. Docs might be overkill.

### Authorship
If you are so kind as to add me to the authors section, please use Taylor Khan as my name.
