### PR TITLE
cmd/stdiscosrv: Delete records for abandoned devices

### DIFF
--- a/cmd/stdiscosrv/database.go
+++ b/cmd/stdiscosrv/database.go
@@ -195,6 +195,7 @@ func (s *levelDBStore) statisticsServe(trigger <-chan struct{}, done chan<- stru
 		nowNanos := t0.UnixNano()
 		cutoff24h := t0.Add(-24 * time.Hour).UnixNano()
 		cutoff1w := t0.Add(-7 * 24 * time.Hour).UnixNano()
+		cutoff2Mon := t0.Add(-60 * 24 * time.Hour).UnixNano()
 		current, last24h, last1w, inactive, errors := 0, 0, 0, 0, 0
 
 		iter := s.db.NewIterator(&util.Range{}, nil)
@@ -217,6 +218,17 @@ func (s *levelDBStore) statisticsServe(trigger <-chan struct{}, done chan<- stru
 				last24h++
 			case rec.Seen > cutoff1w:
 				last1w++
+			case rec.Seen > cutoff2Mon:
+				inactive++
+			case rec.Missed < cutoff2Mon:
+				// It hasn't been seen lately and we haven't recorded
+				// someone asking for this device in a long time either;
+				// delete the record.
+				if err := s.db.Delete(iter.Key(), nil); err != nil {
+					databaseOperations.WithLabelValues(dbOpDelete, dbResError).Inc()
+				} else {
+					databaseOperations.WithLabelValues(dbOpDelete, dbResSuccess).Inc()
+				}
 			default:
 				inactive++
 			}

--- a/cmd/stdiscosrv/stats.go
+++ b/cmd/stdiscosrv/stats.go
@@ -95,6 +95,7 @@ const (
 	dbOpGet             = "get"
 	dbOpPut             = "put"
 	dbOpMerge           = "merge"
+	dbOpDelete          = "delete"
 	dbResSuccess        = "success"
 	dbResNotFound       = "not_found"
 	dbResError          = "error"


### PR DESCRIPTION
Once a device has been missing for a long time, and noone has asked about it for a long time, delete the record.

Already live. (I made a mistake when deploying it live the first time and it deleted old records that still had current `missed` times, hence the current rise in requests and lookup failures.)