### PR TITLE
 lib/dialer: Register dialer for socks URL scheme (fixes #4515)

### DIFF
--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -33,7 +33,7 @@ func init() {
 
 	proxy.RegisterDialerType("socks", socksDialerFunction)
 	proxyDialer = getDialer(proxy.Direct)
-	usingProxy  = proxyDialer != proxy.Direct
+	usingProxy = proxyDialer != proxy.Direct
 
 	if usingProxy {
 		http.DefaultTransport = &http.Transport{

--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -83,7 +83,7 @@ func dialWithFallback(proxyDialFunc dialFunc, fallbackDialFunc dialFunc, network
 	return conn, err
 }
 
-/// This is a rip off of proxy.FromURL for "socks" URL scheme
+// This is a rip off of proxy.FromURL for "socks" URL scheme
 func socksDialerFunction(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
 	var auth *proxy.Auth
 	if u.User != nil {

--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -21,7 +21,7 @@ import (
 
 var (
 	l           = logger.DefaultLogger.NewFacility("dialer", "Dialing connections")
-	proxyDialer = getDialer(proxy.Direct)
+	proxyDialer = getDialer(proxy.Direct, true)
 	usingProxy  = proxyDialer != proxy.Direct
 	noFallback  = os.Getenv("ALL_PROXY_NO_FALLBACK") != ""
 )
@@ -93,8 +93,10 @@ func socksDialerFunction(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error)
 }
 
 // This is a rip off of proxy.FromEnvironment with a custom forward dialer
-func getDialer(forward proxy.Dialer) proxy.Dialer {
-	proxy.RegisterDialerType("socks", socksDialerFunction)
+func getDialer(forward proxy.Dialer, initCall bool) proxy.Dialer {
+	if initCall {
+		proxy.RegisterDialerType("socks", socksDialerFunction)
+	}
 
 	allProxy := os.Getenv("all_proxy")
 	if len(allProxy) == 0 {

--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -78,8 +78,24 @@ func dialWithFallback(proxyDialFunc dialFunc, fallbackDialFunc dialFunc, network
 	return conn, err
 }
 
+/// This is a rip off of proxy.FromURL for "socks" URL scheme
+func socksDialerFunction(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
+	var auth *proxy.Auth
+	if u.User != nil {
+		auth = new(proxy.Auth)
+		auth.User = u.User.Username()
+		if p, ok := u.User.Password(); ok {
+			auth.Password = p
+		}
+	}
+
+	return proxy.SOCKS5("tcp", u.Host, auth, forward)
+}
+
 // This is a rip off of proxy.FromEnvironment with a custom forward dialer
 func getDialer(forward proxy.Dialer) proxy.Dialer {
+	proxy.RegisterDialerType("socks", socksDialerFunction)
+
 	allProxy := os.Getenv("all_proxy")
 	if len(allProxy) == 0 {
 		return forward

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -41,7 +41,7 @@ func DialTimeout(network, addr string, timeout time.Duration) (net.Conn, error) 
 		// Check if the dialer we are getting is not timeoutDirectDialer we just
 		// created. It could happen that usingProxy is true, but getDialer
 		// returns timeoutDirectDialer due to env vars changing.
-		if timeoutProxyDialer := getDialer(dd, false); timeoutProxyDialer != dd {
+		if timeoutProxyDialer := getDialer(dd); timeoutProxyDialer != dd {
 			directDialFunc := func(inetwork, iaddr string) (net.Conn, error) {
 				return net.DialTimeout(inetwork, iaddr, timeout)
 			}

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -41,7 +41,7 @@ func DialTimeout(network, addr string, timeout time.Duration) (net.Conn, error) 
 		// Check if the dialer we are getting is not timeoutDirectDialer we just
 		// created. It could happen that usingProxy is true, but getDialer
 		// returns timeoutDirectDialer due to env vars changing.
-		if timeoutProxyDialer := getDialer(dd); timeoutProxyDialer != dd {
+		if timeoutProxyDialer := getDialer(dd, false); timeoutProxyDialer != dd {
 			directDialFunc := func(inetwork, iaddr string) (net.Conn, error) {
 				return net.DialTimeout(inetwork, iaddr, timeout)
 			}


### PR DESCRIPTION
### Purpose

Hello everyone. Just as described in the issue, Syncthing doesn't work with environment variable all_proxy=socks://host:port. This is my attempt at solving this issue.

### Testing

I'm not sure if it's proper test for this case but I did set up proxy using ssh:
ssh -D 9898 -f -C -q -N user@my_university -p 22
export ALL_PROXY_NO_FALLBACK=1
export all_proxy=socks://127.0.0.1:9898
STTRACE=dialer bin/syncthing

building current origin/master code I got:
[monitor] 2017/12/07 21:16:27.308095 internal.go:51: DEBUG: Dialer logging disabled, as no proxy was detected
[CQLK3] 2017/12/07 21:16:27.311707 internal.go:51: DEBUG: Dialer logging disabled, as no proxy was detected

after fix:
[CQLK3] 2017/12/07 21:17:15.006258 internal.go:43: INFO: Proxy settings detected
[CQLK3] 2017/12/07 21:17:15.006282 internal.go:45: INFO: Proxy fallback disabled
...
[CQLK3] 2017/12/07 21:17:17.020198 internal.go:59: DEBUG: Dialing tcp address 186.195.228.140:22067 via proxy - success, 127.0.0.1:57400 -> 127.0.0.1:9898
[CQLK3] 2017/12/07 21:17:17.073681 internal.go:59: DEBUG: Dialing tcp address 109.230.199.119:22067 via proxy - success, 127.0.0.1:57402 -> 127.0.0.1:9898

With socks5://127.0.0.1:9898 it works, as expected, in both cases.

### Documentation

I think docs should mention that "socks" scheme for all_proxy env variable works the same as socks5 in Using Proxies chapter.
