### PR TITLE
cmd/syncthing: Clean up deadlock envvars

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -179,14 +179,11 @@ are mostly useful for developers. Use with care.
  STPERFSTATS       Write running performance statistics to perf-$pid.csv. Not
                    supported on Windows.
 
- STDEADLOCK        Used for debugging internal deadlocks. Use only under
-                   direction of a developer.
-
  STDEADLOCKTIMEOUT Used for debugging internal deadlocks; sets debug
                    sensitivity. Use only under direction of a developer.
 
- STDEADLOCKTHRESHOLD Used for debugging internal deadlocks; sets debug
-                     sensitivity.  Use only under direction of a developer.
+ STLOCKTHRESHOLD   Used for debugging internal deadlocks; sets debug
+                   sensitivity.  Use only under direction of a developer.
 
  STNORESTART       Equivalent to the -no-restart argument. Disable the
                    Syncthing monitor process which handles restarts for some

--- a/lib/sync/debug.go
+++ b/lib/sync/debug.go
@@ -24,7 +24,7 @@ var (
 	// }" variable, as it may be rather performance critical and does
 	// nonstandard things (from a debug logging PoV).
 	debug       = strings.Contains(os.Getenv("STTRACE"), "sync") || os.Getenv("STTRACE") == "all"
-	useDeadlock = os.Getenv("STDEADLOCK") != ""
+	useDeadlock = os.Getenv("STDEADLOCKTIMEOUT") != ""
 )
 
 func init() {
@@ -33,7 +33,7 @@ func init() {
 	if n, err := strconv.Atoi(os.Getenv("STLOCKTHRESHOLD")); err == nil {
 		threshold = time.Duration(n) * time.Millisecond
 	}
-	if n, err := strconv.Atoi(os.Getenv("STDEADLOCK")); err == nil {
+	if n, err := strconv.Atoi(os.Getenv("STDEADLOCKTIMEOUT")); err == nil {
 		deadlock.Opts.DeadlockTimeout = time.Duration(n) * time.Second
 	}
 	l.Debugf("Enabling lock logging at %v threshold", threshold)


### PR DESCRIPTION
So STDEADLOCK seems to do the same thing as STDEADLOCKTIMEOUT, except in
the other package. Consolidate?

STDEADLOCKTHRESHOLD is actually called STLOCKTHRESHOLD, correct the help
text.
