### PR TITLE
lib/config, lib/model: Handle shared with information in config (fixes #4870)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -261,6 +261,15 @@ func (f FolderConfiguration) RequiresRestartOnly() FolderConfiguration {
 	return copy
 }
 
+func (f *FolderConfiguration) SharedWith(device protocol.DeviceID) bool {
+	for _, dev := range f.Devices {
+		if dev.DeviceID == device {
+			return true
+		}
+	}
+	return false
+}
+
 type FolderDeviceConfigurationList []FolderDeviceConfiguration
 
 func (l FolderDeviceConfigurationList) Less(a, b int) bool {

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -60,12 +60,11 @@ type Wrapper struct {
 	cfg  Configuration
 	path string
 
-	deviceMap       map[protocol.DeviceID]DeviceConfiguration
-	folderMap       map[string]FolderConfiguration
-	folderDeviceSet FolderDeviceSet
-	replaces        chan Configuration
-	subs            []Committer
-	mut             sync.Mutex
+	deviceMap map[protocol.DeviceID]DeviceConfiguration
+	folderMap map[string]FolderConfiguration
+	replaces  chan Configuration
+	subs      []Committer
+	mut       sync.Mutex
 
 	requiresRestart uint32 // an atomic bool
 }
@@ -164,7 +163,6 @@ func (w *Wrapper) replaceLocked(to Configuration) (Waiter, error) {
 	w.cfg = to
 	w.deviceMap = nil
 	w.folderMap = nil
-	w.folderDeviceSet = nil
 
 	return w.notifyListeners(from, to), nil
 }
@@ -453,60 +451,4 @@ func (w *Wrapper) MyName() string {
 // free space, or if home disk free space checking is disabled.
 func (w *Wrapper) CheckHomeFreeSpace() error {
 	return checkFreeSpace(w.Options().MinHomeDiskFree, fs.NewFilesystem(fs.FilesystemTypeBasic, filepath.Dir(w.ConfigPath())))
-}
-
-func (w *Wrapper) IsSharedWith(folder string, device protocol.DeviceID) bool {
-	w.mut.Lock()
-	defer w.mut.Unlock()
-	if w.folderDeviceSet == nil {
-		w.createFolderDeviceSetLocked()
-	}
-	return w.folderDeviceSet.Has(folder, device)
-}
-
-func (w *Wrapper) SharedWith(folder string) map[protocol.DeviceID]struct{} {
-	w.mut.Lock()
-	defer w.mut.Unlock()
-	if w.folderDeviceSet == nil {
-		w.createFolderDeviceSetLocked()
-	}
-	return w.folderDeviceSet[folder]
-}
-
-func (w *Wrapper) createFolderDeviceSetLocked() {
-	w.folderDeviceSet = make(map[string]map[protocol.DeviceID]struct{}, len(w.cfg.Folders))
-	for _, cfg := range w.cfg.Folders {
-		for _, dev := range cfg.Devices {
-			w.folderDeviceSet.Set(cfg.ID, dev.DeviceID)
-		}
-	}
-}
-
-// folderDeviceSet is a set of (folder, deviceID) pairs
-type FolderDeviceSet map[string]map[protocol.DeviceID]struct{}
-
-// Set adds the (dev, folder) pair to the set
-func (s FolderDeviceSet) Set(folder string, dev protocol.DeviceID) {
-	devs, ok := s[folder]
-	if !ok {
-		devs = make(map[protocol.DeviceID]struct{})
-		s[folder] = devs
-	}
-	devs[dev] = struct{}{}
-}
-
-// Has returns true if the (dev, folder) pair is in the set
-func (s FolderDeviceSet) Has(folder string, dev protocol.DeviceID) bool {
-	_, ok := s[folder][dev]
-	return ok
-}
-
-// hasDevice returns true if the device is set on any folder
-func (s FolderDeviceSet) HasDevice(dev protocol.DeviceID) bool {
-	for _, devices := range s {
-		if _, ok := devices[dev]; ok {
-			return true
-		}
-	}
-	return false
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1297,7 +1297,7 @@ func (m *Model) Request(deviceID protocol.DeviceID, folder, name string, offset 
 	// Make sure the path is valid and in canonical form
 	var err error
 	if name, err = fs.Canonicalize(name); err != nil {
-		l.Debugf("Request from %s in paused folder %q for invalid filename %s", deviceID, folder, name)
+		l.Debugf("Request from %s in folder %q for invalid filename %s", deviceID, folder, name)
 		return protocol.ErrInvalid
 	}
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -909,7 +909,8 @@ func (m *Model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	m.fmut.Lock()
 	var paused []string
 	for _, folder := range cm.Folders {
-		if cfg, ok := m.cfg.Folder(folder.ID); !ok || !cfg.SharedWith(deviceID) {
+		cfg, ok := m.cfg.Folder(folder.ID)
+		if !ok || !cfg.SharedWith(deviceID) {
 			if m.cfg.IgnoredFolder(folder.ID) {
 				l.Infof("Ignoring folder %s from device %s since we are configured to", folder.Description(), deviceID)
 				continue
@@ -921,10 +922,12 @@ func (m *Model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 			})
 			l.Infof("Unexpected folder %s sent from device %q; ensure that the folder exists and that this device is selected under \"Share With\" in the folder configuration.", folder.Description(), deviceID)
 			continue
-		} else if folder.Paused {
+		}
+		if folder.Paused {
 			paused = append(paused, folder.ID)
 			continue
-		} else if cfg.Paused {
+		}
+		if cfg.Paused {
 			continue
 		}
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1111,19 +1111,18 @@ func (m *Model) handleDeintroductions(introducerCfg config.DeviceConfiguration, 
 	folders := m.cfg.FolderList()
 	// Check if we should unshare some folders, if the introducer has unshared them.
 	for i := range folders {
-		folderCfg := &folders[i]
-		for i := 0; i < len(folderCfg.Devices); i++ {
-			if folderCfg.Devices[i].IntroducedBy != introducerCfg.DeviceID {
-				devicesNotIntroduced[folderCfg.Devices[i].DeviceID] = struct{}{}
+		for k := 0; k < len(folders[i].Devices); k++ {
+			if folders[i].Devices[k].IntroducedBy != introducerCfg.DeviceID {
+				devicesNotIntroduced[folders[i].Devices[k].DeviceID] = struct{}{}
 				continue
 			}
-			if !foldersDevices.Has(folderCfg.ID, folderCfg.Devices[i].DeviceID) {
+			if !foldersDevices.Has(folders[i].ID, folders[i].Devices[k].DeviceID) {
 				// We could not find that folder shared on the
 				// introducer with the device that was introduced to us.
 				// We should follow and unshare as well.
-				l.Infof("Unsharing folder %s with %v as introducer %v no longer shares the folder with that device", folderCfg.Description(), folderCfg.Devices[i].DeviceID, folderCfg.Devices[i].IntroducedBy)
-				folderCfg.Devices = append(folderCfg.Devices[:i], folderCfg.Devices[i+1:]...)
-				i--
+				l.Infof("Unsharing folder %s with %v as introducer %v no longer shares the folder with that device", folders[i].Description(), folders[i].Devices[k].DeviceID, folders[i].Devices[k].IntroducedBy)
+				folders[i].Devices = append(folders[i].Devices[:k], folders[i].Devices[k+1:]...)
+				k--
 				changed = true
 			}
 		}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1287,7 +1287,6 @@ func TestAutoAcceptPrefersLabel(t *testing.T) {
 		},
 	})
 	if fcfg, ok := wcfg.Folder(id); !ok || !wcfg.IsSharedWith(id, device1) || !strings.HasSuffix(fcfg.Path, label) {
-
 		t.Error("expected shared, or wrong path", id, label, fcfg.Path)
 	}
 }

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1096,7 +1096,7 @@ func TestAutoAcceptRejected(t *testing.T) {
 		},
 	})
 
-	if _, ok := wcfg.Folder(id); ok || m.folderSharedWith(id, device1) {
+	if wcfg.IsSharedWith(id, device1) {
 		t.Error("unexpected shared", id)
 	}
 }
@@ -1114,7 +1114,7 @@ func TestAutoAcceptNewFolder(t *testing.T) {
 			},
 		},
 	})
-	if _, ok := wcfg.Folder(id); !ok || !m.folderSharedWith(id, device1) {
+	if !wcfg.IsSharedWith(id, device1) {
 		t.Error("expected shared", id)
 	}
 }
@@ -1138,10 +1138,10 @@ func TestAutoAcceptMultipleFolders(t *testing.T) {
 			},
 		},
 	})
-	if _, ok := wcfg.Folder(id1); !ok || !m.folderSharedWith(id1, device1) {
+	if !wcfg.IsSharedWith(id1, device1) {
 		t.Error("expected shared", id1)
 	}
-	if _, ok := wcfg.Folder(id2); !ok || !m.folderSharedWith(id2, device1) {
+	if !wcfg.IsSharedWith(id2, device1) {
 		t.Error("expected shared", id2)
 	}
 }
@@ -1161,7 +1161,7 @@ func TestAutoAcceptExistingFolder(t *testing.T) {
 		},
 	}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id); !ok || m.folderSharedWith(id, device1) {
+	if _, ok := wcfg.Folder(id); !ok || m.cfg.IsSharedWith(id, device1) {
 		t.Error("missing folder, or shared", id)
 	}
 	m.ClusterConfig(device1, protocol.ClusterConfig{
@@ -1173,7 +1173,7 @@ func TestAutoAcceptExistingFolder(t *testing.T) {
 		},
 	})
 
-	if fcfg, ok := wcfg.Folder(id); !ok || !m.folderSharedWith(id, device1) || fcfg.Path != filepath.Join("testdata", idOther) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !wcfg.IsSharedWith(id, device1) || fcfg.Path != filepath.Join("testdata", idOther) {
 		t.Error("missing folder, or unshared, or path changed", id)
 	}
 }
