### PR TITLE
Bugfix/snap fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,9 @@ RELEASE
 deb
 lib/auto/gui.files.go
 snapcraft.yaml
+prime/
+snap/
+parts/
+stage/
+*.snap
+*.bz2

--- a/build.go
+++ b/build.go
@@ -618,6 +618,8 @@ func buildSnap(target target) {
 	snaparch := goarch
 	if snaparch == "armhf" {
 		goarch = "arm"
+	} else if snaparch == "i386" {
+		goarch = "386"
 	}
 	snapver := version
 	if strings.HasPrefix(snapver, "v") {

--- a/build.go
+++ b/build.go
@@ -628,9 +628,10 @@ func buildSnap(target target) {
 		snapgrade = "stable"
 	}
 	err = tmpl.Execute(f, map[string]string{
-		"Version":      snapver,
-		"Architecture": snaparch,
-		"Grade":        snapgrade,
+		"Version":            snapver,
+		"HostArchitecture":   runtime.GOARCH,
+		"TargetArchitecture": snaparch,
+		"Grade":              snapgrade,
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -6,7 +6,9 @@ description: |
   trustworthy and decentralized. Your data is your data alone and you deserve
   to choose where it is stored, if it is shared with some third party and how
   it's transmitted over the Internet.
-architectures: [{{.Architecture}}]
+architectures: 
+  - build-on: [{{.HostArchitecture}}]
+    run-on: [{{.TargetArchitecture}}]
 
 grade: {{.Grade}}
 confinement: strict

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -13,8 +13,11 @@ confinement: strict
 
 apps:
   syncthing:
-    command: env HOME="$SNAP_USER_COMMON" XDG_CONFIG_HOME="$SNAP_USER_COMMON" "$SNAP/syncthing"
     plugs: [home, network, network-bind]
+    command: syncthing
+    environment:
+      HOME: ${SNAP_USER_COMMON}
+      XDG_CONFIG_HOME: ${SNAP_USER_COMMON}
 
 parts:
   syncthing:

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -13,11 +13,15 @@ confinement: strict
 
 apps:
   syncthing:
-    plugs: [home, network, network-bind]
     command: syncthing
     environment:
       HOME: ${SNAP_USER_COMMON}
       XDG_CONFIG_HOME: ${SNAP_USER_COMMON}
+    plugs:
+    - home
+    - network
+    - network-bind
+    - removable-media
 
 parts:
   syncthing:


### PR DESCRIPTION
### Purpose

Adds removable-media as a plug for the syncthing command (this fixes https://github.com/syncthing/syncthing/issues/4863)
Also simplifies how the environment variables are set when running syncthing. This is more readable.

### Testing

I built + installed + ran the snap locally with 
```
ijohnson@ijohnson-XPS-15-9560:~/go/src/github.com/syncthing/syncthing/$ go run build.go -version=v0.14.49-rc.2 snap
Pulling syncthing 
Building syncthing 
Staging syncthing 
Priming syncthing 
Snapping 'syncthing' |                                                                                                                                                                              
Snapped syncthing_0.14.49-rc.2_amd64.snap
ijohnson@ijohnson-XPS-15-9560:~/go/src/github.com/syncthing/syncthing/$ sudo snap install --devmode syncthing*.snap
[sudo] password for ijohnson: 
syncthing 0.14.49-rc.2 installed
ijohnson@ijohnson-XPS-15-9560:~/go/src/github.com/syncthing/syncthing/$ syncthing 
[monitor] 10:08:49 INFO: Starting syncthing
[start] 10:08:49 INFO: Generating ECDSA key and certificate for syncthing...
.......
```

Also note that if using removable-media is a common thing for syncthing users, we could request an auto-connection from the snap store team on the snapcraft forum and then users wouldn't need to run 
```
sudo snap connect syncthing:removable-media
```
as the store would authorize this connection for all installs of the snap.