### PR TITLE
Add configurable UID and GID to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,15 +18,15 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
 
-RUN echo 'syncthing:x:1000:1000::/var/syncthing:/sbin/nologin' >> /etc/passwd \
-    && echo 'syncthing:!::0:::::' >> /etc/shadow \
-    && chown syncthing /var/syncthing
+RUN apk update \
+    && apk add su-exec
 
-USER syncthing
 ENV STNOUPGRADE=1
+ENV PUID=1000
+ENV PGID=1000
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z localhost 8384 || exit 1
 
-ENTRYPOINT ["/bin/syncthing", "-home", "/var/syncthing/config", "-gui-address", "0.0.0.0:8384"]
-
+ENTRYPOINT chown $PUID:$PGID /var/syncthing \
+    && su-exec $PUID:$PGID /bin/syncthing -home /var/syncthing/config -gui-address 0.0.0.0:8384

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -11,8 +11,8 @@ The exposed volumes are by default:
 
 You can add more folders and map them as you prefer.
 
-Note that Syncthing runs as UID 1000 in the container. This UID must have
-permission to read and modify the files in the containers.
+Note that Syncthing runs as UID 1000 and GID 1000 by default. These may be
+altered with the ``PUID`` and ``PGID`` environment variables.
 
 Example usage:
 


### PR DESCRIPTION
### Purpose
Allows for configuring the UID and GID Syncthing runs as in the container. Uses [su-exec](https://github.com/ncopa/su-exec) from the Alpine repos to accomplish this. Addition of su-exec results in <2MB increase in image size.

### Testing
I've been using the [same approach](https://github.com/nvllsvm/docker-syncthing/blob/master/entrypoint.sh#L4-L5) in my Syncthing image for sometime on systems with varying UIDs and GIDs without issue.

I performed the following tests, each with a freshly created folder on the host mounted as volume /var/syncthing:

- started container without environment variables overridden. Verified configuration files written to the host folder had UID 1000 and GID 1000.
- started container with PUID=123 and PGID=456. Verified configuration files written to the host folder had UID 123 and GID 456.


### Documentation
Included in this PR.
