### PR TITLE
lib/model: Don't panic if block size in index is larger than protocol block size

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -1260,7 +1260,11 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 				continue
 			}
 
-			buf = buf[:int(block.Size)]
+			if s := int(block.Size); s > cap(buf) {
+				buf = make([]byte, s)
+			} else {
+				buf = buf[:s]
+			}
 
 			found, err := weakHashFinder.Iterate(block.WeakHash, buf, func(offset int64) bool {
 				if _, err := verifyBuffer(buf, block); err != nil {


### PR DESCRIPTION
This doesn't happen today, but it might in the future if the block size were increased or made variable and we were talking to a client from the future...
