### PR TITLE
lib/db: Don't panic on negative counts

### DIFF
--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -134,17 +134,24 @@ func (m *metadataTracker) removeFile(dev protocol.DeviceID, f FileIntf) {
 	}
 	cp.Bytes -= f.FileSize()
 
+	// If we've run into an impossible situation, correct it for now and set
+	// the created timestamp to zero. Next time we start up the metadata
+	// will be seen as infinitely old and recalculated from scratch.
 	if cp.Deleted < 0 {
 		cp.Deleted = 0
+		m.counts.Created = 0
 	}
 	if cp.Files < 0 {
 		cp.Files = 0
+		m.counts.Created = 0
 	}
 	if cp.Directories < 0 {
 		cp.Directories = 0
+		m.counts.Created = 0
 	}
 	if cp.Symlinks < 0 {
 		cp.Symlinks = 0
+		m.counts.Created = 0
 	}
 
 	m.mut.Unlock()

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -134,8 +134,17 @@ func (m *metadataTracker) removeFile(dev protocol.DeviceID, f FileIntf) {
 	}
 	cp.Bytes -= f.FileSize()
 
-	if cp.Deleted < 0 || cp.Files < 0 || cp.Directories < 0 || cp.Symlinks < 0 {
-		panic("bug: removed more than added")
+	if cp.Deleted < 0 {
+		cp.Deleted = 0
+	}
+	if cp.Files < 0 {
+		cp.Files = 0
+	}
+	if cp.Directories < 0 {
+		cp.Directories = 0
+	}
+	if cp.Symlinks < 0 {
+		cp.Symlinks = 0
 	}
 
 	m.mut.Unlock()


### PR DESCRIPTION
So, negative counts should never happen and hence the original idea to
panic. However, this sucks as the panic will happen in a folder runner,
be automatically swallowed by suture, and the runner gets restarted but
now we are in a bad state. (Related: #4758)

At the time of writing the global list is somewhat in flux (we've
changed how ignored files are handled, invalid bits, etc.) and I think
that can cause unusual conditions here. Hence just fixing up the numbers
instead until the next full recount interval.