@@ -1193,7 +1193,7 @@ func TestAutoAcceptNewAndExistingFolder(t *testing.T) {
 		},
 	}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id1); !ok || m.folderSharedWith(id1, device1) {
+	if _, ok := wcfg.Folder(id1); !ok || m.cfg.IsSharedWith(id1, device1) {
 		t.Error("missing folder, or shared", id1)
 	}
 	m.ClusterConfig(device1, protocol.ClusterConfig{
@@ -1210,7 +1210,7 @@ func TestAutoAcceptNewAndExistingFolder(t *testing.T) {
 	})
 
 	for i, id := range []string{id1, id2} {
-		if _, ok := wcfg.Folder(id); !ok || !m.folderSharedWith(id, device1) {
+		if !wcfg.IsSharedWith(id, device1) {
 			t.Error("missing folder, or unshared", i, id)
 		}
 	}
@@ -1233,7 +1233,7 @@ func TestAutoAcceptAlreadyShared(t *testing.T) {
 		},
 	}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id); !ok || !m.folderSharedWith(id, device1) {
+	if !wcfg.IsSharedWith(id, device1) {
 		t.Error("missing folder, or not shared", id)
 	}
 	m.ClusterConfig(device1, protocol.ClusterConfig{
@@ -1245,7 +1245,7 @@ func TestAutoAcceptAlreadyShared(t *testing.T) {
 		},
 	})
 
-	if _, ok := wcfg.Folder(id); !ok || !m.folderSharedWith(id, device1) {
+	if !wcfg.IsSharedWith(id, device1) {
 		t.Error("missing folder, or not shared", id)
 	}
 }
@@ -1266,7 +1266,7 @@ func TestAutoAcceptNameConflict(t *testing.T) {
 			},
 		},
 	})
