### PR TITLE
lib/connections: Fix race condition in parallel dial, minor cleanups

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -746,13 +746,13 @@ func dialParallel(deviceID protocol.DeviceID, dialTargets []dialTarget) (interna
 		wg := sync.NewWaitGroup()
 		for _, tgt := range tgts {
 			wg.Add(1)
-			go func() {
+			go func(tgt dialTarget) {
 				conn, err := tgt.Dial()
 				if err == nil {
 					res <- conn
 				}
 				wg.Done()
-			}()
+			}(tgt)
 		}
 
 		// Spawn a routine which will unblock main routine in case we fail

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -188,6 +188,10 @@ type dialTarget struct {
 func (t dialTarget) Dial() (internalConn, error) {
 	l.Debugln("dialing", t.deviceID, t.uri, "prio", t.priority)
 	conn, err := t.dialer.Dial(t.deviceID, t.uri)
-	l.Debugln("dialing", t.deviceID, t.uri, "outcome", conn, err)
+	if err != nil {
+		l.Debugln("dialing", t.deviceID, t.uri, "error:", err)
+	} else {
+		l.Debugln("dialing", t.deviceID, t.uri, "success:", conn)
+	}
 	return conn, err
 }

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -102,19 +102,18 @@ func (t *tcpListener) Serve() {
 
 		l.Debugln("Listen (BEP/tcp): connect from", conn.RemoteAddr())
 
-		err = dialer.SetTCPOptions(conn)
-		if err != nil {
+		if err := dialer.SetTCPOptions(conn); err != nil {
 			l.Debugln("Listen (BEP/tcp): setting tcp options:", err)
 		}
 
-		err = dialer.SetTrafficClass(conn, t.cfg.Options().TrafficClass)
-		if err != nil {
-			l.Debugln("Listen (BEP/tcp): setting traffic class:", err)
+		if tc := t.cfg.Options().TrafficClass; tc != 0 {
+			if err := dialer.SetTrafficClass(conn, tc); err != nil {
+				l.Debugln("Listen (BEP/tcp): setting traffic class:", err)
+			}
 		}
 
 		tc := tls.Server(conn, t.tlsCfg)
-		err = tlsTimedHandshake(tc)
-		if err != nil {
+		if err := tlsTimedHandshake(tc); err != nil {
 			l.Infoln("Listen (BEP/tcp): TLS handshake:", err)
 			tc.Close()
 			continue


### PR DESCRIPTION
### Purpose

Classic go-in-for race in the dialler.

Because I already made the changes while troubleshooting something else, a couple of style cleanups and log tweaks as well.

### Testing

None whatsoever. But I'm pretty sure this is the right thing.