### PR TITLE
lib/ignore: Add (?s) prefix to ignore patterns

### DIFF
--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -37,14 +37,11 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 		eventMask |= permEventMask
 	}
 
-	if ignore.SkipIgnoredDirs() {
-		absShouldIgnore := func(absPath string) bool {
-			return ignore.ShouldIgnore(f.unrootedChecked(absPath))
-		}
-		err = notify.WatchWithFilter(filepath.Join(absName, "..."), backendChan, absShouldIgnore, eventMask)
-	} else {
-		err = notify.Watch(filepath.Join(absName, "..."), backendChan, eventMask)
+	watchShouldIgnore := func(absPath string) bool {
+		return ignore.ShouldSkip(f.unrootedChecked(absPath))
 	}
+	err = notify.WatchWithFilter(filepath.Join(absName, "..."), backendChan, watchShouldIgnore, eventMask)
+
 	if err != nil {
 		notify.Stop(backendChan)
 		if reachedMaxUserWatches(err) {

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -426,7 +426,10 @@ func (fm fakeMatcher) ShouldIgnore(name string) bool {
 	return name != fm.include && name == fm.ignore
 }
 
-func (fm fakeMatcher) SkipIgnoredDirs() bool {
+func (fm fakeMatcher) ShouldSkip(name string) bool {
+	if !fm.ShouldIgnore(name) {
+		return false
+	}
 	return fm.skipIgnoredDirs
 }
 

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -87,11 +87,7 @@ type Usage struct {
 
 type Matcher interface {
 	ShouldIgnore(name string) bool
-	SkipIgnoredDirs() bool
-}
-
-type MatchResult interface {
-	IsIgnored() bool
+	ShouldSkip(name string) bool
 }
 
 type Event struct {

--- a/lib/ignore/cache_test.go
+++ b/lib/ignore/cache_test.go
@@ -28,7 +28,7 @@ func TestCache(t *testing.T) {
 
 	// Set and check some items
 
-	c.set("true", resultInclude|resultDeletable)
+	c.set("true", resultIgnore|resultDeletable)
 	c.set("false", 0)
 
 	res, ok = c.get("true")

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -25,9 +25,10 @@ import (
 
 const (
 	resultNotMatched Result = 0
-	resultInclude    Result = 1 << iota
+	resultIgnore     Result = 1 << iota
 	resultDeletable         = 1 << iota
 	resultFoldCase          = 1 << iota
+	resultSkip              = 1 << iota
 )
 
 type Pattern struct {
@@ -38,7 +39,7 @@ type Pattern struct {
 
 func (p Pattern) String() string {
 	ret := p.pattern
-	if p.result&resultInclude != resultInclude {
+	if p.result&resultIgnore != resultIgnore {
 		ret = "!" + ret
 	}
 	if p.result&resultFoldCase == resultFoldCase {
@@ -47,13 +48,16 @@ func (p Pattern) String() string {
 	if p.result&resultDeletable == resultDeletable {
 		ret = "(?d)" + ret
 	}
+	if p.result&resultSkip == resultSkip {
+		ret = "(?s)" + ret
+	}
 	return ret
 }
 
 type Result uint8
 
 func (r Result) IsIgnored() bool {
-	return r&resultInclude == resultInclude
+	return r&resultIgnore == resultIgnore
 }
 
 func (r Result) IsDeletable() bool {
@@ -301,10 +305,12 @@ func (m *Matcher) ShouldIgnore(filename string) bool {
 	return false
 }
 
-func (m *Matcher) SkipIgnoredDirs() bool {
-	m.mut.Lock()
-	defer m.mut.Unlock()
-	return m.skipIgnoredDirs
+// ShouldSkip returns true when a file is ignored and can be skipped
+func (m *Matcher) ShouldSkip(filename string) bool {
+	if !m.ShouldIgnore(filename) {
+		return false
+	}
+	return m.skipIgnoredDirs || m.Match(filename)&resultSkip == resultSkip
 }
 
 func hashPatterns(patterns []Pattern) string {
@@ -362,7 +368,7 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 	var lines []string
 	var patterns []Pattern
 
-	defaultResult := resultInclude
+	defaultResult := resultIgnore
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" {
 		defaultResult |= resultFoldCase
 	}
@@ -373,13 +379,13 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 		}
 
 		// Allow prefixes to be specified in any order, but only once.
-		var seenPrefix [3]bool
+		var seenPrefix [4]bool
 
 		for {
 			if strings.HasPrefix(line, "!") && !seenPrefix[0] {
 				seenPrefix[0] = true
 				line = line[1:]
-				pattern.result ^= resultInclude
+				pattern.result ^= resultIgnore
 			} else if strings.HasPrefix(line, "(?i)") && !seenPrefix[1] {
 				seenPrefix[1] = true
 				pattern.result |= resultFoldCase
@@ -387,6 +393,10 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			} else if strings.HasPrefix(line, "(?d)") && !seenPrefix[2] {
 				seenPrefix[2] = true
 				pattern.result |= resultDeletable
+				line = line[4:]
+			} else if strings.HasPrefix(line, "(?s)") && !seenPrefix[3] {
+				seenPrefix[3] = true
+				pattern.result |= resultSkip
 				line = line[4:]
 			} else {
 				break

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -311,8 +311,9 @@ func (m *Matcher) ShouldSkip(filename string) bool {
 		return false
 	}
 	m.mut.Lock()
-	defer m.mut.Unlock()
-	return m.skipIgnoredDirs || m.Match(filename)&resultSkip == resultSkip
+	skip := m.skipIgnoredDirs
+	m.mut.Unlock()
+	return skip || m.Match(filename)&resultSkip == resultSkip
 }
 
 func hashPatterns(patterns []Pattern) string {

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -310,6 +310,8 @@ func (m *Matcher) ShouldSkip(filename string) bool {
 	if !m.ShouldIgnore(filename) {
 		return false
 	}
+	m.mut.Lock()
+	defer m.mut.Unlock()
 	return m.skipIgnoredDirs || m.Match(filename)&resultSkip == resultSkip
 }
 

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -246,7 +246,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, fchan, dchan chan protoco
 		if w.Matcher.Match(path).IsIgnored() {
 			l.Debugln("ignored (patterns):", path)
 			// Only descend if matcher says so and the current file is not a symlink.
-			if w.Matcher.SkipIgnoredDirs() || info.IsSymlink() {
+			if w.Matcher.ShouldSkip(path) || info.IsSymlink() {
 				return skip
 			}
 			// If the parent wasn't ignored already, set this path as the "highest" ignored parent


### PR DESCRIPTION
### Purpose

Paths matching a pattern prefixed with `(?s)` will be skipped, even if there are
include patterns. This is useful e.g. if there are inaccessible files below a
path that would cause fs watcher errors or to speed up the scan.

Also I renamed `resultIncluded` to `resultIgnored` for clarity as discussed before.

### Testing

Adapted and extended the existing include/exclude/skip test.

### Documentation

Needs an update to https://docs.syncthing.net/users/ignoring.html