### PR TITLE
lib/model: Refactor {ro,rw}folder serve loop into just folder

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -115,6 +115,7 @@ func (f *folder) Serve() {
 			}
 
 			// Pulling failed, try again later.
+			l.Infof("Folder %v isn't making sync progress - retrying in %v.", f.Description(), pause)
 			pullFailTimer.Reset(pause)
 			// Back off from retrying to pull with an upper limit.
 			if pause < 60*f.basePause() {

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -189,8 +189,6 @@ func (f *sendReceiveFolder) pull() bool {
 					"errors": folderErrors,
 				})
 			}
-
-			l.Infof("Folder %v isn't making progress. Pausing puller.", f.Description())
 			break
 		}
 	}

--- a/lib/model/rwfolder.go
+++ b/lib/model/rwfolder.go
@@ -94,9 +94,10 @@ type dbUpdateJob struct {
 type sendReceiveFolder struct {
 	folder
 
-	fs        fs.Filesystem
-	versioner versioner.Versioner
-	pause     time.Duration
+	prevIgnoreHash string
+	fs             fs.Filesystem
+	versioner      versioner.Versioner
+	pause          time.Duration
 
 	queue *jobQueue
 
@@ -106,15 +107,13 @@ type sendReceiveFolder struct {
 
 func newSendReceiveFolder(model *Model, cfg config.FolderConfiguration, ver versioner.Versioner, fs fs.Filesystem) service {
 	f := &sendReceiveFolder{
-		folder: newFolder(model, cfg),
-
+		folder:    newFolder(model, cfg),
 		fs:        fs,
 		versioner: ver,
-
-		queue: newJobQueue(),
-
+		queue:     newJobQueue(),
 		errorsMut: sync.NewMutex(),
 	}
+	f.folder.puller = f
 
 	if f.Copiers == 0 {
 		f.Copiers = defaultCopiers
@@ -135,121 +134,29 @@ func newSendReceiveFolder(model *Model, cfg config.FolderConfiguration, ver vers
 	return f
 }
 
-// Serve will run scans and pulls. It will return when Stop()ed or on a
-// critical error.
-func (f *sendReceiveFolder) Serve() {
-	l.Debugln(f, "starting")
-	defer l.Debugln(f, "exiting")
-
-	defer func() {
-		f.scan.timer.Stop()
-		// TODO: Should there be an actual FolderStopped state?
-		f.setState(FolderIdle)
-	}()
-
-	var prevIgnoreHash string
-	var success bool
-	pullFailTimer := time.NewTimer(time.Duration(0))
-	<-pullFailTimer.C
-
-	if f.FSWatcherEnabled && f.CheckHealth() == nil {
-		f.startWatch()
-	}
-
-	initialCompleted := f.initialScanFinished
-
-	for {
-		select {
-		case <-f.ctx.Done():
-			return
-
-		case <-f.pullScheduled:
-			pullFailTimer.Stop()
-			select {
-			case <-pullFailTimer.C:
-			default:
-			}
-
-			if prevIgnoreHash, success = f.pull(prevIgnoreHash); !success {
-				// Pulling failed, try again later.
-				pullFailTimer.Reset(f.pause)
-			}
-
-		case <-pullFailTimer.C:
-			if prevIgnoreHash, success = f.pull(prevIgnoreHash); !success {
-				// Pulling failed, try again later.
-				pullFailTimer.Reset(f.pause)
-				// Back off from retrying to pull with an upper limit.
-				if f.pause < 60*f.basePause() {
-					f.pause *= 2
-				}
-			}
-
-		case <-initialCompleted:
-			// Initial scan has completed, we should do a pull
-			initialCompleted = nil // never hit this case again
-			if prevIgnoreHash, success = f.pull(prevIgnoreHash); !success {
-				// Pulling failed, try again later.
-				pullFailTimer.Reset(f.pause)
-			}
-
-		// The reason for running the scanner from within the puller is that
-		// this is the easiest way to make sure we are not doing both at the
-		// same time.
-		case <-f.scan.timer.C:
-			l.Debugln(f, "Scanning subdirectories")
-			f.scanTimerFired()
-
-		case req := <-f.scan.now:
-			req.err <- f.scanSubdirs(req.subdirs)
-
-		case next := <-f.scan.delay:
-			f.scan.timer.Reset(next)
-
-		case fsEvents := <-f.watchChan:
-			l.Debugln(f, "filesystem notification rescan")
-			f.scanSubdirs(fsEvents)
-
-		case <-f.restartWatchChan:
-			f.restartWatch()
-		}
-	}
-}
-
-func (f *sendReceiveFolder) SchedulePull() {
-	select {
-	case f.pullScheduled <- struct{}{}:
-	default:
-		// We might be busy doing a pull and thus not reading from this
-		// channel. The channel is 1-buffered, so one notification will be
-		// queued to ensure we recheck after the pull, but beyond that we must
-		// make sure to not block index receiving.
-	}
-}
-
 func (f *sendReceiveFolder) String() string {
 	return fmt.Sprintf("sendReceiveFolder/%s@%p", f.folderID, f)
 }
 
-func (f *sendReceiveFolder) pull(prevIgnoreHash string) (curIgnoreHash string, success bool) {
+func (f *sendReceiveFolder) pull() (success bool) {
 	select {
 	case <-f.initialScanFinished:
 	default:
 		// Once the initial scan finished, a pull will be scheduled
-		return prevIgnoreHash, true
+		return true
 	}
 
 	if err := f.CheckHealth(); err != nil {
 		l.Debugln("Skipping pull of", f.Description(), "due to folder error:", err)
-		return prevIgnoreHash, true
+		return true
 	}
 
 	f.model.fmut.RLock()
 	curIgnores := f.model.folderIgnores[f.folderID]
 	f.model.fmut.RUnlock()
 
-	curIgnoreHash = curIgnores.Hash()
-	ignoresChanged := curIgnoreHash != prevIgnoreHash
+	curIgnoreHash := curIgnores.Hash()
+	ignoresChanged := curIgnoreHash != f.prevIgnoreHash
 
 	l.Debugf("%v pulling (ignoresChanged=%v)", f, ignoresChanged)
 
@@ -301,10 +208,11 @@ func (f *sendReceiveFolder) pull(prevIgnoreHash string) (curIgnoreHash string, s
 	close(scanChan)
 
 	if changed == 0 {
-		return curIgnoreHash, true
+		f.prevIgnoreHash = curIgnoreHash
+		return true
 	}
 
-	return prevIgnoreHash, false
+	return false
 }
 
 // pullerIteration runs a single puller iteration for the given folder and
@@ -1798,13 +1706,6 @@ func (f *sendReceiveFolder) PullErrors() []FileError {
 	sort.Sort(fileErrorList(errors))
 	f.errorsMut.Unlock()
 	return errors
-}
-
-func (f *sendReceiveFolder) basePause() time.Duration {
-	if f.PullerPauseS == 0 {
-		return defaultPullerPause
-	}
-	return time.Duration(f.PullerPauseS) * time.Second
 }
 
 // deleteDir attempts to delete a directory. It checks for files/dirs inside


### PR DESCRIPTION
The actual pull method (which is really the only thing that differs between them) is now an interface member which gets overridden by the subclass.

"Subclass?!" Well, this is dynamic dispatch with overriding, I guess.

### Purpose

Yeah, about that. I'm going to implement the damn recv only folder. As part of that I need to clean shit up. I hope to try to do that in manageable steps so it doesn't turn into an impossible-to-review ball of mud diff. No promises, though.

In the end I want something like the `folder` type that has all the scaffolding and looping and stuff, a `puller` member that implements the pull (like this PR) and something similar on the scan side. Possibly a scan results filter of some sort. Then the three folder types built out of these components.

### Testing

It compiles, and it passes the integration tests...