### PR TITLE
lib/db: Update global counts on invalidation (fixes #4701)

### DIFF
--- a/lib/db/leveldb_transactions.go
+++ b/lib/db/leveldb_transactions.go
@@ -168,7 +168,7 @@ insert:
 	if insertedAt == 0 {
 		// We just inserted a new newest version. Fixup the global size
 		// calculation.
-		if !file.Version.Equal(oldFile.Version) {
+		if !file.Version.Equal(oldFile.Version) || file.Invalid != oldFile.Invalid {
 			meta.addFile(globalDeviceID, file)
 			if hasOldFile {
 				// We have the old file that was removed at the head of the list.


### PR DESCRIPTION
### Purpose

Fix #4701

This only fixes calculations in the future. So any existing disparities will stay until the metadata is next recomputed. @calmh Do you think it is worth/necessary to add a config transition to trigger a metadata recalculation or is it fine to just wait until one happens "naturally"?

### Testing

New unit test.
