### PR TITLE
lib/fs: Resolve 8.3 filenames from watcher (ref #3800)

### DIFF
--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strings"
 	"testing"
 	"time"
 )
@@ -305,38 +304,6 @@ func TestUsage(t *testing.T) {
 	}
 }
 
-func TestWindowsPaths(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("Not useful on non-Windows")
-		return
-	}
-
-	testCases := []struct {
-		input        string
-		expectedRoot string
-		expectedURI  string
-	}{
-		{`e:\`, `\\?\e:\`, `e:\`},
-		{`\\?\e:\`, `\\?\e:\`, `e:\`},
-		{`\\192.0.2.22\network\share`, `\\192.0.2.22\network\share`, `\\192.0.2.22\network\share`},
-	}
-
-	for _, testCase := range testCases {
-		fs := newBasicFilesystem(testCase.input)
-		if fs.root != testCase.expectedRoot {
-			t.Errorf("root %q != %q", fs.root, testCase.expectedRoot)
-		}
-		if fs.URI() != testCase.expectedURI {
-			t.Errorf("uri %q != %q", fs.URI(), testCase.expectedURI)
-		}
-	}
-
-	fs := newBasicFilesystem(`relative\path`)
-	if fs.root == `relative\path` || !strings.HasPrefix(fs.root, "\\\\?\\") {
-		t.Errorf("%q == %q, expected absolutification", fs.root, `relative\path`)
-	}
-}
-
 func TestRooted(t *testing.T) {
 	type testcase struct {
 		root   string
@@ -480,36 +447,5 @@ func TestRooted(t *testing.T) {
 			t.Errorf("Unexpected pass for rooted(%q, %q) => %q", tc.root, tc.rel, res)
 			continue
 		}
-	}
-}
-
-func TestWindows83(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("only relevant on windows")
-	}
-
-	fs, dir := setup(t)
-	defer os.RemoveAll(dir)
-
-	shortAbs, _ := fs.rooted("LFDATA~1")
-	long := "LFDataTool"
-	longAbs, _ := fs.rooted(long)
-	deleted, _ := fs.rooted(filepath.Join("foo", "LFDATA~1"))
-	notShort, _ := fs.rooted(filepath.Join("foo", "bar", "baz"))
-
-	fd, err := fs.Create(long)
-	if err != nil {
-		t.Fatal(err)
-	}
-	fd.Close()
-
-	if res := fs.resolveWin83(shortAbs); res != longAbs {
-		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, shortAbs, res, longAbs)
-	}
-	if res := fs.resolveWin83(deleted); res != filepath.Dir(deleted) {
-		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, deleted, res, filepath.Dir(deleted))
-	}
-	if res := fs.resolveWin83(notShort); res != notShort {
-		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, notShort, res, notShort)
 	}
 }

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -494,6 +494,8 @@ func TestWindows83(t *testing.T) {
 	shortAbs := filepath.Join(fs.URI(), "LFDATA~1")
 	long := "LFDataTool"
 	longAbs := filepath.Join(fs.URI(), long)
+	deleted := filepath.Join(fs.URI(), "foo", "LFDATA~1")
+	notShort := filepath.Join(fs.URI(), "foo", "bar", "baz")
 
 	fd, err := fs.Create(long)
 	if err != nil {
@@ -503,5 +505,11 @@ func TestWindows83(t *testing.T) {
 
 	if res := fs.resolveWin83(shortAbs); res != longAbs {
 		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, shortAbs, res, longAbs)
+	}
+	if res := fs.resolveWin83(deleted); res != fs.URI() {
+		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, deleted, res, filepath.Dir(deleted))
+	}
+	if res := fs.resolveWin83(notShort); res != fs.URI() {
+		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, notShort, res, notShort)
 	}
 }

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -500,7 +500,7 @@ func TestWindows83(t *testing.T) {
 	}
 	fd.Close()
 
-	if res := f.resolveWin83(short); res != long {
+	if res := fs.resolveWin83(short); res != long {
 		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, short, res, long)
 	}
 }

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -491,11 +491,11 @@ func TestWindows83(t *testing.T) {
 	fs, dir := setup(t)
 	defer os.RemoveAll(dir)
 
-	shortAbs := filepath.Join(fs.URI(), "LFDATA~1")
+	shortAbs, _ := fs.rooted("LFDATA~1")
 	long := "LFDataTool"
-	longAbs := filepath.Join(fs.URI(), long)
-	deleted := filepath.Join(fs.URI(), "foo", "LFDATA~1")
-	notShort := filepath.Join(fs.URI(), "foo", "bar", "baz")
+	longAbs, _ := fs.rooted(long)
+	deleted, _ := fs.rooted(filepath.Join("foo", "LFDATA~1"))
+	notShort, _ := fs.rooted(filepath.Join("foo", "bar", "baz"))
 
 	fd, err := fs.Create(long)
 	if err != nil {
@@ -506,10 +506,10 @@ func TestWindows83(t *testing.T) {
 	if res := fs.resolveWin83(shortAbs); res != longAbs {
 		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, shortAbs, res, longAbs)
 	}
-	if res := fs.resolveWin83(deleted); res != fs.URI() {
+	if res := fs.resolveWin83(deleted); res != filepath.Dir(deleted) {
 		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, deleted, res, filepath.Dir(deleted))
 	}
-	if res := fs.resolveWin83(notShort); res != fs.URI() {
+	if res := fs.resolveWin83(notShort); res != notShort {
 		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, notShort, res, notShort)
 	}
 }

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func setup(t *testing.T) (Filesystem, string) {
+	t.Helper()
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {
 		t.Fatal(err)
@@ -479,5 +480,27 @@ func TestRooted(t *testing.T) {
 			t.Errorf("Unexpected pass for rooted(%q, %q) => %q", tc.root, tc.rel, res)
 			continue
 		}
+	}
+}
+
+func TestWindows83(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("only relevant on windows")
+	}
+
+	short := "LFDATA~1"
+	long := "LFDataTool"
+
+	fs, dir := setup(t)
+	defer os.RemoveAll(dir)
+
+	fd, err := fs.Create(long)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fd.Close()
+
+	if res := f.resolveWin83(short); res != long {
+		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, short, res, long)
 	}
 }

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-func setup(t *testing.T) (Filesystem, string) {
+func setup(t *testing.T) (*BasicFilesystem, string) {
 	t.Helper()
 	dir, err := ioutil.TempDir("", "")
 	if err != nil {

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -488,11 +488,12 @@ func TestWindows83(t *testing.T) {
 		t.Skip("only relevant on windows")
 	}
 
-	short := "LFDATA~1"
-	long := "LFDataTool"
-
 	fs, dir := setup(t)
 	defer os.RemoveAll(dir)
+
+	shortAbs := filepath.Join(fs.URI(), "LFDATA~1")
+	long := "LFDataTool"
+	longAbs := filepath.Join(fs.URI(), long)
 
 	fd, err := fs.Create(long)
 	if err != nil {
@@ -500,7 +501,7 @@ func TestWindows83(t *testing.T) {
 	}
 	fd.Close()
 
-	if res := fs.resolveWin83(short); res != long {
-		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, short, res, long)
+	if res := fs.resolveWin83(shortAbs); res != longAbs {
+		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, shortAbs, res, longAbs)
 	}
 }

--- a/lib/fs/basicfs_unix.go
+++ b/lib/fs/basicfs_unix.go
@@ -51,3 +51,7 @@ func (f *BasicFilesystem) Hide(name string) error {
 func (f *BasicFilesystem) Roots() ([]string, error) {
 	return []string{"/"}, nil
 }
+
+func (f *BasicFilesystem) resolveWin83(absPath string) string {
+	return absPath
+}

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -117,5 +117,5 @@ func (f *BasicFilesystem) unrootedChecked(absPath string) string {
 	if !strings.HasPrefix(absPath, f.rootSymlinkEvaluated) {
 		panic(fmt.Sprintf("bug: Notify backend is processing a change outside of the filesystem root: root==%v, rootSymEval==%v, path==%v", f.root, f.rootSymlinkEvaluated, absPath))
 	}
-	return f.unrootedSymlinkEvaluated(absPath)
+	return f.unrootedSymlinkEvaluated(f.resolveWin83(absPath))
 }

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -159,13 +159,19 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 	if in, err := syscall.UTF16FromString(absPath); err != nil {
 		out := make([]uint16, 4*len(absPath)) // *2 for UTF16 and *2 to double path length
 		if n, err := syscall.GetLongPathName(&in[0], &out[0], uint32(len(out))); err == nil {
+			l.Infoln("first getLong, n:", n, "len(out):", len(out))
 			if n <= uint32(len(out)) {
 				return syscall.UTF16ToString(out[:n])
 			}
 			out = make([]uint16, n)
 			if _, err = syscall.GetLongPathName(&in[0], &out[0], n); err == nil {
+				l.Infoln("second getLong, n:", n, "len(out):", len(out))
 				return syscall.UTF16ToString(out)
+			} else {
+				l.Infoln("second getLong, err:", err)
 			}
+		} else {
+			l.Infoln("first getLong, err:", err)
 		}
 	}
 	// Failed getting the long path. Return the part of the path which is

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -173,6 +173,8 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 		} else {
 			l.Infoln("first getLong, err:", err)
 		}
+	} else {
+		l.Infoln("utf16 from string, err:", err)
 	}
 	// Failed getting the long path. Return the part of the path which is
 	// already a long path.

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -179,12 +179,8 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 }
 
 func isMaybeWin83(absPath string) bool {
-	parts := strings.Split(absPath, "~")
-	// Return true unless splitting occurs due to "~syncthing~"
-	for i := 1; i < len(parts); i += 2 {
-		if parts[i] != WindowsTempPrefix[1:len(WindowsTempPrefix)-1] {
-			return true
-		}
+	if !strings.Contains(absPath, "~") {
+		return false
 	}
-	return false
+	return strings.Contains(strings.TrimPrefix(absPath, WindowsTempPrefix), "~")
 }

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -155,16 +156,16 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 	if !strings.Contains(absPath, '~') {
 		return absPath
 	}
-	if in, err := windows.UTF16FromString(absPath); err != nil {
-		out = make([]uint16, 2*len(p))
-		n := uint32(len(b))
+	if in, err := syscall.UTF16FromString(absPath); err != nil {
+		out := make([]uint16, 2*len(absPath))
+		n := uint32(len(out))
 		for {
-			n, err = windows.GetLongPathName(&in[0], &out[0], n)
+			n, err = syscall.GetLongPathName(&in[0], &out[0], n)
 			if err != nil {
 				break
 			}
 			if n <= uint32(len(out)) {
-				return windows.UTF16ToString(out[:n])
+				return syscall.UTF16ToString(out[:n])
 			}
 			out = make([]uint16, n)
 		}

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -157,17 +157,15 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 		return absPath
 	}
 	if in, err := syscall.UTF16FromString(absPath); err != nil {
-		out := make([]uint16, 2*len(absPath))
-		n := uint32(len(out))
-		for {
-			n, err = syscall.GetLongPathName(&in[0], &out[0], n)
-			if err != nil {
-				break
-			}
+		out := make([]uint16, 4*len(absPath)) // *2 for UTF16 and *2 to double path length
+		if n, err = syscall.GetLongPathName(&in[0], &out[0], uint32(len(out))); err == nil {
 			if n <= uint32(len(out)) {
 				return syscall.UTF16ToString(out[:n])
 			}
 			out = make([]uint16, n)
+			if _, err = syscall.GetLongPathName(&in[0], &out[0], n); err == nil {
+				return syscall.UTF16ToString(out)
+			}
 		}
 	}
 	// Failed getting the long path. Return the part of the path which is

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -159,22 +159,22 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 	if in, err := syscall.UTF16FromString(absPath); err != nil {
 		out := make([]uint16, 4*len(absPath)) // *2 for UTF16 and *2 to double path length
 		if n, err := syscall.GetLongPathName(&in[0], &out[0], uint32(len(out))); err == nil {
-			l.Infoln("first getLong, n:", n, "len(out):", len(out))
+			l.Infoln(absPath, "first getLong, n:", n, "len(out):", len(out))
 			if n <= uint32(len(out)) {
 				return syscall.UTF16ToString(out[:n])
 			}
 			out = make([]uint16, n)
 			if _, err = syscall.GetLongPathName(&in[0], &out[0], n); err == nil {
-				l.Infoln("second getLong, n:", n, "len(out):", len(out))
+				l.Infoln(absPath, "second getLong, n:", n, "len(out):", len(out))
 				return syscall.UTF16ToString(out)
 			} else {
-				l.Infoln("second getLong, err:", err)
+				l.Infoln(absPath, "second getLong, err:", err)
 			}
 		} else {
-			l.Infoln("first getLong, err:", err)
+			l.Infoln(absPath, "first getLong, err:", err)
 		}
 	} else {
-		l.Infoln("utf16 from string, err:", err)
+		l.Infoln(absPath, "utf16 from string, err:", err)
 	}
 	// Failed getting the long path. Return the part of the path which is
 	// already a long path.
@@ -183,5 +183,6 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 			return absPath
 		}
 	}
+	l.Infoln(absPath, "final, absPath:", absPath, "f.rootSymlinkEvaluated", f.rootSymlinkEvaluated)
 	return f.rootSymlinkEvaluated
 }

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -153,7 +153,7 @@ func (f *BasicFilesystem) Roots() ([]string, error) {
 }
 
 func (f *BasicFilesystem) resolveWin83(absPath string) string {
-	if !strings.Contains(absPath, '~') {
+	if !strings.Contains(absPath, "~") {
 		return absPath
 	}
 	if in, err := syscall.UTF16FromString(absPath); err != nil {
@@ -173,7 +173,7 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 	// Failed getting the long path. Return the part of the path which is
 	// already a long path.
 	for absPath = filepath.Dir(absPath); strings.HasPrefix(absPath, f.rootSymlinkEvaluated); absPath = filepath.Dir(absPath) {
-		if !strings.Contains(absPath, '~') {
+		if !strings.Contains(absPath, "~") {
 			return absPath
 		}
 	}

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -182,5 +182,8 @@ func isMaybeWin83(absPath string) bool {
 	if !strings.Contains(absPath, "~") {
 		return false
 	}
-	return strings.Contains(strings.TrimPrefix(absPath, WindowsTempPrefix), "~")
+	if strings.Contains(filepath.Dir(absPath), "~") {
+		return true
+	}
+	return strings.Contains(strings.TrimPrefix(filepath.Base(absPath), WindowsTempPrefix), "~")
 }

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -156,7 +156,7 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 	if !strings.Contains(absPath, "~") {
 		return absPath
 	}
-	if in, err := syscall.UTF16FromString(absPath); err != nil {
+	if in, err := syscall.UTF16FromString(absPath); err == nil {
 		out := make([]uint16, 4*len(absPath)) // *2 for UTF16 and *2 to double path length
 		if n, err := syscall.GetLongPathName(&in[0], &out[0], uint32(len(out))); err == nil {
 			l.Infoln(absPath, "first getLong, n:", n, "len(out):", len(out))

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -158,7 +158,7 @@ func (f *BasicFilesystem) resolveWin83(absPath string) string {
 	}
 	if in, err := syscall.UTF16FromString(absPath); err != nil {
 		out := make([]uint16, 4*len(absPath)) // *2 for UTF16 and *2 to double path length
-		if n, err = syscall.GetLongPathName(&in[0], &out[0], uint32(len(out))); err == nil {
+		if n, err := syscall.GetLongPathName(&in[0], &out[0], uint32(len(out))); err == nil {
 			if n <= uint32(len(out)) {
 				return syscall.UTF16ToString(out[:n])
 			}

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -79,13 +79,13 @@ func TestIsWindows83(t *testing.T) {
 	tempAndShort, _ := fs.rooted(filepath.Join("LFDATA~1", TempName("baz")))
 
 	for _, f := range []string{tempTop, tempBelow} {
-		if isMaybeWin83(tempTop) {
+		if isMaybeWin83(f) {
 			t.Errorf(`"%v" is not a windows 8.3 path"`, f)
 		}
 	}
 
 	for _, f := range []string{short, tempAndShort} {
-		if !isMaybeWin83(tempTop) {
+		if !isMaybeWin83(f) {
 			t.Errorf(`"%v" is not a windows 8.3 path"`, f)
 		}
 	}

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -1,0 +1,89 @@
+// Copyright (C) 2018 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// +build windows
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWindowsPaths(t *testing.T) {
+	testCases := []struct {
+		input        string
+		expectedRoot string
+		expectedURI  string
+	}{
+		{`e:\`, `\\?\e:\`, `e:\`},
+		{`\\?\e:\`, `\\?\e:\`, `e:\`},
+		{`\\192.0.2.22\network\share`, `\\192.0.2.22\network\share`, `\\192.0.2.22\network\share`},
+	}
+
+	for _, testCase := range testCases {
+		fs := newBasicFilesystem(testCase.input)
+		if fs.root != testCase.expectedRoot {
+			t.Errorf("root %q != %q", fs.root, testCase.expectedRoot)
+		}
+		if fs.URI() != testCase.expectedURI {
+			t.Errorf("uri %q != %q", fs.URI(), testCase.expectedURI)
+		}
+	}
+
+	fs := newBasicFilesystem(`relative\path`)
+	if fs.root == `relative\path` || !strings.HasPrefix(fs.root, "\\\\?\\") {
+		t.Errorf("%q == %q, expected absolutification", fs.root, `relative\path`)
+	}
+}
+
+func TestResolveWindows83(t *testing.T) {
+	fs, dir := setup(t)
+	defer os.RemoveAll(dir)
+
+	shortAbs, _ := fs.rooted("LFDATA~1")
+	long := "LFDataTool"
+	longAbs, _ := fs.rooted(long)
+	deleted, _ := fs.rooted(filepath.Join("foo", "LFDATA~1"))
+	notShort, _ := fs.rooted(filepath.Join("foo", "bar", "baz"))
+
+	fd, err := fs.Create(long)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fd.Close()
+
+	if res := fs.resolveWin83(shortAbs); res != longAbs {
+		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, shortAbs, res, longAbs)
+	}
+	if res := fs.resolveWin83(deleted); res != filepath.Dir(deleted) {
+		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, deleted, res, filepath.Dir(deleted))
+	}
+	if res := fs.resolveWin83(notShort); res != notShort {
+		t.Errorf(`Resolving for 8.3 names of "%v" resulted in "%v", expected "%v"`, notShort, res, notShort)
+	}
+}
+
+func TestIsWindows83(t *testing.T) {
+	tempTop, _ := fs.rooted(TempName("baz"))
+	tempBelow, _ := fs.rooted(filepath.Join("foo", "bar", TempName("baz")))
+	short, _ := fs.rooted(filepath.Join("LFDATA~1", TempName("baz")))
+	tempAndShort, _ := fs.rooted(filepath.Join("LFDATA~1", TempName("baz")))
+
+	for _, f := range []string{tempTop, tempBelow} {
+		if isMaybeWin83(tempTop) {
+			t.Errorf(`"%v" is not a windows 8.3 path"`, f)
+		}
+	}
+
+	for _, f := range []string{short, tempAndShort} {
+		if !isMaybeWin83(tempTop) {
+			t.Errorf(`"%v" is not a windows 8.3 path"`, f)
+		}
+	}
+}

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -70,6 +70,9 @@ func TestResolveWindows83(t *testing.T) {
 }
 
 func TestIsWindows83(t *testing.T) {
+	fs, dir := setup(t)
+	defer os.RemoveAll(dir)
+
 	tempTop, _ := fs.rooted(TempName("baz"))
 	tempBelow, _ := fs.rooted(filepath.Join("foo", "bar", TempName("baz")))
 	short, _ := fs.rooted(filepath.Join("LFDATA~1", TempName("baz")))


### PR DESCRIPTION
On windows, check if paths coming from the FS watcher are 8.3 ones and convert to "normal", similar to how @canton7 did it for synctrayzor: https://github.com/syncthing/syncthing/issues/4956#issuecomment-389580448