### PR TITLE
lib/config, lib/model: Include paused folders in cluster config (fixes #4897)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -325,13 +325,18 @@ func (cfg *Configuration) clean() error {
 		existingDevices[device.DeviceID] = true
 	}
 
-	// Ensure that the device list is free from duplicates
+	// Ensure that the device list is
+	// - free from duplicates
+	// - sorted by ID
 	cfg.Devices = ensureNoDuplicateDevices(cfg.Devices)
-
 	sort.Sort(DeviceConfigurationList(cfg.Devices))
-	// Ensure that any loose devices are not present in the wrong places
-	// Ensure that there are no duplicate devices
-	// Ensure that the versioning configuration parameter map is not nil
+
+	// Ensure that the folder list is sorted by ID
+	sort.Sort(FolderConfigurationList(cfg.Folders))
+	// Ensure that in all folder configs
+	// - any loose devices are not present in the wrong places
+	// - there are no duplicate devices
+	// - the versioning configuration parameter map is not nil
 	for i := range cfg.Folders {
 		cfg.Folders[i].Devices = ensureExistingDevices(cfg.Folders[i].Devices, existingDevices)
 		cfg.Folders[i].Devices = ensureNoDuplicateFolderDevices(cfg.Folders[i].Devices)

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -278,3 +278,17 @@ func (l FolderDeviceConfigurationList) Len() int {
 func (f *FolderConfiguration) CheckFreeSpace() (err error) {
 	return checkFreeSpace(f.MinDiskFree, f.Filesystem())
 }
+
+type FolderConfigurationList []FolderConfiguration
+
+func (l FolderConfigurationList) Len() int {
+	return len(l)
+}
+
+func (l FolderConfigurationList) Less(a, b int) bool {
+	return l[a].ID < l[b].ID
+}
+
+func (l FolderConfigurationList) Swap(a, b int) {
+	l[a], l[b] = l[b], l[a]
+}

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -267,7 +267,7 @@ func (w *Wrapper) Folders() map[string]FolderConfiguration {
 	return w.folderMap
 }
 
-// FolderList returns a slice of devices.
+// FolderList returns a slice of folders.
 func (w *Wrapper) FolderList() []FolderConfiguration {
 	w.mut.Lock()
 	defer w.mut.Unlock()

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -445,3 +445,39 @@ func (w *Wrapper) MyName() string {
 func (w *Wrapper) CheckHomeFreeSpace() error {
 	return checkFreeSpace(w.Options().MinHomeDiskFree, fs.NewFilesystem(fs.FilesystemTypeBasic, filepath.Dir(w.ConfigPath())))
 }
+
+// GenerateClusterConfig returns a protocol.ClusterConfig for the given peer device
+// with all the relevant configuration information. It still needs to be completed
+// with database information.
+func (w *Wrapper) GenerateClusterConfig(device protocol.DeviceID) protocol.ClusterConfig {
+	var message protocol.ClusterConfig
+
+	for _, folderCfg := range w.cfg.Folders {
+		protocolFolder := protocol.Folder{
+			ID:                 folderCfg.ID,
+			Label:              folderCfg.Label,
+			ReadOnly:           folderCfg.Type == FolderTypeSendOnly,
+			IgnorePermissions:  folderCfg.IgnorePerms,
+			IgnoreDelete:       folderCfg.IgnoreDelete,
+			DisableTempIndexes: folderCfg.DisableTempIndexes,
+			Paused:             folderCfg.Paused,
+		}
+
+		for _, device := range folderCfg.Devices {
+			deviceCfg, _ := w.Device(device.DeviceID)
+			protocolDevice := protocol.Device{
+				ID:          deviceCfg.DeviceID,
+				Name:        deviceCfg.Name,
+				Addresses:   deviceCfg.Addresses,
+				Compression: deviceCfg.Compression,
+				CertName:    deviceCfg.CertName,
+				Introducer:  deviceCfg.Introducer,
+			}
+
+			protocolFolder.Devices = append(protocolFolder.Devices, protocolDevice)
+		}
+		message.Folders = append(message.Folders, protocolFolder)
+	}
+
+	return message
+}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1043,6 +1043,32 @@ func TestIntroducer(t *testing.T) {
 	}
 }
 
+func TestIssue4897(t *testing.T) {
+	_, m := newState(config.Configuration{
+		Devices: []config.DeviceConfiguration{
+			{
+				DeviceID:   device1,
+				Introducer: true,
+			},
+		},
+		Folders: []config.FolderConfiguration{
+			{
+				ID:   "folder1",
+				Path: "testdata",
+				Devices: []config.FolderDeviceConfiguration{
+					{DeviceID: device1},
+				},
+				Paused: true,
+			},
+		},
+	})
+
+	cm := m.generateClusterConfig(device1)
+	if l := len(cm.Folders); l != 1 {
+		t.Errorf("Cluster config contains %v folders, expected 1", l)
+	}
+}
+
 func TestAutoAcceptRejected(t *testing.T) {
 	// Nothing happens if AutoAcceptFolders not set
 	tcfg := defaultAutoAcceptCfg.Copy()


### PR DESCRIPTION
### Purpose

Currently cluster configs are built based on the folders in the model internals. Paused folders are removed from the model, so they don't get into the cluster config. Thus to another device it looks like the folder was removed/unshared. This in itself is already incorrect. If this happens to all folders shared with one device, this device is removed on the remote if we are marked as introducer (#4897).
 
This delegates the creation of cluster configs to the config package and only adds the
index IDs and sequence numbers in the model. It also ensures that all lists of devices and
folders in the config are sorted by ID.

### Testing

Added a test to check that the cluster config contains paused folders.