### PR TITLE
lib/fs: Use correct facility name

### DIFF
--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -35,10 +35,7 @@ func TestMain(m *testing.M) {
 		panic("Cannot get real path to working dir")
 	}
 	testDirAbs = filepath.Join(dir, testDir)
-	testFs = newBasicFilesystem(testDirAbs)
-	if l.ShouldDebug("filesystem") {
-		testFs = &logFilesystem{testFs}
-	}
+	testFs = NewFilesystem(FilesystemTypeBasic, testDirAbs)
 
 	backendBuffer = 10
 	defer func() {

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -170,7 +170,7 @@ func NewFilesystem(fsType FilesystemType, uri string) Filesystem {
 		}
 	}
 
-	if l.ShouldDebug("filesystem") {
+	if l.ShouldDebug("fs") {
 		fs = &logFilesystem{fs}
 	}
 	return fs


### PR DESCRIPTION
This was forgotten when renaming the logging facillity "filesystem" to "fs".