### PR TITLE
lib/db: Catch unignored/conflicting files as needed (fixes #5053)

### DIFF
--- a/lib/db/leveldb_dbinstance_updateschema.go
+++ b/lib/db/leveldb_dbinstance_updateschema.go
@@ -20,11 +20,10 @@ import (
 //   2: v0.14.48
 //   3: v0.14.49
 //   4: v0.14.49
-//   5: v0.14.50 (never released, skipped)
-//   6: v0.14.49
-//   7: v0.14.50
+//   5: v0.14.49
+//   6: v0.14.50
 const (
-	dbVersion             = 7
+	dbVersion             = 6
 	dbMinSyncthingVersion = "v0.14.50"
 )
 
@@ -64,13 +63,12 @@ func (db *Instance) updateSchema() error {
 	if prevVersion < 3 {
 		db.updateSchema2to3()
 	}
-	// This update fixes problems existing in versions 3 to 5
-	if prevVersion < 6 && prevVersion > 2 {
-		db.updateSchema3to4()
+	// This update fixes problems existing in versions 3 and 4
+	if prevVersion == 3 || prevVersion == 4 {
+		db.updateSchemato5()
 	}
-	// This was originally a transition to 5, but 6 had to be retroactively fit in
-	if prevVersion < 7 && prevVersion != 5 {
-		db.updateSchema4to5()
+	if prevVersion < 6 {
+		db.updateSchema5to6()
 	}
 
 	miscDB.PutInt64("dbVersion", dbVersion)
@@ -195,10 +193,11 @@ func (db *Instance) updateSchema2to3() {
 	}
 }
 
-// updateSchema3to4 resets the need bucket due a bug existing in dbVersion 3 /
-// v0.14.49-rc.1
+// updateSchemato5 resets the need bucket due to bugs existing in the v0.14.49
+// release candidates (dbVersion 3 and 4)
 // https://github.com/syncthing/syncthing/issues/5007
-func (db *Instance) updateSchema3to4() {
+// https://github.com/syncthing/syncthing/issues/5053
+func (db *Instance) updateSchemato5() {
 	t := db.newReadWriteTransaction()
 	var nk []byte
 	for _, folderStr := range db.ListFolders() {
@@ -210,7 +209,7 @@ func (db *Instance) updateSchema3to4() {
 	db.updateSchema2to3()
 }
 
-func (db *Instance) updateSchema4to5() {
+func (db *Instance) updateSchema5to6() {
 	// For every local file with the Invalid bit set, clear the Invalid bit and
 	// set LocalFlags = FlagLocalIgnored.
 

--- a/lib/db/leveldb_dbinstance_updateschema.go
+++ b/lib/db/leveldb_dbinstance_updateschema.go
@@ -65,7 +65,7 @@ func (db *Instance) updateSchema() error {
 	}
 	// This update fixes problems existing in versions 3 and 4
 	if prevVersion == 3 || prevVersion == 4 {
-		db.updateSchemato5()
+		db.updateSchemaTo5()
 	}
 	if prevVersion < 6 {
 		db.updateSchema5to6()
@@ -193,11 +193,11 @@ func (db *Instance) updateSchema2to3() {
 	}
 }
 
-// updateSchemato5 resets the need bucket due to bugs existing in the v0.14.49
+// updateSchemaTo5 resets the need bucket due to bugs existing in the v0.14.49
 // release candidates (dbVersion 3 and 4)
 // https://github.com/syncthing/syncthing/issues/5007
 // https://github.com/syncthing/syncthing/issues/5053
-func (db *Instance) updateSchemato5() {
+func (db *Instance) updateSchemaTo5() {
 	t := db.newReadWriteTransaction()
 	var nk []byte
 	for _, folderStr := range db.ListFolders() {

--- a/lib/db/leveldb_dbinstance_updateschema.go
+++ b/lib/db/leveldb_dbinstance_updateschema.go
@@ -20,10 +20,12 @@ import (
 //   2: v0.14.48
 //   3: v0.14.49
 //   4: v0.14.49
-//   5: v0.14.50
+//   5: v0.14.50 (never released, skipped)
+//   6: v0.14.49
+//   7: v0.14.50
 const (
-	dbVersion             = 5
-	dbMinSyncthingVersion = "v0.14.49"
+	dbVersion             = 7
+	dbMinSyncthingVersion = "v0.14.50"
 )
 
 type databaseDowngradeError struct {
@@ -62,11 +64,12 @@ func (db *Instance) updateSchema() error {
 	if prevVersion < 3 {
 		db.updateSchema2to3()
 	}
-	// This update fixes a problem that only exists in dbVersion 3.
-	if prevVersion == 3 {
+	// This update fixes problems existing in versions 3 to 5
+	if prevVersion < 6 && prevVersion > 2 {
 		db.updateSchema3to4()
 	}
-	if prevVersion < 5 {
+	// This was originally a transition to 5, but 6 had to be retroactively fit in
+	if prevVersion < 7 && prevVersion != 5 {
 		db.updateSchema4to5()
 	}
 

--- a/lib/db/leveldb_transactions.go
+++ b/lib/db/leveldb_transactions.go
@@ -99,11 +99,31 @@ func (t readWriteTransaction) updateGlobal(gk, folder, device []byte, file proto
 
 	name := []byte(file.Name)
 
-	if removedAt != 0 && insertedAt != 0 {
-		if bytes.Equal(device, protocol.LocalDeviceID[:]) && file.Version.Equal(fl.Versions[0].Version) {
-			l.Debugf("local need delete; folder=%q, name=%q", folder, name)
-			t.Delete(t.db.needKey(folder, name))
+	var newGlobal protocol.FileInfo
+	if insertedAt == 0 {
+		// Inserted a new newest version
+		newGlobal = file
+	} else if new, ok := t.getFile(folder, fl.Versions[0].Device, name); ok {
+		// The previous second version is now the first
+		newGlobal = new
+	} else {
+		panic("This file must exist in the db")
+	}
+
+	// Fixup the list of files we need.
+	nk := t.db.needKey(folder, name)
+	hasNeeded, _ := t.db.Has(nk, nil)
+	if localFV, haveLocalFV := fl.Get(protocol.LocalDeviceID[:]); need(newGlobal, haveLocalFV, localFV.Version) {
+		if !hasNeeded {
+			l.Debugf("local need insert; folder=%q, name=%q", folder, name)
+			t.Put(nk, nil)
 		}
+	} else if hasNeeded {
+		l.Debugf("local need delete; folder=%q, name=%q", folder, name)
+		t.Delete(nk)
+	}
+
+	if removedAt != 0 && insertedAt != 0 {
 		l.Debugf(`new global for "%v" after update: %v`, file.Name, fl)
 		t.Put(gk, mustMarshal(&fl))
 		return true
@@ -124,30 +144,7 @@ func (t readWriteTransaction) updateGlobal(gk, folder, device []byte, file proto
 	}
 
 	// Add the new global to the global size counter
-	var newGlobal protocol.FileInfo
-	if insertedAt == 0 {
-		// Inserted a new newest version
-		newGlobal = file
-	} else if new, ok := t.getFile(folder, fl.Versions[0].Device, name); ok {
-		// The previous second version is now the first
-		newGlobal = new
-	} else {
-		panic("This file must exist in the db")
-	}
 	meta.addFile(globalDeviceID, newGlobal)
-
-	// Fixup the list of files we need.
-	nk := t.db.needKey(folder, name)
-	hasNeeded, _ := t.db.Has(nk, nil)
-	if localFV, haveLocalFV := fl.Get(protocol.LocalDeviceID[:]); need(newGlobal, haveLocalFV, localFV.Version) {
-		if !hasNeeded {
-			l.Debugf("local need insert; folder=%q, name=%q", folder, name)
-			t.Put(nk, nil)
-		}
-	} else if hasNeeded {
-		l.Debugf("local need delete; folder=%q, name=%q", folder, name)
-		t.Delete(nk)
-	}
 
 	l.Debugf(`new global for "%v" after update: %v`, file.Name, fl)
 	t.Put(gk, mustMarshal(&fl))


### PR DESCRIPTION
### Purpose

Fixes #5053 by doing the check, if the globally updated file needs to be added/removed from the need bucket, before updating the meta counter. Thus it happens on every update, not only if the first item in the global list is affected by the update. An update can be relevant to what's locally needed without happening at the front of the global list, if it involves conflicting files.

This also requires a recalculation of the need bucket. As the local flags change was introduced in dbVersion 5, but is not yet introduced in the release branch, dbVersion 5 needs to be skipped. The local flags change now happens to 7 (for master), while the need bucket reset happens to 6 (for release). Thus even if someone is running master, the transition will happen correctly. 

The diff looks bigger than it is, it's just moving the need bucket part of the code ahead.

### Testing

New unit test.