### PR TITLE
gui: Fix incorrect label

### DIFF
--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -121,7 +121,7 @@
                 </div>
                 <div class="col-md-6" ng-class="{'has-error': deviceEditor.maxRecvKbps.$invalid && deviceEditor.maxRecvKbps.$dirty}">
                   <div class="row">
-                    <span class="col-md-8" translate>Outgoing Rate Limit (KiB/s)</span>
+                    <span class="col-md-8" translate>Incoming Rate Limit (KiB/s)</span>
                     <div class="col-md-4">
                       <input name="maxRecvKbps" id="maxRecvKbps" class="form-control" type="number" pattern="\d+" ng-model="currentDevice.maxRecvKbps" min="0"/>
                     </div>


### PR DESCRIPTION
Fix the Device modal's "Incoming Rate Limit" label from "Outgoing" to "Incoming".