### PR TITLE
cmd/syncthing/gui_statics.go: Set Content-Type header regardless of asset location

### DIFF
--- a/cmd/syncthing/gui_statics.go
+++ b/cmd/syncthing/gui_statics.go
@@ -89,6 +89,10 @@ func (s *staticsServer) serveAsset(w http.ResponseWriter, r *http.Request) {
 	if s.assetDir != "" {
 		p := filepath.Join(s.assetDir, theme, filepath.FromSlash(file))
 		if _, err := os.Stat(p); err == nil {
+			mtype := s.mimeTypeForFile(file)
+			if len(mtype) != 0 {
+				w.Header().Set("Content-Type", mtype)
+			}
 			http.ServeFile(w, r, p)
 			return
 		}
@@ -101,6 +105,10 @@ func (s *staticsServer) serveAsset(w http.ResponseWriter, r *http.Request) {
 		if s.assetDir != "" {
 			p := filepath.Join(s.assetDir, config.DefaultTheme, filepath.FromSlash(file))
 			if _, err := os.Stat(p); err == nil {
+				mtype := s.mimeTypeForFile(file)
+				if len(mtype) != 0 {
+					w.Header().Set("Content-Type", mtype)
+				}
 				http.ServeFile(w, r, p)
 				return
 			}


### PR DESCRIPTION
### Purpose

mimetypes for assets aren't always submitted (for example, if not using compiled-in assets).

### Testing

I used Chrome developer tools to ensure that assets were loaded properly when the value of the envvar `STGUIASSETS` was non-empty at runtime. Before this fix, the browser refused to load the assets due to identical mimetype errors triggered for each asset. After this fix, all assets are loaded successfully.

