### PR TITLE
lib/connections: Trust the model to tell us if we are connected

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/rcrowley/go-metrics"
 	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/connections"
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/events"
@@ -98,7 +99,7 @@ type modelIntf interface {
 	ScanFolders() map[string]error
 	ScanFolderSubdirs(folder string, subs []string) error
 	BringToFront(folder, file string)
-	ConnectedTo(deviceID protocol.DeviceID) bool
+	Connection(deviceID protocol.DeviceID) (connections.Connection, bool)
 	GlobalSize(folder string) db.Counts
 	LocalSize(folder string) db.Counts
 	CurrentSequence(folder string) (int64, bool)
@@ -1259,7 +1260,7 @@ func (s *apiService) getPeerCompletion(w http.ResponseWriter, r *http.Request) {
 	for _, folder := range s.cfg.Folders() {
 		for _, device := range folder.DeviceIDs() {
 			deviceStr := device.String()
-			if s.model.ConnectedTo(device) {
+			if _, ok := s.model.Connection(device); ok {
 				tot[deviceStr] += s.model.Completion(device, folder.ID).CompletionPct
 			} else {
 				tot[deviceStr] = 0

--- a/cmd/syncthing/mocked_model_test.go
+++ b/cmd/syncthing/mocked_model_test.go
@@ -9,6 +9,7 @@ package main
 import (
 	"time"
 
+	"github.com/syncthing/syncthing/lib/connections"
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/protocol"
@@ -91,8 +92,8 @@ func (m *mockedModel) ScanFolderSubdirs(folder string, subs []string) error {
 
 func (m *mockedModel) BringToFront(folder, file string) {}
 
-func (m *mockedModel) ConnectedTo(deviceID protocol.DeviceID) bool {
-	return false
+func (m *mockedModel) Connection(deviceID protocol.DeviceID) (connections.Connection, bool) {
+	return nil, false
 }
 
 func (m *mockedModel) GlobalSize(folder string) db.Counts {

--- a/cmd/syncthing/summaryservice.go
+++ b/cmd/syncthing/summaryservice.go
@@ -198,7 +198,7 @@ func (c *folderSummaryService) sendSummary(folder string) {
 			// We already know about ourselves.
 			continue
 		}
-		if !c.model.ConnectedTo(devCfg.DeviceID) {
+		if _, ok := c.model.Connection(devCfg.DeviceID); !ok {
 			// We're not interested in disconnected devices.
 			continue
 		}

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -27,6 +27,7 @@ type Connection interface {
 	Type() string
 	Transport() string
 	RemoteAddr() net.Addr
+	Priority() int
 }
 
 // completeConn is the aggregation of an internalConn and the
@@ -92,6 +93,10 @@ func (c internalConn) Type() string {
 	return c.connType.String()
 }
 
+func (c internalConn) Priority() int {
+	return c.priority
+}
+
 func (c internalConn) Transport() string {
 	transport := c.connType.Transport()
 	host, _, err := net.SplitHostPort(c.LocalAddr().String())
@@ -152,7 +157,7 @@ type genericListener interface {
 type Model interface {
 	protocol.Model
 	AddConnection(conn Connection, hello protocol.HelloResult)
-	ConnectedTo(remoteID protocol.DeviceID) bool
+	Connection(remoteID protocol.DeviceID) (Connection, bool)
 	OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult) error
 	GetHello(protocol.DeviceID) protocol.HelloIntf
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1330,15 +1330,15 @@ func (cf cFiler) CurrentFile(file string) (protocol.FileInfo, bool) {
 	return cf.m.CurrentFolderFile(cf.r, file)
 }
 
-// ConnectedTo returns true if we are connected to the named device.
-func (m *Model) ConnectedTo(deviceID protocol.DeviceID) bool {
+// Connection returns the current connection for device, and a boolean wether a connection was found.
+func (m *Model) Connection(deviceID protocol.DeviceID) (connections.Connection, bool) {
 	m.pmut.RLock()
-	_, ok := m.conn[deviceID]
+	cn, ok := m.conn[deviceID]
 	m.pmut.RUnlock()
 	if ok {
 		m.deviceWasSeen(deviceID)
 	}
-	return ok
+	return cn, ok
 }
 
 func (m *Model) GetIgnores(folder string) ([]string, []string, error) {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -311,6 +311,9 @@ func (f *fakeConnection) Type() string {
 func (f *fakeConnection) Transport() string {
 	return "fake"
 }
+func (f *fakeConnection) Priority() int {
+	return 9000
+}
 
 func (f *fakeConnection) DownloadProgress(folder string, updates []protocol.FileDownloadProgressUpdate) {
 	f.downloadProgressMessages = append(f.downloadProgressMessages, downloadProgressMessage{

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -399,7 +399,7 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher, ignoresChan
 
 			devices := folderFiles.Availability(file.Name)
 			for _, dev := range devices {
-				if f.model.ConnectedTo(dev) {
+				if _, ok := f.model.Connection(dev); ok {
 					f.queue.Push(file.Name, file.Size, file.ModTime())
 					changed++
 					return true


### PR DESCRIPTION
Well Tested(TM)

This should address issue as described in https://forum.syncthing.net/t/stun-nig-party-with-paused-devices/10942/13
Essentially the model and the connection service goes out of sync in terms of thinking if we are connected or not.
Resort to model as being the ultimate source of truth.

I can't immediately pin down how this happens, yet some ideas.

ConfigSaved happens in separate routine, so it's possbile that we have some sort of device removed yet connection comes in parallel kind of thing.
However, in this case the connection exists in the model, and does not exist in the connection service and the only way for the connection to be removed
in the connection service is device removal from the config.

Given the subject, this might also be related to the device being paused.

Also, adds more info to the logs
