### PR TITLE
cmd/syncthing, lib/config, lib/osutil: Lower process priority (fixes #4628)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -916,8 +916,9 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	cleanConfigDirectory()
 
 	if cfg.Options().SetLowPriority {
-		// This is best effort and we ignore failures.
-		osutil.SetLowPriority()
+		if err := osutil.SetLowPriority(); err != nil {
+			l.Warnln("Lowering process priority:", err)
+		}
 	}
 
 	code := <-stop

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -917,7 +917,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	if cfg.Options().SetLowPriority {
 		if err := osutil.SetLowPriority(); err != nil {
-			l.Warnln("Lowering process priority:", err)
+			l.Warnln("Failed to lower process priority:", err)
 		}
 	}
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -915,6 +915,11 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	cleanConfigDirectory()
 
+	if cfg.Options().SetLowPriority {
+		// This is best effort and we ignore failures.
+		osutil.SetLowPriority()
+	}
+
 	code := <-stop
 
 	mainService.Stop()

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -76,6 +76,7 @@ func TestDefaultValues(t *testing.T) {
 		KCPUpdateIntervalMs:     25,
 		KCPFastResend:           false,
 		DefaultFolderPath:       "~",
+		SetLowPriority:          true,
 	}
 
 	cfg := New(device1)
@@ -224,6 +225,7 @@ func TestOverriddenValues(t *testing.T) {
 		KCPUpdateIntervalMs:     1000,
 		KCPFastResend:           true,
 		DefaultFolderPath:       "/media/syncthing",
+		SetLowPriority:          false,
 	}
 
 	os.Unsetenv("STNOUPGRADE")

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -143,6 +143,7 @@ type OptionsConfiguration struct {
 	KCPSendWindowSize       int                     `xml:"kcpSendWindowSize" json:"kcpSendWindowSize" default:"128"`
 	KCPReceiveWindowSize    int                     `xml:"kcpReceiveWindowSize" json:"kcpReceiveWindowSize" default:"128"`
 	DefaultFolderPath       string                  `xml:"defaultFolderPath" json:"defaultFolderPath" default:"~"`
+	SetLowPriority          bool                    `xml:"setLowPriority" json:"setLowPriority" default:"true"`
 
 	DeprecatedUPnPEnabled        bool     `xml:"upnpEnabled,omitempty" json:"-"`
 	DeprecatedUPnPLeaseM         int      `xml:"upnpLeaseMinutes,omitempty" json:"-"`

--- a/lib/config/testdata/overridenvalues.xml
+++ b/lib/config/testdata/overridenvalues.xml
@@ -44,5 +44,6 @@
         <kcpUpdateIntervalMs>1000</kcpUpdateIntervalMs>
         <kcpFastResend>true</kcpFastResend>
         <defaultFolderPath>/media/syncthing</defaultFolderPath>
+        <setLowPriority>false</setLowPriority>
     </options>
 </configuration>

--- a/lib/osutil/lowprio_linux.go
+++ b/lib/osutil/lowprio_linux.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2017 The Syncthing Authors.
+// Copyright (C) 2018 The Syncthing Authors.
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
@@ -49,13 +49,13 @@ func SetLowPriority() error {
 	}
 
 	// Process zero is "self", niceness value 9 is something between 0
-	// (default) and 19 (worst priority). Error return ignored.
+	// (default) and 19 (worst priority).
 	if err := syscall.Setpriority(syscall.PRIO_PGRP, 0, 9); err != nil {
 		return errors.Wrap(err, "set niceness")
 	}
 
 	// Best effort, somewhere to the end of the scale (0 through 7 being the
-	// range). Error return ignored.
+	// range).
 	err := ioprioSet(ioprioClassBE, 5)
 	return errors.Wrap(err, "set I/O priority") // wraps nil as nil
 }

--- a/lib/osutil/lowprio_linux.go
+++ b/lib/osutil/lowprio_linux.go
@@ -1,0 +1,54 @@
+// Copyright (C) 2017 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package osutil
+
+import (
+	"os"
+	"syscall"
+)
+
+const ioprioClassShift = 13
+
+type ioprioClass int
+
+const (
+	ioprioClassRT ioprioClass = iota + 1
+	ioprioClassBE
+	ioprioClassIdle
+)
+
+const (
+	ioprioWhoProcess = iota + 1
+	ioprioWhoPGRP
+	ioprioWhoUser
+)
+
+func ioprioSet(class ioprioClass, value int) {
+	// error return ignored
+	syscall.Syscall(syscall.SYS_IOPRIO_SET,
+		uintptr(ioprioWhoPGRP), uintptr(os.Getpid()),
+		uintptr(class)<<ioprioClassShift|uintptr(value))
+}
+
+// SetLowPriority lowers the process CPU scheduling priority, and possibly
+// I/O priority depending on the platform and OS.
+func SetLowPriority() {
+	// Move ourselves to a new process group so that we can use the process
+	// group variants of Setpriority etc to affect all of our threads in one
+	// go. If this fails, bail, so that we don't affect things we shouldn't.
+	if err := syscall.Setpgid(0, 0); err != nil {
+		return
+	}
+
+	// Process zero is "self", niceness value 9 is something between 0
+	// (default) and 19 (worst priority). Error return ignored.
+	syscall.Setpriority(syscall.PRIO_PGRP, 0, 9)
+
+	// Best effort, somewhere to the end of the scale (0 through 7 being the
+	// range). Error return ignored.
+	ioprioSet(ioprioClassBE, 5)
+}

--- a/lib/osutil/lowprio_unix.go
+++ b/lib/osutil/lowprio_unix.go
@@ -1,0 +1,19 @@
+// Copyright (C) 2018 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// +build !windows,!linux
+
+package osutil
+
+import "syscall"
+
+// SetLowPriority lowers the process CPU scheduling priority, and possibly
+// I/O priority depending on the platform and OS.
+func SetLowPriority() {
+	// Process zero is "self", niceness value 9 is something between 0
+	// (default) and 19 (worst priority). Error return ignored.
+	syscall.Setpriority(syscall.PRIO_PROCESS, 0, 9)
+}

--- a/lib/osutil/lowprio_unix.go
+++ b/lib/osutil/lowprio_unix.go
@@ -8,12 +8,17 @@
 
 package osutil
 
-import "syscall"
+import (
+	"syscall"
+
+	"github.com/pkg/errors"
+)
 
 // SetLowPriority lowers the process CPU scheduling priority, and possibly
 // I/O priority depending on the platform and OS.
-func SetLowPriority() {
+func SetLowPriority() error {
 	// Process zero is "self", niceness value 9 is something between 0
-	// (default) and 19 (worst priority). Error return ignored.
-	syscall.Setpriority(syscall.PRIO_PROCESS, 0, 9)
+	// (default) and 19 (worst priority).
+	err := syscall.Setpriority(syscall.PRIO_PROCESS, 0, 9)
+	return errors.Wrap(err, "set niceness") // wraps nil as nil
 }

--- a/lib/osutil/lowprio_windows.go
+++ b/lib/osutil/lowprio_windows.go
@@ -38,6 +38,10 @@ func SetLowPriority() error {
 	}
 	defer syscall.CloseHandle(handle)
 
-	_, _, err := syscall.Syscall(uintptr(setPriorityClass), uintptr(handle), belowNormalPriorityClass, 0, 0)
+	res, _, err = syscall.Syscall(uintptr(setPriorityClass), uintptr(handle), belowNormalPriorityClass, 0, 0)
+	if res != 0 {
+		// "If the function succeeds, the return value is nonzero."
+		return nil
+	}
 	return errors.Wrap(err, "set priority class") // wraps nil as nil
 }

--- a/lib/osutil/lowprio_windows.go
+++ b/lib/osutil/lowprio_windows.go
@@ -38,7 +38,7 @@ func SetLowPriority() error {
 	}
 	defer syscall.CloseHandle(handle)
 
-	res, _, err = syscall.Syscall(uintptr(setPriorityClass), uintptr(handle), belowNormalPriorityClass, 0, 0)
+	res, _, err := syscall.Syscall(uintptr(setPriorityClass), uintptr(handle), belowNormalPriorityClass, 0, 0)
 	if res != 0 {
 		// "If the function succeeds, the return value is nonzero."
 		return nil

--- a/lib/osutil/lowprio_windows.go
+++ b/lib/osutil/lowprio_windows.go
@@ -8,6 +8,8 @@ package osutil
 
 import (
 	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -29,13 +31,13 @@ const (
 
 // SetLowPriority lowers the process CPU scheduling priority, and possibly
 // I/O priority depending on the platform and OS.
-func SetLowPriority() {
+func SetLowPriority() error {
 	handle, err := syscall.GetCurrentProcess()
 	if err != nil {
-		return
+		return errors.Wrap(err, "get process handler")
 	}
 	defer syscall.CloseHandle(handle)
 
-	// error return ignored
-	syscall.Syscall(uintptr(setPriorityClass), uintptr(handle), belowNormalPriorityClass, 0, 0)
+	_, _, err := syscall.Syscall(uintptr(setPriorityClass), uintptr(handle), belowNormalPriorityClass, 0, 0)
+	return errors.Wrap(err, "set priority class") // wraps nil as nil
 }

--- a/lib/osutil/lowprio_windows.go
+++ b/lib/osutil/lowprio_windows.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2018 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package osutil
+
+import (
+	"syscall"
+)
+
+var (
+	kernel32, _         = syscall.LoadLibrary("kernel32.dll")
+	setPriorityClass, _ = syscall.GetProcAddress(kernel32, "SetPriorityClass")
+)
+
+const (
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms686219(v=vs.85).aspx
+	aboveNormalPriorityClass   = 0x00008000
+	belowNormalPriorityClass   = 0x00004000
+	highPriorityClass          = 0x00000080
+	idlePriorityClass          = 0x00000040
+	normalPriorityClass        = 0x00000020
+	processModeBackgroundBegin = 0x00100000
+	processModeBackgroundEnd   = 0x00200000
+	realtimePriorityClass      = 0x00000100
+)
+
+// SetLowPriority lowers the process CPU scheduling priority, and possibly
+// I/O priority depending on the platform and OS.
+func SetLowPriority() {
+	handle, err := syscall.GetCurrentProcess()
+	if err != nil {
+		return
+	}
+	defer syscall.CloseHandle(handle)
+
+	// error return ignored
+	syscall.Syscall(uintptr(setPriorityClass), uintptr(handle), belowNormalPriorityClass, 0, 0)
+}


### PR DESCRIPTION
### Purpose

Be nicer to the rest of the system by default.

Adds a new option `setLowPriority` which is true by default. If set to false we do nothing to change our priority on startup, like before.

### Testing

I've tested this on Mac, Linux and FreeBSD and see the desired result on all of them: all threads in the final syncthing process (not the monitor) become niceness level 9.

I have not inspected the result on Windows... I don't have a Windows VM on my laptop right now, I'd really appreciate if someone ran the resulting binary and checked if it did what it's supposed to and didn't, like, crash or something...