### PR TITLE
build: Remove ulimit from build.sh (fixes #4653)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -48,9 +48,6 @@ case "${1:-default}" in
 		;;
 
 	test)
-		ulimit -t 600 &>/dev/null || true
-		ulimit -d 512000 &>/dev/null || true
-		ulimit -m 512000 &>/dev/null || true
 		LOGGER_DISCARD=1 build test
 		;;
 
@@ -94,9 +91,6 @@ case "${1:-default}" in
 		;;
 
 	test-xunit)
-		ulimit -t 600 &>/dev/null || true
-		ulimit -d 512000 &>/dev/null || true
-		ulimit -m 512000 &>/dev/null || true
 
 		(GOPATH="$(pwd)/Godeps/_workspace:$GOPATH" go test -v -race ./lib/... ./cmd/... || true) > tests.out
 		go2xunit -output tests.xml -fail < tests.out


### PR DESCRIPTION
### Purpose

Previous "reasonable resource limits" cause test failures with Go 1.9.
They were added to protect the previous generation of the build server
and no longer needed.

Fixes issue #4653.

### Testing

`./build.sh test`
