### PR TITLE
gui: Use one instead of on to have callbacks fire one

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1099,10 +1099,10 @@ angular.module('syncthing.core')
                 $scope.logging.timer = $timeout($scope.logging.fetch);
                 var textArea = $('#logViewerText');
                 textArea.on("scroll", $scope.logging.onScroll);
-                $('#logViewer').modal().on('shown.bs.modal', function() {
+                $('#logViewer').modal().one('shown.bs.modal', function() {
                     // Scroll to bottom.
                     textArea.scrollTop(textArea[0].scrollHeight);
-                }).on('hidden.bs.modal', function () {
+                }).one('hidden.bs.modal', function () {
                     $timeout.cancel($scope.logging.timer);
                     textArea.off("scroll", $scope.logging.onScroll);
                     $scope.logging.timer = null;
@@ -1178,7 +1178,7 @@ angular.module('syncthing.core')
                 $scope.tmpOptions.upgrades = "candidate";
             }
             $scope.tmpGUI = angular.copy($scope.config.gui);
-            $('#settings').modal().on('hidden.bs.modal', function () {
+            $('#settings').modal().one('hidden.bs.modal', function () {
                 window.location.hash = "";
             });
         };
@@ -1560,15 +1560,12 @@ angular.module('syncthing.core')
         $scope.editFolderModal = function () {
             $scope.folderPathErrors = {};
             $scope.folderEditor.$setPristine();
-            $('#editFolder').modal().on({
-                'shown.bs.tab': function (e) {
-                    if (e.target.attributes.href.value === "#folder-ignores") {
-                        $('#folder-ignores textarea').focus();
-                    }
-                },
-                'hidden.bs.modal': function () {
-                    window.location.hash = "";
+            $('#editFolder').modal().one('shown.bs.tab', function (e) {
+                if (e.target.attributes.href.value === "#folder-ignores") {
+                    $('#folder-ignores textarea').focus();
                 }
+            }).one('hidden.bs.modal', function () {
+                window.location.hash = "";
             });
         };
 
@@ -1884,10 +1881,10 @@ angular.module('syncthing.core')
 
                     var closed = false;
                     var modalShown = $q.defer();
-                    $('#restoreVersions').modal().on('hidden.bs.modal', function () {
+                    $('#restoreVersions').modal().one('hidden.bs.modal', function () {
                         closed = true;
                         resetRestoreVersions();
-                    }).on('shown.bs.modal', function() {
+                    }).one('shown.bs.modal', function() {
                         modalShown.resolve();
                     });
 
@@ -2060,7 +2057,7 @@ angular.module('syncthing.core')
         $scope.showNeed = function (folder) {
             $scope.neededFolder = folder;
             refreshNeed(folder);
-            $('#needed').modal().on('hidden.bs.modal', function () {
+            $('#needed').modal().one('hidden.bs.modal', function () {
                 $scope.neededFolder = undefined;
                 $scope.needed = undefined;
                 $scope.neededCurrentPage = 1;
@@ -2078,7 +2075,7 @@ angular.module('syncthing.core')
                 $scope.remoteNeedFolders.push(folder);
                 $scope.refreshRemoteNeed(folder, 1, 10);
             });
-            $('#remoteNeed').modal().on('hidden.bs.modal', function () {
+            $('#remoteNeed').modal().one('hidden.bs.modal', function () {
                 resetRemoteNeed();
             });
         };
@@ -2086,7 +2083,7 @@ angular.module('syncthing.core')
         $scope.showFailed = function (folder) {
             $scope.failed.folder = folder;
             $scope.failed = $scope.refreshFailed(1, 10);
-            $('#failed').modal().on('hidden.bs.modal', function () {
+            $('#failed').modal().one('hidden.bs.modal', function () {
                 $scope.failed = {};
             });
         };


### PR DESCRIPTION
Every time we open a dialog we register a new callback, but never deregister the old one. 
This uses one time callbacks in places where I think it makes sense (such as paths where the callback will be re-registered on modal being shown).