### PR TITLE
lib/model: Don't leak fd when truncate fails (fixes #4593)

### DIFF
--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -167,8 +167,8 @@ func (s *sharedPullerState) tempFile() (io.WriterAt, error) {
 				// corner case when the old file is larger than the new one
 				// and we can't just overwrite blocks and let the old data
 				// linger at the end. In this case we attempt a delete of
-				// the file and hope for best luck next time, when we should
-				// come around with s.reused == 0.
+				// the file and hope for better luck next time, when we
+				// should come around with s.reused == 0.
 
 				fd.Close()
 

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -158,8 +158,27 @@ func (s *sharedPullerState) tempFile() (io.WriterAt, error) {
 		// Truncate sets the size of the file. This creates a sparse file or a
 		// space reservation, depending on the underlying filesystem.
 		if err := fd.Truncate(s.file.Size); err != nil {
-			s.failLocked("dst truncate", err)
-			return nil, err
+			// The truncate call failed. That can happen in some cases when
+			// space reservation isn't possible or over some network
+			// filesystems... This generally doesn't matter.
+
+			if s.reused > 0 {
+				// ... but if we are attempting to reuse a file we have a
+				// corner case when the old file is larger than the new one
+				// and we can't just overwrite blocks and let the old data
+				// linger at the end. In this case we attempt a delete of
+				// the file and hope for best luck next time, when we should
+				// come around with s.reused == 0.
+
+				fd.Close()
+
+				if err := s.fs.Remove(s.tempName); err != nil {
+					l.Debugln("failed to remove temporary file:", err)
+				}
+
+				s.failLocked("dst truncate", err)
+				return nil, err
+			}
 		}
 	}
 

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -172,8 +172,8 @@ func (s *sharedPullerState) tempFile() (io.WriterAt, error) {
 
 				fd.Close()
 
-				if err := s.fs.Remove(s.tempName); err != nil {
-					l.Debugln("failed to remove temporary file:", err)
+				if remErr := s.fs.Remove(s.tempName); remErr != nil {
+					l.Debugln("failed to remove temporary file:", remErr)
 				}
 
 				s.failLocked("dst truncate", err)


### PR DESCRIPTION
Also attempt to handle this nicer by ignoring the truncate failure when
it doesn't matter, and recover by deleting the temp file when it does.
