### PR TITLE
lib/protocol: Correct block size calculation on 32 bit archs (fixes #4990)

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -54,7 +54,7 @@ func init() {
 func BlockSize(fileSize int64) int {
 	var blockSize int
 	for _, blockSize = range BlockSizes {
-		if fileSize < int64(DesiredPerFileBlocks*blockSize) {
+		if fileSize < DesiredPerFileBlocks*int64(blockSize) {
 			break
 		}
 	}

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -4,6 +4,7 @@ package protocol
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -11,8 +12,6 @@ import (
 	"strings"
 	"testing"
 	"testing/quick"
-
-	"encoding/hex"
 
 	"github.com/syncthing/syncthing/lib/rand"
 )


### PR DESCRIPTION
Tested by adding a GOARCH=386 test run to the builder...