### PR TITLE
lib/model: Release both locks when waiting for services to stop (fixes #5028)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -344,11 +344,13 @@ func (m *Model) tearDownFolderLocked(cfg config.FolderConfiguration) {
 	// Stop the services running for this folder and wait for them to finish
 	// stopping to prevent races on restart.
 	tokens := m.folderRunnerTokens[cfg.ID]
+	m.pmut.Unlock()
 	m.fmut.Unlock()
 	for _, id := range tokens {
 		m.RemoveAndWait(id, 0)
 	}
 	m.fmut.Lock()
+	m.pmut.Lock()
 
 	// Close connections to affected devices
 	for _, dev := range cfg.Devices {


### PR DESCRIPTION
### Purpose

Fixing #5028 as followup to #4982.

### Testing

None due to the racy nature of the issue.