### PR TITLE
lib/model: Properly schedule pull on reconnect (fixes #4504)

### DIFF
--- a/test/reset_test.go
+++ b/test/reset_test.go
@@ -10,7 +10,9 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -128,25 +130,15 @@ func TestReset(t *testing.T) {
 }
 
 func createFiles(t *testing.T) int {
-	// Create eight empty files and directories
-	files := []string{"f1", "f2", "f3", "f4", "f11", "f12", "f13", "f14"}
-	dirs := []string{"d1", "d2", "d3", "d4", "d11", "d12", "d13", "d14"}
-	all := append(files, dirs...)
+	// Create a few files
 
-	for _, file := range files {
-		fd, err := os.Create(filepath.Join("s1", file))
-		if err != nil {
-			t.Fatal(err)
-		}
-		fd.Close()
-	}
-
-	for _, dir := range dirs {
-		err := os.Mkdir(filepath.Join("s1", dir), 0755)
-		if err != nil {
+	const n = 8
+	for i := 0; i < n; i++ {
+		file := fmt.Sprintf("f%d", i)
+		if err := ioutil.WriteFile(filepath.Join("s1", file), []byte("data"), 0644); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	return len(all)
+	return n
 }

--- a/test/sync_test.go
+++ b/test/sync_test.go
@@ -20,8 +20,8 @@ import (
 )
 
 const (
-	longTimeLimit  = 5 * time.Minute
-	shortTimeLimit = 45 * time.Second
+	longTimeLimit  = 1 * time.Minute
+	shortTimeLimit = 25 * time.Second
 	s12Folder      = `¯\_(ツ)_/¯ Räksmörgås 动作 Адрес` // This was renamed to ensure arbitrary folder IDs are fine.
 )
 


### PR DESCRIPTION
### Purpose

We need to reset prevSeq so that we force a full check when someone reconnects - the sequence number may not have changed due to the reconnect. (This is a regression; we did this before f6ea2a7.)

Also add an optimization: we schedule a pull after scanning, but there is no need to do so if no changes were detected. This matters now because the scheduled pull actually traverses the database which is expensive.

This, however, makes the pull not happen on initial scan if there were no changes during the initial scan. Compensate by always scheduling a pull after initial scan in the rwfolder itself.

### Testing

Previously failing integration test now passes