### PR TITLE
lib/fs: Fix MkdirAll failure due to \\?\

### DIFF
--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -154,6 +154,19 @@ func (f *BasicFilesystem) Mkdir(name string, perm FileMode) error {
 	return os.Mkdir(name, os.FileMode(perm))
 }
 
+// MkdirAll creates a directory named path, along with any necessary parents,
+// and returns nil, or else returns an error.
+// The permission bits perm are used for all directories that MkdirAll creates.
+// If path is already a directory, MkdirAll does nothing and returns nil.
+func (f *BasicFilesystem) MkdirAll(path string, perm FileMode) error {
+	path, err := f.rooted(path)
+	if err != nil {
+		return err
+	}
+
+	return f.mkdirAll(path, os.FileMode(perm))
+}
+
 func (f *BasicFilesystem) Lstat(name string) (FileInfo, error) {
 	name, err := f.rooted(name)
 	if err != nil {

--- a/lib/fs/basicfs_unix.go
+++ b/lib/fs/basicfs_unix.go
@@ -30,12 +30,8 @@ func (f *BasicFilesystem) ReadSymlink(name string) (string, error) {
 	return os.Readlink(name)
 }
 
-func (f *BasicFilesystem) MkdirAll(name string, perm FileMode) error {
-	name, err := f.rooted(name)
-	if err != nil {
-		return err
-	}
-	return os.MkdirAll(name, os.FileMode(perm))
+func (f *BasicFilesystem) mkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
 }
 
 // Unhide is a noop on unix, as unhiding files requires renaming them.

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -32,19 +32,6 @@ func (BasicFilesystem) CreateSymlink(target, name string) error {
 	return errNotSupported
 }
 
-// MkdirAll creates a directory named path, along with any necessary parents,
-// and returns nil, or else returns an error.
-// The permission bits perm are used for all directories that MkdirAll creates.
-// If path is already a directory, MkdirAll does nothing and returns nil.
-func (f *BasicFilesystem) MkdirAll(path string, perm FileMode) error {
-	path, err := f.rooted(path)
-	if err != nil {
-		return err
-	}
-
-	return f.mkdirAll(path, os.FileMode(perm))
-}
-
 // Required due to https://github.com/golang/go/issues/10900
 func (f *BasicFilesystem) mkdirAll(path string, perm os.FileMode) error {
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
@@ -75,7 +62,7 @@ func (f *BasicFilesystem) mkdirAll(path string, perm os.FileMode) error {
 		// Create parent
 		parent := path[0 : j-1]
 		if parent != filepath.VolumeName(parent) {
-			err = os.MkdirAll(parent, perm)
+			err = f.mkdirAll(parent, perm)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
https://forum.syncthing.net/t/error-when-sync-dest-to-nonexistant-root-directory-on-windows/11277/18  
Main purpose of this PR for now is to provide diffs/builds for testing to @wwutz that actually compile on windows (anyone else interested is obviously also welcome to test).

To reproduce run the following while `F:\FOO` does not exist:

```golang
package main

import (
	"fmt"

	"github.com/syncthing/syncthing/lib/fs"
)

func main() {
	base := `F:\`
	targ := `FOO\BAR`
	testFs := fs.NewFilesystem(fs.FilesystemTypeBasic, base)
	if err := testFs.MkdirAll(targ, 777); err != nil {
		fmt.Printf("Base: %v, target: %v, err: %v", base, targ, err)
	}
}
```
Result:  
`Base: F:\, target: FOO\BAR, err: mkdir \\?: The filename, directory name, or volume label syntax is incorrect.`

@calmh Am I right assuming that a unit test can't successfully run ```os.MkdirAll(`C:\FOO\BAR\`)``` on the build server?