### PR TITLE
cmd/strelaysrv: Don't patch the default HTTP client (fixes #4745)

### DIFF
--- a/cmd/strelaysrv/pool.go
+++ b/cmd/strelaysrv/pool.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"log"
-	"net/http"
 	"net/url"
 	"time"
 )
@@ -27,7 +26,7 @@ func poolHandler(pool string, uri *url.URL, mapping mapping) {
 			uriCopy.String(),
 		})
 
-		resp, err := http.Post(pool, "application/json", &b)
+		resp, err := httpClient.Post(pool, "application/json", &b)
 		if err != nil {
 			log.Println("Error joining pool", pool, err)
 		} else if resp.StatusCode == 500 {


### PR DESCRIPTION
### Purpose

Fix what used to work but now doesn't.

### Testing

None whatsoever. @wwwutz?