### PR TITLE
cmd/syncthing: Reset delta indexes after the latest index changes

### DIFF
--- a/lib/db/leveldb.go
+++ b/lib/db/leveldb.go
@@ -26,6 +26,7 @@ const (
 	KeyTypeDeviceIdx
 	KeyTypeIndexID
 	KeyTypeFolderMeta
+	KeyTypeMiscData
 )
 
 func (l VersionList) String() string {


### PR DESCRIPTION
This was necessary for me to get everything to play nice after imsodins latest changes, and I think we might as well throw it in there as part of this release.