### PR TITLE
lib/model: Record error for unavailable files

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -66,6 +66,7 @@ var (
 	errDirHasToBeScanned   = errors.New("directory contains unexpected files, scheduling scan")
 	errDirHasIgnored       = errors.New("directory contains ignored files (see ignore documentation for (?d) prefix)")
 	errDirNotEmpty         = errors.New("directory is not empty")
+	errNotAvailable        = errors.New("no peers that have this file are connected. Will be retried on next connection.")
 )
 
 const (
@@ -353,7 +354,7 @@ func (f *sendReceiveFolder) processNeeded(ignores *ignore.Matcher, dbUpdateChan 
 					return true
 				}
 			}
-			l.Debugln(f, "Needed file is unavailable", file)
+			f.newError("checking availability", file.Name, errNotAvailable)
 
 		case runtime.GOOS == "windows" && file.IsSymlink():
 			file.SetUnsupported(f.shortID)

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -319,7 +319,7 @@ func (f *sendReceiveFolder) processNeeded(ignores *ignore.Matcher, dbUpdateChan 
 			changed++
 
 		case runtime.GOOS == "windows" && fs.WindowsInvalidFilename(file.Name):
-			f.newError("processing needed", file.Name, fs.ErrInvalidFilename)
+			f.newError("pull", file.Name, fs.ErrInvalidFilename)
 
 		case file.IsDeleted():
 			if file.IsDirectory() {
@@ -353,7 +353,7 @@ func (f *sendReceiveFolder) processNeeded(ignores *ignore.Matcher, dbUpdateChan 
 					return true
 				}
 			}
-			f.newError("processing needed", file.Name, errNotAvailable)
+			f.newError("pull", file.Name, errNotAvailable)
 
 		case runtime.GOOS == "windows" && file.IsSymlink():
 			file.SetUnsupported(f.shortID)

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -66,7 +66,7 @@ var (
 	errDirHasToBeScanned   = errors.New("directory contains unexpected files, scheduling scan")
 	errDirHasIgnored       = errors.New("directory contains ignored files (see ignore documentation for (?d) prefix)")
 	errDirNotEmpty         = errors.New("directory is not empty")
-	errNotAvailable        = errors.New("no peers that have this file are connected. Will be retried on next connection.")
+	errNotAvailable        = errors.New("no connected device has the required version of this file")
 )
 
 const (
@@ -319,8 +319,7 @@ func (f *sendReceiveFolder) processNeeded(ignores *ignore.Matcher, dbUpdateChan 
 			changed++
 
 		case runtime.GOOS == "windows" && fs.WindowsInvalidFilename(file.Name):
-			f.newError("need", file.Name, fs.ErrInvalidFilename)
-			changed++
+			f.newError("processing needed", file.Name, fs.ErrInvalidFilename)
 
 		case file.IsDeleted():
 			if file.IsDirectory() {
@@ -354,7 +353,7 @@ func (f *sendReceiveFolder) processNeeded(ignores *ignore.Matcher, dbUpdateChan 
 					return true
 				}
 			}
-			f.newError("checking availability", file.Name, errNotAvailable)
+			f.newError("processing needed", file.Name, errNotAvailable)
 
 		case runtime.GOOS == "windows" && file.IsSymlink():
 			file.SetUnsupported(f.shortID)


### PR DESCRIPTION
### Purpose

Currently unavailable files show up as out-of-sync in the UI without any progress
or explanation. Now these files will be added to the failed items. The changed
count isn't inreased, as there is no point in retrying those files until a change
in connection happens. At that point, a pull will be scheduled anyway.

### Testing

None.