### PR TITLE
lib/fs: Prolong test timeout on darwin, hopefully fixing flakyness

### DIFF
--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -218,7 +218,11 @@ func testScenario(t *testing.T, name string, testCase func(), expectedEvents []E
 
 	go testWatchOutput(t, name, eventChan, expectedEvents, allowOthers, ctx, cancel)
 
-	timeout := time.NewTimer(2 * time.Second)
+	timeoutDuration := 2 * time.Second
+	if runtime.GOOS == "darwin" {
+		timeoutDuration *= 2
+	}
+	timeout := time.NewTimer(timeoutDuration)
 
 	testCase()
 


### PR DESCRIPTION
Teamcity reports long durations when the flaky test passes on darwin, so extending the timeout seems to have a good chance of minimizing flakyness - lets see (and hope).