### PR TITLE
lib/model: Check for invalid filenames after ignore patterns

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2909,14 +2909,14 @@ func TestPullInvalid(t *testing.T) {
 		t.Skip("Windows only")
 	}
 
-	tmpFolder, err := ioutil.TempDir(".", "_model-")
+	tmpDir, err := ioutil.TempDir(".", "_model-")
 	if err != nil {
 		panic("Failed to create temporary testing dir")
 	}
-	defer os.RemoveAll(tmpFolder)
+	defer os.RemoveAll(tmpDir)
 
 	cfg := defaultConfig.RawCopy()
-	cfg.Folders[0] = config.NewFolderConfiguration(protocol.LocalDeviceID, "default", "default", fs.FilesystemTypeBasic, tmpFolder)
+	cfg.Folders[0] = config.NewFolderConfiguration(protocol.LocalDeviceID, "default", "default", fs.FilesystemTypeBasic, tmpDir)
 	cfg.Folders[0].Devices = []config.FolderDeviceConfiguration{{DeviceID: device1}}
 	w := config.Wrap("/tmp/cfg", cfg)
 

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -382,14 +382,6 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher, ignoresChan
 			return true
 		}
 
-		// If filename isn't valid, we can terminate early with an appropriate error.
-		// in case it is deleted, we don't care about the filename, so don't complain.
-		if !intf.IsDeleted() && runtime.GOOS == "windows" && fs.WindowsInvalidFilename(intf.FileName()) {
-			f.newError("need", intf.FileName(), fs.ErrInvalidFilename)
-			changed++
-			return true
-		}
-
 		file := intf.(protocol.FileInfo)
 
 		switch {
@@ -401,6 +393,12 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher, ignoresChan
 		case file.IsDeleted():
 			processDirectly = append(processDirectly, file)
 			changed++
+
+		// We don't care about invalid filenames if the file is ignored or deleted.
+		case runtime.GOOS == "windows" && fs.WindowsInvalidFilename(file.Name):
+			f.newError("need", file.Name, fs.ErrInvalidFilename)
+			changed++
+			return true
 
 		case file.Type == protocol.FileInfoTypeFile:
 			// Queue files for processing after directories and symlinks, if

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -390,15 +390,14 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher, ignoresChan
 			l.Debugln(f, "Handling ignored file", file)
 			dbUpdateChan <- dbUpdateJob{file, dbUpdateInvalidate}
 
-		case file.IsDeleted():
-			processDirectly = append(processDirectly, file)
-			changed++
-
-		// We don't care about invalid filenames if the file is ignored or deleted.
 		case runtime.GOOS == "windows" && fs.WindowsInvalidFilename(file.Name):
 			f.newError("need", file.Name, fs.ErrInvalidFilename)
 			changed++
 			return true
+
+		case file.IsDeleted():
+			processDirectly = append(processDirectly, file)
+			changed++
 
 		case file.Type == protocol.FileInfoTypeFile:
 			// Queue files for processing after directories and symlinks, if


### PR DESCRIPTION
If files with invalid characters on windows are ignored, they should not cause errors when pulling. Came up [in the forum](https://forum.syncthing.net/t/ignoring-osx-icon-r-files-on-windows/11067/6?u=imsodin).

The first commit contains only the test to verify that it actually reproduces this problem.