### PR TITLE
lib/config, lib/discover: Support new discovery cluster (ref #4618)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -53,16 +53,14 @@ var (
 	// DefaultDiscoveryServersV4 should be substituted when the configuration
 	// contains <globalAnnounceServer>default-v4</globalAnnounceServer>.
 	DefaultDiscoveryServersV4 = []string{
-		"https://discovery-v4-2.syncthing.net/v2/?id=DVU36WY-H3LVZHW-E6LLFRE-YAFN5EL-HILWRYP-OC2M47J-Z4PE62Y-ADIBDQC", // 45.55.230.38, USA
-		"https://discovery-v4-3.syncthing.net/v2/?id=VK6HNJ3-VVMM66S-HRVWSCR-IXEHL2H-U4AQ4MW-UCPQBWX-J2L2UBK-NVZRDQZ", // 128.199.95.124, Singapore
-		"https://discovery-v4-4.syncthing.net/v2/?id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW", // 95.85.19.244, NL
+		"https://discovery.syncthing.net/v2/?noannounce&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
+		"https://discovery-v4.syncthing.net/v2/?nolookup&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
 	}
 	// DefaultDiscoveryServersV6 should be substituted when the configuration
 	// contains <globalAnnounceServer>default-v6</globalAnnounceServer>.
 	DefaultDiscoveryServersV6 = []string{
-		"https://discovery-v6-2.syncthing.net/v2/?id=DVU36WY-H3LVZHW-E6LLFRE-YAFN5EL-HILWRYP-OC2M47J-Z4PE62Y-ADIBDQC", // 2604:a880:800:10::182:a001, USA
-		"https://discovery-v6-3.syncthing.net/v2/?id=VK6HNJ3-VVMM66S-HRVWSCR-IXEHL2H-U4AQ4MW-UCPQBWX-J2L2UBK-NVZRDQZ", // 2400:6180:0:d0::d9:d001, Singapore
-		"https://discovery-v6-4.syncthing.net/v2/?id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW", // 2a03:b0c0:0:1010::4ed:3001, NL
+		"https://discovery.syncthing.net/v2/?noannounce&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
+		"https://discovery-v6.syncthing.net/v2/?nolookup&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
 	}
 	// DefaultDiscoveryServers should be substituted when the configuration
 	// contains <globalAnnounceServer>default</globalAnnounceServer>.

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -30,6 +30,7 @@ type globalClient struct {
 	announceClient httpClient
 	queryClient    httpClient
 	noAnnounce     bool
+	noLookup       bool
 	stop           chan struct{}
 	errorHolder
 }
@@ -52,6 +53,7 @@ type announcement struct {
 type serverOptions struct {
 	insecure   bool   // don't check certificate
 	noAnnounce bool   // don't announce
+	noLookup   bool   // don't use for lookups
 	id         string // expected server device ID
 }
 
@@ -119,15 +121,26 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister) (Fin
 		announceClient: announceClient,
 		queryClient:    queryClient,
 		noAnnounce:     opts.noAnnounce,
+		noLookup:       opts.noLookup,
 		stop:           make(chan struct{}),
 	}
-	cl.setError(errors.New("not announced"))
+	if !opts.noAnnounce {
+		// If we are supposed to annonce, it's an error until we've done so.
+		cl.setError(errors.New("not announced"))
+	}
 
 	return cl, nil
 }
 
 // Lookup returns the list of addresses where the given device is available
 func (c *globalClient) Lookup(device protocol.DeviceID) (addresses []string, err error) {
+	if c.noLookup {
+		return nil, lookupError{
+			error:    errors.New("lookups not supported"),
+			cacheFor: time.Hour,
+		}
+	}
+
 	qURL, err := url.Parse(c.server)
 	if err != nil {
 		return nil, err
@@ -201,7 +214,6 @@ func (c *globalClient) Serve() {
 }
 
 func (c *globalClient) sendAnnouncement(timer *time.Timer) {
-
 	var ann announcement
 	if c.addrList != nil {
 		ann.Addresses = c.addrList.ExternalAddresses()
@@ -287,6 +299,7 @@ func parseOptions(dsn string) (server string, opts serverOptions, err error) {
 	opts.id = q.Get("id")
 	opts.insecure = opts.id != "" || queryBool(q, "insecure")
 	opts.noAnnounce = queryBool(q, "noannounce")
+	opts.noLookup = queryBool(q, "nolookup")
 
 	// Check for disallowed combinations
 	if p.Scheme == "http" {


### PR DESCRIPTION
### Purpose

This adds one new feature, that discovery servers can have ?nolookup to
be used only for announces. The default set of discovery servers is
changed to:

- discovery.s.n used for lookups. This is dual stack load balanced over
  all discovery servers, and returns both IPv4 and IPV6 results when they
  exist.

- discovery-v4.s.n used for announces. This has IPv4 addresses only and
  the discovery servers will update the unspecified address with the IPv4
  source address, as usual.

- discovery-v6.s.n which is exactly the same for IPv6.

### Testing

Works for me in manual testing...

```
[SYNO4] 2018/01/05 14:51:21.131470 main.go:812: INFO: Using discovery server https://discovery-v4.syncthing.net/v2/?nolookup&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW
[SYNO4] 2018/01/05 14:51:21.131563 main.go:812: INFO: Using discovery server https://discovery-v6.syncthing.net/v2/?nolookup&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW
[SYNO4] 2018/01/05 14:51:21.131647 main.go:812: INFO: Using discovery server https://discovery.syncthing.net/v2/?noannounce&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW
...
[SYNO4] 2018/01/05 14:51:22.136859 cache.go:91: DEBUG: negative cache entry for ITZRNXE-YNROGBZ-HXTH5P7-VK5NYE5-QHRQGE2-7JQ6VNJ-KZUEDIU-5PPR5AM at global@https://discovery-v4.syncthing.net/v2/ valid until 2018-01-05 14:52:21.131634 +0100 CET m=+62.325603657 or 2018-01-05 15:51:21.131654 +0100 CET m=+3602.325623251
[SYNO4] 2018/01/05 14:51:22.136885 cache.go:91: DEBUG: negative cache entry for ITZRNXE-YNROGBZ-HXTH5P7-VK5NYE5-QHRQGE2-7JQ6VNJ-KZUEDIU-5PPR5AM at global@https://discovery-v6.syncthing.net/v2/ valid until 2018-01-05 14:52:21.131663 +0100 CET m=+62.325632091 or 2018-01-05 15:51:21.131664 +0100 CET m=+3602.325633396
[SYNO4] 2018/01/05 14:51:22.290133 cache.go:100: DEBUG: lookup for ITZRNXE-YNROGBZ-HXTH5P7-VK5NYE5-QHRQGE2-7JQ6VNJ-KZUEDIU-5PPR5AM at global@https://discovery.syncthing.net/v2/
[SYNO4] 2018/01/05 14:51:22.290154 cache.go:101: DEBUG:   addresses: [kcp://83.233.120.154:22020 kcp://[2001:7a0:8003:32::11]:22020 tcp://83.233.120.154:22000 tcp://[2001:7a0:8003:32::11]:22000]
```

### Compatibility

There is no protocol changes for the new stuff. We will retain the DNS records for `discovery-v4-4` and `discovery-v6-4` (same certificate as the new cluster) so clients using the old method will still work (forever), just using wastefully twice as many lookups as necessary and getting red flags for `discovery-v[46]-[23]` once those are removed in the future.
  