### PR TITLE
cmd/stcli: Add config command and output pretty JSON

### DIFF
--- a/cmd/stcli/cmd_general.go
+++ b/cmd/stcli/cmd_general.go
@@ -3,9 +3,9 @@
 package main
 
 import (
-	"os"
 	"encoding/json"
 	"fmt"
+	"os"
 
 	"github.com/AudriusButkevicius/cli"
 )
@@ -82,7 +82,7 @@ func generalConfiguration(c *cli.Context) {
 	var jsResponse interface{}
 	json.Unmarshal(responseToBArray(response), &jsResponse)
 	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "    ")
+	enc.SetIndent("", "  ")
 	enc.Encode(jsResponse)
 }
 

--- a/cmd/stcli/cmd_general.go
+++ b/cmd/stcli/cmd_general.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"os"
 	"encoding/json"
 	"fmt"
 
@@ -22,6 +23,12 @@ func init() {
 			Usage:    "Configuration status, whether or not a restart is required for changes to take effect",
 			Requires: &cli.Requires{},
 			Action:   generalStatus,
+		},
+		{
+			Name:     "config",
+			Usage:    "Configuration",
+			Requires: &cli.Requires{},
+			Action:   generalConfiguration,
 		},
 		{
 			Name:     "restart",
@@ -68,6 +75,15 @@ func generalStatus(c *cli.Context) {
 		die("Config out of sync")
 	}
 	fmt.Println("Config in sync")
+}
+
+func generalConfiguration(c *cli.Context) {
+	response := httpGet(c, "system/config")
+	var jsResponse interface{}
+	json.Unmarshal(responseToBArray(response), &jsResponse)
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "    ")
+	enc.Encode(jsResponse)
 }
 
 func generalVersion(c *cli.Context) {


### PR DESCRIPTION
### Purpose

The `stcli` now knows a new trick to get and prettyprint the config in JSON format and print it pretty on the console. This very handy for development and remote debugging.

### Testing

It seems the stcli tool has no tests (manual only). The addition can be manually tested as follows:

```
$ stcli --apikey <apikey> config
{
    "devices": [
        {
            "addresses": [
                "dynamic"
            ],
            "allowedNetworks": [],
            "autoAcceptFolders": false,
            "certName": "",
            "compression": "metadata",
.......
}
```

### Documentation

I have searched through the docs but it seems the `stcli` tool is undocumented. So I have no documentation to add.
