### PR TITLE
lib/watchaggregator: Don't care about timings during testing on darwin

### DIFF
--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -110,7 +110,7 @@ type aggregator struct {
 	ctx                   context.Context
 }
 
-func new(folderCfg config.FolderConfiguration, ctx context.Context) *aggregator {
+func newAggregator(folderCfg config.FolderConfiguration, ctx context.Context) *aggregator {
 	a := &aggregator{
 		folderCfgUpdate:       make(chan config.FolderConfiguration),
 		notifyTimerNeedsReset: false,
@@ -124,7 +124,7 @@ func new(folderCfg config.FolderConfiguration, ctx context.Context) *aggregator 
 }
 
 func Aggregate(in <-chan fs.Event, out chan<- []string, folderCfg config.FolderConfiguration, cfg *config.Wrapper, ctx context.Context) {
-	a := new(folderCfg, ctx)
+	a := newAggregator(folderCfg, ctx)
 
 	// Necessary for unit tests where the backend is mocked
 	go a.mainLoop(in, out, cfg)


### PR DESCRIPTION
This now stops checking the timings of notifications on darwin, but still does it on other platforms. I guess that's an ok compromise - internal timings will hardly vary between platforms.
While at it I renamed s/new/newAggregator/, that was a leftover of un-exporting `New`. And I sped up timings a bit (not waiting anymore for timeouts once everything we need was received).