### PR TITLE
[docker] Create a dedicated syncthing user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,30 @@ COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncth
 RUN apk add --no-cache su-exec
 
 ENV STNOUPGRADE=1
+ENV PUSR=syncthing
 ENV PUID=1000
+ENV PGRP=syncthing
 ENV PGID=1000
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z localhost 8384 || exit 1
 
-ENTRYPOINT chown $PUID:$PGID /var/syncthing \
-    && su-exec $PUID:$PGID /bin/syncthing -home /var/syncthing/config -gui-address 0.0.0.0:8384
+ENTRYPOINT true \
+ && ( getent group "${PGRP}" >/dev/null \
+      || addgroup \
+          -g "${PGID}" \
+          "${PGRP}" \
+    ) \
+ && ( getent passwd "${PUSR}" >/dev/null \
+      || adduser \
+          -h /var/syncthing \
+          -G "${PGRP}" \
+          -u "${PUID}" \
+          "${PUSR}" \
+    ) \
+ && chown "${PUSR}:${PGRP}" /var/syncthing \
+ && su-exec "${PUSR}:${PGRP}" \
+     /bin/syncthing \
+       -home /var/syncthing/config \
+       -gui-address 0.0.0.0:8384 \
+ && true


### PR DESCRIPTION
### Purpose

A dedicated user is necessary to create relative references via `~/<folder>` or `$HOME/<folder>`. Having the syncthing process just running under a unprivileged UID/GID, will remove the home folder relation and therefore will result in nonexistent shares after update.

Fixes the changes introduced in #5041