### PR TITLE
Fixes error in syncthing-cli for 'errors show' command

### DIFF
--- a/cmd/stcli/cmd_errors.go
+++ b/cmd/stcli/cmd_errors.go
@@ -44,9 +44,9 @@ func errorsShow(c *cli.Context) {
 	json.Unmarshal(responseToBArray(response), &data)
 	writer := newTableWriter()
 	for _, item := range data["errors"] {
-		time := item["time"].(string)[:19]
+		time := item["when"].(string)[:19]
 		time = strings.Replace(time, "T", " ", 1)
-		err := item["error"].(string)
+		err := item["message"].(string)
 		err = strings.TrimSpace(err)
 		fmt.Fprintln(writer, time+":\t"+err)
 	}


### PR DESCRIPTION
### Purpose

Was getting this error on 

```
$ ./stcli -k APIKEY -e 'ENDPOINT' errors show
panic: interface conversion: interface {} is nil, not string

goroutine 1 [running]:
main.errorsShow(0xc4200d8300)
	/home/pkp/go/src/github.com/syncthing/syncthing/cmd/stcli/cmd_errors.go:48 +0x424
github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli.Command.Run(0x89eabb, 0x4, 0x0, 0x0, 0x8a55d2, 0x13, 0x0, 0x0, 0x0, 0x0, ...)
	/home/pkp/go/src/github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli/command.go:108 +0x5d4
github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli.(*App).RunAsSubcommand(0xc42007d6c0, 0xc4200d8180, 0xc420051918, 0x2)
	/home/pkp/go/src/github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli/app.go:217 +0x56e
github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli.Command.startApp(0x89f503, 0x6, 0x0, 0x0, 0x8a5443, 0x13, 0x0, 0x0, 0x0, 0x0, ...)
	/home/pkp/go/src/github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli/command.go:147 +0x23a
github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli.Command.Run(0x89f503, 0x6, 0x0, 0x0, 0x8a5443, 0x13, 0x0, 0x0, 0x0, 0x0, ...)
	/home/pkp/go/src/github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli/command.go:42 +0xcaf
github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli.(*App).Run(0xc42007d2b0, 0xc4200100e0, 0x7, 0x7, 0x0, 0x6)
	/home/pkp/go/src/github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli/app.go:131 +0x559
github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli.(*App).RunAndExitOnError(0xc42007d2b0)
	/home/pkp/go/src/github.com/syncthing/syncthing/vendor/github.com/AudriusButkevicius/cli/app.go:142 +0x53
main.main()
```

### Testing

After the fix:

```
2018-03-26 16:15:31:	Error on folder "foldername" (folder_id): folder marker missing
```
