### PR TITLE
lib/model: Check availability later to catch renames

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -282,7 +282,7 @@ func (l FolderDeviceConfigurationList) Len() int {
 	return len(l)
 }
 
-func (f *FolderConfiguration) CheckFreeSpace() (err error) {
+func (f *FolderConfiguration) CheckFreeSpace() error {
 	return checkFreeSpace(f.MinDiskFree, f.Filesystem())
 }
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -342,18 +342,8 @@ func (f *sendReceiveFolder) processNeeded(ignores *ignore.Matcher, dbUpdateChan 
 			changed++
 
 		case file.Type == protocol.FileInfoTypeFile:
-			// Queue files for processing after directories and symlinks, if
-			// it has availability.
-
-			devices := folderFiles.Availability(file.Name)
-			for _, dev := range devices {
-				if _, ok := f.model.Connection(dev); ok {
-					f.queue.Push(file.Name, file.Size, file.ModTime())
-					changed++
-					return true
-				}
-			}
-			f.newError("pull", file.Name, errNotAvailable)
+			// Queue files for processing after directories and symlinks.
+			f.queue.Push(file.Name, file.Size, file.ModTime())
 
 		case runtime.GOOS == "windows" && file.IsSymlink():
 			file.SetUnsupported(f.shortID)
@@ -485,8 +475,16 @@ nextFile:
 			}
 		}
 
-		// Handle the file normally, by coping and pulling, etc.
-		f.handleFile(fi, copyChan, finisherChan, dbUpdateChan)
+		devices := folderFiles.Availability(fileName)
+		for _, dev := range devices {
+			if _, ok := f.model.Connection(dev); ok {
+				changed++
+				// Handle the file normally, by coping and pulling, etc.
+				f.handleFile(fi, copyChan, finisherChan, dbUpdateChan)
+				continue nextFile
+			}
+		}
+		f.newError("pull", fileName, errNotAvailable)
 	}
 
 	return changed, fileDeletions, dirDeletions, nil


### PR DESCRIPTION
### Purpose

I was thinking about the keep pulling and deleting stuff when disk is full and noticed that currently the availabilty check happens too early: If a file is unavailable, it's not pushed to the queue meaning deletes can't be matched against it -> potential renames (don't need availability) won't be detected.

### Testing

None, passes existing tests. This is a small optimization not a bug and I am lazy right now -> no additional unit test.