### PR TITLE
gui: remove faulty char in remoteNeededFiles

### DIFF
--- a/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
+++ b/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
@@ -1,4 +1,4 @@
-é<modal id="remoteNeed" status="info" icon="exchange" heading="{{'Out of Sync Items' | translate}} - {{deviceName(remoteNeedDevice)}}" large="yes" closeable="yes">
+<modal id="remoteNeed" status="info" icon="exchange" heading="{{'Out of Sync Items' | translate}} - {{deviceName(remoteNeedDevice)}}" large="yes" closeable="yes">
   <div class="modal-body">
     <div ng-if="sizeOf(remoteNeed) == 0">
       <span translate>Loading data...</span>


### PR DESCRIPTION
### Purpose

For some reason, there is a char at the beginning of the remoteNeededFilesModalView.html file. Maybe a BOM gone wrong. This is displayed permanently in the gui on the left below the folder and device lists.

### Screenshots

![grafik](https://user-images.githubusercontent.com/1026763/34739558-ee9fef26-f57c-11e7-9e80-b695032bf3c1.png)

  