### PR TITLE
lib/model: Catch racy nil deref in ClusterConfig

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -953,12 +953,17 @@ func (m *Model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 		if cfg.Paused {
 			continue
 		}
+		fs, ok := m.folderFiles[folder.ID]
+		if !ok {
+			// Shouldn't happen because !cfg.Paused, but might happen
+			// if the folder is about to be unpaused, but not yet.
+			continue
+		}
 
 		if !folder.DisableTempIndexes {
 			tempIndexFolders = append(tempIndexFolders, folder.ID)
 		}
 
-		fs := m.folderFiles[folder.ID]
 		myIndexID := fs.IndexID(protocol.LocalDeviceID)
 		mySequence := fs.Sequence(protocol.LocalDeviceID)
 		var startSequence int64


### PR DESCRIPTION
### Purpose

Next try at fixing the following panic (from https://github.com/syncthing/syncthing/issues/5043#issuecomment-411097106):

```
Panic at 2018-08-07T10:24:04-05:00
panic: runtime error: invalid memory address or nil pointer dereference
    panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x91f1cc]

goroutine 577 [running]:
github.com/syncthing/syncthing/lib/model.(*Model).Closed(0xc420211320, 0x7f3481835e60, 0xc4224d3710, 0x0, 0x0)
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/model/model.go:1262 +0x50c
github.com/syncthing/syncthing/lib/protocol.(*rawConnection).close.func1()
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/protocol/protocol.go:833 +0x206
sync.(*Once).Do(0xc420730148, 0xc420efb120)
    /media/ext4_data/Linux/source/go/src/sync/once.go:44 +0xbe
github.com/syncthing/syncthing/lib/protocol.(*rawConnection).close(0xc4207300c0, 0x0, 0x0)
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/protocol/protocol.go:820 +0x6b
github.com/syncthing/syncthing/lib/protocol.(*rawConnection).readerLoop.func1(0xc4207300c0, 0xc420efbfd0)
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/protocol/protocol.go:335 +0x41
panic(0xa75380, 0x1117ca0)
    /media/ext4_data/Linux/source/go/src/runtime/panic.go:502 +0x229
github.com/syncthing/syncthing/lib/db.(*FileSet).IndexID(0x0, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xffffffffffffffff, 0xc422e5c501)
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/set.go:263 +0x5e
github.com/syncthing/syncthing/lib/model.(*Model).ClusterConfig(0xc420211320, 0x4b91a04c26d701c3, 0xeb45ab20275c2e1e, 0x81bc97fd845af037, 0x4df64d3c0e0a8595, 0xc420ea8500, 0x4, 0x4)
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/model/model.go:949 +0xda6
github.com/syncthing/syncthing/lib/protocol.(*rawConnection).readerLoop(0xc4207300c0, 0x0, 0x0)
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/protocol/protocol.go:361 +0xed0
created by github.com/syncthing/syncthing/lib/protocol.(*rawConnection).Start
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/protocol/protocol.go:225 +0x43
```

Line numbers refer to a PR - the following
```
github.com/syncthing/syncthing/lib/model.(*Model).ClusterConfig(0xc420211320, 0x4b91a04c26d701c3, 0xeb45ab20275c2e1e, 0x81bc97fd845af037, 0x4df64d3c0e0a8595, 0xc420ea8500, 0x4, 0x4)
    /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/model/model.go:949 +0xda6
```
points to https://github.com/syncthing/syncthing/blob/master/lib/model/model.go#L962.

My theory: `ClusterConfig` happens before `CommitConfiguration` finishes -> config is present, but the respective entry in `m.folderFiles` is still missing. Even if that theory is wrong in this case(I would expect the call to `fs.IndexID` to panic, but here `s.db.getIndexID` within `fs.IndexID` does) it could happen and it doesn't hurt to be safe. Continuing is fine, because when the folder is started, the connection is dropped -> new cluster config.

### Testing

None as this is racy.

EDIT: Actually I am really not on top of everything at the moment: The panic above is the same as in #5078.