### PR TITLE
lib/model, lib/protocol: Fix error handling when terminating a connection

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1270,10 +1270,15 @@ func (m *Model) Closed(conn protocol.Connection, err error) {
 	m.pmut.Unlock()
 
 	l.Infof("Connection to %s at %s closed: %v", device, conn.Name(), err)
-	events.Default.Log(events.DeviceDisconnected, map[string]string{
-		"id":    device.String(),
-		"error": err.Error(),
-	})
+
+	data := map[string]string{
+		"id": device.String(),
+	}
+	if err != nil {
+		data["error"] = err.Error()
+	}
+	events.Default.Log(events.DeviceDisconnected, data)
+
 	close(closed)
 }
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3791,6 +3791,15 @@ func TestIssue5002(t *testing.T) {
 	m.recheckFile(protocol.LocalDeviceID, defaultFolderConfig.Filesystem(), "default", "foo", nBlocks+1, []byte{1, 2, 3, 4})
 }
 
+// TestClosedNilDeref just checks that it doesn't panics with nil error
+func TestClosedNilDeref(t *testing.T) {
+	m, fc, tmpDir := setupModelWithConnection()
+	m.Closed(fc, nil)
+	m.Stop()
+	os.RemoveAll(tmpDir)
+
+}
+
 func addFakeConn(m *Model, dev protocol.DeviceID) *fakeConnection {
 	fc := &fakeConnection{id: dev, model: m}
 	m.AddConnection(fc, protocol.HelloResult{})

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -340,11 +340,12 @@ func (c *rawConnection) readerLoop() (err error) {
 	for {
 		select {
 		case <-c.closed:
-			err = errClosed
+			err = ErrClosed
 			return
 		default:
 		}
 
+		var msg message
 		msg, err = c.readMessage()
 		if err == errUnknownMessage {
 			// Unknown message types are skipped, for future extensibility.
@@ -370,8 +371,8 @@ func (c *rawConnection) readerLoop() (err error) {
 				err = fmt.Errorf("protocol error: index message in state %d", state)
 				return
 			}
-			if err := checkIndexConsistency(msg.Files); err != nil {
-				err = fmt.Errorf("protocol error: index: %v", err)
+			if e := checkIndexConsistency(msg.Files); e != nil {
+				err = fmt.Errorf("protocol error: index: %v", e)
 				return
 			}
 			c.handleIndex(*msg)
@@ -383,8 +384,8 @@ func (c *rawConnection) readerLoop() (err error) {
 				err = fmt.Errorf("protocol error: index update message in state %d", state)
 				return
 			}
-			if err := checkIndexConsistency(msg.Files); err != nil {
-				err = fmt.Errorf("protocol error: index update: %v", err)
+			if e := checkIndexConsistency(msg.Files); e != nil {
+				err = fmt.Errorf("protocol error: index update: %v", e)
 				return
 			}
 			c.handleIndexUpdate(*msg)
@@ -396,8 +397,8 @@ func (c *rawConnection) readerLoop() (err error) {
 				err = fmt.Errorf("protocol error: request message in state %d", state)
 				return
 			}
-			if err := checkFilename(msg.Name); err != nil {
-				err = fmt.Errorf("protocol error: request: %q: %v", msg.Name, err)
+			if e := checkFilename(msg.Name); e != nil {
+				err = fmt.Errorf("protocol error: request: %q: %v", msg.Name, e)
 				return
 			}
 			// Requests are handled asynchronously


### PR DESCRIPTION
### Purpose

In the protocol's readerloop do actually set the err variable instead of
returning directly, such that it is correctly passed to c.close in the deferred
statement.
In the model do a nil-check before calling err.Error().

### Testing

Simple unit test that doesn't panic anymore.