### PR TITLE
lib/config, lib/model: Don't warn and return error to prevent double warning

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -190,9 +190,7 @@ func (f *FolderConfiguration) CreateRoot() (err error) {
 	filesystem := f.Filesystem()
 
 	if _, err = filesystem.Stat("."); fs.IsNotExist(err) {
-		if err = filesystem.MkdirAll(".", permBits); err != nil {
-			l.Warnf("Creating directory for %v: %v", f.Description(), err)
-		}
+		err = filesystem.MkdirAll(".", permBits)
 	}
 
 	return err

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -231,13 +231,10 @@ func (m *Model) startFolderLocked(folder string) config.FolderType {
 		// if these things don't work, we still want to start the folder and
 		// it'll show up as errored later.
 
-		// Directory permission bits. Will be filtered down to something
-		// sane by umask on Unixes.
-
-		cfg.CreateRoot()
-
-		if err := cfg.CreateMarker(); err != nil {
-			l.Warnln("Creating folder marker:", err)
+		if err := cfg.CreateRoot(); err != nil {
+			l.Warnln("Failed to create folder root directory", err)
+		} else if err = cfg.CreateMarker(); err != nil {
+			l.Warnln("Failed to create folder marker:", err)
 		}
 	}
 


### PR DESCRIPTION
### Purpose

Currently an error while creating the folder root is both handled by logging at warning level and returned. Now it is not logged and it's left to the caller to handle the error. The warning is logged in the model and if such an error occurs, the folder marker creation is skipped, as it will fail anyway and create a redundant warning.

### Testing

None.