### PR TITLE
build: Also copy gui to temporary GOPATH

### DIFF
--- a/build.go
+++ b/build.go
@@ -1258,7 +1258,7 @@ func temporaryBuildDir() (string, error) {
 
 func buildGOPATH(gopath string) error {
 	pkg := filepath.Join(gopath, "src/github.com/syncthing/syncthing")
-	dirs := []string{"cmd", "lib", "meta", "script", "test", "vendor"}
+	dirs := []string{"cmd", "gui", "lib", "meta", "script", "test", "vendor"}
 
 	if debug {
 		t0 := time.Now()


### PR DESCRIPTION
@wwwutz (https://github.com/syncthing/syncthing/pull/5093#issuecomment-409890926)

> oops, I should have tested better!
> 
> Now I get a 404 page not found so it builds, but the assets are missing.
> 
> any hints how to debug ?

It's me that should have tested better... Thanks for catching this!  
I didn't expect it to build fine, but generate empty assets. However it's actually quite obvious: Before generation happened in the non-temprorary dir, now it happens in the temporary dir. However the `gui/` dir isn't copied to the temp dir -> no assets. Fixed by copying over `gui/`.