### PR TITLE
Add sorting Devices by status, second attempt (fixes #2636)

### DIFF
--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -36,18 +36,6 @@ syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvi
 
 // @TODO: extract global level functions into separate service(s)
 
-function deviceCompare(a, b) {
-    if (typeof a.name !== 'undefined' && typeof b.name !== 'undefined') {
-        if (a.name < b.name)
-            return -1;
-        return a.name > b.name;
-    }
-    if (a.deviceID < b.deviceID) {
-        return -1;
-    }
-    return a.deviceID > b.deviceID;
-}
-
 function folderCompare(a, b) {
     var labelA = a.id;
     if (typeof a.label !== 'undefined' && a.label !== null && a.label.length > 0) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -222,11 +222,13 @@ angular.module('syncthing.core')
         $scope.$on(Events.LOCAL_INDEX_UPDATED, function (event, arg) {
             refreshFolderStats();
             refreshGlobalChanges();
+
         });
 
         $scope.$on(Events.DEVICE_DISCONNECTED, function (event, arg) {
             $scope.connections[arg.data.id].connected = false;
             refreshDeviceStats();
+            $scope.devices.sort(deviceCompare);
         });
 
         $scope.$on(Events.DEVICE_CONNECTED, function (event, arg) {
@@ -244,6 +246,8 @@ angular.module('syncthing.core')
                     _needBytes: 0
                 };
             }
+            $scope.connections[arg.data.id].connected = true
+            $scope.devices.sort(deviceCompare);
         });
 
         $scope.$on('ConfigLoaded', function () {
@@ -1204,6 +1208,35 @@ angular.module('syncthing.core')
             }).error($scope.emitHTTPError);
             $scope.configInSync = true;
         };
+
+        function deviceCompare(a, b) {
+            var aConn = $scope.connections[a.deviceID];
+            var bConn = $scope.connections[b.deviceID];
+            if (typeof aConn === 'undefined') {
+                aConn = false;
+            }
+            else {
+                aConn = aConn.connected;
+            }
+            if (typeof bConn === 'undefined') {
+                bConn = false;
+            }
+            else {
+                bConn = bConn.connected;
+            }
+            if (aConn != bConn) {
+                return bConn-aConn;
+            }
+            if (typeof a.name !== 'undefined' && typeof b.name !== 'undefined') {
+                if (a.name < b.name)
+                    return -1;
+                return a.name > b.name;
+            }
+            if (a.deviceID < b.deviceID) {
+                return -1;
+            }
+            return a.deviceID > b.deviceID;
+        }
 
         $scope.editDevice = function (deviceCfg) {
             $scope.currentDevice = $.extend({}, deviceCfg);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -222,7 +222,6 @@ angular.module('syncthing.core')
         $scope.$on(Events.LOCAL_INDEX_UPDATED, function (event, arg) {
             refreshFolderStats();
             refreshGlobalChanges();
-
         });
 
         $scope.$on(Events.DEVICE_DISCONNECTED, function (event, arg) {


### PR DESCRIPTION
### Purpose
Add sorting Devices by status, second attempt (fixes #2636).
Also, I believe there was a bug in DEVICE_CONNECTED handler, hence line 248 (setting connected to true)
It's a second attempt: My previous approach was to add a button, which can be seen here: https://github.com/syncthing/syncthing/pull/4553

### Testing
No tests - but the code is quite easy and follows standards.

### Documentation
https://docs.syncthing.net/intro/gui.html
The sentence "The local device is always at the top, with remote devices in alphabetical order below." should be corrected. (I can try to do it after successful pull)
