### PR TITLE
lib/scanner: Error handling in walk function (fixes #4753)

### DIFF
--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -255,19 +255,15 @@ func (w *walker) createFSWalkFn(ctx context.Context, fsChan chan<- fsWalkResult)
 			skip = fs.SkipDir
 		}
 
-		if path == "." {
-			if err != nil {
-				fsWalkError(ctx, fsChan, path, err)
-				return skip
-			}
-			return nil
-		}
-
 		if err != nil {
 			if sendErr := fsWalkError(ctx, fsChan, path, err); sendErr != nil {
 				return sendErr
 			}
 			return skip
+		}
+
+		if path == "." {
+			return nil
 		}
 
 		if fs.IsTemporary(path) {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -263,6 +263,13 @@ func (w *walker) createFSWalkFn(ctx context.Context, fsChan chan<- fsWalkResult)
 			return nil
 		}
 
+		if err != nil {
+			if sendErr := fsWalkError(ctx, fsChan, path, err); sendErr != nil {
+				return sendErr
+			}
+			return skip
+		}
+
 		if fs.IsTemporary(path) {
 			l.Debugln("temporary:", path)
 			if info.IsRegular() && info.ModTime().Add(w.TempLifetime).Before(now) {
@@ -279,13 +286,6 @@ func (w *walker) createFSWalkFn(ctx context.Context, fsChan chan<- fsWalkResult)
 
 		if w.Matcher.Match(path).IsIgnored() {
 			l.Debugln("skip walking (patterns):", path)
-			return skip
-		}
-
-		if err != nil {
-			if sendErr := fsWalkError(ctx, fsChan, path, err); sendErr != nil {
-				return sendErr
-			}
 			return skip
 		}
 


### PR DESCRIPTION
### Purpose

Do not panic.

### Testing

Yeah, that's the thing. @imsodin I don't understand the error handling here. What does the thing above my code do, exactly (the thing with `path == "."`)? If I attempt to homogenize it with the regular error handling, in returning `sendErr` for example, tests fail. Why?