### PR TITLE
gui: split listen addresses input field (fixes #4518)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -58,6 +58,10 @@ ul+h5 {
     border-top: none;
 }
 
+.panel-body .form-group {
+    margin-bottom: 0;
+}
+
 .logo {
     margin: 0;
     padding: 0;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -474,9 +474,9 @@ angular.module('syncthing.core')
             };
 
             for (var f in $scope.model) {
-                $scope.localStateTotal.bytes += $scope.model[f].localBytes;
-                $scope.localStateTotal.files += $scope.model[f].localFiles;
-                $scope.localStateTotal.directories += $scope.model[f].localDirectories;
+               $scope.localStateTotal.bytes += $scope.model[f].localBytes;
+               $scope.localStateTotal.files += $scope.model[f].localFiles;
+               $scope.localStateTotal.directories += $scope.model[f].localDirectories;
             }
         }
 
@@ -1263,7 +1263,6 @@ angular.module('syncthing.core')
 
                 ['listenAddresses', 'globalAnnounceServers'].forEach(function (key) {
                     $scope.config.options[key] = $scope.config.options["_" + key + "Str"].split(/[ ,]+/).map(function (x) {
-
                         return x.trim();
                     });
                 });
@@ -1330,7 +1329,7 @@ angular.module('syncthing.core')
             $scope.currentDevice = $.extend({}, deviceCfg);
             $scope.editingExisting = true;
             $scope.willBeReintroducedBy = undefined;
