### PR TITLE
gui: Hide "allowed networks" if empty

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -653,7 +653,7 @@
                       <th><span class="fas fa-fw fa-exclamation-triangle text-danger"></span>&nbsp;<span translate>Connection Type</span></th>
                       <td class="text-right">{{connections[deviceCfg.deviceID].type}}</td>
                     </tr>
-                    <tr ng-if="deviceCfg.allowedNetworks">
+                    <tr ng-if="deviceCfg.allowedNetworks.length > 0">
                       <th><span class="fas fa-fw fa-filter"></span>&nbsp;<span translate>Allowed Networks</span></th>
                       <td class="text-right">
                         <span>{{deviceCfg.allowedNetworks.join(", ")}}</span>


### PR DESCRIPTION
### Purpose

Hide line for "allowed networks" (advanced config) in device panel if it is empty.

### Testing

yep

