### PR TITLE
lib/config, lib/model: Configurable folder marker name (fixes #1126)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -399,17 +399,21 @@ func convertV22V23(cfg *Configuration) {
 		// begin with.
 		permBits = 0700
 	}
+
+	// Upgrade code remains hardcoded for .stfolder despite configurable
+	// marker name in later versions.
+
 	for i := range cfg.Folders {
 		fs := cfg.Folders[i].Filesystem()
 		// Invalid config posted, or tests.
 		if fs == nil {
 			continue
 		}
-		if stat, err := fs.Stat(".stfolder"); err == nil && !stat.IsDir() {
-			err = fs.Remove(".stfolder")
+		if stat, err := fs.Stat(DefaultMarkerName); err == nil && !stat.IsDir() {
+			err = fs.Remove(DefaultMarkerName)
 			if err == nil {
-				err = fs.Mkdir(".stfolder", permBits)
-				fs.Hide(".stfolder") // ignore error
+				err = fs.Mkdir(DefaultMarkerName, permBits)
+				fs.Hide(DefaultMarkerName) // ignore error
 			}
 			if err != nil {
 				l.Infoln("Failed to upgrade folder marker:", err)

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -85,13 +85,13 @@ func TestDefaultValues(t *testing.T) {
 
 func TestDeviceConfig(t *testing.T) {
 	for i := OldestHandledVersion; i <= CurrentVersion; i++ {
-		os.RemoveAll("testdata/.stfolder")
+		os.RemoveAll(filepath.Join("testdata", DefaultMarkerName))
 		wr, err := Load(fmt.Sprintf("testdata/v%d.xml", i), device1)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		_, err = os.Stat("testdata/.stfolder")
+		_, err = os.Stat(filepath.Join("testdata", DefaultMarkerName))
 		if i < 6 && err != nil {
 			t.Fatal(err)
 		} else if i >= 6 && err == nil {
@@ -120,6 +120,7 @@ func TestDeviceConfig(t *testing.T) {
 					Params: map[string]string{},
 				},
 				WeakHashThresholdPct: 25,
+				MarkerName:           DefaultMarkerName,
 			},
 		}
 

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -177,6 +177,7 @@ func NewFilesystem(fsType FilesystemType, uri string) Filesystem {
 // root, represents an internal file that should always be ignored. The file
 // path must be clean (i.e., in canonical shortest form).
 func IsInternal(file string) bool {
+	// fs cannot import config, so we hard code .stfolder here (config.DefaultMarkerName)
 	internals := []string{".stfolder", ".stignore", ".stversions"}
 	pathSep := string(PathSeparator)
 	for _, internal := range internals {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -254,7 +254,7 @@ func (m *Model) startFolderLocked(folder string) config.FolderType {
 	ffs := fs.MtimeFS()
 
 	// These are our metadata files, and they should always be hidden.
-	ffs.Hide(".stfolder")
+	ffs.Hide(config.DefaultMarkerName)
 	ffs.Hide(".stversions")
 	ffs.Hide(".stignore")
 
@@ -339,7 +339,7 @@ func (m *Model) RemoveFolder(cfg config.FolderConfiguration) {
 	m.fmut.Lock()
 	m.pmut.Lock()
 	// Delete syncthing specific files
-	cfg.Filesystem().RemoveAll(".stfolder")
+	cfg.Filesystem().RemoveAll(config.DefaultMarkerName)
 
 	m.tearDownFolderLocked(cfg.ID)
 	// Remove it from the database


### PR DESCRIPTION
### Purpose

Make the folder marker name configurable. When it is set to something custom we do not attempt to create, hide, delete or ignore it. It can still be ignored in the usual way if the user so wishes.

### Testing

Unit test that the health check still passes.

### Screenshots

Advanced config only:

![32405590-980b0058-c168-11e7-960a-a63e4c316ba8](https://user-images.githubusercontent.com/125426/32413608-3281fff4-c215-11e7-8239-1888a78ef720.png)
