### PR TITLE
lib/osutil: prevent using SYS_IOPRIO_SET on Android OS

### DIFF
--- a/lib/osutil/lowprio_linux.go
+++ b/lib/osutil/lowprio_linux.go
@@ -10,6 +10,7 @@ package osutil
 
 import (
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -32,6 +33,12 @@ const (
 )
 
 func ioprioSet(class ioprioClass, value int) error {
+	// Syscall SYS_IOPRIO_SET is blocked by seccomp
+	// on Android 8.
+	if runtime.GOOS == "android" {
+		return nil
+	}
+
 	res, _, err := syscall.Syscall(syscall.SYS_IOPRIO_SET,
 		uintptr(ioprioWhoProcess), 0,
 		uintptr(class)<<ioprioClassShift|uintptr(value))


### PR DESCRIPTION
### Purpose

SYS_IOPRIO_SET causes syncthing to crash when running on Android 8.
More information here: https://github.com/termux/termux-packages/issues/2391

```
SIGSYS: bad system call
PC=0xaecdf308 m=9 sigcode=1

goroutine 1 [syscall]:
syscall.Syscall(0x13a, 0x1, 0x0, 0x4005, 0x0, 0x0, 0x0)
	/home/builder/.termux-build/_cache/go1.10/src/syscall/asm_linux_arm.s:17 +0x8 fp=0x8e75c794 sp=0x8e75c790 pc=0xaecdf2e8
github.com/syncthing/syncthing/lib/osutil.ioprioSet(0x2, 0x5, 0xb, 0x0)
	/home/builder/.termux-build/syncthing/build/go/src/github.com/syncthing/syncthing/lib/osutil/lowprio_linux.go:33 +0x3c fp=0x8e75c7b8 sp=0x8e75c794 pc=0xaefdd6f8
github.com/syncthing/syncthing/lib/osutil.SetLowPriority(0x8e612380, 0x8e5af280)
```