### PR TITLE
all: Serialize folder types to new names

### DIFF
--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -79,7 +79,8 @@ func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf,
 
 	var rescanIntvs []int
 	folderUses := map[string]int{
-		"readonly":            0,
+		"sendonly":            0,
+		"sendreceive":         0,
 		"ignorePerms":         0,
 		"ignoreDelete":        0,
 		"autoNormalize":       0,
@@ -91,8 +92,11 @@ func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf,
 	for _, cfg := range cfg.Folders() {
 		rescanIntvs = append(rescanIntvs, cfg.RescanIntervalS)
 
-		if cfg.Type == config.FolderTypeSendOnly {
-			folderUses["readonly"]++
+		switch cfg.Type {
+		case config.FolderTypeSendOnly:
+			folderUses["sendonly"]++
+		case config.FolderTypeSendReceive:
+			folderUses["sendreceive"]++
 		}
 		if cfg.IgnorePerms {
 			folderUses["ignorePerms"]++

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -274,7 +274,7 @@
               <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id)}}%"></div>
               <h4 class="panel-title">
                 <div class="panel-icon hidden-xs">
-                  <span class="fa fa-fw" ng-class="[folder.type == 'readonly' ? 'fa-lock' : 'fa-folder']"></span>
+                  <span class="fa fa-fw" ng-class="[folder.type == 'sendonly' ? 'fa-lock' : 'fa-folder']"></span>
                 </div>
                 <div class="panel-status pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
                   <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs">&#9724;</span></span>
@@ -358,11 +358,11 @@
                         <a href="" ng-click="showFailed(folder.id)">{{model[folder.id].pullErrors | alwaysNumber | localeNumber}}&nbsp;<span translate>items</span></a>
                       </td>
                     </tr>
-                    <tr ng-if="folder.type != 'readwrite'">
+                    <tr ng-if="folder.type != 'sendreceive'">
                       <th><span class="fa fa-fw fa-lock"></span>&nbsp;<span translate>Folder Type</span></th>
                       <td class="text-right">
-                        <span ng-if="folder.type == 'readonly'" translate>Send Only</span>
-                        <span ng-if="folder.type != 'readonly'">{{ folder.type.charAt(0).toUpperCase() + folder.type.slice(1) }}</span>
+                        <span ng-if="folder.type == 'sendonly'" translate>Send Only</span>
+                        <span ng-if="folder.type == 'sendreceive'" translate>Send & Receive</span>
                       </td>
                     </tr>
                     <tr ng-if="folder.ignorePerms">
@@ -435,7 +435,7 @@
                         <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
                       </td>
                     </tr>
-                    <tr ng-if="folder.type != 'readonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">
+                    <tr ng-if="folder.type != 'sendonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">
                       <th><span class="fa fa-fw fa-exchange"></span>&nbsp;<span translate>Latest Change</span></th>
                       <td class="text-right">
                         <span tooltip data-original-title="{{folderStats[folder.id].lastFile.filename}} @ {{folderStats[folder.id].lastFile.at | date:'yyyy-MM-dd HH:mm:ss'}}">
@@ -449,7 +449,7 @@
                 </table>
               </div>
               <div class="panel-footer">
-                <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="override(folder.id)" ng-if="folderStatus(folder) == 'outofsync' && folder.type == 'readonly'">
+                <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="override(folder.id)" ng-if="folderStatus(folder) == 'outofsync' && folder.type == 'sendonly'">
                   <span class="fa fa-arrow-circle-up"></span>&nbsp;<span translate>Override Changes</span>
                 </button>
                 <span class="pull-right">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -362,7 +362,6 @@
                       <th><span class="fa fa-fw fa-lock"></span>&nbsp;<span translate>Folder Type</span></th>
                       <td class="text-right">
                         <span ng-if="folder.type == 'sendonly'" translate>Send Only</span>
-                        <span ng-if="folder.type == 'sendreceive'" translate>Send & Receive</span>
                       </td>
                     </tr>
                     <tr ng-if="folder.ignorePerms">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -62,7 +62,7 @@ angular.module('syncthing.core')
 
         $scope.folderDefaults = {
             selectedDevices: {},
-            type: "readwrite",
+            type: "sendreceive",
             rescanIntervalS: 3600,
             fsWatcherDelayS: 10,
             fsWatcherEnabled: true,

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -160,10 +160,10 @@
               <label translate>Folder Type</label>
               &nbsp;<a href="https://docs.syncthing.net/users/foldertypes.html" target="_blank"><span class="fa fa-book"></span>&nbsp;<span translate>Help</span></a>
               <select class="form-control" ng-model="currentFolder.type">
-                <option value="readwrite" translate>Send &amp; Receive</option>
-                <option value="readonly" translate>Send Only</option>
+                <option value="sendreceive" translate>Send &amp; Receive</option>
+                <option value="sendonly" translate>Send Only</option>
               </select>
-              <p ng-if="currentFolder.type == 'readonly'" translate class="help-block">Files are protected from changes made on other devices, but changes made on this device will be sent to the rest of the cluster.</p>
+              <p ng-if="currentFolder.type == 'sendonly'" translate class="help-block">Files are protected from changes made on other devices, but changes made on this device will be sent to the rest of the cluster.</p>
             </div>
             <div class="col-md-6 form-group">
               <label translate>File Pull Order</label>

--- a/lib/config/foldertype.go
+++ b/lib/config/foldertype.go
@@ -16,9 +16,9 @@ const (
 func (t FolderType) String() string {
 	switch t {
 	case FolderTypeSendReceive:
-		return "readwrite"
+		return "sendreceive"
 	case FolderTypeSendOnly:
-		return "readonly"
+		return "sendonly"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
It's been a year and a half since we started accepting the new names.
It's time we start producing them.

@AudriusButkevicius @canton7 @kozec will this break all the wrappers? It changes the folder type returned by the /rest/system/config call and the string on disk. If so should we hold off a little while or should we just say that we will *never* change the names and scrap this?

We still accept the old type in incoming configs, and should probably continue to do so forever.

The reason for the change is that the future trio `readwrite`, `readonly`, `recvonly` [makes no sense whatsoever](https://thedailywtf.com/articles/What_Is_Truth_0x3f_) (which is why Heiko introduced the new names way back).