### PR TITLE
vendor: Don't panic in FS watcher on old FreeBSD (fixes #4806)

### DIFF
--- a/vendor/github.com/Zillode/notify/notify.go
+++ b/vendor/github.com/Zillode/notify/notify.go
@@ -19,7 +19,31 @@
 
 package notify
 
-var defaultTree = newTree()
+import "fmt"
+
+var defaultTree tree // lazy init
+
+func lazyInitDefaultTree() (err error) {
+	if defaultTree != nil {
+		// already initialized
+		return nil
+	}
+
+	defer func() {
+		// newTree might panic. Patch it up.
+		if rec := recover(); rec != nil {
+			switch rec := rec.(type) {
+			case error:
+				err = rec
+			default:
+				err = fmt.Errorf("init default tree: %v", rec)
+			}
+		}
+	}()
+
+	defaultTree = newTree()
+	return nil
+}
 
 // Watch sets up a watchpoint on path listening for events given by the events
 // argument.
@@ -61,6 +85,9 @@ var defaultTree = newTree()
 // e.g. use persistent paths like %userprofile% or watch additionally parent
 // directory of a recursive watchpoint in order to receive delete events for it.
 func Watch(path string, c chan<- EventInfo, events ...Event) error {
+	if err := lazyInitDefaultTree(); err != nil {
+		return err
+	}
 	return defaultTree.Watch(path, c, nil, events...)
 }
 
@@ -70,6 +97,9 @@ func Watch(path string, c chan<- EventInfo, events ...Event) error {
 // file or directory should not be watched.
 func WatchWithFilter(path string, c chan<- EventInfo,
 	doNotWatch func(string) bool, events ...Event) error {
+	if err := lazyInitDefaultTree(); err != nil {
+		return err
+	}
 	return defaultTree.Watch(path, c, doNotWatch, events...)
 }
 
@@ -79,5 +109,8 @@ func WatchWithFilter(path string, c chan<- EventInfo,
 // Stop does not close c. When Stop returns, it is guaranteed that c will
 // receive no more signals.
 func Stop(c chan<- EventInfo) {
+	if defaultTree == nil {
+		return
+	}
 	defaultTree.Stop(c)
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -42,6 +42,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/Zillode/notify",
+			"repository": "https://github.com/calmh/notify",
+			"vcs": "git",
+			"revision": "53dd6873a851fc377c87d82f994b1fecdf25aadb",
+			"branch": "nopanic",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/a8m/mark",
 			"repository": "https://github.com/a8m/mark",
 			"vcs": "git",
@@ -514,14 +522,6 @@
 			"revision": "bf64b92db6b05651d6c25a3dabf2d543b360c0aa",
 			"branch": "master",
 			"path": "/qr",
-			"notests": true
-		},
-		{
-			"importpath": "github.com/Zillode/notify",
-			"repository": "https://github.com/Zillode/notify",
-			"vcs": "git",
-			"revision": "a8abcfb1ce88ee8d79a300ed65d94b8fb616ddb3",
-			"branch": "master",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
This adds a recover step to the notify package to avoid the panic. We should get something like this upstreamed. In the meantime I want to get a release out and this fixes the issue for our FreeBSD build.

(Slightly related, I think we should adopt the Zillode/notify fork into the syncthing organization so we can more easily manage it, as I think it's single-use for Syncthing only at this point? We can do that as another fork if we want to keep the Zillode/notify import path around as well.)