### PR TITLE
lib/db: Remove updated invalid files from need bucket (fixes #5007)

### DIFF
--- a/lib/db/leveldb_transactions.go
+++ b/lib/db/leveldb_transactions.go
@@ -97,13 +97,17 @@ func (t readWriteTransaction) updateGlobal(gk, folder, device []byte, file proto
 		return false
 	}
 
+	name := []byte(file.Name)
+
 	if removedAt != 0 && insertedAt != 0 {
+		if bytes.Equal(device, protocol.LocalDeviceID[:]) && file.IsInvalid() && file.Version.Equal(fl.Versions[0].Version) {
+			l.Debugf("local need delete; folder=%q, name=%q", folder, name)
+			t.Delete(t.db.needKey(folder, name))
+		}
 		l.Debugf(`new global for "%v" after update: %v`, file.Name, fl)
 		t.Put(gk, mustMarshal(&fl))
 		return true
 	}
-
-	name := []byte(file.Name)
 
 	// Remove the old global from the global size counter
 	var oldGlobalFV FileVersion

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -272,11 +272,11 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher, ignoresChan
 			file.Invalidate(f.shortID)
 			l.Debugln(f, "Handling ignored file", file)
 			dbUpdateChan <- dbUpdateJob{file, dbUpdateInvalidate}
+			changed++
 
 		case runtime.GOOS == "windows" && fs.WindowsInvalidFilename(file.Name):
 			f.newError("need", file.Name, fs.ErrInvalidFilename)
 			changed++
-			return true
 
 		case file.IsDeleted():
 			processDirectly = append(processDirectly, file)
@@ -300,6 +300,7 @@ func (f *sendReceiveFolder) pullerIteration(ignores *ignore.Matcher, ignoresChan
 			file.Invalidate(f.shortID)
 			l.Debugln(f, "Invalidating symlink (unsupported)", file.Name)
 			dbUpdateChan <- dbUpdateJob{file, dbUpdateInvalidate}
+			changed++
 
 		default:
 			// Directories, symlinks


### PR DESCRIPTION
### Purpose

Fixes #5007, Also in the puller updating invalid files wasn't considered a change, so in the logs it looks like everything works fine in the puller, while it doesn't.

An additional problem is, that for RC users that had an update to ignored files while using the newest rc the need bucket is out of sync with reality. That requires either manual db backup/rest by the user or a db transition just for DBs exactly at version 4 (?). I can do that, just not today anymore.

### Testing

Unit test.