### PR TITLE
Update Dockerfile to incorporate exposed ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN rm -f syncthing && go run build.go build syncthing
 
 FROM alpine
 
+EXPOSE 8384 22000 21027/udp
+
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,14 @@ FROM alpine
 
 EXPOSE 8384 22000 21027/udp
 
+VOLUME ["/var/syncthing"]
+
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
 
 RUN echo 'syncthing:x:1000:1000::/var/syncthing:/sbin/nologin' >> /etc/passwd \
     && echo 'syncthing:!::0:::::' >> /etc/shadow \
-    && mkdir /var/syncthing \
     && chown syncthing /var/syncthing
 
 USER syncthing


### PR DESCRIPTION
added EXPOSE to Dockerfile. this way these ports will show up in docker front-ends like cockpit.

### Purpose

When including the EXPOSE and VOLUME functions, a front-end for docker will know which ports and what folders this container will use, therefore allowing users to more easily adjust these settings. 

### Testing

I re-built the container from scratch and no issues were found. To test it for yourself just paste in the one line and re-build the container with docker build.