### PR TITLE
Substitute '\' with '/' in paths in External File Versionining (fixes #4560)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1581,6 +1581,7 @@ angular.module('syncthing.core')
                 $scope.currentFolder.staggeredMaxAge = 365;
             }
             $scope.currentFolder.externalCommand = $scope.currentFolder.externalCommand || "";
+            $scope.currentFolder.externalCommand = $scope.currentFolder.externalCommand.split(String.fromCharCode(92)).join(String.fromCharCode(47));
 
             $scope.editFolderModal();
         };

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1581,7 +1581,6 @@ angular.module('syncthing.core')
                 $scope.currentFolder.staggeredMaxAge = 365;
             }
             $scope.currentFolder.externalCommand = $scope.currentFolder.externalCommand || "";
-            $scope.currentFolder.externalCommand = $scope.currentFolder.externalCommand.split(String.fromCharCode(92)).join(String.fromCharCode(47));
 
             $scope.editFolderModal();
         };

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1666,7 +1666,7 @@ angular.module('syncthing.core')
                 folderCfg.versioning = {
                     'Type': 'external',
                     'Params': {
-                        'command': '' + folderCfg.externalCommand.replace(/\\(?! )/g, '/')
+                        'command': '' + folderCfg
                     }
                 };
                 delete folderCfg.externalFileVersioning;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1581,7 +1581,6 @@ angular.module('syncthing.core')
                 $scope.currentFolder.staggeredMaxAge = 365;
             }
             $scope.currentFolder.externalCommand = $scope.currentFolder.externalCommand || "";
-
             $scope.editFolderModal();
         };
 
@@ -1667,7 +1666,7 @@ angular.module('syncthing.core')
                 folderCfg.versioning = {
                     'Type': 'external',
                     'Params': {
-                        'command': '' + folderCfg.externalCommand
+                        'command': '' + folderCfg.externalCommand.replace(/\\(?! )/g, '/')
                     }
                 };
                 delete folderCfg.externalFileVersioning;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1581,6 +1581,7 @@ angular.module('syncthing.core')
                 $scope.currentFolder.staggeredMaxAge = 365;
             }
             $scope.currentFolder.externalCommand = $scope.currentFolder.externalCommand || "";
+
             $scope.editFolderModal();
         };
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1666,7 +1666,7 @@ angular.module('syncthing.core')
                 folderCfg.versioning = {
                     'Type': 'external',
                     'Params': {
-                        'command': '' + folderCfg
+                        'command': '' + folderCfg.externalCommand
                     }
                 };
                 delete folderCfg.externalFileVersioning;

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -176,7 +176,7 @@
               <p translate class="help-block">Path where versions should be stored (leave empty for the default .stversions directory in the shared folder).</p>
             </div>
             <div class="form-group" ng-if="currentFolder.fileVersioningSelector=='external'" ng-class="{'has-error': folderEditor.externalCommand.$invalid && folderEditor.externalCommand.$dirty}">
-              <p translate class="help-block">An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted with double quotation marks: ".</p>
+              <p translate class="help-block">An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.</p>
               <label translate for="externalCommand">Command</label>
               <input name="externalCommand" id="externalCommand" class="form-control" type="text" ng-model="currentFolder.externalCommand" required="" aria-required="true" />
               <p class="help-block">

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -176,7 +176,7 @@
               <p translate class="help-block">Path where versions should be stored (leave empty for the default .stversions directory in the shared folder).</p>
             </div>
             <div class="form-group" ng-if="currentFolder.fileVersioningSelector=='external'" ng-class="{'has-error': folderEditor.externalCommand.$invalid && folderEditor.externalCommand.$dirty}">
-              <p translate class="help-block">An external command handles the versioning. It has to remove the file from the shared folder.</p>
+              <p translate class="help-block">An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted with double quotation marks: ".</p>
               <label translate for="externalCommand">Command</label>
               <input name="externalCommand" id="externalCommand" class="form-control" type="text" ng-model="currentFolder.externalCommand" required="" aria-required="true" />
               <p class="help-block">

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -64,7 +64,7 @@ func (v External) Archive(filePath string) error {
 		} else {
 			v.command = "'" + v.command + "'"
 		}
