### PR TITLE
lib/fs: Add case insensitivity to MtimeFS

### DIFF
--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -1,3 +1,9 @@
+// Copyright (C) 2017 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package fs
 
 import (

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -1,0 +1,13 @@
+package fs
+
+import (
+	"unicode"
+)
+
+func UnicodeLowercase(s string) string {
+	rs := []rune(s)
+	for i, r := range rs {
+		rs[i] = unicode.ToLower(unicode.ToUpper(r))
+	}
+	return string(rs)
+}

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -1,0 +1,38 @@
+package fs
+
+import "testing"
+
+func TestUnicodeLowercase(t *testing.T) {
+	cases := [][2]string{
+		{"", ""},
+		{"hej", "hej"},
+		{"HeJ!@#", "hej!@#"},
+		// Western Europe diacritical stuff is trivial
+		{"ÜBERRÄKSMÖRGÅS", "überräksmörgås"},
+		// Cyrillic seems regular as well
+		{"Привет", "привет"},
+		// Greek has multiple lower case characters for things depending on
+		// context; we should always choose the right one.
+		{"Ὀδυσσεύς", "ὀδυσσεύσ"},
+		{"ὈΔΥΣΣΕΎΣ", "ὀδυσσεύσ"},
+		// German ß doesn't really have an upper case variant, and we
+		// shouldn't mess things up when lower casing it either. We don't
+		// attempt to make ß equivalant to "ss".
+		{"Reichwaldstraße", "reichwaldstraße"},
+		// The Turks do their thing with the Is.... Like the Greek example
+		// we pick just the one canonicalized "i" although you can argue
+		// with this... From what I understand most operating systems don't
+		// get this right anyway.
+		{"İI", "ii"},
+		// Arabic doesn't do case folding.
+		{"العَرَبِيَّة", "العَرَبِيَّة"},
+		// Neither does Hebrew.
+		{"עברית", "עברית"},
+	}
+	for _, tc := range cases {
+		res := UnicodeLowercase(tc[0])
+		if res != tc[1] {
+			t.Errorf("UnicodeLowercase(%q) => %q, expected %q", tc[0], res, tc[1])
+		}
+	}
+}

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) 2017 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package fs
 
 import "testing"

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -34,6 +34,10 @@ func TestUnicodeLowercase(t *testing.T) {
 		{"العَرَبِيَّة", "العَرَبِيَّة"},
 		// Neither does Hebrew.
 		{"עברית", "עברית"},
+		// Nor Chinese, in any variant.
+		{"汉语/漢語 or 中文", "汉语/漢語 or 中文"},
+		// Niether katakana as far as I can tell.
+		{"チャーハン", "チャーハン"},
 	}
 	for _, tc := range cases {
 		res := UnicodeLowercase(tc[0])

--- a/lib/fs/mtimefs_test.go
+++ b/lib/fs/mtimefs_test.go
@@ -120,7 +120,7 @@ func TestMtimeFSInsensitive(t *testing.T) {
 		theTest(t, NewMtimeFS(newBasicFilesystem("."), make(mapStore)), false)
 	})
 
-	// And succeed with a cases insensitive one.
+	// And succeed with a case insensitive one.
 	t.Run("with case insensitive mtimefs", func(t *testing.T) {
 		theTest(t, NewMtimeFS(newBasicFilesystem("."), make(mapStore), WithCaseInsensitivity(true)), true)
 	})

--- a/lib/fs/mtimefs_test.go
+++ b/lib/fs/mtimefs_test.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -78,6 +79,51 @@ func TestMtimeFS(t *testing.T) {
 	} else if !info.ModTime().Equal(testTime) {
 		t.Errorf("Time mismatch; %v != expected %v", info.ModTime(), testTime)
 	}
+}
+
+func TestMtimeFSInsensitive(t *testing.T) {
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		// blatantly assume file systems here are case insensitive. Might be
+		// a spurious failure on oddly configured systems.
+	default:
+		t.Skip("need case insensitive FS")
+	}
+
+	theTest := func(t *testing.T, fs *MtimeFS, shouldSucceed bool) {
+		os.RemoveAll("testdata")
+		defer os.RemoveAll("testdata")
+		os.Mkdir("testdata", 0755)
+		ioutil.WriteFile("testdata/FiLe", []byte("hello"), 0644)
+
+		// a random time with nanosecond precision
+		testTime := time.Unix(1234567890, 123456789)
+
+		// Do one call that gets struck by an exceptionally evil Chtimes, with a
+		// different case from what is on disk.
+		fs.chtimes = evilChtimes
+		if err := fs.Chtimes("testdata/fIlE", testTime, testTime); err != nil {
+			t.Error("Should not have failed:", err)
+		}
+
+		// Check that we get back the mtime we set, if we were supposed to succed.
+		info, err := fs.Lstat("testdata/FILE")
+		if err != nil {
+			t.Error("Lstat shouldn't fail:", err)
+		} else if info.ModTime().Equal(testTime) != shouldSucceed {
+			t.Errorf("Time mismatch; got %v, comparison %v, expected equal=%v", info.ModTime(), testTime, shouldSucceed)
+		}
+	}
+
+	// The test should fail with a case sensitive mtimefs
+	t.Run("with case sensitive mtimefs", func(t *testing.T) {
+		theTest(t, NewMtimeFS(newBasicFilesystem("."), make(mapStore)), false)
+	})
+
+	// And succeed with a cases insensitive one.
+	t.Run("with case insensitive mtimefs", func(t *testing.T) {
+		theTest(t, NewMtimeFS(newBasicFilesystem("."), make(mapStore), WithCaseInsensitivity(true)), true)
+	})
 }
 
 // The mapStore is a simple database


### PR DESCRIPTION
This is step one of a hundred fifty on the path to case insensitivity.
It brings in the basic case folding mechanism and adds it to the
mtimefs, as this is something outside the fileset that touches stuff in
the database based on name. No effort to convert or handle existing
entries when the insensitivity is changed, I don't think we need it...

Useless by itself but includes tests and will reduce the review load
along the way.