-            if (deviceCfg.introducedBy) {
+             if (deviceCfg.introducedBy) {
                 var introducerDevice = $scope.findDevice(deviceCfg.introducedBy);
                 if (introducerDevice && introducerDevice.introducer) {
                     $scope.willBeReintroducedBy = $scope.deviceName(introducerDevice);
@@ -1350,17 +1349,17 @@ angular.module('syncthing.core')
                 .success(function (registry) {
                     $scope.discovery = [];
                     outer:
-                        for (var id in registry) {
-                            if ($scope.discovery.length === 5) {
-                                break;
-                            }
-                            for (var i = 0; i < $scope.devices.length; i++) {
-                                if ($scope.devices[i].deviceID === id) {
-                                    continue outer;
-                                }
-                            }
-                            $scope.discovery.push(id);
+                    for (var id in registry) {
+                        if ($scope.discovery.length === 5) {
+                            break;
                         }
+                        for (var i = 0; i < $scope.devices.length; i++) {
+                            if ($scope.devices[i].deviceID === id) {
+                                continue outer;
+                            }
+                        }
+                        $scope.discovery.push(id);
+                    }
                 })
                 .then(function () {
                     $scope.currentDevice = {
@@ -1994,13 +1993,13 @@ angular.module('syncthing.core')
                         $scope.restoreVersions.filters['end'] = maxDate;
 
                         var ranges = {
-                            'All time': [minDate, maxDate],
-                            'Today': [moment(), moment()],
-                            'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
-                            'Last 7 Days': [moment().subtract(6, 'days'), moment()],
-                            'Last 30 Days': [moment().subtract(29, 'days'), moment()],
-                            'This Month': [moment().startOf('month'), moment().endOf('month')],
-                            'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
+                           'All time': [minDate, maxDate],
+                           'Today': [moment(), moment()],
+                           'Yesterday': [moment().subtract(1, 'days'), moment().subtract(1, 'days')],
+                           'Last 7 Days': [moment().subtract(6, 'days'), moment()],
+                           'Last 30 Days': [moment().subtract(29, 'days'), moment()],
+                           'This Month': [moment().startOf('month'), moment().endOf('month')],
+                           'Last Month': [moment().subtract(1, 'month').startOf('month'), moment().subtract(1, 'month').endOf('month')]
                         };
 
                         // Filter out invalid ranges.

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -152,10 +152,76 @@
         </div>
 
         <div id="settings-connections" class="tab-pane">
-          <div class="form-group">
-            <label translate for="ListenAddressesStr">Sync Protocol Listen Addresses</label>&emsp;<a href="https://docs.syncthing.net/users/config.html#listen-addresses" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
-            <input id="ListenAddressesStr" class="form-control" type="text" ng-model="tmpOptions._listenAddressesStr"/>
+          <div class="panel-group">
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <label translate for="TCPConnections"><span translate>TCP Connections:</span></label>
+              </div>
+              <div id="TCPConnections" class="panel-body">
+                <div class="form-group row">
+                  <div class="col-sm-4 col-form-label">
+                    <label for="TCPAddress"><span translate>Listen Address:</span></label>&emsp;<a href="https://docs.syncthing.net/users/config.html#listen-addresses" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
+                  </div>
+                  <div class="col-sm-8" >
+                    <input id="TCPAddress" class="form-control" type="text" ng-model="tmpOptions._tcpAddressesStr"/>
+                  </div>
+                </div>
+                <div class="form-group row">
+                  <label for="NATEnabled" class="col-sm-4 col-form-label"><span translate>Enable NAT Traversal:</span></label>
+                  <div class="col-sm-8">
+                    <input id="NATEnabled" type="checkbox" ng-model="tmpOptions.natEnabled"/>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <label translate for="RelayConnections"><span translate>Relay Connections:</span></label>
+              </div>
+              <div id="RelayConnections" class="panel-body">
+                <div class="form-group row">
+                  <label for="RelaysEnabled" class="col-sm-4 col-form-label"><span translate>Enable Relaying:</span></label>
+                  <div class="col-sm-8">
+                    <input id="RelaysEnabled" type="checkbox" ng-model="tmpOptions.relaysEnabled"/>
+                  </div>
+                </div>
+                <div class="form-group row">
+                  <div class="col-sm-4 col-form-label">
+                    <label for="RelayAddress" ><span translate>Listen Address:</span></label>&emsp;<a href="https://docs.syncthing.net/users/config.html#listen-addresses" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
+                  </div>
+                  <div class="col-sm-8">
+                    <input ng-disabled="!tmpOptions.relaysEnabled" id="RelayAddress" class="form-control" type="text" ng-model="tmpOptions._relayAddressesStr"/>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="panel panel-default">
+              <div class="panel-heading">
+                <label translate for="DiscoverySettings"><span translate>Discovery Settings:</span></label>
+              </div>
+              <div id="DiscoverySettings" class="panel-body">
+                <div class="form-group row">
+                  <label for="LocalAnnEnabled" class="col-sm-4 col-form-label"><span translate>Local Discovery:</span></label>
+                  <div class="col-sm-8">
+                    <input id="LocalAnnEnabled" type="checkbox" ng-model="tmpOptions.localAnnounceEnabled"/>
+                  </div>
+                </div>
+                <div class="form-group row">
+                  <label for="GlobalAnnEnabled" class="col-sm-4 col-form-label"><span translate>Global Discovery:</span></label>
+                  <div class="col-sm-8">
+                    <input id="GlobalAnnEnabled" type="checkbox" ng-model="tmpOptions.globalAnnounceEnabled"/>
+                  </div>
+                </div>
+                <div class="form-group row">
+                  <label translate for="GlobalAnnServersStr" class="col-sm-4 col-form-label"><span translate>Global Discovery Servers:</span></label>
+                  <div class="col-sm-8">
+                    <input ng-disabled="!tmpOptions.globalAnnounceEnabled" id="GlobalAnnServersStr" class="form-control" type="text" ng-model="tmpOptions._globalAnnounceServersStr"/>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
+
           <div class="row">
             <div class="col-md-6">
               <div class="form-group" ng-class="{'has-error': settingsEditor.MaxRecvKbps.$invalid && settingsEditor.MaxRecvKbps.$dirty}">
@@ -174,56 +240,6 @@
                   <span translate ng-if="settingsEditor.MaxSendKbps.$error.min && settingsEditor.MaxSendKbps.$dirty">The rate limit must be a non-negative number (0: no limit)</span>
                 </p>
               </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <div class="form-group">
-                <div class="checkbox">
-                  <label>
-                    <input id="NATEnabled" type="checkbox" ng-model="tmpOptions.natEnabled"/> <span translate>Enable NAT traversal</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <div class="form-group">
-                <div class="checkbox">
-                  <label>
-                    <input id="LocalAnnEnabled" type="checkbox" ng-model="tmpOptions.localAnnounceEnabled"/> <span translate>Local Discovery</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <div class="form-group">
-                <div class="checkbox">
-                  <label>
-                    <input id="GlobalAnnEnabled" type="checkbox" ng-model="tmpOptions.globalAnnounceEnabled"/> <span translate>Global Discovery</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div class="col-md-6">
-              <div class="form-group">
-                <div class="checkbox">
-                  <label>
-                    <input id="RelaysEnabled" type="checkbox" ng-model="tmpOptions.relaysEnabled"/> <span translate>Enable Relaying</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col-md-6">
-              <div class="form-group">
-                <label translate for="GlobalAnnServersStr">Global Discovery Servers</label>
-                <input ng-disabled="!tmpOptions.globalAnnounceEnabled" id="GlobalAnnServersStr" class="form-control" type="text" ng-model="tmpOptions._globalAnnounceServersStr"/>
-              </div>
-            </div>
-            <div class="col-md-6">
             </div>
           </div>
         </div>


### PR DESCRIPTION
### Purpose

Making listen addresses more accessible and expandable. Variation on issue description given the fact that KCP is no longer supported.

### Testing

Tested on default options (frontend converts combination of 'default' from and into corresponding relay and tcp listen addresses) and other non-default combinations

### Screenshots

![image of connectons](https://i.imgur.com/2FxsECe.png)
