### PR TITLE
gui: Info icon for folder ID

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -332,7 +332,7 @@
                 <table class="table table-condensed table-striped">
                   <tbody>
                     <tr ng-show="folder.label != undefined && folder.label.length > 0">
-                      <th><span class="fas fa-fw fa-folder-open"></span>&nbsp;<span translate>Folder ID</span></th>
+                      <th><span class="fas fa-fw fa-info-circle"></span>&nbsp;<span translate>Folder ID</span></th>
                       <td class="text-right no-overflow-ellipse">{{folder.id}}</td>
                     </tr>
                     <tr>


### PR DESCRIPTION
Folder ID and folder path currently have the same icon `folder-open`.
This changes the icon for folder ID to `info-circle`