### PR TITLE
lib/scanner: Fix UTF-8 normalization on ZFS

### DIFF
--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -299,6 +299,18 @@ func (f *BasicFilesystem) URI() string {
 	return strings.TrimPrefix(f.root, `\\?\`)
 }
 
+func (f *BasicFilesystem) SameFile(fi1, fi2 FileInfo) bool {
+	// Like os.SameFile, we always return false unless fi1 and fi2 were created
+	// by this package's Stat/Lstat method.
+	f1, ok1 := fi1.(fsFileInfo)
+	f2, ok2 := fi2.(fsFileInfo)
+	if !ok1 || !ok2 {
+		return false
+	}
+
+	return os.SameFile(f1.FileInfo, f2.FileInfo)
+}
+
 // fsFile implements the fs.File interface on top of an os.File
 type fsFile struct {
 	*os.File

--- a/lib/fs/errorfs.go
+++ b/lib/fs/errorfs.go
@@ -42,6 +42,7 @@ func (fs *errorFilesystem) Roots() ([]string, error)                            
 func (fs *errorFilesystem) Usage(name string) (Usage, error)                            { return Usage{}, fs.err }
 func (fs *errorFilesystem) Type() FilesystemType                                        { return fs.fsType }
 func (fs *errorFilesystem) URI() string                                                 { return fs.uri }
+func (fs *errorFilesystem) SameFile(fi1, fi2 FileInfo) bool                             { return false }
 func (fs *errorFilesystem) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, error) {
 	return nil, fs.err
 }

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -43,6 +43,7 @@ type Filesystem interface {
 	Usage(name string) (Usage, error)
 	Type() FilesystemType
 	URI() string
+	SameFile(fi1, fi2 FileInfo) bool
 }
 
 // The File interface abstracts access to a regular file, being a somewhat

--- a/lib/fs/tempname.go
+++ b/lib/fs/tempname.go
@@ -46,7 +46,7 @@ func IsTemporary(name string) bool {
 	return false
 }
 
-func TempName(name string) string {
+func TempNameWithPrefix(name, prefix string) string {
 	tdir := filepath.Dir(name)
 	tbase := filepath.Base(name)
 	if len(tbase) > maxFilenameLength {
@@ -54,6 +54,10 @@ func TempName(name string) string {
 		hash.Write([]byte(name))
 		tbase = fmt.Sprintf("%x", hash.Sum(nil))
 	}
-	tname := fmt.Sprintf("%s%s.tmp", TempPrefix, tbase)
+	tname := fmt.Sprintf("%s%s.tmp", prefix, tbase)
 	return filepath.Join(tdir, tname)
+}
+
+func TempName(name string) string {
+	return TempNameWithPrefix(name, TempPrefix)
 }

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -259,9 +259,9 @@ func TestNormalization(t *testing.T) {
 	files := fileList(tmp).testfiles()
 
 	// We should have one file per combination, plus the directories
-	// themselves
+	// themselves, plus the "testdata/normalization" directory
 
-	expectedNum := numValid*numValid + numValid
+	expectedNum := numValid*numValid + numValid + 1
 	if len(files) != expectedNum {
 		t.Errorf("Expected %d files, got %d", expectedNum, len(files))
 	}


### PR DESCRIPTION
It turns out that ZFS doesn't do any normalization when storing files,
but does do normalization "as part of any comparison process".

In practice, this seems to mean that if you LStat a normalized filename,
ZFS will return the FileInfo for the un-normalized version of that
filename.

This meant that our test to see whether a separate file with a
normalized version of the filename already exists was failing, as we
were detecting the same file.

The fix is to use os.SameFile, to see whether we're getting the same
FileInfo from the normalized and un-normalized versions of the same
filename.

One complication is that ZFS also seems to apply its magic to os.Rename,
meaning that we can't use it to rename an un-normalized file to its
normalized filename. Instead we have to move via a temporary object. If
the move to the temporary object fails, that's OK, we can skip it and
move on. If the move from the temporary object fails however, I'm not
sure of the best approach: the current one is to leave the temporary
file name as-is, and get Syncthing to syncronize it, so at least we
don't lose the file. I'm not sure if there are any implications of this
however.

As part of reworking normalizePath, I spotted that it appeared to be
returning the wrong thing: the doc and the surrounding code expecting it
to return the normalized filename, but it was returning the
un-normalized one. I fixed this, but it seems suspicious that, if the
previous behaviour was incorrect, noone ever ran afoul of it. Maybe all
filesystems will do some searching and give you a normalized filename if
you request an unnormalized one.

As part of this, I found that TestNormalization was broken: it was
passing, when in fact one of the files it should have verified was
present was missing. Maybe this was related to the above issue with
normalizePath's return value, I'm not sure. Fixed en route.

Kindly tested by @khinsen on the forum, and it appears to work.
  