### PR TITLE
lib/config: Copy inputs and copy config outputs

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -154,6 +154,7 @@ func (cfg Configuration) Copy() Configuration {
 	}
 
 	newCfg.Options = cfg.Options.Copy()
+	newCfg.GUI = cfg.GUI.Copy()
 
 	// DeviceIDs are values
 	newCfg.IgnoredDevices = make([]protocol.DeviceID, len(cfg.IgnoredDevices))

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -93,3 +93,7 @@ func (c GUIConfiguration) IsValidAPIKey(apiKey string) bool {
 		return false
 	}
 }
+
+func (c GUIConfiguration) Copy() GUIConfiguration {
+	return c
+}

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -265,7 +265,7 @@ func (w *Wrapper) Folders() map[string]FolderConfiguration {
 func (w *Wrapper) FolderList() []FolderConfiguration {
 	w.mut.Lock()
 	defer w.mut.Unlock()
-	return append(nil, w.cfg.Copy().Folders...)
+	return w.cfg.Copy().Folders
 }
 
 // SetFolder adds a new folder to the configuration, or overwrites an existing

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1101,6 +1101,35 @@ func TestIssue4897(t *testing.T) {
 	}
 }
 
+func TestIssue5063(t *testing.T) {
+	wcfg, m := newState(defaultAutoAcceptCfg)
+
+	addAndVerify := func(wg *sync.WaitGroup) {
+		id := srand.String(8)
+		m.ClusterConfig(device1, protocol.ClusterConfig{
+			Folders: []protocol.Folder{
+				{
+					ID:    id,
+					Label: id,
+				},
+			},
+		})
+		os.RemoveAll(filepath.Join("testdata", id))
+		wg.Done()
+		if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
+			t.Error("expected shared", id)
+		}
+	}
+
+	wg := &sync.WaitGroup{}
+	for i := 0; i <= 10; i++ {
+		wg.Add(1)
+		go addAndVerify(wg)
+	}
+
+	wg.Wait()
+}
+
 func TestAutoAcceptRejected(t *testing.T) {
 	// Nothing happens if AutoAcceptFolders not set
 	tcfg := defaultAutoAcceptCfg.Copy()


### PR DESCRIPTION
This is a guess as to what could be the cause for #5063.

In the last debug logs the relevant part was:

```
[GXVUP] 22:26:43 INFO: Existing folder default false
[GXVUP] 22:26:43 INFO: Existing folder gdrxc-frazc false
[GXVUP] 22:26:43 INFO: Existing folder jjnhx-nhqzq false
[GXVUP] 22:26:43 INFO: Missing folder ewa2m-zcpje

// CommitConfiguration in the model coming in:

[GXVUP] 22:26:43 INFO: from folder map[
default:...
ewa2m-zcpje:...
gdrxc-frazc:...


[GXVUP] 22:26:43 INFO: to folder map[
ewa2m-zcpje:...
gdrxc-frazc:...
jjnhx-nhqzq:...
default:...

[GXVUP] 22:26:43 INFO: Adding folder "test1" (jjnhx-nhqzq)
```

So `ewa2m-zcpje` was introduced, but it somehow overwrote an existing folders spot in the config.