### PR TITLE
lib/db: Remove all sequences related to the folder (fixes #4928)

### DIFF
--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -538,6 +538,14 @@ func (db *Instance) dropFolder(folder []byte) {
 		}
 	}
 	dbi.Release()
+	
+	//Remove all items related to the given folder from the sequence
+	sequenceKey := db.sequenceKey([]byte(folder), 0)
+	dbi = t.NewIterator(util.BytesPrefix(sequenceKey[:4]), nil)
+	for dbi.Next() {
+		db.Delete(dbi.Key(), nil)
+	}
+	dbi.Release()
 
 	// Remove all items related to the given folder from the global bucket
 	dbi = t.NewIterator(util.BytesPrefix([]byte{KeyTypeGlobal}), nil)

--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -539,7 +539,7 @@ func (db *Instance) dropFolder(folder []byte) {
 	}
 	dbi.Release()
 	
-	//Remove all items related to the given folder from the sequence
+	// Remove all sequences related to the folder
 	sequenceKey := db.sequenceKey([]byte(folder), 0)
 	dbi = t.NewIterator(util.BytesPrefix(sequenceKey[:4]), nil)
 	for dbi.Next() {

--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -538,7 +538,7 @@ func (db *Instance) dropFolder(folder []byte) {
 		}
 	}
 	dbi.Release()
-	
+
 	// Remove all sequences related to the folder
 	sequenceKey := db.sequenceKey([]byte(folder), 0)
 	dbi = t.NewIterator(util.BytesPrefix(sequenceKey[:4]), nil)


### PR DESCRIPTION
syncthing version git-2343c82c33dea213d9ccd0236f3132e161cb270c
- How to  reproduce
1. Add a folder ~/test/0000  get folder ID apv4v-f4ngi
2. Remove the folder in the previous step
3. Re-Add folder and keep folder ID is apv4v-f4ngi
4. SendIndexes is Endless loop. like sequence id from 0-200,86-200,86-200,86-200..... 

model.go:1783 insert line
```
		l.Infof("222222222## sequence: %d %s", f.Sequence, f.Name)
```
can be see the log

....
....
[ABCDE] 2018/05/08 23:43:18.185937 model.go:1783: INFO: 222222222## sequence: 100 README.md
[ABCDE] 2018/05/08 23:43:18.185956 model.go:1783: INFO: 222222222## sequence: 101 syncmap.go
[ABCDE] 2018/05/08 23:43:18.185978 model.go:1783: INFO: 222222222## sequence: 102 syncmap.go

[ABCDE] 2018/05/08 23:43:18.185999 model.go:1783: INFO: 222222222## sequence: 86  README.html
[ABCDE] 2018/05/08 23:43:18.186017 model.go:1783: INFO: 222222222## sequence: 87 buffer.go
[ABCDE] 2018/05/08 23:43:18.186035 model.go:1783: INFO: 222222222## sequence: 88 test.go

