### PR TITLE
lib/model: Don't set watch error on folder creation (fixes 5005)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -83,7 +83,6 @@ func newFolder(model *Model, cfg config.FolderConfiguration) folder {
 
 		watchCancel:      func() {},
 		restartWatchChan: make(chan struct{}, 1),
-		watchErr:         errWatchNotStarted,
 		watchErrMut:      sync.NewMutex(),
 	}
 }


### PR DESCRIPTION
Tested manually.

Don't cut a new RC quickly. The ignores stuff might need fixing/adjustments (haven't investigated the reports yet) too, and this PR is purely cosmetic.