### PR TITLE
build: Build and set GOPATH before generating assets

### DIFF
--- a/build.go
+++ b/build.go
@@ -211,14 +211,14 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		os.Setenv("GOPATH", gopath)
+		log.Println("GOPATH is", gopath)
 		if !noBuildGopath {
-			lazyRebuildAssets()
 			if err := buildGOPATH(gopath); err != nil {
 				log.Fatal(err)
 			}
+			lazyRebuildAssets()
 		}
-		os.Setenv("GOPATH", gopath)
-		log.Println("GOPATH is", gopath)
 	} else {
 		inside := false
 		wd, _ := os.Getwd()


### PR DESCRIPTION
From the v0.14.49 announcement thread: https://forum.syncthing.net/t/syncthing-v0-14-49/11875/6

Since `go` took over generating the assets in https://github.com/syncthing/syncthing/commit/ef5ca0c218cfd072860d2b06d63c3d36ddc63813 the mechanism to build and set a temporary `GOPATH` is broken, as assets are generated before `GOPATH` is set. This PR inverts the order of that.