### PR TITLE
gui: New rest endpoint to get errors when web UI is opened

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -1366,25 +1366,29 @@ func (s *apiService) getPullErrors(w http.ResponseWriter, r *http.Request) {
 	folder := qs.Get("folder")
 	page, perpage := getPagingParams(qs)
 
-	if errors, err := s.model.PullErrors(folder); err != nil {
+	errors, err := s.model.PullErrors(folder)
+
+	if err != nil {
 		http.Error(w, err.Error(), http.StatusNotFound)
-	} else {
-		start := (page - 1) * perpage
-		if start >= len(errors) {
-			errors = nil
-		} else {
-			errors = errors[start:]
-			if perpage < len(errors) {
-				errors = errors[:perpage]
-			}
-		}
-		sendJSON(w, map[string]interface{}{
-			"folder":  folder,
-			"errors":  errors,
-			"page":    page,
-			"perpage": perpage,
-		})
+		return
 	}
+
+	start := (page - 1) * perpage
+	if start >= len(errors) {
+		errors = nil
+	} else {
+		errors = errors[start:]
+		if perpage < len(errors) {
+			errors = errors[:perpage]
+		}
+	}
+
+	sendJSON(w, map[string]interface{}{
+		"folder":  folder,
+		"errors":  errors,
+		"page":    page,
+		"perpage": perpage,
+	})
 }
 
 func (s *apiService) getSystemBrowse(w http.ResponseWriter, r *http.Request) {

--- a/cmd/syncthing/mocked_model_test.go
+++ b/cmd/syncthing/mocked_model_test.go
@@ -133,6 +133,6 @@ func (m *mockedModel) UsageReportingStats(version int, preview bool) map[string]
 	return nil
 }
 
-func (m *mockedModel) PullErrors(folder string) ([]model.FileError, error) {
+func (m *mockedModel) PullErrors(folder string, page, perpage int) ([]model.FileError, error) {
 	return nil, nil
 }

--- a/cmd/syncthing/mocked_model_test.go
+++ b/cmd/syncthing/mocked_model_test.go
@@ -133,6 +133,6 @@ func (m *mockedModel) UsageReportingStats(version int, preview bool) map[string]
 	return nil
 }
 
-func (m *mockedModel) PullErrors(folder string, page, perpage int) ([]model.FileError, error) {
+func (m *mockedModel) PullErrors(folder string) ([]model.FileError, error) {
 	return nil, nil
 }

--- a/cmd/syncthing/mocked_model_test.go
+++ b/cmd/syncthing/mocked_model_test.go
@@ -132,3 +132,7 @@ func (m *mockedModel) State(folder string) (string, time.Time, error) {
 func (m *mockedModel) UsageReportingStats(version int, preview bool) map[string]interface{} {
 	return nil
 }
+
+func (m *mockedModel) PullErrors(folder string) ([]model.FileError, error) {
+	return nil, nil
+}

--- a/cmd/syncthing/summaryservice.go
+++ b/cmd/syncthing/summaryservice.go
@@ -187,7 +187,10 @@ func (c *folderSummaryService) foldersToHandle() []string {
 func (c *folderSummaryService) sendSummary(folder string) {
 	// The folder summary contains how many bytes, files etc
 	// are in the folder and how in sync we are.
-	data := folderSummary(c.cfg, c.model, folder)
+	data, err := folderSummary(c.cfg, c.model, folder)
+	if err != nil {
+		return
+	}
 	events.Default.Log(events.FolderSummary, map[string]interface{}{
 		"folder":  folder,
 		"summary": data,

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -355,7 +355,7 @@
                       <th><span class="fa fa-fw fa-exclamation-circle"></span>&nbsp;<span translate>Failed Items</span></th>
                       <!-- Show the number of failed items as a link to bring up the list. -->
                       <td class="text-right">
-                        <a href="" ng-click="showFailed(folder.id)">{{failed[folder.id].length | alwaysNumber}}&nbsp;<span translate>items</span></a>
+                        <a href="" ng-click="showFailed(folder.id)">{{model[folder.id].pullErrors | alwaysNumber}}&nbsp;<span translate>items</span></a>
                       </td>
                     </tr>
                     <tr ng-if="folder.type != 'readwrite'">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -578,7 +578,7 @@ angular.module('syncthing.core')
 
         function refreshPullErrors() {
             $.each($scope.folderList(), function(folder) {
-                if folder.type === "readonly" {
+                if (folder.type === "readonly") {
                     return;
                 }
                 var url = urlbase + '/folder/pullerrors?folder=' + encodeURIComponent(folder);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -123,6 +123,7 @@ angular.module('syncthing.core')
             refreshFolderStats();
             refreshGlobalChanges();
             refreshThemes();
+            refreshPullErrors();
 
             $http.get(urlbase + '/system/version').success(function (data) {
                 if ($scope.version.version && $scope.version.version !== data.version) {
@@ -573,6 +574,18 @@ angular.module('syncthing.core')
             $http.get(urlbase + '/system/config/insync').success(function (data) {
                 $scope.configInSync = data.configInSync;
             }).error($scope.emitHTTPError);
+        }
+
+        function refreshPullErrors() {
+            $.each($scope.folderList(), function(folder) {
+                if folder.type === "readonly" {
+                    return;
+                }
+                var url = urlbase + '/folder/pullerrors?folder=' + encodeURIComponent(folder);
+                $http.get(url).success(function (data) {
+                    $scope.failed[folder.id] = data;
+                }).error($scope.emitHTTPError);
+            });
         }
 
         function refreshNeed(folder) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -48,8 +48,6 @@ angular.module('syncthing.core')
         $scope.neededCurrentPage = 1;
         $scope.neededPageSize = 10;
         $scope.failed = {};
-        $scope.failedCurrentPage = 1;
-        $scope.failedPageSize = 10;
         $scope.scanProgress = {};
         $scope.themes = [];
         $scope.globalChangeEvents = {};
@@ -123,7 +121,6 @@ angular.module('syncthing.core')
             refreshFolderStats();
             refreshGlobalChanges();
             refreshThemes();
-            refreshPullErrors();
 
             $http.get(urlbase + '/system/version').success(function (data) {
                 if ($scope.version.version && $scope.version.version !== data.version) {
@@ -198,13 +195,6 @@ angular.module('syncthing.core')
             if ($scope.model[data.folder]) {
                 $scope.model[data.folder].state = data.to;
                 $scope.model[data.folder].error = data.error;
-
-                // If a folder has started syncing, then any old list of
-                // errors is obsolete. We may get a new list of errors very
-                // shortly though.
-                if (data.to === 'syncing') {
-                    $scope.failed[data.folder] = [];
-                }
 
                 // If a folder has started scanning, then any scan progress is
                 // also obsolete.
@@ -345,8 +335,7 @@ angular.module('syncthing.core')
         });
 
         $scope.$on(Events.FOLDER_ERRORS, function (event, arg) {
-            var data = arg.data;
-            $scope.failed[data.folder] = data.errors;
+            $scope.model[arg.data.folder].pullErrors = arg.data.errors.length;
         });
 
         $scope.$on(Events.FOLDER_SCAN_PROGRESS, function (event, arg) {
@@ -576,18 +565,6 @@ angular.module('syncthing.core')
             }).error($scope.emitHTTPError);
         }
 
-        function refreshPullErrors() {
-            $.each($scope.folderList(), function(folder) {
-                if (folder.type === "readonly") {
-                    return;
-                }
-                var url = urlbase + '/folder/pullerrors?folder=' + encodeURIComponent(folder);
-                $http.get(url).success(function (data) {
-                    $scope.failed[folder.id] = data;
-                }).error($scope.emitHTTPError);
-            });
-        }
-
         function refreshNeed(folder) {
             var url = urlbase + "/db/need?folder=" + encodeURIComponent(folder);
             url += "&page=" + $scope.neededCurrentPage;
@@ -670,12 +647,12 @@ angular.module('syncthing.core')
             refreshNeed($scope.neededFolder);
         };
 
-        $scope.failedPageChanged = function (page) {
-            $scope.failedCurrentPage = page;
-        };
-
-        $scope.failedChangePageSize = function (perpage) {
-            $scope.failedPageSize = perpage;
+        $scope.refreshFailed = function (page, perpage) {
+            var url = urlbase + '/folder/pullerrors?folder=' + encodeURIComponent($scope.failed.folder);
+            url += "&page=" + page + "&perpage=" + perpage;
+            $http.get(url).success(function (data) {
+                $scope.failed = data;
+            }).error($scope.emitHTTPError);
         };
 
         $scope.refreshRemoteNeed = function (folder, page, perpage) {
@@ -1029,14 +1006,6 @@ angular.module('syncthing.core')
                 return conn.address;
             }
             return '?';
-        };
-
-        $scope.deviceCompletion = function (deviceCfg) {
-            var conn = $scope.connections[deviceCfg.deviceID];
-            if (conn) {
-                return conn.completion + '%';
-            }
-            return '';
         };
 
         $scope.friendlyNameFromShort = function (shortID) {
@@ -2079,24 +2048,18 @@ angular.module('syncthing.core')
         };
 
         $scope.showFailed = function (folder) {
-            $scope.failedCurrent = $scope.failed[folder];
-            $scope.failedFolderPath = $scope.folders[folder].path;
-            if ($scope.failedFolderPath[$scope.failedFolderPath.length - 1] !== $scope.system.pathSeparator) {
-                $scope.failedFolderPath += $scope.system.pathSeparator;
-            }
+            $scope.failed.folder = folder;
+            $scope.failed = $scope.refreshFailed(1, 10);
             $('#failed').modal().on('hidden.bs.modal', function () {
-                $scope.failedCurrent = undefined;
+                $scope.failed = {};
             });
         };
 
         $scope.hasFailedFiles = function (folder) {
-            if (!$scope.failed[folder]) {
+            if (!$scope.model[folder]) {
                 return false;
             }
-            if ($scope.failed[folder].length === 0) {
-                return false;
-            }
-            return true;
+            return $scope.model[folder].pullErrors !== 0;
         };
 
         $scope.override = function (folder) {

--- a/gui/default/syncthing/transfer/failedFilesModalView.html
+++ b/gui/default/syncthing/transfer/failedFilesModalView.html
@@ -5,15 +5,15 @@
       <span translate>They are retried automatically and will be synced when the error is resolved.</span>
     </p>
     <table class="table table-striped table-dynamic">
-      <tr dir-paginate="e in failedCurrent | itemsPerPage: failedPageSize" current-page="failedCurrentPage" pagination-id="failed">
-        <td>{{failedFolderPath}}{{e.path}}</td>
+      <tr dir-paginate="e in failed.errors | itemsPerPage: failed.perpage" current-page="failed.page" total-items="model[failed.folder].pullErrors" pagination-id="failed">
+        <td>{{e.path}}</td>
         <td><abbr tooltip data-original-title="{{e.error}}">{{e.error | lastErrorComponent}}</abbr></td>
       </tr>
     </table>
-    <dir-pagination-controls on-page-change="failedPageChanged(newPageNumber)" pagination-id="failed"></dir-pagination-controls>
+    <dir-pagination-controls on-page-change="refreshFailed(newPageNumber, failed.perpage)" pagination-id="failed"></dir-pagination-controls>
     <ul class="pagination pull-right">
-      <li ng-repeat="option in [10, 25, 50]" ng-class="{ active: failedPageSize == option }">
-        <a href="#" ng-click="failedChangePageSize(option)">{{option}}</a>
+      <li ng-repeat="option in [10, 25, 50]" ng-class="{ active: failed.page == option }">
+        <a href="#" ng-click="refreshFailed(failed.page, option)">{{option}}</a>
       </li>
     </ul>
     <div class="clearfix"></div>

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2229,6 +2229,7 @@ func (m *Model) State(folder string) (string, time.Time, error) {
 func (m *Model) PullErrors(folder string) ([]FileError, error) {
 	m.fmut.RLock()
 	if err := m.checkFolderRunningLocked(folder); err != nil {
+		m.fmut.RUnlock()
 		return nil, err
 	}
 	runner := m.folderRunners[folder]

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2226,25 +2226,13 @@ func (m *Model) State(folder string) (string, time.Time, error) {
 	return state.String(), changed, err
 }
 
-func (m *Model) PullErrors(folder string, page, perpage int) ([]FileError, error) {
+func (m *Model) PullErrors(folder string) ([]FileError, error) {
 	m.fmut.RLock()
+	defer m.fmut.RUnlock()
 	if err := m.checkFolderRunningLocked(folder); err != nil {
-		m.fmut.RUnlock()
 		return nil, err
 	}
-	runner := m.folderRunners[folder]
-	m.fmut.RUnlock()
-
-	errors := runner.PullErrors()
-	start := (page - 1) * perpage
-	if start >= len(errors) {
-		return nil, nil
-	}
-	errors = errors[start:]
-	if perpage >= len(errors) {
-		return errors, nil
-	}
-	return errors[:perpage], nil
+	return m.folderRunners[folder].PullErrors(), nil
 }
 
 func (m *Model) Override(folder string) {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -64,6 +64,7 @@ type service interface {
 	Serve()
 	Stop()
 	CheckHealth() error
+	PullErrors() []FileError
 
 	getState() (folderState, time.Time, error)
 	setState(state folderState)
@@ -2223,6 +2224,17 @@ func (m *Model) State(folder string) (string, time.Time, error) {
 	}
 	state, changed, err := runner.getState()
 	return state.String(), changed, err
+}
+
+func (m *Model) PullErrors(folder string) ([]FileError, error) {
+	m.fmut.RLock()
+	if err := m.checkFolderRunningLocked(folder); err != nil {
+		return nil, err
+	}
+	runner := m.folderRunners[folder]
+	m.fmut.RUnlock()
+
+	return runner.PullErrors(), nil
 }
 
 func (m *Model) Override(folder string) {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3225,7 +3225,7 @@ func TestPausedFolders(t *testing.T) {
 	}
 	w.Wait()
 
-	if err := m.ScanFolder("default"); err != errFolderPaused {
+	if err := m.ScanFolder("default"); err != ErrFolderPaused {
 		t.Errorf("Expected folder paused error, received: %v", err)
 	}
 

--- a/lib/model/rofolder.go
+++ b/lib/model/rofolder.go
@@ -66,3 +66,7 @@ func (f *sendOnlyFolder) Serve() {
 func (f *sendOnlyFolder) String() string {
 	return fmt.Sprintf("sendOnlyFolder/%s@%p", f.folderID, f)
 }
+
+func (f *sendOnlyFolder) PullErrors() []FileError {
+	return nil
+}

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1728,11 +1728,11 @@ func (f *sendReceiveFolder) clearErrors() {
 	f.errorsMut.Unlock()
 }
 
-func (f *sendReceiveFolder) currentErrors() []fileError {
+func (f *sendReceiveFolder) currentErrors() []FileError {
 	f.errorsMut.Lock()
-	errors := make([]fileError, 0, len(f.errors))
+	errors := make([]FileError, 0, len(f.errors))
 	for path, err := range f.errors {
-		errors = append(errors, fileError{path, err})
+		errors = append(errors, FileError{path, err})
 	}
 	sort.Sort(fileErrorList(errors))
 	f.errorsMut.Unlock()
@@ -1811,13 +1811,20 @@ func (f *sendReceiveFolder) deleteDir(dir string, ignores *ignore.Matcher, scanC
 	return err
 }
 
-// A []fileError is sent as part of an event and will be JSON serialized.
-type fileError struct {
+func (f *sendReceiveFolder) PullErrors() []FileError {
+	if state, _, _ := f.getState(); state == FolderSyncing {
+		return nil
+	}
+	return f.currentErrors()
+}
+
+// A []FileError is sent as part of an event and will be JSON serialized.
+type FileError struct {
 	Path string `json:"path"`
 	Err  string `json:"error"`
 }
 
-type fileErrorList []fileError
+type fileErrorList []FileError
 
 func (l fileErrorList) Len() int {
 	return len(l)

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1812,9 +1812,6 @@ func (f *sendReceiveFolder) deleteDir(dir string, ignores *ignore.Matcher, scanC
 }
 
 func (f *sendReceiveFolder) PullErrors() []FileError {
-	if state, _, _ := f.getState(); state == FolderSyncing {
-		return nil
-	}
 	return f.currentErrors()
 }
 

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -284,7 +284,7 @@ func (f *sendReceiveFolder) pull(prevIgnoreHash string) (curIgnoreHash string, s
 			// we're not making it. Probably there are write
 			// errors preventing us. Flag this with a warning and
 			// wait a bit longer before retrying.
-			if folderErrors := f.currentErrors(); len(folderErrors) > 0 {
+			if folderErrors := f.PullErrors(); len(folderErrors) > 0 {
 				events.Default.Log(events.FolderErrors, map[string]interface{}{
 					"folder": f.folderID,
 					"errors": folderErrors,
@@ -1728,7 +1728,7 @@ func (f *sendReceiveFolder) clearErrors() {
 	f.errorsMut.Unlock()
 }
 
-func (f *sendReceiveFolder) currentErrors() []FileError {
+func (f *sendReceiveFolder) PullErrors() []FileError {
 	f.errorsMut.Lock()
 	errors := make([]FileError, 0, len(f.errors))
 	for path, err := range f.errors {
@@ -1809,10 +1809,6 @@ func (f *sendReceiveFolder) deleteDir(dir string, ignores *ignore.Matcher, scanC
 	}
 
 	return err
-}
-
-func (f *sendReceiveFolder) PullErrors() []FileError {
-	return f.currentErrors()
 }
 
 // A []FileError is sent as part of an event and will be JSON serialized.


### PR DESCRIPTION
Since #4340 pulls aren't happening every 10s anymore and may be delayed up to 1h.
This means that no folder error event reaches the web UI for a long time, thus no
failed items will show up for a long time. Now pulling errors are populated when the
web UI is opened.

One thing I noticed: A whole lot of functions on the folders, queue, folderstate, ... are exported but never used anywhere outside of the model package. Is this legacy or hopeful planning that all this stuff could be completely separated from model one day? :D