-    }
+	}
 
 	words, err := shellquote.Split(v.command)
 	if err != nil {

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -52,12 +52,19 @@ func (v External) Archive(filePath string) error {
 	if info.IsSymlink() {
 		panic("bug: attempting to version a symlink")
 	}
-
 	l.Debugln("archiving", filePath)
 
 	if v.command == "" {
 		return errors.New("Versioner: command is empty, please enter a valid command")
 	}
+    if strings.HasPrefix(v.command, "\"") == false  { // need to surround path with double-quotes (path doesn't include space)
+        if strings.Contains(v.command, " ") { // add quote after path, before space and arguments
+            v.command = strings.Replace(v.command, " ", "\" ", 1)
+            v.command = "\"" + v.command
+        } else {
+            v.command = "\"" + v.command + "\""
+        }
+    }
 
 	words, err := shellquote.Split(v.command)
 	if err != nil {

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -57,14 +57,14 @@ func (v External) Archive(filePath string) error {
 	if v.command == "" {
 		return errors.New("Versioner: command is empty, please enter a valid command")
 	}
-	if strings.HasPrefix(v.command, "\"") == false { // need to surround path with double-quotes (path doesn't include space)
+	if strings.HasPrefix(v.command, "'") == false && strings.HasPrefix(v.command, "\"") == false { // need to quote a path (it doesn't include space)
 		if strings.Contains(v.command, " ") { // add quote after path, before space and arguments
-			v.command = strings.Replace(v.command, " ", "\" ", 1)
-			v.command = "\"" + v.command
+			v.command = strings.Replace(v.command, " ", "' ", 1)
+			v.command = "'" + v.command
 		} else {
-			v.command = "\"" + v.command + "\""
+			v.command = "'" + v.command + "'"
 		}
-	}
+    }
 
 	words, err := shellquote.Split(v.command)
 	if err != nil {

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -29,7 +29,9 @@ type External struct {
 
 func NewExternal(folderID string, filesystem fs.Filesystem, params map[string]string) Versioner {
 	command := params["command"]
-
+	if runtime.GOOS == "windows" {
+		command = strings.Replace(command, `\`, `\\`, -1)
+	}
 	s := External{
 		command:    command,
 		filesystem: filesystem,
@@ -56,14 +58,6 @@ func (v External) Archive(filePath string) error {
 
 	if v.command == "" {
 		return errors.New("Versioner: command is empty, please enter a valid command")
-	}
-	if strings.HasPrefix(v.command, "'") == false && strings.HasPrefix(v.command, "\"") == false { // need to quote a path (it doesn't include space)
-		if strings.Contains(v.command, " ") { // add quote after path, before space and arguments
-			v.command = strings.Replace(v.command, " ", "' ", 1)
-			v.command = "'" + v.command
-		} else {
-			v.command = "'" + v.command + "'"
-		}
 	}
 
 	words, err := shellquote.Split(v.command)

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/syncthing/syncthing/lib/fs"
@@ -29,9 +30,11 @@ type External struct {
 
 func NewExternal(folderID string, filesystem fs.Filesystem, params map[string]string) Versioner {
 	command := params["command"]
+
 	if runtime.GOOS == "windows" {
 		command = strings.Replace(command, `\`, `\\`, -1)
 	}
+
 	s := External{
 		command:    command,
 		filesystem: filesystem,
@@ -54,6 +57,7 @@ func (v External) Archive(filePath string) error {
 	if info.IsSymlink() {
 		panic("bug: attempting to version a symlink")
 	}
+
 	l.Debugln("archiving", filePath)
 
 	if v.command == "" {

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -57,14 +57,14 @@ func (v External) Archive(filePath string) error {
 	if v.command == "" {
 		return errors.New("Versioner: command is empty, please enter a valid command")
 	}
-    if strings.HasPrefix(v.command, "\"") == false  { // need to surround path with double-quotes (path doesn't include space)
-        if strings.Contains(v.command, " ") { // add quote after path, before space and arguments
-            v.command = strings.Replace(v.command, " ", "\" ", 1)
-            v.command = "\"" + v.command
-        } else {
-            v.command = "\"" + v.command + "\""
-        }
-    }
+	if strings.HasPrefix(v.command, "\"") == false { // need to surround path with double-quotes (path doesn't include space)
+		if strings.Contains(v.command, " ") { // add quote after path, before space and arguments
+			v.command = strings.Replace(v.command, " ", "\" ", 1)
+			v.command = "\"" + v.command
+		} else {
+			v.command = "\"" + v.command + "\""
+		}
+	}
 
 	words, err := shellquote.Split(v.command)
 	if err != nil {


### PR DESCRIPTION
### Purpose

Substitute '\\' with '/' in paths in External File Versionining (fixes #4560). Spaces are handled correctly. When the variable is read in back-end (Go file), the '\\' is already parsed, hence substitution is done in front-end.

Edit: I was wrong, we can see unparsed input in .go file as well
### Testing

I've just changed path separator from Windows-style to Linux-style. Both separators work well on Windows, so there is no need to test.

### Documentation

Previously documentation didn't work, now it will.
