### PR TITLE
vendor: Update pfilter (ref #4561)

### DIFF
--- a/vendor/github.com/AudriusButkevicius/pfilter/conn.go
+++ b/vendor/github.com/AudriusButkevicius/pfilter/conn.go
@@ -17,7 +17,7 @@ type FilteredConn struct {
 
 	filter Filter
 
-	closed   chan struct{}
+	closed chan struct{}
 }
 
 // LocalAddr returns the local address
@@ -74,7 +74,7 @@ func (r *FilteredConn) ReadFrom(b []byte) (n int, addr net.Addr, err error) {
 
 	select {
 	case <-timeout:
-		return 0, nil, &timeoutError{}
+		return 0, nil, errTimeout
 	case pkt := <-r.recvBuffer:
 		copy(b[:pkt.n], pkt.buf)
 		bufPool.Put(pkt.buf[:maxPacketSize])

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -29,7 +29,7 @@
 			"importpath": "github.com/AudriusButkevicius/pfilter",
 			"repository": "https://github.com/AudriusButkevicius/pfilter",
 			"vcs": "git",
-			"revision": "56143fe9cebe95636de1275acf30fcca36a1383d",
+			"revision": "9dca34a5b530bfc9843fa8aa2ff08ff9821032cb",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
This can still happen if kcp or smux returns something non-networky, so needs a fix in the stun library, hence ref not fixes.