### PR TITLE
gui: Prevent error without completion and nicer wrapping (fixes #4636)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2054,7 +2054,7 @@ angular.module('syncthing.core')
             resetRemoteNeed();
             $scope.remoteNeedDevice = device;
             $scope.deviceFolders(device).forEach(function(folder) {
-                if ($scope.completion[device.deviceID][folder].needItems === 0) {
+                if ($scope.completion[device.deviceID][folder] !== undefined && $scope.completion[device.deviceID][folder].needItems === 0) {
                     return;
                 }
                 $scope.remoteNeedFolders.push(folder);

--- a/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
+++ b/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
@@ -12,7 +12,7 @@
         </button>
         <div id="remoteNeed-{{folder}}" class="panel-collapse collapse">
           <div class="panel-body">
-            <table class="table table-striped table-dynamic">
+            <table class="table table-striped">
               <thead>
                 <tr>
                   <th translate>Path</th>


### PR DESCRIPTION
Old compared to new word breaking:

![wrap](https://user-images.githubusercontent.com/15955093/34482276-35fbe7e2-efb7-11e7-8d23-000920537447.png)

The "fix" for undefined completions just disables the early return, meaning there will be a few needless rest calls, but I think that's ok (it's anyway not likely that this scenario is triggered unconsciously).

@calmh As this is minor, I think you can wait for the autoaccept panic issue to be fixed before releasing a new rc.