-	if _, ok := wcfg.Folder(id); ok || m.folderSharedWith(id, device1) {
+	if wcfg.IsSharedWith(id, device1) {
 		t.Error("unexpected folder", id)
 	}
 }
@@ -1286,7 +1286,8 @@ func TestAutoAcceptPrefersLabel(t *testing.T) {
 			},
 		},
 	})
-	if fcfg, ok := wcfg.Folder(id); !ok || !m.folderSharedWith(id, device1) || !strings.HasSuffix(fcfg.Path, label) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !wcfg.IsSharedWith(id, device1) || !strings.HasSuffix(fcfg.Path, label) {
+
 		t.Error("expected shared, or wrong path", id, label, fcfg.Path)
 	}
 }
@@ -1307,7 +1308,7 @@ func TestAutoAcceptFallsBackToID(t *testing.T) {
 			},
 		},
 	})
-	if fcfg, ok := wcfg.Folder(id); !ok || !m.folderSharedWith(id, device1) || !strings.HasSuffix(fcfg.Path, id) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !wcfg.IsSharedWith(id, device1) || !strings.HasSuffix(fcfg.Path, id) {
 		t.Error("expected shared, or wrong path", id, label, fcfg.Path)
 	}
 }
@@ -1330,8 +1331,8 @@ func TestAutoAcceptPausedWhenFolderConfigChanged(t *testing.T) {
 	})
 	tcfg.Folders = []config.FolderConfiguration{fcfg}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id); !ok || m.folderSharedWith(id, device1) {
-		t.Error("missing folder, or shared", id)
+	if _, ok := wcfg.Folder(id); !ok || !m.cfg.IsSharedWith(id, device1) {
+		t.Error("missing folder, or not shared", id)
 	}
 	if _, ok := m.folderRunners[id]; ok {
 		t.Fatal("folder running?")
@@ -1360,7 +1361,7 @@ func TestAutoAcceptPausedWhenFolderConfigChanged(t *testing.T) {
 		t.Error("device missing")
 	}
 
-	if _, ok := m.folderDevices[id]; ok {
+	if _, ok := m.folderRunners[id]; ok {
 		t.Error("folder started")
 	}
 }
@@ -1386,8 +1387,8 @@ func TestAutoAcceptPausedWhenFolderConfigNotChanged(t *testing.T) {
 	}, fcfg.Devices...) // Need to ensure this device order to avoid folder restart.
 	tcfg.Folders = []config.FolderConfiguration{fcfg}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id); !ok || m.folderSharedWith(id, device1) {
-		t.Error("missing folder, or shared", id)
+	if _, ok := wcfg.Folder(id); !ok || !m.cfg.IsSharedWith(id, device1) {
+		t.Error("missing folder, or not shared", id)
 	}
 	if _, ok := m.folderRunners[id]; ok {
 		t.Fatal("folder running?")
@@ -1416,7 +1417,7 @@ func TestAutoAcceptPausedWhenFolderConfigNotChanged(t *testing.T) {
 		t.Error("device missing")
 	}
 
-	if _, ok := m.folderDevices[id]; ok {
+	if _, ok := m.folderRunners[id]; ok {
 		t.Error("folder started")
 	}
 }
@@ -1536,7 +1537,7 @@ func TestIgnores(t *testing.T) {
 	pausedDefaultFolderConfig := defaultFolderConfig
 	pausedDefaultFolderConfig.Paused = true
 
-	m.RestartFolder(pausedDefaultFolderConfig)
+	m.RestartFolder(defaultFolderConfig, pausedDefaultFolderConfig)
 	// Here folder initialization is not an issue as a paused folder isn't
 	// added to the model and thus there is no initial scan happening.
 
@@ -2623,10 +2624,10 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		},
 	})
 
