### PR TITLE
lib/upgrade: Always return latest version, even if older than current (fixes #4654)

### DIFF
--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -134,34 +134,25 @@ func SelectLatestRelease(rels []Release, current string, upgradeToPreReleases bo
 
 	var selected Release
 	for _, rel := range rels {
-		switch CompareVersions(rel.Tag, current) {
-		case Older, MajorOlder:
-			// This is older than what we're already running
-			continue
-
-		case MajorNewer:
+		if CompareVersions(rel.Tag, current) == MajorNewer {
 			// We've found a new major version. That's fine, but if we've
 			// already found a minor upgrade that is acceptable we should go
 			// with that one first and then revisit in the future.
 			if selected.Tag != "" && CompareVersions(selected.Tag, current) == Newer {
 				return selected, nil
 			}
-			// else it may be viable, do the needful below
-
-		default:
-			// New minor release, do the usual processing
 		}
 
 		if rel.Prerelease && !upgradeToPreReleases {
+			l.Debugln("skipping pre-release", rel.Tag)
 			continue
 		}
 		for _, asset := range rel.Assets {
 			assetName := path.Base(asset.Name)
 			// Check for the architecture
 			expectedRelease := releaseName(rel.Tag)
-			l.Debugf("expected release asset %q", expectedRelease)
-			l.Debugln("considering release", assetName)
 			if strings.HasPrefix(assetName, expectedRelease) {
+				l.Debugln("selected", rel.Tag)
 				selected = rel
 			}
 		}


### PR DESCRIPTION
The only special check remaining is the one to prefer a minor upgrade over a major one.

### Purpose

Fix the case where RCs error out because they are set not to upgrade to RCs and the only other available releases are older and filtered out.

### Testing

The current latest release is 0.14.43. I tested compiling this as 0.14.42, 0.14.43-rc.1, 0.14.43, 0.14.43-rc.1, 0.14.44 and verified that the upgrade happened for 0.14.42, 0.14.43-rc.1 and no error thrown (or erroneous downgrades) on the others.
