### PR TITLE
build: Increase test timeout to 2min

### DIFF
--- a/build.go
+++ b/build.go
@@ -47,6 +47,7 @@ var (
 	installSuffix string
 	pkgdir        string
 	debugBinary   bool
+	timeout       = "120s"
 )
 
 type target struct {
@@ -401,9 +402,9 @@ func test(pkgs ...string) {
 	}
 
 	if useRace {
-		runPrint("go", append([]string{"test", "-short", "-race", "-timeout", "60s", "-tags", "purego"}, pkgs...)...)
+		runPrint("go", append([]string{"test", "-short", "-race", "-timeout", timeout, "-tags", "purego"}, pkgs...)...)
 	} else {
-		runPrint("go", append([]string{"test", "-short", "-timeout", "60s", "-tags", "purego"}, pkgs...)...)
+		runPrint("go", append([]string{"test", "-short", "-timeout", timeout, "-tags", "purego"}, pkgs...)...)
 	}
 }
 


### PR DESCRIPTION
After a huge pull on master (i.e. no caching), the test timed out repeatedly (intel i5-2520M) due to the scanner package (I think it's the hysteresis tests which needs to do a lot of hashing). I propose to extend the test timeout to 2min.