-	if !m.folderSharedWith("default", device1) {
+	if !m.cfg.IsSharedWith("default", device1) {
 		t.Error("not shared with device1")
 	}
-	if !m.folderSharedWith("default", device2) {
+	if !m.cfg.IsSharedWith("default", device2) {
 		t.Error("not shared with device2")
 	}
 
@@ -2643,10 +2644,10 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond) // Committer notification happens in a separate routine
 
-	if !m.folderSharedWith("default", device1) {
+	if !m.cfg.IsSharedWith("default", device1) {
 		t.Error("not shared with device1")
 	}
-	if m.folderSharedWith("default", device2) { // checks m.deviceFolders
+	if m.cfg.IsSharedWith("default", device2) { // checks m.deviceFolders
 		t.Error("shared with device2")
 	}
 
@@ -2658,12 +2659,7 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		t.Error("device still in config")
 	}
 
-	fdevs, ok := m.folderDevices["default"]
-	if !ok {
-		t.Error("folder missing?")
-	}
-
-	for id := range fdevs {
+	for id := range wcfg.SharedWith("default") {
 		if id == device2 {
 			t.Error("still there")
 		}
@@ -3250,7 +3246,7 @@ func TestIssue4475(t *testing.T) {
 	conn := addFakeConn(m, device1)
 	conn.folder = "default"
 
-	if !m.folderSharedWith("default", device1) {
+	if !m.cfg.IsSharedWith("default", device1) {
 		t.Fatal("not shared with device1")
 	}
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1084,7 +1084,7 @@ func TestAutoAcceptRejected(t *testing.T) {
 	for i := range tcfg.Devices {
 		tcfg.Devices[i].AutoAcceptFolders = false
 	}
-	wcfg, m := newState(tcfg)
+	_, m := newState(tcfg)
 	id := srand.String(8)
 	defer os.RemoveAll(filepath.Join("testdata", id))
 	m.ClusterConfig(device1, protocol.ClusterConfig{
@@ -1096,7 +1096,7 @@ func TestAutoAcceptRejected(t *testing.T) {
 		},
 	})
 
-	if wcfg.IsSharedWith(id, device1) {
+	if cfg, ok := m.cfg.Folder(id); ok && cfg.SharedWith(device1) {
 		t.Error("unexpected shared", id)
 	}
 }
@@ -1114,7 +1114,7 @@ func TestAutoAcceptNewFolder(t *testing.T) {
 			},
 		},
 	})
-	if !wcfg.IsSharedWith(id, device1) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
 		t.Error("expected shared", id)
 	}
 }
@@ -1138,10 +1138,10 @@ func TestAutoAcceptMultipleFolders(t *testing.T) {
 			},
 		},
 	})
