### PR TITLE
lib/config, lib/model: Limit size of puller queue (fixes #4976)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -41,6 +41,7 @@ type FolderConfiguration struct {
 	Versioning            VersioningConfiguration     `xml:"versioning" json:"versioning"`
 	Copiers               int                         `xml:"copiers" json:"copiers"` // This defines how many files are handled concurrently.
 	PullerMaxPendingKiB   int                         `xml:"pullerMaxPendingKiB" json:"pullerMaxPendingKiB"`
+	PullerMaxQueueLength  int                         `xml:"pullerMaxQueueLength" json:"pullerMaxQueueLength"`
 	Hashers               int                         `xml:"hashers" json:"hashers"` // Less than one sets the value to the number of cores. These are CPU bound due to hashing.
 	Order                 PullOrder                   `xml:"order" json:"order"`
 	IgnoreDelete          bool                        `xml:"ignoreDelete" json:"ignoreDelete"`


### PR DESCRIPTION
**Not necessarily for immediate merge given the discussion on the issue, but for consideration at least in the meantime.**

### Purpose

This adds a new config PullerMaxQueueLength that sets the maximum number of items we handle in one puller iteration. If set to <= 0 it defaults to 1000. Point of this is to limit the amount of RAM used for the queue. Downside is that renames that fall accross batches will not be correctly detected... Feels more and more like renames should be flagged somehow on the sending side.

### Testing

Integration tests (50k files and one single file) still pass, and use a but less RAM on the receiving side in the 50k files case.