### PR TITLE
Test and fix added for cases where the the root folder path is linked to via …

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -90,6 +90,7 @@ Michael Jephcote (Rewt0r) <rewt0r@gmx.com> <Rewt0r@users.noreply.github.com>
 Michael Ploujnikov (plouj) <ploujj@gmail.com>
 Michael Tilli (pyfisch) <pyfisch@gmail.com>
 Nate Morrison (nrm21) <natemorrison@gmail.com>
+Nicholas Rishel (PrototypeNM1) <PrototypeNM1@users.noreply.github.com>
 Niels Peter Roest (Niller303) <nielsproest@hotmail.com> <seje.niels@hotmail.com>
 Pascal Jungblut (pascalj) <github@pascalj.com> <mail@pascal-jungblut.com>
 Pawel Palenica (qepasa) <pawelpalenica11@gmail.com>

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -29,6 +29,33 @@ type BasicFilesystem struct {
 }
 
 func newBasicFilesystem(root string) *BasicFilesystem {
+	root = cleanRoot(root)
+
+	// Check if root is a symlink to a directory
+	// filepath.EvalSymlinks does not support windows long filenames as of Go 1.9.2
+	// thus symlink traversal needs to occur before adding long filename support
+	if symTarget, err := checkRootSymlink(root); err == nil {
+		root = cleanRoot(symTarget)
+	}
+
+	// Attempt to enable long filename support on Windows. We may still not
+	// have an absolute path here if the previous steps failed.
+	if runtime.GOOS == "windows" {
+		if filepath.IsAbs(root) && !strings.HasPrefix(root, `\\`) {
+			root = `\\?\` + root
+		}
+		// If we're not on Windows, we want the path to end with a slash to
+		// penetrate symlinks. On Windows, paths must not end with a slash.
+	} else if root[len(root)-1] != filepath.Separator {
+		root = root + string(filepath.Separator)
+	}
+
+	return &BasicFilesystem{
+		root: root,
+	}
+}
+
+func cleanRoot(root string) string {
 	// The reason it's done like this:
 	// C:          ->  C:\            ->  C:\        (issue that this is trying to fix)
 	// C:\somedir  ->  C:\somedir\    ->  C:\somedir
@@ -52,21 +79,36 @@ func newBasicFilesystem(root string) *BasicFilesystem {
 		}
 	}
 
-	// Attempt to enable long filename support on Windows. We may still not
-	// have an absolute path here if the previous steps failed.
-	if runtime.GOOS == "windows" {
-		if filepath.IsAbs(root) && !strings.HasPrefix(root, `\\`) {
-			root = `\\?\` + root
-		}
-		// If we're not on Windows, we want the path to end with a slash to
-		// penetrate symlinks. On Windows, paths must not end with a slash.
-	} else if root[len(root)-1] != filepath.Separator {
-		root = root + string(filepath.Separator)
+	return root
+}
+
+func checkRootSymlink(root string) (string, error) {
+	// Check if root is a symlink
+	info, infoErr := underlyingLstat(root)
+	if infoErr != nil {
+		return root, infoErr
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return root, errors.New("Not a symlink")
 	}
 
-	return &BasicFilesystem{
-		root: root,
+	// Find target of the symlink
+	// NOTE: does not support Windows long filenames as of Go 1.9.2
+	target, targetErr := filepath.EvalSymlinks(root)
+	if targetErr != nil {
+		return root, targetErr
 	}
+
+	// Verify the target is a directory
+	targetInfo, targetInfoErr := underlyingLstat(target)
+	if targetInfoErr != nil {
+		return root, targetInfoErr
+	}
+	if targetInfo.IsDir() {
+		// Successfully found target directory
+		return target, nil
+	}
+	return root, errors.New("Symlink is not a directory")
 }
 
 // rooted expands the relative path to the full path that is then used with os

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -29,33 +29,6 @@ type BasicFilesystem struct {
 }
 
 func newBasicFilesystem(root string) *BasicFilesystem {
-	root = cleanRoot(root)
-
-	// Check if root is a symlink to a directory
-	// filepath.EvalSymlinks does not support windows long filenames as of Go 1.9.2
-	// thus symlink traversal needs to occur before adding long filename support
-	if symTarget, err := checkRootSymlink(root); err == nil {
-		root = cleanRoot(symTarget)
-	}
-
-	// Attempt to enable long filename support on Windows. We may still not
-	// have an absolute path here if the previous steps failed.
-	if runtime.GOOS == "windows" {
-		if filepath.IsAbs(root) && !strings.HasPrefix(root, `\\`) {
-			root = `\\?\` + root
-		}
-		// If we're not on Windows, we want the path to end with a slash to
-		// penetrate symlinks. On Windows, paths must not end with a slash.
-	} else if root[len(root)-1] != filepath.Separator {
-		root = root + string(filepath.Separator)
-	}
-
-	return &BasicFilesystem{
-		root: root,
-	}
-}
-
-func cleanRoot(root string) string {
 	// The reason it's done like this:
 	// C:          ->  C:\            ->  C:\        (issue that this is trying to fix)
 	// C:\somedir  ->  C:\somedir\    ->  C:\somedir
@@ -79,36 +52,21 @@ func cleanRoot(root string) string {
 		}
 	}
 
-	return root
-}
-
-func checkRootSymlink(root string) (string, error) {
-	// Check if root is a symlink
-	info, infoErr := underlyingLstat(root)
-	if infoErr != nil {
-		return root, infoErr
-	}
-	if info.Mode()&os.ModeSymlink == 0 {
-		return root, errors.New("Not a symlink")
-	}
-
-	// Find target of the symlink
-	// NOTE: does not support Windows long filenames as of Go 1.9.2
-	target, targetErr := filepath.EvalSymlinks(root)
-	if targetErr != nil {
-		return root, targetErr
+	// Attempt to enable long filename support on Windows. We may still not
+	// have an absolute path here if the previous steps failed.
+	if runtime.GOOS == "windows" {
+		if filepath.IsAbs(root) && !strings.HasPrefix(root, `\\`) {
+			root = `\\?\` + root
+		}
+		// If we're not on Windows, we want the path to end with a slash to
+		// penetrate symlinks. On Windows, paths must not end with a slash.
+	} else if root[len(root)-1] != filepath.Separator {
+		root = root + string(filepath.Separator)
 	}
 
-	// Verify the target is a directory
-	targetInfo, targetInfoErr := underlyingLstat(target)
-	if targetInfoErr != nil {
-		return root, targetInfoErr
+	return &BasicFilesystem{
+		root: root,
 	}
-	if targetInfo.IsDir() {
-		// Successfully found target directory
-		return target, nil
-	}
-	return root, errors.New("Symlink is not a directory")
 }
 
 // rooted expands the relative path to the full path that is then used with os

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -32,10 +32,10 @@ func newBasicFilesystem(root string) *BasicFilesystem {
 	root = cleanRoot(root)
 
 	// Check if root is a symlink to a directory
-	// NOTE: filepath.EvalSymlinks does not support Windows long filenames as of Go 1.9.2
+	// filepath.EvalSymlinks does not support windows long filenames as of Go 1.9.2
 	// thus symlink traversal needs to occur before adding long filename support
-	if target, err := filepath.EvalSymlinks(root); err == nil {
-		root = cleanRoot(target)
+	if symTarget, err := checkRootSymlink(root); err == nil {
+		root = cleanRoot(symTarget)
 	}
 
 	// Attempt to enable long filename support on Windows. We may still not
@@ -80,6 +80,35 @@ func cleanRoot(root string) string {
 	}
 
 	return root
+}
+
+func checkRootSymlink(root string) (string, error) {
+	// Check if root is a symlink
+	info, infoErr := underlyingLstat(root)
+	if infoErr != nil {
+		return root, infoErr
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		return root, errors.New("Not a symlink")
+	}
+
+	// Find target of the symlink
+	// NOTE: does not support Windows long filenames as of Go 1.9.2
+	target, targetErr := filepath.EvalSymlinks(root)
+	if targetErr != nil {
+		return root, targetErr
+	}
+
+	// Verify the target is a directory
+	targetInfo, targetInfoErr := underlyingLstat(target)
+	if targetInfoErr != nil {
+		return root, targetInfoErr
+	}
+	if targetInfo.IsDir() {
+		// Successfully found target directory
+		return target, nil
+	}
+	return root, errors.New("Symlink is not a directory")
 }
 
 // rooted expands the relative path to the full path that is then used with os

--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -79,10 +79,9 @@ func (f *walkFilesystem) walk(path string, info FileInfo, walkFn WalkFunc) error
 // and directories are filtered by walkFn. The files are walked in lexical
 // order, which makes the output deterministic but means that for very
 // large directories Walk can be inefficient.
-// Walk follows root symbolic links (in all cases on Windows, with trailing
-// '/' on *nix).
+// Walk does not follow symbolic links.
 func (f *walkFilesystem) Walk(root string, walkFn WalkFunc) error {
-	info, err := f.Stat(root)
+	info, err := f.Lstat(root)
 	if err != nil {
 		return walkFn(root, nil, err)
 	}

--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -46,7 +46,7 @@ func (f *walkFilesystem) walk(path string, info FileInfo, walkFn WalkFunc) error
 		return err
 	}
 
-	if !info.IsDir() {
+	if !info.IsDir() && path != "." {
 		return nil
 	}
 

--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -79,9 +79,10 @@ func (f *walkFilesystem) walk(path string, info FileInfo, walkFn WalkFunc) error
 // and directories are filtered by walkFn. The files are walked in lexical
 // order, which makes the output deterministic but means that for very
 // large directories Walk can be inefficient.
-// Walk does not follow symbolic links.
+// Walk follows root symbolic links (in all cases on Windows, with trailing
+// '/' on *nix).
 func (f *walkFilesystem) Walk(root string, walkFn WalkFunc) error {
-	info, err := f.Lstat(root)
+	info, err := f.Stat(root)
 	if err != nil {
 		return walkFn(root, nil, err)
 	}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2071,7 +2071,7 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 		})
 
 		if iterError != nil {
-			l.Debugln("Stopping scan of folder %s due to: %s", folderCfg.Description(), err)
+			l.Debugln("Stopping scan of folder %s due to: %s", folderCfg.Description(), iterError)
 			return iterError
 		}
 	}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1970,6 +1970,10 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 		UseWeakHashes:         weakhash.Enabled,
 	})
 
+	if err := runner.CheckHealth(); err != nil {
+		return err
+	}
+
 	batch := make([]protocol.FileInfo, 0, maxBatchSizeFiles)
 	batchSizeBytes := 0
 	changes := 0

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1954,7 +1954,7 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 
 	runner.setState(FolderScanning)
 
-	fchan, err := scanner.Walk(ctx, scanner.Config{
+	fchan := scanner.Walk(ctx, scanner.Config{
 		Folder:                folderCfg.ID,
 		Subs:                  subDirs,
 		Matcher:               ignores,
@@ -1969,17 +1969,6 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 		ProgressTickIntervalS: folderCfg.ScanProgressIntervalS,
 		UseWeakHashes:         weakhash.Enabled,
 	})
-
-	if err != nil {
-		// The error we get here is likely an OS level error, which might not be
-		// as readable as our health check errors. Check if we can get a health
-		// check error first, and use that if it's available.
-		if ferr := runner.CheckHealth(); ferr != nil {
-			err = ferr
-		}
-		runner.setError(err)
-		return err
-	}
 
 	batch := make([]protocol.FileInfo, 0, maxBatchSizeFiles)
 	batchSizeBytes := 0

--- a/lib/scanner/infinitefs_test.go
+++ b/lib/scanner/infinitefs_test.go
@@ -31,6 +31,10 @@ func (i infiniteFS) Lstat(name string) (fs.FileInfo, error) {
 	return fakeInfo{name, i.filesize}, nil
 }
 
+func (i infiniteFS) Stat(name string) (fs.FileInfo, error) {
+	return fakeInfo{name, i.filesize}, nil
+}
+
 func (i infiniteFS) DirNames(name string) ([]string, error) {
 	// Returns a list of fake files and directories. Names are such that
 	// files appear before directories - this makes it so the scanner will

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -100,10 +100,6 @@ type walker struct {
 func (w *walker) walk(ctx context.Context) (chan protocol.FileInfo, error) {
 	l.Debugln("Walk", w.Subs, w.BlockSize, w.Matcher)
 
-	if err := w.checkDir(); err != nil {
-		return nil, err
-	}
-
 	toHashChan := make(chan protocol.FileInfo)
 	finishedChan := make(chan protocol.FileInfo)
 
@@ -477,17 +473,6 @@ func (w *walker) normalizePath(path string, info fs.FileInfo) (normPath string, 
 	}
 
 	return normPath, false
-}
-
-func (w *walker) checkDir() error {
-	info, err := w.Filesystem.Lstat(".")
-	if err != nil {
-		return err
-	}
-
-	l.Debugln("checkDir", w.Filesystem.Type(), w.Filesystem.URI(), info)
-
-	return nil
 }
 
 func PermsEqual(a, b uint32) bool {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -8,7 +8,6 @@ package scanner
 
 import (
 	"context"
-	"errors"
 	"runtime"
 	"sync/atomic"
 	"time"
@@ -484,10 +483,6 @@ func (w *walker) checkDir() error {
 	info, err := w.Filesystem.Lstat(".")
 	if err != nil {
 		return err
-	}
-
-	if !info.IsDir() {
-		return errors.New(w.Filesystem.URI() + ": not a directory")
 	}
 
 	l.Debugln("checkDir", w.Filesystem.Type(), w.Filesystem.URI(), info)

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -75,7 +75,7 @@ type CurrentFiler interface {
 	CurrentFile(name string) (protocol.FileInfo, bool)
 }
 
-func Walk(ctx context.Context, cfg Config) (chan protocol.FileInfo, error) {
+func Walk(ctx context.Context, cfg Config) chan protocol.FileInfo {
 	w := walker{cfg}
 
 	if w.CurrentFiler == nil {
@@ -97,7 +97,7 @@ type walker struct {
 
 // Walk returns the list of files found in the local folder by scanning the
 // file system. Files are blockwise hashed.
-func (w *walker) walk(ctx context.Context) (chan protocol.FileInfo, error) {
+func (w *walker) walk(ctx context.Context) chan protocol.FileInfo {
 	l.Debugln("Walk", w.Subs, w.BlockSize, w.Matcher)
 
 	toHashChan := make(chan protocol.FileInfo)
@@ -121,7 +121,7 @@ func (w *walker) walk(ctx context.Context) (chan protocol.FileInfo, error) {
 	// and feed inputs directly from the walker.
 	if w.ProgressTickIntervalS < 0 {
 		newParallelHasher(ctx, w.Filesystem, w.BlockSize, w.Hashers, finishedChan, toHashChan, nil, nil, w.UseWeakHashes)
-		return finishedChan, nil
+		return finishedChan
 	}
 
 	// Defaults to every 2 seconds.
@@ -193,7 +193,7 @@ func (w *walker) walk(ctx context.Context) (chan protocol.FileInfo, error) {
 		close(realToHashChan)
 	}()
 
-	return finishedChan, nil
+	return finishedChan
 }
 
 func (w *walker) walkAndHashFiles(ctx context.Context, fchan, dchan chan protocol.FileInfo) fs.WalkFunc {

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -334,7 +334,7 @@ func TestWalkRootSymlinkUnix(t *testing.T) {
 		return
 	}
 
-	// Create a folder with a symlink in it
+	// Create a folder with a symlink to it
 
 	destination := "destination"
 	link := "link"

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -12,6 +12,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -368,17 +369,22 @@ func TestWalkSymlinkWindows(t *testing.T) {
 }
 
 func TestWalkRootSymlink(t *testing.T) {
+	// Create a folder with a symlink in it
+	tmp, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
 
-	// Create a folder with a symlink to it
-
-	link := "link"
-
-	os.Remove(link)
-	defer os.Remove(link)
-
-	if err := osutil.DebugSymlinkForTestsOnly("testdata/dir1", link); err != nil && runtime.GOOS == "windows" {
-		// Probably we require permissions we don't have.
-		t.Skip("Need admin permissions or developer mode to run symlink test on Windows: " + err.Error())
+	link := tmp + "/link"
+	dest, _ := filepath.Abs("testdata/dir1")
+	if err := osutil.DebugSymlinkForTestsOnly(dest, link); err != nil {
+		if runtime.GOOS == "windows" {
+			// Probably we require permissions we don't have.
+			t.Skip("Need admin permissions or developer mode to run symlink test on Windows: " + err.Error())
+		} else {
+			t.Fatal(err)
+		}
 	}
 
 	// Scan it

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -382,20 +382,12 @@ func TestWalkRootSymlink(t *testing.T) {
 	}
 
 	// Scan it
-
-	fchan, err := Walk(context.TODO(), Config{
-		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, link),
-		BlockSize:  128 * 1024,
-	})
+	files, err := walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, link), ".")
 
 	if err != nil {
 		t.Error("Expected no error when root folder path is provided via a symlink: " + err.Error())
 	}
 
-	var files []protocol.FileInfo
-	for f := range fchan {
-		files = append(files, f)
-	}
 
 	// Verify that we got two files
 

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -62,7 +62,7 @@ func TestWalkSub(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fchan, err := Walk(context.TODO(), Config{
+	fchan := Walk(context.TODO(), Config{
 		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, "testdata"),
 		Subs:       []string{"dir2"},
 		BlockSize:  128 * 1024,
@@ -72,9 +72,6 @@ func TestWalkSub(t *testing.T) {
 	var files []protocol.FileInfo
 	for f := range fchan {
 		files = append(files, f)
-	}
-	if err != nil {
-		t.Fatal(err)
 	}
 
 	// The directory contains two files, where one is ignored from a higher
@@ -99,16 +96,12 @@ func TestWalk(t *testing.T) {
 	}
 	t.Log(ignores)
 
-	fchan, err := Walk(context.TODO(), Config{
+	fchan := Walk(context.TODO(), Config{
 		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, "testdata"),
 		BlockSize:  128 * 1024,
 		Matcher:    ignores,
 		Hashers:    2,
 	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var tmp []protocol.FileInfo
 	for f := range fchan {
@@ -281,14 +274,10 @@ func TestWalkSymlinkUnix(t *testing.T) {
 
 	// Scan it
 
-	fchan, err := Walk(context.TODO(), Config{
+	fchan := Walk(context.TODO(), Config{
 		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, "_symlinks"),
 		BlockSize:  128 * 1024,
 	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var files []protocol.FileInfo
 	for f := range fchan {
@@ -326,14 +315,10 @@ func TestWalkSymlinkWindows(t *testing.T) {
 
 	// Scan it
 
-	fchan, err := Walk(context.TODO(), Config{
+	fchan := Walk(context.TODO(), Config{
 		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, "_symlinks"),
 		BlockSize:  128 * 1024,
 	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	var files []protocol.FileInfo
 	for f := range fchan {
@@ -378,17 +363,13 @@ func TestWalkRootSymlink(t *testing.T) {
 }
 
 func walkDir(fs fs.Filesystem, dir string) ([]protocol.FileInfo, error) {
-	fchan, err := Walk(context.TODO(), Config{
+	fchan := Walk(context.TODO(), Config{
 		Filesystem:    fs,
 		Subs:          []string{dir},
 		BlockSize:     128 * 1024,
 		AutoNormalize: true,
 		Hashers:       2,
 	})
-
-	if err != nil {
-		return nil, err
-	}
 
 	var tmp []protocol.FileInfo
 	for f := range fchan {
@@ -488,16 +469,12 @@ func TestStopWalk(t *testing.T) {
 
 	const numHashers = 4
 	ctx, cancel := context.WithCancel(context.Background())
-	fchan, err := Walk(ctx, Config{
+	fchan := Walk(ctx, Config{
 		Filesystem:            fs,
 		BlockSize:             128 * 1024,
 		Hashers:               numHashers,
 		ProgressTickIntervalS: -1, // Don't attempt to build the full list of files before starting to scan...
 	})
-
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	// Receive a few entries to make sure the walker is up and running,
 	// scanning both files and dirs. Do some quick sanity tests on the

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -122,27 +122,6 @@ func TestWalk(t *testing.T) {
 	}
 }
 
-func TestWalkError(t *testing.T) {
-	_, err := Walk(context.TODO(), Config{
-		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, "testdata-missing"),
-		BlockSize:  128 * 1024,
-		Hashers:    2,
-	})
-
-	if err == nil {
-		t.Error("no error from missing directory")
-	}
-
-	_, err = Walk(context.TODO(), Config{
-		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, "testdata/bar"),
-		BlockSize:  128 * 1024,
-	})
-
-	if err == nil {
-		t.Error("no error from non-directory")
-	}
-}
-
 func TestVerify(t *testing.T) {
 	blocksize := 16
 	// data should be an even multiple of blocksize long

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -389,14 +389,10 @@ func TestWalkRootSymlink(t *testing.T) {
 
 	// Scan it
 	files, err := walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, link), ".")
-
 	if err != nil {
-		t.Error("Expected no error when root folder path is provided via a symlink: " + err.Error())
+		t.Fatal("Expected no error when root folder path is provided via a symlink: " + err.Error())
 	}
-
-
 	// Verify that we got two files
-
 	if len(files) != 2 {
 		t.Errorf("expected two files, not %d", len(files))
 	}

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -378,7 +378,7 @@ func TestWalkRootSymlink(t *testing.T) {
 
 	link := tmp + "/link"
 	dest, _ := filepath.Abs("testdata/dir1")
-	if err := osutil.DebugSymlinkForTestsOnly(dest, link); err != nil {
+	if err := os.Symlink(dest, link); err != nil {
 		if runtime.GOOS == "windows" {
 			// Probably we require permissions we don't have.
 			t.Skip("Need admin permissions or developer mode to run symlink test on Windows: " + err.Error())

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -378,7 +378,7 @@ func TestWalkRootSymlink(t *testing.T) {
 
 	link := tmp + "/link"
 	dest, _ := filepath.Abs("testdata/dir1")
-	if err := os.Symlink(dest, link); err != nil {
+	if err := osutil.DebugSymlinkForTestsOnly(dest, link); err != nil {
 		if runtime.GOOS == "windows" {
 			// Probably we require permissions we don't have.
 			t.Skip("Need admin permissions or developer mode to run symlink test on Windows: " + err.Error())

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -328,37 +328,6 @@ func TestWalkSymlinkUnix(t *testing.T) {
 	}
 }
 
-func TestWalkRootSymlinkUnix(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping unsupported symlink test")
-		return
-	}
-
-	// Create a folder with a symlink to it
-
-	destination := "destination"
-	link := "link"
-
-	os.RemoveAll(destination)
-	defer os.RemoveAll(destination)
-	os.Remove(link)
-	defer os.Remove(link)
-
-	os.Mkdir(destination, 0755)
-	os.Symlink(destination, link)
-
-	// Scan it
-
-	_, err := Walk(context.TODO(), Config{
-		Filesystem: fs.NewFilesystem(fs.FilesystemTypeBasic, link),
-		BlockSize:  128 * 1024,
-	})
-
-	if err != nil {
-		t.Error("Expected no error when root folder path is provided via a symlink: " + err.Error())
-	}
-}
-
 func TestWalkSymlinkWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
 		t.Skip("skipping unsupported symlink test")
@@ -398,10 +367,7 @@ func TestWalkSymlinkWindows(t *testing.T) {
 	}
 }
 
-func TestWalkRootSymlinkWindows(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("skipping unsupported symlink test")
-	}
+func TestWalkRootSymlink(t *testing.T) {
 
 	// Create a folder with a symlink to it
 
@@ -414,9 +380,9 @@ func TestWalkRootSymlinkWindows(t *testing.T) {
 	defer os.Remove(link)
 
 	os.Mkdir(destination, 0755)
-	if err := osutil.DebugSymlinkForTestsOnly(destination, link); err != nil {
+	if err := osutil.DebugSymlinkForTestsOnly(destination, link); err != nil && runtime.GOOS == "windows" {
 		// Probably we require permissions we don't have.
-		t.Skip(err)
+		t.Skip("Need admin permissions or developer mode to run symlink test on Windows: " + err.Error())
 	}
 
 	// Scan it


### PR DESCRIPTION
…a symlink for *nix and Windows.

Signed-off-by: Nicholas Rishel <PrototypeNM1@users.noreply.github.com>

### Purpose

Requested by @AudriusButkevicius in #4353 to demonstrate symlinks to the root sync directory failing on Windows. Opened the pull request to get feedback and direction, not expecting the code to be merged as-is.

### Testing

Open Windows command line as administrator for symlink creation privileges (admin redundant if you're running W10 in developer mode). Run `go run build.go test` and look for the error `Expected no error when root folder path is provided via a symlink: ...` If there is a way to run the walk.go tests more directly please let me know.

### Note

I only got as far as verifying the issue in the walk.go code, but I'm guessing this isn't the primary problem. Just as a test I added an !info.IsSymlink() check at https://github.com/syncthing/syncthing/blob/14df5211af7c4a6a3b0defd427173939fc78cebd/lib/scanner/walk.go#L489 (not committed) which successfully silenced the error but did not allow files to sync.