-	if !wcfg.IsSharedWith(id1, device1) {
+	if fcfg, ok := wcfg.Folder(id1); !ok || !fcfg.SharedWith(device1) {
 		t.Error("expected shared", id1)
 	}
-	if !wcfg.IsSharedWith(id2, device1) {
+	if fcfg, ok := wcfg.Folder(id2); !ok || !fcfg.SharedWith(device1) {
 		t.Error("expected shared", id2)
 	}
 }
@@ -1161,7 +1161,7 @@ func TestAutoAcceptExistingFolder(t *testing.T) {
 		},
 	}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id); !ok || m.cfg.IsSharedWith(id, device1) {
+	if fcfg, ok := wcfg.Folder(id); !ok || fcfg.SharedWith(device1) {
 		t.Error("missing folder, or shared", id)
 	}
 	m.ClusterConfig(device1, protocol.ClusterConfig{
@@ -1173,7 +1173,7 @@ func TestAutoAcceptExistingFolder(t *testing.T) {
 		},
 	})
 
-	if fcfg, ok := wcfg.Folder(id); !ok || !wcfg.IsSharedWith(id, device1) || fcfg.Path != filepath.Join("testdata", idOther) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) || fcfg.Path != filepath.Join("testdata", idOther) {
 		t.Error("missing folder, or unshared, or path changed", id)
 	}
 }
@@ -1193,7 +1193,7 @@ func TestAutoAcceptNewAndExistingFolder(t *testing.T) {
 		},
 	}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id1); !ok || m.cfg.IsSharedWith(id1, device1) {
+	if fcfg, ok := wcfg.Folder(id1); !ok || fcfg.SharedWith(device1) {
 		t.Error("missing folder, or shared", id1)
 	}
 	m.ClusterConfig(device1, protocol.ClusterConfig{
@@ -1210,7 +1210,7 @@ func TestAutoAcceptNewAndExistingFolder(t *testing.T) {
 	})
 
 	for i, id := range []string{id1, id2} {
-		if !wcfg.IsSharedWith(id, device1) {
+		if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
 			t.Error("missing folder, or unshared", i, id)
 		}
 	}
@@ -1233,7 +1233,7 @@ func TestAutoAcceptAlreadyShared(t *testing.T) {
 		},
 	}
 	wcfg, m := newState(tcfg)
-	if !wcfg.IsSharedWith(id, device1) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
 		t.Error("missing folder, or not shared", id)
 	}
 	m.ClusterConfig(device1, protocol.ClusterConfig{
@@ -1245,7 +1245,7 @@ func TestAutoAcceptAlreadyShared(t *testing.T) {
 		},
 	})
 
-	if !wcfg.IsSharedWith(id, device1) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
 		t.Error("missing folder, or not shared", id)
 	}
 }
@@ -1266,7 +1266,7 @@ func TestAutoAcceptNameConflict(t *testing.T) {
 			},
 		},
 	})
-	if wcfg.IsSharedWith(id, device1) {
+	if fcfg, ok := wcfg.Folder(id); ok && fcfg.SharedWith(device1) {
 		t.Error("unexpected folder", id)
 	}
 }
@@ -1286,7 +1286,7 @@ func TestAutoAcceptPrefersLabel(t *testing.T) {
 			},
 		},
 	})
