### PR TITLE
lib/model: Split db path by '/' in windowsInvalidFilenames (fixes #4484)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1736,7 +1736,7 @@ func fileValid(file db.FileIntf) error {
 }
 
 var windowsDisallowedCharacters = string([]rune{
-	'<', '>', ':', '"', '|', '?', '*',
+	'<', '>', ':', '"', '|', '?', '*', '\\',
 	0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 	11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
 	21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
@@ -1745,7 +1745,8 @@ var windowsDisallowedCharacters = string([]rune{
 
 func windowsInvalidFilename(name string) bool {
 	// None of the path components should end in space
-	for _, part := range strings.Split(name, `\`) {
+	// db/protocol filenames always use '/' as path separator
+	for _, part := range strings.Split(name, `/`) {
 		if len(part) == 0 {
 			continue
 		}


### PR DESCRIPTION
See #4484.