### PR TITLE
lib/model: Mark files below newly created symlinks as deleted (fixes #2571)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1944,8 +1944,6 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 	if err := runner.CheckHealth(); err != nil {
 		l.Debugln("Stopping scan of folder %s due to: %s", folderCfg.Description(), err)
 		return err
-	} else if len(batch) > 0 {
-		m.updateLocalsFromScanning(folder, batch)
 	}
 
 	if len(subDirs) == 0 {
@@ -1956,8 +1954,6 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 
 	// Do a scan of the database for each prefix, to check for deleted and
 	// ignored files.
-	batch = batch[:0]
-	batchSizeBytes = 0
 	for _, sub := range subDirs {
 		var iterError error
 
@@ -1986,13 +1982,17 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 				// The file is valid and not deleted. Lets check if it's
 				// still here.
 
-				if _, err := mtimefs.Lstat(f.Name); err != nil {
+				if _, err := mtimefs.Lstat(f.Name); err != nil || osutil.TraversesSymlink(mtimefs, filepath.Dir(f.Name)) != nil {
 					// We don't specifically verify that the error is
 					// fs.IsNotExist because there is a corner case when a
 					// directory is suddenly transformed into a file. When that
 					// happens, files that were in the directory (that is now a
 					// file) are deleted but will return a confusing error ("not a
 					// directory") when we try to Lstat() them.
+					// If a parent directory was replaced by a symlink, the
+					// Lstat may succeed but anything below that symlink
+					// should still be considered deleted, as we never descend
+					// into symlinks.
 
 					nf := protocol.FileInfo{
 						Name:       f.Name,

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
+	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	srand "github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/scanner"
@@ -2472,7 +2473,10 @@ func TestIssue2571(t *testing.T) {
 	if err = testFs.RemoveAll("A"); err != nil {
 		t.Fatal(err)
 	}
-	if err = testFs.CreateSymlink("B", "A"); err != nil {
+	if err := osutil.DebugSymlinkForTestsOnly(filepath.Join(testFs.URI(), "B"), filepath.Join(testFs.URI(), "A")); err != nil {
+		if runtime.GOOS == "windows" {
+			t.Skip("Symlinks aren't working")
+		}
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
### Purpose

The scenario is well described in #2571, in short: If a dir is replaced by a symlink, the files within the dir aren't marked as deleted in the database if they exist at the location the new symlink points to. The other device will therefore fail to remove the directory because it isn't empty.  
The issue further describes that when you manually delete the directory, contents from the symlink target gets deleted: This isn't the case even previous to this PR, as we check that we don't descend into symlinks.

### Testing

New unit test for this scenario.