### PR TITLE
cmd/syncthing, lib/sync: Don't do deadlock detection when STDEADLOCKTIMEOUT=0 (fixes #4644)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -770,10 +770,9 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	m := model.NewModel(cfg, myID, "syncthing", Version, ldb, protectedFiles)
 
-	if t := os.Getenv("STDEADLOCKTIMEOUT"); len(t) > 0 {
-		it, err := strconv.Atoi(t)
-		if err == nil {
-			m.StartDeadlockDetector(time.Duration(it) * time.Second)
+	if t := os.Getenv("STDEADLOCKTIMEOUT"); t != "" {
+		if secs, _ := strconv.Atoi(t); secs > 0 {
+			m.StartDeadlockDetector(time.Duration(secs) * time.Second)
 		}
 	} else if !IsRelease || IsBeta {
 		m.StartDeadlockDetector(20 * time.Minute)

--- a/lib/sync/debug.go
+++ b/lib/sync/debug.go
@@ -24,17 +24,20 @@ var (
 	// }" variable, as it may be rather performance critical and does
 	// nonstandard things (from a debug logging PoV).
 	debug       = strings.Contains(os.Getenv("STTRACE"), "sync") || os.Getenv("STTRACE") == "all"
-	useDeadlock = os.Getenv("STDEADLOCKTIMEOUT") != ""
+	useDeadlock = false
 )
 
 func init() {
 	l.SetDebug("sync", strings.Contains(os.Getenv("STTRACE"), "sync") || os.Getenv("STTRACE") == "all")
 
-	if n, err := strconv.Atoi(os.Getenv("STLOCKTHRESHOLD")); err == nil {
+	if n, _ := strconv.Atoi(os.Getenv("STLOCKTHRESHOLD")); n > 0 {
 		threshold = time.Duration(n) * time.Millisecond
 	}
-	if n, err := strconv.Atoi(os.Getenv("STDEADLOCKTIMEOUT")); err == nil {
-		deadlock.Opts.DeadlockTimeout = time.Duration(n) * time.Second
-	}
 	l.Debugf("Enabling lock logging at %v threshold", threshold)
+
+	if n, _ := strconv.Atoi(os.Getenv("STDEADLOCKTIMEOUT")); n > 0 {
+		deadlock.Opts.DeadlockTimeout = time.Duration(n) * time.Second
+		l.Debugf("Enabling lock deadlocking at %v", deadlock.Opts.DeadlockTimeout)
+		useDeadlock = true
+	}
 }


### PR DESCRIPTION
Allows setting STDEADLOCKTIMEOUT =0 (or any integer <= 0) to disable the deadlock detection entirely.

### Testing

I ran it with `STTRACE=sync STDEADLOCKTIMEOUT=<various>` and the output seemed like what I expected.