### PR TITLE
Missing datalist for parameter DefaultFolderPath

### DIFF
--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -82,6 +82,9 @@
           <div class="form-group">
             <label translate for="urVersion">Default Folder Path</label>
             <input id="DefaultFolderPath" class="form-control" type="text" ng-model="tmpOptions.defaultFolderPath"/>
+            <datalist id="directory-list">
+              <option ng-repeat="directory in directoryList" value="{{ directory }}" />
+            </datalist>
             <p class="help-block">
               <span translate translate-value-tilde="{{system.tilde}}">
                 Path where new auto accepted folders will be created, as well as the default suggested path when adding new folders via the UI. Tilde character (~) expands to {%tilde%}.


### PR DESCRIPTION
Add missing datalist for parameter DefaultFolderPath in SettingsForm

### Purpose

When setting the folder path on the "editFolder"-Dialog there is a list of subdirs below the current directory.

When setting the DefaultFolderPath in the settings dialog, this list of subdirs is missing.

