### PR TITLE
lib/model: Increase the default pull limit (fixes #4883)

### DIFF
--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -81,7 +81,7 @@ const (
 const (
 	defaultCopiers          = 2
 	defaultPullerPause      = 60 * time.Second
-	defaultPullerPendingKiB = 8192 // must be larger than block size
+	defaultPullerPendingKiB = 2 * protocol.MaxBlockSize
 
 	maxPullerIterations = 3
 )


### PR DESCRIPTION
Bumping the limit to 2 * the max block size (16 MiB) is a slight
increase compared to previously. Nonetheless I think it's good to allow
us to queue one request and have one on the way in, or conversely have
one large block on the way in and be able to ask for smaller blocks from
others at the same time.
