### PR TITLE
 lib/db: Optimize memory usage for huge files, refactor updating and fix benchs

### DIFF
--- a/lib/db/benchmark_test.go
+++ b/lib/db/benchmark_test.go
@@ -16,17 +16,18 @@ import (
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/db"
+	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
 var files, oneFile, firstHalf, secondHalf []protocol.FileInfo
-var fs *db.FileSet
+var s *db.FileSet
 
 func init() {
 	for i := 0; i < 1000; i++ {
 		files = append(files, protocol.FileInfo{
 			Name:    fmt.Sprintf("file%d", i),
-			Version: protocol.Vector{{ID: myID, Value: 1000}},
+			Version: protocol.Vector{[]protocol.Counter{{ID: myID, Value: 1000}}},
 			Blocks:  genBlocks(i),
 		})
 	}
@@ -37,9 +38,9 @@ func init() {
 	oneFile = firstHalf[middle-1 : middle]
 
 	ldb, _ := tempDB()
-	fs = db.NewFileSet("test", ldb)
-	fs.Replace(remoteDevice0, files)
-	fs.Replace(protocol.LocalDeviceID, firstHalf)
+	s = db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
+	replace(s, remoteDevice0, files)
+	replace(s, protocol.LocalDeviceID, firstHalf)
 }
 
 func tempDB() (*db.Instance, string) {
@@ -63,8 +64,8 @@ func BenchmarkReplaceAll(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m := db.NewFileSet("test", ldb)
-		m.Replace(protocol.LocalDeviceID, files)
+		m := db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
+		replace(m, protocol.LocalDeviceID, files)
 	}
 
 	b.ReportAllocs()
@@ -78,9 +79,9 @@ func BenchmarkUpdateOneChanged(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		if i%1 == 0 {
-			fs.Update(protocol.LocalDeviceID, changed)
+			s.Update(protocol.LocalDeviceID, changed)
 		} else {
-			fs.Update(protocol.LocalDeviceID, oneFile)
+			s.Update(protocol.LocalDeviceID, oneFile)
 		}
 	}
 
@@ -89,7 +90,7 @@ func BenchmarkUpdateOneChanged(b *testing.B) {
 
 func BenchmarkUpdateOneUnchanged(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		fs.Update(protocol.LocalDeviceID, oneFile)
+		s.Update(protocol.LocalDeviceID, oneFile)
 	}
 
 	b.ReportAllocs()
@@ -98,7 +99,7 @@ func BenchmarkUpdateOneUnchanged(b *testing.B) {
 func BenchmarkNeedHalf(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		count := 0
-		fs.WithNeed(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
+		s.WithNeed(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
 			count++
 			return true
 		})
@@ -113,7 +114,7 @@ func BenchmarkNeedHalf(b *testing.B) {
 func BenchmarkHave(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		count := 0
-		fs.WithHave(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
+		s.WithHave(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
 			count++
 			return true
 		})
@@ -128,7 +129,7 @@ func BenchmarkHave(b *testing.B) {
 func BenchmarkGlobal(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		count := 0
-		fs.WithGlobal(func(fi db.FileIntf) bool {
+		s.WithGlobal(func(fi db.FileIntf) bool {
 			count++
 			return true
 		})
@@ -143,7 +144,7 @@ func BenchmarkGlobal(b *testing.B) {
 func BenchmarkNeedHalfTruncated(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		count := 0
-		fs.WithNeedTruncated(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
+		s.WithNeedTruncated(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
 			count++
 			return true
 		})
@@ -158,7 +159,7 @@ func BenchmarkNeedHalfTruncated(b *testing.B) {
 func BenchmarkHaveTruncated(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		count := 0
-		fs.WithHaveTruncated(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
+		s.WithHaveTruncated(protocol.LocalDeviceID, func(fi db.FileIntf) bool {
 			count++
 			return true
 		})
@@ -173,7 +174,7 @@ func BenchmarkHaveTruncated(b *testing.B) {
 func BenchmarkGlobalTruncated(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		count := 0
-		fs.WithGlobalTruncated(func(fi db.FileIntf) bool {
+		s.WithGlobalTruncated(func(fi db.FileIntf) bool {
 			count++
 			return true
 		})

--- a/lib/db/blockmap_test.go
+++ b/lib/db/blockmap_test.go
@@ -68,11 +68,11 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 		t.Fatal("db not empty")
 	}
 
-	m := NewBlockMap(db, db.folderIdx.ID([]byte("folder1")))
+	m := NewBlockMap(db, []byte("folder1"))
 
 	f3.Type = protocol.FileInfoTypeDirectory
 
-	err := m.Add([]protocol.FileInfo{f1, f2, f3})
+	err := m.Update([]protocol.FileInfo{f1, f2, f3})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -135,7 +135,7 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 	}
 
 	// Should not add
-	err = m.Add([]protocol.FileInfo{f1, f2})
+	err = m.Update([]protocol.FileInfo{f1, f2})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,14 +158,14 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 func TestBlockFinderLookup(t *testing.T) {
 	db, f := setup()
 
-	m1 := NewBlockMap(db, db.folderIdx.ID([]byte("folder1")))
-	m2 := NewBlockMap(db, db.folderIdx.ID([]byte("folder2")))
+	m1 := NewBlockMap(db, []byte("folder1"))
+	m2 := NewBlockMap(db, []byte("folder2"))
 
-	err := m1.Add([]protocol.FileInfo{f1})
+	err := m1.Update([]protocol.FileInfo{f1})
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = m2.Add([]protocol.FileInfo{f1})
+	err = m2.Update([]protocol.FileInfo{f1})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -227,8 +227,8 @@ func TestBlockFinderFix(t *testing.T) {
 		return true
 	}
 
-	m := NewBlockMap(db, db.folderIdx.ID([]byte("folder1")))
-	err := m.Add([]protocol.FileInfo{f1})
+	m := NewBlockMap(db, []byte("folder1"))
+	err := m.Update([]protocol.FileInfo{f1})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This started in a discussion about memory use spiking when scanning is finished here: https://forum.syncthing.net/t/out-of-memory-crash-while-scanning/11170/13
The I thought I saw unnecessary block copies abound, but it turned out I was wrong. However in the process I saw other potential memory optimizations and some refactor potential:

 - The function `(m *BlockMap) Add` is only used in test and there it can be replaced by `Update` -> remove
 - Do not store existing files to be discarded in a list -> move discarding into `(m *BlockMap) Update`.  
This might also be achievable while keeping `Discard` separate, but I quite like having a single `Update` function as they are never used alone and it's the equivalent function to `Update` on `FileSet`.
 - Check whether the block map batch exceeds the maximum size after every block instead of after every file (i.e. for one large file, the transaction will be split into several batches).
 - Discard block data early when removing an old file from the block map.

### Testing

I fixed the previously broken benchmarks (unnoticed due to build tags). There is no consistent change visible between master and this PR - so this may save some memory and should not impact performance (much).