### PR TITLE
lib/watchaggregator: Don't delay mixed events only

### DIFF
--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -308,8 +308,8 @@ func (a *aggregator) actOnTimer(out chan<- []string) {
 	}
 	oldEvents := make(map[string]*aggregatedEvent, c)
 	a.popOldEventsTo(oldEvents, a.root, ".", time.Now(), true)
-	if a.notifyDelay != a.notifyTimeout && a.counts[fs.NonRemove]+a.counts[fs.Mixed] == 0 && a.counts[fs.Remove] != 0 {
-		// Only deletion events remaining, no need to delay them additionally
+	if a.notifyDelay != a.notifyTimeout && a.counts[fs.NonRemove] == 0 && a.counts[fs.Remove]+a.counts[fs.Mixed] != 0 {
+		// Only delayed events remaining, no need to delay them additionally
 		a.popOldEventsTo(oldEvents, a.root, ".", time.Now(), false)
 	}
 	if len(oldEvents) == 0 {


### PR DESCRIPTION
This is a follow-up to #4955, where the notification of deletions was made faster.  In the logs from #5092 (unrelated issue) I realized a small mistake in the implementation: Currently only "pure" deletions are returned early, if there is no other types of events. There's no point in delaying mixed events either, if no non-remove events exist.

I wrote a small test to check that there is no delay in this scenario. And I also fixed a minor bug in the output in case of a timing test failure.