### PR TITLE
cmd/syncthing: Return formatted JSON in API

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -219,14 +219,14 @@ func sendJSON(w http.ResponseWriter, jsonObject interface{}) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	// Marshalling might fail, in which case we should return a 500 with the
 	// actual error.
-	bs, err := json.Marshal(jsonObject)
+	bs, err := json.MarshalIndent(jsonObject, "", "  ")
 	if err != nil {
 		// This Marshal() can't fail though.
 		bs, _ = json.Marshal(map[string]string{"error": err.Error()})
 		http.Error(w, string(bs), http.StatusInternalServerError)
 		return
 	}
-	w.Write(bs)
+	fmt.Fprintf(w, "%s\n", bs)
 }
 
 func (s *apiService) Serve() {


### PR DESCRIPTION
Because machines don't care, and sometimes humans read the output.
