### PR TITLE
lib/fs: Fix and update error about inotify watch limit (fixes #4833)

### DIFF
--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -7,14 +7,12 @@
 package fs
 
 import (
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -481,25 +479,5 @@ func TestRooted(t *testing.T) {
 			t.Errorf("Unexpected pass for rooted(%q, %q) => %q", tc.root, tc.rel, res)
 			continue
 		}
-	}
-}
-
-func TestWatchErrorLinuxInterpretation(t *testing.T) {
-	if runtime.GOOS != "linux" {
-		t.Skip("testing of linux specific error codes")
-	}
-
-	var errTooManyFiles syscall.Errno = 24
-	var errNoSpace syscall.Errno = 28
-
-	if !reachedMaxUserWatches(errTooManyFiles) {
-		t.Errorf("Errno %v should be recognised to be about inotify limits.", errTooManyFiles)
-	}
-	if !reachedMaxUserWatches(errNoSpace) {
-		t.Errorf("Errno %v should be recognised to be about inotify limits.", errNoSpace)
-	}
-	err := errors.New("Another error")
-	if reachedMaxUserWatches(err) {
-		t.Errorf("This error does not concern inotify limits: %#v", err)
 	}
 }

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -42,7 +42,7 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 	if err := notify.WatchWithFilter(filepath.Join(absName, "..."), backendChan, absShouldIgnore, eventMask); err != nil {
 		notify.Stop(backendChan)
 		if reachedMaxUserWatches(err) {
-			err = errors.New("failed to install inotify handler. Please increase inotify limits, see https://github.com/syncthing/syncthing-inotify#troubleshooting-for-folders-with-many-files-on-linux for more information")
+			err = errors.New("failed to setup inotify handler. Please increase inotify limits, see https://docs.syncthing.net/users/faq.html#inotify-limits")
 		}
 		return nil, err
 	}

--- a/lib/fs/basicfs_watch_errors_linux.go
+++ b/lib/fs/basicfs_watch_errors_linux.go
@@ -8,11 +8,16 @@
 
 package fs
 
-import "syscall"
+import (
+	"os"
+	"syscall"
+)
 
 func reachedMaxUserWatches(err error) bool {
-	if errno, ok := err.(syscall.Errno); ok {
-		return errno == 24 || errno == 28
+	if pathErr, ok := err.(*os.PathError); ok {
+		if errno, ok := pathErr.Err.(syscall.Errno); ok {
+			return errno == 24 || errno == 28
+		}
 	}
 	return false
 }


### PR DESCRIPTION
### Purpose

Fix error detection and modify the error message to point to the appropriate FAQ entry (syncthing/docs#381).

### Testing

Updated existing, incorrect test. It still is "artificial", as we can't reproduce the actual error in the backend (needs root).