### PR TITLE
lib/events: Fix unmarshaling of EventType

### DIFF
--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -8,6 +8,7 @@
 package events
 
 import (
+	"encoding/json"
 	"errors"
 	"runtime"
 	"time"
@@ -116,6 +117,18 @@ func (t EventType) String() string {
 
 func (t EventType) MarshalText() ([]byte, error) {
 	return []byte(t.String()), nil
+}
+
+func (t *EventType) UnmarshalJSON(b []byte) error {
+	var s string
+
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	*t = UnmarshalEventType(s)
+
+	return nil
 }
 
 func UnmarshalEventType(s string) EventType {

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -7,6 +7,7 @@
 package events
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -319,5 +320,22 @@ func TestSinceUsesSubscriptionId(t *testing.T) {
 	events := bs.Since(1, nil, time.Minute)
 	if len(events) != 1 {
 		t.Fatal("Incorrect number of events:", len(events))
+	}
+}
+
+func TestUnmarshalEvent(t *testing.T) {
+	var event Event
+
+	s := `
+	{
+		"id": 1,
+		"globalID": 1,
+		"time": "2006-01-02T15:04:05.999999999Z",
+		"type": "Starting",
+		"data": {}
+	}`
+
+	if err := json.Unmarshal([]byte(s), &event); err != nil {
+		t.Fatal("Failed to unmarshal event:", err)
 	}
 }


### PR DESCRIPTION
### Purpose

This allows to properly unmarshal an `Event`. Prior to this change, unmarshaling would have failed with:
```
json: cannot unmarshal string into Go struct field Event.type of type events.EventType
```

### Testing

A Test has been added which tries unmarshaling an `Event`.
