### PR TITLE
lib/db: Fix prefixed walks (fixes #4925)

### DIFF
--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -186,20 +186,27 @@ func (db *Instance) removeSequences(folder []byte, fs []protocol.FileInfo) {
 }
 
 func (db *Instance) withHave(folder, device, prefix []byte, truncate bool, fn Iterator) {
+	if len(prefix) > 0 && !bytes.HasSuffix(prefix, []byte{'/'}) {
+		f, ok := db.getFileTrunc(db.deviceKey(folder, device, prefix), true)
+		if !ok {
+			// nothing to be done if the root element doesn't exist
+			return
+		}
+		if !fn(f) {
+			return
+		}
+		prefix = append(prefix, '/')
+	}
+
 	t := db.newReadOnlyTransaction()
 	defer t.close()
 
 	dbi := t.NewIterator(util.BytesPrefix(db.deviceKey(folder, device, prefix)[:keyPrefixLen+keyFolderLen+keyDeviceLen+len(prefix)]), nil)
 	defer dbi.Release()
 
-	slashedPrefix := prefix
-	if !bytes.HasSuffix(prefix, []byte{'/'}) {
-		slashedPrefix = append(slashedPrefix, '/')
-	}
-
 	for dbi.Next() {
 		name := db.deviceKeyName(dbi.Key())
-		if len(prefix) > 0 && !bytes.Equal(name, prefix) && !bytes.HasPrefix(name, slashedPrefix) {
+		if len(prefix) > 0 && !bytes.HasPrefix(name, prefix) {
 			return
 		}
 
@@ -277,20 +284,26 @@ func (db *Instance) withAllFolderTruncated(folder []byte, fn func(device []byte,
 }
 
 func (db *Instance) getFile(key []byte) (protocol.FileInfo, bool) {
+	if f, ok := db.getFileTrunc(key, false); ok {
+		return f.(protocol.FileInfo), true
+	}
+	return protocol.FileInfo{}, false
+}
+
+func (db *Instance) getFileTrunc(key []byte, trunc bool) (FileIntf, bool) {
 	bs, err := db.Get(key, nil)
 	if err == leveldb.ErrNotFound {
-		return protocol.FileInfo{}, false
+		return nil, false
 	}
 	if err != nil {
 		l.Debugln("surprise error:", err)
-		return protocol.FileInfo{}, false
+		return nil, false
 	}
 
-	var f protocol.FileInfo
-	err = f.Unmarshal(bs)
+	f, err := unmarshalTrunc(bs, trunc)
 	if err != nil {
 		l.Debugln("unmarshal error:", err)
-		return protocol.FileInfo{}, false
+		return nil, false
 	}
 	return f, true
 }
@@ -306,75 +319,53 @@ func (db *Instance) getGlobal(folder, file []byte, truncate bool) (FileIntf, boo
 		return nil, false
 	}
 
-	var vl VersionList
-	err = vl.Unmarshal(bs)
-	if err == leveldb.ErrNotFound {
-		return nil, false
-	}
-	if err != nil {
-		l.Debugln("unmarshal error:", k, err)
-		return nil, false
-	}
-	if len(vl.Versions) == 0 {
-		l.Debugln("no versions:", k)
+	vl, ok := unmarshalVersionList(bs)
+	if !ok {
 		return nil, false
 	}
 
-	k = db.deviceKey(folder, vl.Versions[0].Device, file)
-	bs, err = t.Get(k, nil)
-	if err != nil {
-		l.Debugln("surprise error:", k, err)
-		return nil, false
+	if fi, ok := db.getFileTrunc(db.deviceKey(folder, vl.Versions[0].Device, file), truncate); ok {
+		return fi, true
 	}
 
-	fi, err := unmarshalTrunc(bs, truncate)
-	if err != nil {
-		l.Debugln("unmarshal error:", k, err)
-		return nil, false
-	}
-	return fi, true
+	return nil, false
 }
 
 func (db *Instance) withGlobal(folder, prefix []byte, truncate bool, fn Iterator) {
+	if len(prefix) > 0 && !bytes.HasSuffix(prefix, []byte{'/'}) {
+		f, ok := db.getGlobal(folder, prefix, truncate)
+		if !ok {
+			// nothing to be done if the root element doesn't exist
+			return
+		}
+		if !fn(f) {
+			return
+		}
+		prefix = append(prefix, '/')
+	}
+
 	t := db.newReadOnlyTransaction()
 	defer t.close()
 
 	dbi := t.NewIterator(util.BytesPrefix(db.globalKey(folder, prefix)), nil)
 	defer dbi.Release()
 
-	slashedPrefix := prefix
-	if !bytes.HasSuffix(prefix, []byte{'/'}) {
-		slashedPrefix = append(slashedPrefix, '/')
-	}
-
 	var fk []byte
 	for dbi.Next() {
-		var vl VersionList
-		err := vl.Unmarshal(dbi.Value())
-		if err != nil {
-			l.Debugln("unmarshal error:", err)
-			continue
-		}
-		if len(vl.Versions) == 0 {
-			l.Debugln("no versions:", dbi.Key())
-			continue
-		}
-
 		name := db.globalKeyName(dbi.Key())
-		if len(prefix) > 0 && !bytes.Equal(name, prefix) && !bytes.HasPrefix(name, slashedPrefix) {
+		if len(prefix) > 0 && !bytes.HasPrefix(name, prefix) {
 			return
 		}
 
-		fk = db.deviceKeyInto(fk, folder, vl.Versions[0].Device, name)
-		bs, err := t.Get(fk, nil)
-		if err != nil {
-			l.Debugln("surprise error:", err)
+		vl, ok := unmarshalVersionList(dbi.Value())
+		if !ok {
 			continue
 		}
 
-		f, err := unmarshalTrunc(bs, truncate)
-		if err != nil {
-			l.Debugln("unmarshal error:", err)
+		fk = db.deviceKeyInto(fk, folder, vl.Versions[0].Device, name)
+
+		f, ok := db.getFileTrunc(fk, truncate)
+		if !ok {
 			continue
 		}
 
@@ -395,10 +386,8 @@ func (db *Instance) availability(folder, file []byte) []protocol.DeviceID {
 		return nil
 	}
 
-	var vl VersionList
-	err = vl.Unmarshal(bs)
-	if err != nil {
-		l.Debugln("unmarshal error:", err)
+	vl, ok := unmarshalVersionList(bs)
+	if !ok {
 		return nil
 	}
 
@@ -426,14 +415,8 @@ func (db *Instance) withNeed(folder, device []byte, truncate bool, fn Iterator) 
 
 	var fk []byte
 	for dbi.Next() {
-		var vl VersionList
-		err := vl.Unmarshal(dbi.Value())
-		if err != nil {
-			l.Debugln("unmarshal error:", err)
-			continue
-		}
-		if len(vl.Versions) == 0 {
-			l.Debugln("no versions:", dbi.Key())
+		vl, ok := unmarshalVersionList(dbi.Value())
+		if !ok {
 			continue
 		}
 
@@ -586,11 +569,8 @@ func (db *Instance) checkGlobals(folder []byte, meta *metadataTracker) {
 
 	var fk []byte
 	for dbi.Next() {
-		gk := dbi.Key()
-		var vl VersionList
-		err := vl.Unmarshal(dbi.Value())
-		if err != nil {
-			l.Debugln("unmarshal error:", err)
+		vl, ok := unmarshalVersionList(dbi.Value())
+		if !ok {
 			continue
 		}
 
@@ -599,7 +579,7 @@ func (db *Instance) checkGlobals(folder []byte, meta *metadataTracker) {
 		// there are global entries pointing to no longer existing files. Here
 		// we find those and clear them out.
 
-		name := db.globalKeyName(gk)
+		name := db.globalKeyName(dbi.Key())
 		var newVL VersionList
 		for i, version := range vl.Versions {
 			fk = db.deviceKeyInto(fk, folder, version.Device, name)
@@ -921,6 +901,19 @@ func unmarshalTrunc(bs []byte, truncate bool) (FileIntf, error) {
 	var tf protocol.FileInfo
 	err := tf.Unmarshal(bs)
 	return tf, err
+}
+
+func unmarshalVersionList(data []byte) (VersionList, bool) {
+	var vl VersionList
+	if err := vl.Unmarshal(data); err != nil {
+		l.Debugln("unmarshal error:", err)
+		return VersionList{}, false
+	}
+	if len(vl.Versions) == 0 {
+		l.Debugln("empty version list")
+		return VersionList{}, false
+	}
+	return vl, true
 }
 
 // A "better" version of leveldb's errors.IsCorrupted.

--- a/lib/db/leveldb_dbinstance.go
+++ b/lib/db/leveldb_dbinstance.go
@@ -186,16 +186,17 @@ func (db *Instance) removeSequences(folder []byte, fs []protocol.FileInfo) {
 }
 
 func (db *Instance) withHave(folder, device, prefix []byte, truncate bool, fn Iterator) {
-	if len(prefix) > 0 && !bytes.HasSuffix(prefix, []byte{'/'}) {
-		f, ok := db.getFileTrunc(db.deviceKey(folder, device, prefix), true)
-		if !ok {
-			// nothing to be done if the root element doesn't exist
+	if len(prefix) > 0 {
+		unslashedPrefix := prefix
+		if bytes.HasSuffix(prefix, []byte{'/'}) {
+			unslashedPrefix = unslashedPrefix[:len(unslashedPrefix)-1]
+		} else {
+			prefix = append(prefix, '/')
+		}
+
+		if f, ok := db.getFileTrunc(db.deviceKey(folder, device, unslashedPrefix), true); ok && !fn(f) {
 			return
 		}
-		if !fn(f) {
-			return
-		}
-		prefix = append(prefix, '/')
 	}
 
 	t := db.newReadOnlyTransaction()
@@ -332,16 +333,17 @@ func (db *Instance) getGlobal(folder, file []byte, truncate bool) (FileIntf, boo
 }
 
 func (db *Instance) withGlobal(folder, prefix []byte, truncate bool, fn Iterator) {
-	if len(prefix) > 0 && !bytes.HasSuffix(prefix, []byte{'/'}) {
-		f, ok := db.getGlobal(folder, prefix, truncate)
-		if !ok {
-			// nothing to be done if the root element doesn't exist
+	if len(prefix) > 0 {
+		unslashedPrefix := prefix
+		if bytes.HasSuffix(prefix, []byte{'/'}) {
+			unslashedPrefix = unslashedPrefix[:len(unslashedPrefix)-1]
+		} else {
+			prefix = append(prefix, '/')
+		}
+
+		if f, ok := db.getGlobal(folder, unslashedPrefix, truncate); ok && !fn(f) {
 			return
 		}
-		if !fn(f) {
-			return
-		}
-		prefix = append(prefix, '/')
 	}
 
 	t := db.newReadOnlyTransaction()

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -193,8 +193,10 @@ func (s *FileSet) WithHaveSequence(startSeq int64, fn Iterator) {
 	s.db.withHaveSequence([]byte(s.folder), startSeq, nativeFileIterator(fn))
 }
 
+// Except for an item with a path equal to prefix, only children of prefix are iterated.
+// E.g. for prefix "dir", "dir/file" is iterated, but "dir.file" is not.
 func (s *FileSet) WithPrefixedHaveTruncated(device protocol.DeviceID, prefix string, fn Iterator) {
-	l.Debugf("%s WithPrefixedHaveTruncated(%v)", s.folder, device)
+	l.Debugf(`%s WithPrefixedHaveTruncated(%v, "%v")`, s.folder, device, prefix)
 	s.db.withHave([]byte(s.folder), device[:], []byte(osutil.NormalizedFilename(prefix)), true, nativeFileIterator(fn))
 }
 func (s *FileSet) WithGlobal(fn Iterator) {
@@ -207,8 +209,10 @@ func (s *FileSet) WithGlobalTruncated(fn Iterator) {
 	s.db.withGlobal([]byte(s.folder), nil, true, nativeFileIterator(fn))
 }
 
+// Except for an item with a path equal to prefix, only children of prefix are iterated.
+// E.g. for prefix "dir", "dir/file" is iterated, but "dir.file" is not.
 func (s *FileSet) WithPrefixedGlobalTruncated(prefix string, fn Iterator) {
-	l.Debugf("%s WithPrefixedGlobalTruncated()", s.folder, prefix)
+	l.Debugf(`%s WithPrefixedGlobalTruncated("%v")`, s.folder, prefix)
 	s.db.withGlobal([]byte(s.folder), []byte(osutil.NormalizedFilename(prefix)), true, nativeFileIterator(fn))
 }
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2403,7 +2403,8 @@ func (m *Model) GlobalDirectoryTree(folder, prefix string, levels int, dirsonly 
 	files.WithPrefixedGlobalTruncated(prefix, func(fi db.FileIntf) bool {
 		f := fi.(db.FileInfoTruncated)
 
-		if f.IsInvalid() || f.IsDeleted() || f.Name == prefix {
+		// Don't include the prefix itself.
+		if f.IsInvalid() || f.IsDeleted() || strings.HasPrefix(prefix, f.Name) {
 			return true
 		}
 


### PR DESCRIPTION
### Purpose

Currently walking the db with a prefix is broken in the presence of a file, that has the same prefix, as the entire walk is aborted when such a file is encountered.

### Testing

Added new unit test.