### PR TITLE
lib/model: Add String() for folder

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -9,6 +9,7 @@ package model
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/rand"
 	"time"
 
@@ -388,4 +389,8 @@ func (f *folder) basePause() time.Duration {
 		return defaultPullerPause
 	}
 	return time.Duration(f.PullerPauseS) * time.Second
+}
+
+func (f *folder) String() string {
+	return fmt.Sprintf("%s/%s@%p", f.Type, f.folderID, f)
 }

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -7,8 +7,6 @@
 package model
 
 import (
-	"fmt"
-
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/fs"
@@ -30,10 +28,6 @@ func newSendOnlyFolder(model *Model, cfg config.FolderConfiguration, _ versioner
 	}
 	f.folder.puller = f
 	return f
-}
-
-func (f *sendOnlyFolder) String() string {
-	return fmt.Sprintf("sendOnlyFolder/%s@%p", f.folderID, f)
 }
 
 func (f *sendOnlyFolder) PullErrors() []FileError {

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -131,10 +131,6 @@ func newSendReceiveFolder(model *Model, cfg config.FolderConfiguration, ver vers
 	return f
 }
 
-func (f *sendReceiveFolder) String() string {
-	return fmt.Sprintf("sendReceiveFolder/%s@%p", f.folderID, f)
-}
-
 func (f *sendReceiveFolder) pull() bool {
 	select {
 	case <-f.initialScanFinished:


### PR DESCRIPTION
### Purpose

The missing `String` method on `folder` meant, that the new debug log statements due to the recent refactor caused the entire struct to be printed.