### PR TITLE
gui: Display rescan button when out of sync and remove deprecated folder state

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -439,7 +439,7 @@
                   <button type="button" class="btn btn-default btn-sm" ng-click="restoreVersions.show(folder.id)" ng-if="folder.versioning.type">
                     <span class="fa fa-undo"></span>&nbsp;<span translate>Versions</span>
                   </button>
-                  <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-show="['paused', 'unknown'].indexOf(folderStatus(folder)) < 0">
+                  <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-show="['idle', 'stopped', 'unshared', 'outofsync'].indexOf(folderStatus(folder)) > -1">
                     <span class="fa fa-refresh"></span>&nbsp;<span translate>Rescan</span>
                   </button>
                   <button type="button" class="btn btn-sm btn-default" ng-click="editFolder(folder)">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -439,7 +439,7 @@
                   <button type="button" class="btn btn-default btn-sm" ng-click="restoreVersions.show(folder.id)" ng-if="folder.versioning.type">
                     <span class="fa fa-undo"></span>&nbsp;<span translate>Versions</span>
                   </button>
-                  <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-show="['idle', 'stopped', 'unshared'].indexOf(folderStatus(folder)) > -1">
+                  <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-show="['paused', 'unknown'].indexOf(folderStatus(folder)) < 0">
                     <span class="fa fa-refresh"></span>&nbsp;<span translate>Rescan</span>
                   </button>
                   <button type="button" class="btn btn-sm btn-default" ng-click="editFolder(folder)">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -731,10 +731,6 @@ angular.module('syncthing.core')
                 return 'unknown';
             }
 
-            if ($scope.model[folderCfg.id].invalid) {
-                return 'stopped';
-            }
-
             var state = '' + $scope.model[folderCfg.id].state;
             if (state === 'error') {
                 return 'stopped'; // legacy, the state is called "stopped" in the GUI


### PR DESCRIPTION
It should be possible to trigger a scan on an out of sync folder, i.e. in case a problem was resolved manually on disk. I reversed the condition from displaying rescan for some specific folder states to all states except unknown and paused.

The invalid parameter on the folder summary is deprecated as per comment in gui.go -> removed.