### PR TITLE
lib/ignore, lib/scanner: Fix recursion to catch included paths (fixes #5009)

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -173,7 +173,7 @@ func (m *Matcher) parseLocked(r io.Reader, file string) error {
 
 	m.skipIgnoredDirs = true
 	for _, p := range patterns {
-		if p.result&resultInclude == resultInclude {
+		if !p.result.IsIgnored() {
 			m.skipIgnoredDirs = false
 			break
 		}

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -246,8 +246,8 @@ func (w *walker) walkAndHashFiles(ctx context.Context, fchan, dchan chan protoco
 		if w.Matcher.Match(path).IsIgnored() {
 			l.Debugln("ignored (patterns):", path)
 			// Only descend if matcher says so and the current file is not a symlink.
-			if w.Matcher.SkipIgnoredDirs() || (info.IsSymlink() && info.IsDir()) {
-				return fs.SkipDir
+			if w.Matcher.SkipIgnoredDirs() || info.IsSymlink() {
+				return skip
 			}
 			// If the parent wasn't ignored already, set this path as the "highest" ignored parent
 			if info.IsDir() && (ignoredParent == "" || !strings.HasPrefix(path, ignoredParent+string(fs.PathSeparator))) {


### PR DESCRIPTION
### Purpose

Recursing into ignored directories was broken twice:
 1. Recursion happened when there are no includes and did not happen when there are includes.
 2. If there is no recursion, the entire parent directory was skipped wrongly for ignored files.

### Testing

New unit test for point 1, existing scanner unit tests triggered on point 2 after fixing point 1.