### PR TITLE
lib/fs: Evaluate root when watching not on fs creation (fixes #5043)

### DIFF
--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -24,7 +24,12 @@ import (
 var backendBuffer = 500
 
 func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, error) {
-	absName, err := f.rootedSymlinkEvaluated(name)
+	absName, err := f.rooted(name)
+	if err != nil {
+		return nil, err
+	}
+
+	evalRoot, err := filepath.EvalSymlinks(f.root)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +44,7 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 
 	if ignore.SkipIgnoredDirs() {
 		absShouldIgnore := func(absPath string) bool {
-			return ignore.ShouldIgnore(f.unrootedChecked(absPath))
+			return ignore.ShouldIgnore(f.unrootedChecked(absPath, evalRoot))
 		}
 		err = notify.WatchWithFilter(filepath.Join(absName, "..."), backendChan, absShouldIgnore, eventMask)
 	} else {
@@ -53,12 +58,12 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 		return nil, err
 	}
 
-	go f.watchLoop(name, backendChan, outChan, ignore, ctx)
+	go f.watchLoop(name, evalRoot, backendChan, outChan, ignore, ctx)
 
 	return outChan, nil
 }
 
-func (f *BasicFilesystem) watchLoop(name string, backendChan chan notify.EventInfo, outChan chan<- Event, ignore Matcher, ctx context.Context) {
+func (f *BasicFilesystem) watchLoop(name, evalRoot string, backendChan chan notify.EventInfo, outChan chan<- Event, ignore Matcher, ctx context.Context) {
 	for {
 		// Detect channel overflow
 		if len(backendChan) == backendBuffer {
@@ -77,7 +82,7 @@ func (f *BasicFilesystem) watchLoop(name string, backendChan chan notify.EventIn
 
 		select {
 		case ev := <-backendChan:
-			relPath := f.unrootedChecked(ev.Path())
+			relPath := f.unrootedChecked(ev.Path(), evalRoot)
 			if ignore.ShouldIgnore(relPath) {
 				l.Debugln(f.Type(), f.URI(), "Watch: Ignoring", relPath)
 				continue
@@ -110,12 +115,13 @@ func (f *BasicFilesystem) eventType(notifyType notify.Event) EventType {
 // unrooted). It panics if the given path is not a subpath and handles the
 // special case when the given path is the folder root without a trailing
 // pathseparator.
-func (f *BasicFilesystem) unrootedChecked(absPath string) string {
-	if absPath+string(PathSeparator) == f.rootSymlinkEvaluated {
+func (f *BasicFilesystem) unrootedChecked(absPath, root string) string {
+	absPath = f.resolveWin83(absPath)
+	if absPath+string(PathSeparator) == root {
 		return "."
 	}
-	if !strings.HasPrefix(absPath, f.rootSymlinkEvaluated) {
-		panic(fmt.Sprintf("bug: Notify backend is processing a change outside of the filesystem root: root==%v, rootSymEval==%v, path==%v", f.root, f.rootSymlinkEvaluated, absPath))
+	if !strings.HasPrefix(absPath, root) {
+		panic(fmt.Sprintf("bug: Notify backend is processing a change outside of the filesystem root: f.root==%v, root==%v, path==%v", f.root, root, absPath))
 	}
-	return f.unrootedSymlinkEvaluated(f.resolveWin83(absPath))
+	return rel(absPath, root)
 }

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -154,7 +154,7 @@ func TestWatchOutside(t *testing.T) {
 			}
 			cancel()
 		}()
-		fs.watchLoop(".", backendChan, outChan, fakeMatcher{}, ctx)
+		fs.watchLoop(".", testDirAbs, backendChan, outChan, fakeMatcher{}, ctx)
 	}()
 
 	backendChan <- fakeEventInfo(filepath.Join(filepath.Dir(testDirAbs), "outside"))
@@ -177,7 +177,7 @@ func TestWatchSubpath(t *testing.T) {
 	fs := newBasicFilesystem(testDirAbs)
 
 	abs, _ := fs.rooted("sub")
-	go fs.watchLoop("sub", backendChan, outChan, fakeMatcher{}, ctx)
+	go fs.watchLoop("sub", testDirAbs, backendChan, outChan, fakeMatcher{}, ctx)
 
 	backendChan <- fakeEventInfo(filepath.Join(abs, "file"))
 
@@ -291,7 +291,7 @@ func TestUnrootedChecked(t *testing.T) {
 		}
 	}()
 	fs := newBasicFilesystem(testDirAbs)
-	unrooted = fs.unrootedChecked("/random/other/path")
+	unrooted = fs.unrootedChecked("/random/other/path", testDirAbs)
 }
 
 func TestWatchIssue4877(t *testing.T) {


### PR DESCRIPTION
### Purpose

Currently the folder root is evaluated (to resolve symlinks) at fs creation. At that point the directory may not exist or `EvalSymlinks` may fail for other reasons. The current implementation just ignores that case by assuming there are no symlinks. That's dangerous because if there are, it will lead to panics on watching. Also the only place where this evaluated root is needed is for watching. Therefore the evaluation of the root path now happens when `fs.Watch` is called. This call will then just fail if `filepath.EvalSymlinks` returns an error, making it transparent to the user, leading to retries and preventing the panic.

### Testing

Existing ones still pass.