### PR TITLE
lib/osutil: Don't attempt to reduce our niceness level (fixes #4681)

### DIFF
--- a/lib/osutil/lowprio_linux.go
+++ b/lib/osutil/lowprio_linux.go
@@ -49,6 +49,11 @@ func SetLowPriority() error {
 		wantNiceLevel = 9
 	)
 
+	if cur, _ := syscall.Getpriority(syscall.PRIO_PROCESS, pidSelf); cur >= wantNiceLevel {
+		// We're done here.
+		return nil
+	}
+
 	// Move ourselves to a new process group so that we can use the process
 	// group variants of Setpriority etc to affect all of our threads in one
 	// go. If this fails, bail, so that we don't affect things we shouldn't.
@@ -61,11 +66,6 @@ func SetLowPriority() error {
 		if err := syscall.Setpgid(pidSelf, 0); err != nil {
 			return errors.Wrap(err, "set process group")
 		}
-	}
-
-	if cur, _ := syscall.Getpriority(syscall.PRIO_PROCESS, pidSelf); cur >= wantNiceLevel {
-		// We're done here.
-		return nil
 	}
 
 	if err := syscall.Setpriority(syscall.PRIO_PGRP, pidSelf, wantNiceLevel); err != nil {

--- a/lib/osutil/lowprio_linux.go
+++ b/lib/osutil/lowprio_linux.go
@@ -43,19 +43,19 @@ func ioprioSet(class ioprioClass, value int) error {
 // I/O priority depending on the platform and OS.
 func SetLowPriority() error {
 	// Process zero is "self", niceness value 9 is something between 0
-	// (default) and 19 (worst priority). But then, this is linux, so we get
-	// this to take care of as well:
+	// (default) and 19 (worst priority). But then, this is Linux, so of
+	// course we get this to take care of as well:
 	//
 	// "C library/kernel differences
 	//
 	// Within  the  kernel,  nice  values are actually represented using the
 	// range 40..1 (since negative numbers are error codes) and  these  are
 	// the  values employed  by  the  setpriority() and getpriority() system
-	// calls.  The glibc wrapper functions for these system calls handle
-	// the  translations  between the user-land and kernel representations
-	// of the nice value according to the formula unice = 20 - knice.
-	// (Thus, the kernel's 40..1 range corresponds to the range -20..19 as
-	// seen by user space.)"
+	// calls.  The glibc wrapper functions for these system calls handle the
+	// translations  between the user-land and kernel representations of the
+	// nice value according to the formula unice = 20 - knice. (Thus, the
+	// kernel's 40..1 range corresponds to the range -20..19 as seen by user
+	// space.)"
 
 	const (
 		pidSelf       = 0
@@ -72,6 +72,11 @@ func SetLowPriority() error {
 	// group variants of Setpriority etc to affect all of our threads in one
 	// go. If this fails, bail, so that we don't affect things we shouldn't.
 	// If we are already the leader of our own process group, do nothing.
+	//
+	// Oh and this is because Linux doesn't follow the POSIX threading model
+	// where setting the niceness of the process would actually set the
+	// niceness of the process, instead it just affects the current thread
+	// so we need this workaround...
 	if pgid, err := syscall.Getpgid(pidSelf); err != nil {
 		// This error really shouldn't happen
 		return errors.Wrap(err, "get process group")

--- a/lib/osutil/lowprio_unix.go
+++ b/lib/osutil/lowprio_unix.go
@@ -9,6 +9,7 @@
 package osutil
 
 import (
+	"os"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -24,7 +25,7 @@ func SetLowPriority() error {
 		wantNiceLevel = 9
 	)
 
-	if cur, _ := syscall.Getpriority(syscall.PRIO_PROCESS, pidSelf); cur >= wantNiceLevel {
+	if cur, err := syscall.Getpriority(syscall.PRIO_PROCESS, os.Getpid()); err == nil && cur >= wantNiceLevel {
 		// We're done here.
 		return nil
 	}

--- a/lib/osutil/lowprio_unix.go
+++ b/lib/osutil/lowprio_unix.go
@@ -19,6 +19,13 @@ import (
 func SetLowPriority() error {
 	// Process zero is "self", niceness value 9 is something between 0
 	// (default) and 19 (worst priority).
-	err := syscall.Setpriority(syscall.PRIO_PROCESS, 0, 9)
+	const wantNiceLevel = 9
+
+	if cur, _ := syscall.Getpriority(syscall.PRIO_PROCESS, 0); cur >= wantNiceLevel {
+		// We're done here.
+		return nil
+	}
+
+	err := syscall.Setpriority(syscall.PRIO_PROCESS, 0, wantNiceLevel)
 	return errors.Wrap(err, "set niceness") // wraps nil as nil
 }

--- a/lib/osutil/lowprio_unix.go
+++ b/lib/osutil/lowprio_unix.go
@@ -19,13 +19,16 @@ import (
 func SetLowPriority() error {
 	// Process zero is "self", niceness value 9 is something between 0
 	// (default) and 19 (worst priority).
-	const wantNiceLevel = 9
+	const (
+		pidSelf       = 0
+		wantNiceLevel = 9
+	)
 
-	if cur, _ := syscall.Getpriority(syscall.PRIO_PROCESS, 0); cur >= wantNiceLevel {
+	if cur, _ := syscall.Getpriority(syscall.PRIO_PROCESS, pidSelf); cur >= wantNiceLevel {
 		// We're done here.
 		return nil
 	}
 
-	err := syscall.Setpriority(syscall.PRIO_PROCESS, 0, wantNiceLevel)
+	err := syscall.Setpriority(syscall.PRIO_PROCESS, pidSelf, wantNiceLevel)
 	return errors.Wrap(err, "set niceness") // wraps nil as nil
 }

--- a/lib/osutil/lowprio_unix.go
+++ b/lib/osutil/lowprio_unix.go
@@ -9,7 +9,6 @@
 package osutil
 
 import (
-	"os"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -25,7 +24,7 @@ func SetLowPriority() error {
 		wantNiceLevel = 9
 	)
 
-	if cur, err := syscall.Getpriority(syscall.PRIO_PROCESS, os.Getpid()); err == nil && cur >= wantNiceLevel {
+	if cur, err := syscall.Getpriority(syscall.PRIO_PROCESS, pidSelf); err == nil && cur >= wantNiceLevel {
 		// We're done here.
 		return nil
 	}


### PR DESCRIPTION
### Purpose

Avoid complaining to the user about permission denied when this happens.