-	if fcfg, ok := wcfg.Folder(id); !ok || !wcfg.IsSharedWith(id, device1) || !strings.HasSuffix(fcfg.Path, label) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) || !strings.HasSuffix(fcfg.Path, label) {
 		t.Error("expected shared, or wrong path", id, label, fcfg.Path)
 	}
 }
@@ -1307,7 +1307,7 @@ func TestAutoAcceptFallsBackToID(t *testing.T) {
 			},
 		},
 	})
-	if fcfg, ok := wcfg.Folder(id); !ok || !wcfg.IsSharedWith(id, device1) || !strings.HasSuffix(fcfg.Path, id) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) || !strings.HasSuffix(fcfg.Path, id) {
 		t.Error("expected shared, or wrong path", id, label, fcfg.Path)
 	}
 }
@@ -1330,7 +1330,7 @@ func TestAutoAcceptPausedWhenFolderConfigChanged(t *testing.T) {
 	})
 	tcfg.Folders = []config.FolderConfiguration{fcfg}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id); !ok || !m.cfg.IsSharedWith(id, device1) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
 		t.Error("missing folder, or not shared", id)
 	}
 	if _, ok := m.folderRunners[id]; ok {
@@ -1386,7 +1386,7 @@ func TestAutoAcceptPausedWhenFolderConfigNotChanged(t *testing.T) {
 	}, fcfg.Devices...) // Need to ensure this device order to avoid folder restart.
 	tcfg.Folders = []config.FolderConfiguration{fcfg}
 	wcfg, m := newState(tcfg)
-	if _, ok := wcfg.Folder(id); !ok || !m.cfg.IsSharedWith(id, device1) {
+	if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
 		t.Error("missing folder, or not shared", id)
 	}
 	if _, ok := m.folderRunners[id]; ok {
@@ -2623,10 +2623,10 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		},
 	})
 
-	if !m.cfg.IsSharedWith("default", device1) {
+	if fcfg, ok := m.cfg.Folder("default"); !ok || !fcfg.SharedWith(device1) {
 		t.Error("not shared with device1")
 	}
-	if !m.cfg.IsSharedWith("default", device2) {
+	if fcfg, ok := m.cfg.Folder("default"); !ok || !fcfg.SharedWith(device2) {
 		t.Error("not shared with device2")
 	}
 
@@ -2643,11 +2643,20 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond) // Committer notification happens in a separate routine
 
-	if !m.cfg.IsSharedWith("default", device1) {
+	fcfg, ok := m.cfg.Folder("default")
+	if !ok {
+		t.Fatal("default folder missing")
+	}
+	if !fcfg.SharedWith(device1) {
 		t.Error("not shared with device1")
 	}
-	if m.cfg.IsSharedWith("default", device2) { // checks m.deviceFolders
+	if fcfg.SharedWith(device2) {
 		t.Error("shared with device2")
+	}
+	for _, dev := range fcfg.Devices {
+		if dev.DeviceID == device2 {
+			t.Error("still there")
+		}
 	}
 
 	if !conn2.Closed() {
@@ -2656,12 +2665,6 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 
 	if _, ok := wcfg.Devices()[device2]; ok {
 		t.Error("device still in config")
-	}
-
-	for id := range wcfg.SharedWith("default") {
-		if id == device2 {
-			t.Error("still there")
-		}
 	}
 
 	if _, ok := m.conn[device2]; !ok {
@@ -3245,7 +3248,7 @@ func TestIssue4475(t *testing.T) {
 	conn := addFakeConn(m, device1)
 	conn.folder = "default"
 
-	if !m.cfg.IsSharedWith("default", device1) {
+	if fcfg, ok := m.cfg.Folder("default"); !ok || !fcfg.SharedWith(device1) {
 		t.Fatal("not shared with device1")
 	}
 


### PR DESCRIPTION
Original/main purpose is to actually fix #4870. In the previous PR I tried to deduce whether the folder is paused from the information within the model. That clearly fails, because paused folders aren't in the model. 

Paused folders also caused problems elsewhere in the past (cluster config for one). `folderDevices` and `deviceFolders` is fully redundant and additionally they track information about which folder is shared with whom -> that's actually config business (again, paused folders). So I moved that functionality to wrapper.go and adapted all affected sections in model.go (sometimes adding the distinction between a unshared vs just paused folder).