### PR TITLE
all: Various debug logging improvements

### DIFF
--- a/lib/db/leveldb.go
+++ b/lib/db/leveldb.go
@@ -36,7 +36,7 @@ func (l VersionList) String() string {
 			b.WriteString(", ")
 		}
 		copy(id[:], v.Device)
-		fmt.Fprintf(&b, "{%d, %v}", v.Version, id)
+		fmt.Fprintf(&b, "{%v, %v}", v.Version, id)
 	}
 	b.WriteString("}")
 	return b.String()

--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -404,7 +404,7 @@ func (db *Instance) withNeed(folder, device []byte, truncate bool, needAllInvali
 				break
 			}
 
-			l.Debugf("need folder=%q device=%v name=%q need=%v have=%v invalid=%v haveV=%d globalV=%d globalDev=%v", folder, protocol.DeviceIDFromBytes(device), name, need, have, haveFileVersion.Invalid, haveFileVersion.Version, needVersion, needDevice)
+			l.Debugf("need folder=%q device=%v name=%q need=%v have=%v invalid=%v haveV=%v globalV=%v globalDev=%v", folder, protocol.DeviceIDFromBytes(device), name, need, have, haveFileVersion.Invalid, haveFileVersion.Version, needVersion, needDevice)
 
 			if cont := fn(gf); !cont {
 				return
@@ -589,7 +589,7 @@ func (db *Instance) AddInvalidToGlobal(folder, device []byte) int {
 		if file.Invalid {
 			changed++
 
-			l.Debugf("add invalid to global; folder=%q device=%v file=%q version=%d", folder, protocol.DeviceIDFromBytes(device), file.Name, file.Version)
+			l.Debugf("add invalid to global; folder=%q device=%v file=%q version=%v", folder, protocol.DeviceIDFromBytes(device), file.Name, file.Version)
 
 			// this is an adapted version of readWriteTransaction.updateGlobal
 			name := []byte(file.Name)

--- a/lib/db/leveldb_transactions.go
+++ b/lib/db/leveldb_transactions.go
@@ -86,7 +86,7 @@ func (t readWriteTransaction) insertFile(folder, device []byte, file protocol.Fi
 // file. If the device is already present in the list, the version is updated.
 // If the file does not have an entry in the global list, it is created.
 func (t readWriteTransaction) updateGlobal(folder, device []byte, file protocol.FileInfo, globalSize *sizeTracker) bool {
-	l.Debugf("update global; folder=%q device=%v file=%q version=%d", folder, protocol.DeviceIDFromBytes(device), file.Name, file.Version)
+	l.Debugf("update global; folder=%q device=%v file=%q version=%v invalid=%v", folder, protocol.DeviceIDFromBytes(device), file.Name, file.Version, file.Invalid)
 	name := []byte(file.Name)
 	gk := t.db.globalKey(folder, name)
 	svl, _ := t.Get(gk, nil) // skip error, we check len(svl) != 0 later

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -89,7 +89,7 @@ func (l fileList) String() string {
 	var b bytes.Buffer
 	b.WriteString("[]protocol.FileList{\n")
 	for _, f := range l {
-		fmt.Fprintf(&b, "  %q: #%d, %d bytes, %d blocks, perms=%o\n", f.Name, f.Version, f.Size, len(f.Blocks), f.Permissions)
+		fmt.Fprintf(&b, "  %q: #%v, %d bytes, %d blocks, perms=%o\n", f.Name, f.Version, f.Size, len(f.Blocks), f.Permissions)
 	}
 	b.WriteString("}")
 	return b.String()

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -251,7 +251,7 @@ func (f *sendReceiveFolder) pull(prevIgnoreHash string) (curIgnoreHash string, s
 	curIgnoreHash = curIgnores.Hash()
 	ignoresChanged := curIgnoreHash != prevIgnoreHash
 
-	l.Debugln(f, "pulling")
+	l.Debugf("%v pulling (ignoresChanged=%v)", f, ignoresChanged)
 
 	f.setState(FolderSyncing)
 	f.clearErrors()
@@ -370,6 +370,7 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher, ignoresChan
 
 	iterate(protocol.LocalDeviceID, func(intf db.FileIntf) bool {
 		if f.IgnoreDelete && intf.IsDeleted() {
+			l.Debugln(f, "ignore file deletion (config)", intf.FileName())
 			return true
 		}
 
@@ -1698,7 +1699,7 @@ func (f *sendReceiveFolder) newError(context, path string, err error) {
 	if _, ok := f.errors[path]; ok {
 		return
 	}
-	l.Infof("Puller (folder %q, file %q): %s: %v", f.Description(), path, context, err)
+	l.Infof("Puller (folder %s, file %q): %s: %v", f.Description(), path, context, err)
 	f.errors[path] = fmt.Sprintf("%s: %s", context, err.Error())
 }
 


### PR DESCRIPTION
Fixes the quoting ugliness in 

```
INFO: Puller (folder "\"Programme\" (Programme)", file "..."): finisher:...
```

,makes ids in version human readable and other minor stuff.