### PR TITLE
dockerfile: install su-exec without updating.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN apk add --no-cache ca-certificates
 
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
 
-RUN apk update \
-    && apk add su-exec
+RUN apk add --no-cache su-exec
 
 ENV STNOUPGRADE=1
 ENV PUID=1000


### PR DESCRIPTION
### Purpose
A slight optimization on the recent Dockerfile updates in
https://github.com/syncthing/syncthing/commit/5bb72dfe5dc063ceec0b0617246bd3d86a64bfe8#diff-3254677a7917c6c01f55212f86c57fbf

* Using --no-cache instead prevents unnecessarily
  adding about 1.3MB of Alpine package data
* This reduces the uncompressed image size with about 6%.

### Testing

Local build and run works