### PR TITLE
lib/upgrade: Handle version containing spaces

### DIFF
--- a/lib/upgrade/upgrade_common.go
+++ b/lib/upgrade/upgrade_common.go
@@ -199,6 +199,7 @@ func versionParts(v string) ([]int, []interface{}) {
 		v = v[1:]
 	}
 	parts := strings.SplitN(v, "+", 2)
+	parts = strings.SplitN(parts[0], " ", 2)
 	parts = strings.SplitN(parts[0], "-", 2)
 	fields := strings.Split(parts[0], ".")
 

--- a/lib/upgrade/upgrade_test.go
+++ b/lib/upgrade/upgrade_test.go
@@ -46,6 +46,7 @@ var versions = []struct {
 	{"1.0.0+45", "1.0.0+23-dev-foo", Equal},
 	{"1.0.0-beta.23+45", "1.0.0-beta.23+23-dev-foo", Equal},
 	{"1.0.0-beta.3+99", "1.0.0-beta.24+0", Older},
+	{"0.14.45 (+dev)", "0.14.13", Newer},
 
 	{"v1.1.2", "1.1.2", Equal},
 	{"v1.1.2", "V1.1.2", Equal},


### PR DESCRIPTION
### Purpose

The release name of the android hotfix is `v0.14.45 (+dev)`, resulting in patch version 0 (as conversion to string of `45 (` fails). This is somewhat relevant because of the symlink compatibility check here: https://github.com/syncthing/syncthing/blob/master/lib/model/model.go#L922  

### Testing

Test comparing  `v0.14.45 (+dev)` with `v0.14.13`.