### PR TITLE
lib/model: Fix test function for introducer

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -690,7 +690,7 @@ func TestIntroducer(t *testing.T) {
 				if introducedBy.Equals(introducedByAnyone) {
 					return true
 				}
-				return introducedBy.Equals(introducedBy)
+				return dev.IntroducedBy.Equals(introducedBy)
 			}
 		}
 		return false


### PR DESCRIPTION
I by accident stumbled over 
```golang
				return introducedBy.Equals(introducedBy)
```
in model_test.go which looks decidedly incorrect. <strike>Fixing it also lets `TestIntroducer` fail. Looks like a big review fail. I am looking into the test failures atm.</strike> `TestIntroducer` still passes though, so I guess reviewers got lucky (and code writer made his homework) :P 