### PR TITLE
lib/fs: Introduce walkfs debug facility

### DIFF
--- a/lib/fs/debug.go
+++ b/lib/fs/debug.go
@@ -18,5 +18,11 @@ var (
 )
 
 func init() {
-	l.SetDebug("fs", strings.Contains(os.Getenv("STTRACE"), "fs") || os.Getenv("STTRACE") == "all")
+	if strings.Contains(os.Getenv("STTRACE"), "walkfs") || os.Getenv("STTRACE") == "all" {
+		l.SetDebug("fs", true)
+		logger.DefaultLogger.NewFacility("walkfs", "Filesystem access while walking")
+		l.SetDebug("walkfs", true)
+		return
+	}
+	l.SetDebug("fs", strings.Contains(os.Getenv("STTRACE"), "fs"))
 }

--- a/lib/fs/debug.go
+++ b/lib/fs/debug.go
@@ -19,10 +19,11 @@ var (
 
 func init() {
 	logger.DefaultLogger.NewFacility("walkfs", "Filesystem access while walking")
-	if strings.Contains(os.Getenv("STTRACE"), "walkfs") || os.Getenv("STTRACE") == "all" {
-		l.SetDebug("fs", true)
+	switch {
+	case strings.Contains(os.Getenv("STTRACE"), "walkfs") || os.Getenv("STTRACE") == "all":
 		l.SetDebug("walkfs", true)
-		return
+		fallthrough
+	case strings.Contains(os.Getenv("STTRACE"), "fs"):
+		l.SetDebug("fs", true)
 	}
-	l.SetDebug("fs", strings.Contains(os.Getenv("STTRACE"), "fs"))
 }

--- a/lib/fs/debug.go
+++ b/lib/fs/debug.go
@@ -18,9 +18,9 @@ var (
 )
 
 func init() {
+	logger.DefaultLogger.NewFacility("walkfs", "Filesystem access while walking")
 	if strings.Contains(os.Getenv("STTRACE"), "walkfs") || os.Getenv("STTRACE") == "all" {
 		l.SetDebug("fs", true)
-		logger.DefaultLogger.NewFacility("walkfs", "Filesystem access while walking")
 		l.SetDebug("walkfs", true)
 		return
 	}

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -160,7 +160,7 @@ func NewFilesystem(fsType FilesystemType, uri string) Filesystem {
 	var fs Filesystem
 	switch fsType {
 	case FilesystemTypeBasic:
-		fs = NewWalkFilesystem(newBasicFilesystem(uri))
+		fs = newBasicFilesystem(uri)
 	default:
 		l.Debugln("Unknown filesystem", fsType, uri)
 		fs = &errorFilesystem{
@@ -170,10 +170,15 @@ func NewFilesystem(fsType FilesystemType, uri string) Filesystem {
 		}
 	}
 
-	if l.ShouldDebug("fs") {
-		fs = &logFilesystem{fs}
+	if l.ShouldDebug("walkfs") {
+		return NewWalkFilesystem(&logFilesystem{fs})
 	}
-	return fs
+
+	if l.ShouldDebug("fs") {
+		return &logFilesystem{NewWalkFilesystem(fs)}
+	}
+
+	return NewWalkFilesystem(fs)
 }
 
 // IsInternal returns true if the file, as a path relative to the folder


### PR DESCRIPTION
This adds a new debug facility "walkfs" which does the same thing as "fs", but it also applies to operations when walking a filesystem. I added this unconditionally on another PR for debugging, but it doesn't really belong there, so lets discuss/decide here (original comments: https://github.com/syncthing/syncthing/pull/4584/files#r156240587).

