### PR TITLE
[dockerfile] Fix 'permission denied'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,19 @@ RUN rm -f syncthing && go run build.go build syncthing
 
 FROM alpine
 
-EXPOSE 8384 22000 21027/udp
-
-VOLUME ["/var/syncthing"]
-
 RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
 
 RUN echo 'syncthing:x:1000:1000::/var/syncthing:/sbin/nologin' >> /etc/passwd \
     && echo 'syncthing:!::0:::::' >> /etc/shadow \
+    && mkdir /var/syncthing \
     && chown syncthing /var/syncthing
 
 USER syncthing
 ENV STNOUPGRADE=1
+
+EXPOSE 8384 22000 21027/udp
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z localhost 8384 || exit 1


### PR DESCRIPTION
Signed-off-by: weiyang <weiyang.ones@gmail.com>

### Purpose

https://github.com/syncthing/syncthing/blob/master/Dockerfile#L15
`VOLUME` will mount new volume and change the owner of `/var/syncthing` to `root`
```
This Dockerfile results in an image that causes docker run to create a new mount point at /myvol and copy the greeting file into the newly created volume.
```
https://docs.docker.com/engine/reference/builder/#volume

![image](https://user-images.githubusercontent.com/4213483/41286527-6a463a5e-6e72-11e8-8aa6-110e5f59d476.png)

### Testing

![image](https://user-images.githubusercontent.com/4213483/41286458-2502f3f6-6e72-11e8-92c3-8c05ce9ec396.png)

