### PR TITLE
Correctly account handling of sparse blocks (fixes #4657)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1200,6 +1200,7 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 
 				// Pretend we copied it.
 				state.copiedFromOrigin()
+				state.copyDone(block)
 				continue
 			}
 


### PR DESCRIPTION
### Purpose

Decrease the "pull needed" count when we skip a block so the finisher will correctly see that the file is completed.

### Testing

I'm going to try to rig up a test for this, hang on.