### PR TITLE
lib/model: Microoptimization of unifySubs and blockDiff

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2786,7 +2786,7 @@ func unifySubs(dirs []string, exists func(dir string) bool) []string {
 			continue
 		}
 		parent := filepath.Dir(dir)
-		for !(exists(parent) || parent == "." || parent == string(fs.PathSeparator)) {
+		for !exists(parent) && parent != "." && parent != string(fs.PathSeparator) {
 			dir = parent
 			parent = filepath.Dir(dir)
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2778,11 +2778,11 @@ func unifySubs(dirs []string, exists func(dir string) bool) []string {
 	if dirs[0] == "" || dirs[0] == "." || dirs[0] == string(fs.PathSeparator) {
 		return nil
 	}
-	unified := dirs[:0]
 	prev := "./" // Anything that can't be parent of a clean path
-	for _, dir := range dirs {
-		dir = filepath.Clean(dir)
+	for i := 0; i < len(dirs); {
+		dir := filepath.Clean(dirs[i])
 		if dir == prev || strings.HasPrefix(dir, prev+string(fs.PathSeparator)) {
+			dirs = append(dirs[:i], dirs[i+1:]...)
 			continue
 		}
 		parent := filepath.Dir(dir)
@@ -2790,10 +2790,11 @@ func unifySubs(dirs []string, exists func(dir string) bool) []string {
 			dir = parent
 			parent = filepath.Dir(dir)
 		}
-		unified = append(unified, dir)
+		dirs[i] = dir
 		prev = dir
+		i++
 	}
-	return unified
+	return dirs
 }
 
 // makeForgetUpdate takes an index update and constructs a download progress update

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2786,7 +2786,7 @@ func unifySubs(dirs []string, exists func(dir string) bool) []string {
 			continue
 		}
 		parent := filepath.Dir(dir)
-		for !exists(parent) && parent != "." && parent != string(fs.PathSeparator) {
+		for parent != "." && parent != string(fs.PathSeparator) && !exists(parent) {
 			dir = parent
 			parent = filepath.Dir(dir)
 		}

--- a/lib/model/rwfolder_test.go
+++ b/lib/model/rwfolder_test.go
@@ -692,6 +692,22 @@ func TestDiff(t *testing.T) {
 	}
 }
 
+func BenchmarkDiff(b *testing.B) {
+	testCases := make([]struct{ a, b []protocol.BlockInfo }, 0, len(diffTestData))
+	for _, test := range diffTestData {
+		a, _ := scanner.Blocks(context.TODO(), bytes.NewBufferString(test.a), test.s, -1, nil, false)
+		b, _ := scanner.Blocks(context.TODO(), bytes.NewBufferString(test.b), test.s, -1, nil, false)
+		testCases = append(testCases, struct{ a, b []protocol.BlockInfo }{a, b})
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, tc := range testCases {
+			blockDiff(tc.a, tc.b)
+		}
+	}
+}
+
 func TestDiffEmpty(t *testing.T) {
 	emptyCases := []struct {
 		a    []protocol.BlockInfo


### PR DESCRIPTION
Recently unnecessary allocs came up in some comments and I noticed some in the code. This "optimization" is cosmetic and the benchmarks are definitely over the top, but as I have already written them out, why not keep it. Also I personally consider the rewritten `unifySubs` simpler.

```
BenchmarkUnifySubs-4      200000              7947 ns/op            1008 B/op        36 allocs/op
BenchmarkUnifySubs-4      500000              3143 ns/op             256 B/op         8 allocs/op

BenchmarkDiff-4           300000              5334 ns/op            1920 B/op        27 allocs/op
BenchmarkDiff-4           300000              5013 ns/op            2592 B/op        24 allocs/op
```