### PR TITLE
build: adds flag for debugging the binary with delve

### DIFF
--- a/build.go
+++ b/build.go
@@ -462,11 +462,11 @@ func build(target target, tags []string) {
 		args = append(args, "-race")
 	}
 
+	// omit -ldflags because enabled will get
+	// `Could not launch program: decoding dwarf section info at offset 0x0: too short` on 'dlv exec ...'
+	// see https://github.com/derekparker/delve/issues/79
 	if debugBinary {
 		args = append(args, "-gcflags=-N -l")
-		// omit -ldflags because enabled will get
-		// `Could not launch program: decoding dwarf section info at offset 0x0: too short` on 'dlv exec ...'
-		// see https://github.com/derekparker/delve/issues/79
 	} else {
 		args = append(args, "-ldflags", ldflags())
 	}

--- a/build.go
+++ b/build.go
@@ -359,7 +359,7 @@ func parseFlags() {
 	flag.StringVar(&extraTags, "tags", extraTags, "Extra tags, space separated")
 	flag.StringVar(&installSuffix, "installsuffix", installSuffix, "Install suffix, optional")
 	flag.StringVar(&pkgdir, "pkgdir", "", "Set -pkgdir parameter for `go build`")
-	flag.BoolVar(&debugBinary, "debugBinary", debugBinary, "enable not-optimzed binary to use with delve, set -gcflags='-N -l' and omit -ldflags")
+	flag.BoolVar(&debugBinary, "debug-binary", debugBinary, "enable not-optimzed binary to use with delve, set -gcflags='-N -l' and omit -ldflags")
 	flag.Parse()
 }
 

--- a/build.go
+++ b/build.go
@@ -463,15 +463,9 @@ func appendParameters(args []string, tags []string, target target) []string {
 	// `Could not launch program: decoding dwarf section info at offset 0x0: too short` on 'dlv exec ...'
 	// see https://github.com/derekparker/delve/issues/79
 	if debugBinary {
-		args = append(args, "-gcflags=-N -l")
+		args = append(args, "-gcflags", "-N -l")
 	} else {
-		ldflags := new(bytes.Buffer)
-		ldflags.WriteString("-w")
-		fmt.Fprintf(ldflags, " -X main.Version=%s", version)
-		fmt.Fprintf(ldflags, " -X main.BuildStamp=%d", buildStamp())
-		fmt.Fprintf(ldflags, " -X main.BuildUser=%s", buildUser())
-		fmt.Fprintf(ldflags, " -X main.BuildHost=%s", buildHost())
-		args = append(args, "-ldflags", ldflags.String())
+		args = append(args, "-ldflags", ldflags())
 	}
 
 	return append(args, target.buildPkg)
@@ -731,6 +725,21 @@ func transifex() {
 func clean() {
 	rmr("bin")
 	rmr(filepath.Join(os.Getenv("GOPATH"), fmt.Sprintf("pkg/%s_%s/github.com/syncthing", goos, goarch)))
+}
+
+func ldflags() string {
+	sep := '='
+	if goVersion > 0 && goVersion < 1.5 {
+		sep = ' '
+	}
+
+	b := new(bytes.Buffer)
+	b.WriteString("-w")
+	fmt.Fprintf(b, " -X main.Version%c%s", sep, version)
+	fmt.Fprintf(b, " -X main.BuildStamp%c%d", sep, buildStamp())
+	fmt.Fprintf(b, " -X main.BuildUser%c%s", sep, buildUser())
+	fmt.Fprintf(b, " -X main.BuildHost%c%s", sep, buildHost())
+	return b.String()
 }
 
 func rmr(paths ...string) {

--- a/build.go
+++ b/build.go
@@ -459,13 +459,15 @@ func appendParameters(args []string, tags []string, target target) []string {
 		args = append(args, "-race")
 	}
 
-	// omit -ldflags because enabled will get
-	// `Could not launch program: decoding dwarf section info at offset 0x0: too short` on 'dlv exec ...'
-	// see https://github.com/derekparker/delve/issues/79
-	if debugBinary {
-		args = append(args, "-gcflags", "-N -l")
-	} else {
+	if !debugBinary {
+		// Regular binaries get version tagged and skip some debug symbols
 		args = append(args, "-ldflags", ldflags())
+	} else {
+		// -gcflags to disable optimizations and inlining. Skip -ldflags
+		// because `Could not launch program: decoding dwarf section info at
+		// offset 0x0: too short` on 'dlv exec ...' see
+		// https://github.com/derekparker/delve/issues/79
+		args = append(args, "-gcflags", "-N -l")
 	}
 
 	return append(args, target.buildPkg)


### PR DESCRIPTION
…ry with delve

### Purpose

enables debugging with delve, see documentation [PR/366 in docs](https://github.com/syncthing/docs/pull/366)

`go run build.go -debugBinary build` (omits -ldflags)
