### PR TITLE
lib/ignores: Update lines even if patterns didn't change (fixes #4689)

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -156,6 +156,8 @@ func (m *Matcher) parseLocked(r io.Reader, file string) error {
 	// Error is saved and returned at the end. We process the patterns
 	// (possibly blank) anyway.
 
+	m.lines = lines
+
 	newHash := hashPatterns(patterns)
 	if newHash == m.curHash {
 		// We've already loaded exactly these patterns.
@@ -163,7 +165,6 @@ func (m *Matcher) parseLocked(r io.Reader, file string) error {
 	}
 
 	m.curHash = newHash
-	m.lines = lines
 	m.patterns = patterns
 	if m.withCache {
 		m.matches = newCache(patterns)

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -956,3 +956,28 @@ func TestIssue4680(t *testing.T) {
 		}
 	}
 }
+
+func TestIssue4689(t *testing.T) {
+	stignore := `// orig`
+
+	pats := New(fs.NewFilesystem(fs.FilesystemTypeBasic, "."), WithCache(true))
+	err := pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lines := pats.Lines(); len(lines) != 1 || lines[0] != "// orig" {
+		t.Fatalf("wrong lines parsing original comment:\n%q", lines)
+	}
+
+	stignore = `// new`
+
+	err = pats.Parse(bytes.NewBufferString(stignore), ".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lines := pats.Lines(); len(lines) != 1 || lines[0] != "// new" {
+		t.Fatalf("wrong lines parsing changed comment:\n%v", lines)
+	}
+}


### PR DESCRIPTION
If only comments are edited, the hash of the patterns doesn't change and thus the changed comment lines are discarded. This PR ensures  lines are updated regardless of patterns and adds a test for this problem.