### PR TITLE
lib/db: Do not modify underlying array of argument

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -126,7 +126,7 @@ func (s *FileSet) Update(device protocol.DeviceID, fs []protocol.FileInfo) {
 	l.Debugf("%s Update(%v, [%d])", s.folder, device, len(fs))
 
 	// do not modify fs in place, it is still used in outer scope
-	fs = append([]protocol.FileInfo{}, fs...)
+	fs = append([]protocol.FileInfo(nil), fs...)
 
 	normalizeFilenames(fs)
 

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -124,6 +124,10 @@ func (s *FileSet) Drop(device protocol.DeviceID) {
 
 func (s *FileSet) Update(device protocol.DeviceID, fs []protocol.FileInfo) {
 	l.Debugf("%s Update(%v, [%d])", s.folder, device, len(fs))
+
+	// do not modify fs in place, it is still used in outer scope
+	fs = append([]protocol.FileInfo{}, fs...)
+
 	normalizeFilenames(fs)
 
 	s.updateMutex.Lock()

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -447,10 +447,10 @@ func TestGlobalReset(t *testing.T) {
 	m := db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
 	local := []protocol.FileInfo{
-		{Name: "a", Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
-		{Name: "b", Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
-		{Name: "c", Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
-		{Name: "d", Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
+		{Name: "a", Sequence: 1, Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
+		{Name: "b", Sequence: 2, Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
+		{Name: "c", Sequence: 3, Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
+		{Name: "d", Sequence: 4, Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1000}}}},
 	}
 
 	remote := []protocol.FileInfo{
@@ -464,8 +464,8 @@ func TestGlobalReset(t *testing.T) {
 	g := globalList(m)
 	sort.Sort(fileList(g))
 
-	if fmt.Sprint(g) != fmt.Sprint(local) {
-		t.Errorf("Global incorrect;\n%v !=\n%v", g, local)
+	if diff, equal := messagediff.PrettyDiff(local, g); !equal {
+		t.Errorf("Global incorrect;\nglobal: %v\n!=\nlocal: %v\ndiff:\n%s", g, local, diff)
 	}
 
 	replace(m, remoteDevice0, remote)
@@ -474,8 +474,8 @@ func TestGlobalReset(t *testing.T) {
 	g = globalList(m)
 	sort.Sort(fileList(g))
 
-	if fmt.Sprint(g) != fmt.Sprint(local) {
-		t.Errorf("Global incorrect;\n%v !=\n%v", g, local)
+	if diff, equal := messagediff.PrettyDiff(local, g); !equal {
+		t.Errorf("Global incorrect;\nglobal: %v\n!=\nlocal: %v\ndiff:\n%s", g, local, diff)
 	}
 }
 


### PR DESCRIPTION
Previously the fileinfo list was filtered in place, now a copy is used. This list is used in other functions than this, so it should not be modified. I noticed this problem while writing and debugging a new test, when repeat fileinfo entries showd in the index updates. I cannot reproduce this anymore and I do not know whether it can occur in practice, but modifying in place is anyway the wrong thing to do in this case.