### PR TITLE
lib/db: Use indirect file keys (fixes #5047)

### DIFF
--- a/lib/db/leveldb.go
+++ b/lib/db/leveldb.go
@@ -14,19 +14,20 @@ import (
 )
 
 const (
-	KeyTypeDevice = iota
-	KeyTypeGlobal
-	KeyTypeBlock
-	KeyTypeDeviceStatistic
-	KeyTypeFolderStatistic
-	KeyTypeVirtualMtime
-	KeyTypeFolderIdx
-	KeyTypeDeviceIdx
-	KeyTypeIndexID
-	KeyTypeFolderMeta
-	KeyTypeMiscData
-	KeyTypeSequence
-	KeyTypeNeed
+	KeyTypeDevice          = 0
+	KeyTypeGlobal          = 1
+	KeyTypeBlock           = 2
+	KeyTypeDeviceStatistic = 3
+	KeyTypeFolderStatistic = 4
+	KeyTypeVirtualMtime    = 5
+	KeyTypeFolderIdx       = 6
+	KeyTypeDeviceIdx       = 7
+	KeyTypeIndexID         = 8
+	KeyTypeFolderMeta      = 9
+	KeyTypeMiscData        = 10
+	KeyTypeSequence        = 11
+	KeyTypeNeed            = 12
+	KeyTypeIndirect        = 128 // see resolveIndirectFileKey
 )
 
 func (vl VersionList) String() string {

--- a/vendor/github.com/DataDog/mmh3/mmh3.go
+++ b/vendor/github.com/DataDog/mmh3/mmh3.go
@@ -1,0 +1,447 @@
+package mmh3
+
+import (
+	"encoding/binary"
+	"reflect"
+	"unsafe"
+)
+
+const (
+	h32c1 uint32 = 0xcc9e2d51
+	h32c2 uint32 = 0x1b873593
+	h64c1 uint64 = 0x87c37b91114253d5
+	h64c2 uint64 = 0x4cf5ad432745937f
+)
+
+func Hash32(key []byte) uint32 {
+	length := len(key)
+	if length == 0 {
+		return 0
+	}
+	nblocks := length / 4
+	var h, k uint32
+	for i := 0; i < nblocks; i++ {
+		k = binary.LittleEndian.Uint32(key[i*4:])
+		k *= h32c1
+		k = (k << 15) | (k >> (32 - 15))
+		k *= h32c2
+		h ^= k
+		h = (h << 13) | (h >> (32 - 13))
+		h = (h * 5) + 0xe6546b64
+	}
+	k = 0
+	tailIndex := nblocks * 4
+	switch length & 3 {
+	case 3:
+		k ^= uint32(key[tailIndex+2]) << 16
+		fallthrough
+	case 2:
+		k ^= uint32(key[tailIndex+1]) << 8
+		fallthrough
+	case 1:
+		k ^= uint32(key[tailIndex])
+		k *= h32c1
+		k = (k << 15) | (k >> (32 - 15))
+		k *= h32c2
+		h ^= k
+	}
+	h ^= uint32(length)
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+}
+
+func Hash128(key []byte) []byte {
+	length := len(key)
+	ret := make([]byte, 16)
+	if length == 0 {
+		return ret
+	}
+	nblocks := length / 16
+	var h1, h2, k1, k2 uint64
+	for i := 0; i < nblocks; i++ {
+		k1 = binary.LittleEndian.Uint64(key[i*16:])
+		k2 = binary.LittleEndian.Uint64(key[(i*16)+8:])
+		k1 *= h64c1
+		k1 = (k1 << 31) | (k1 >> (64 - 31))
+		k1 *= h64c2
+		h1 ^= k1
+		h1 = (h1 << 27) | (h1 >> (64 - 27))
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+		k2 *= h64c2
+		k2 = (k2 << 33) | (k2 >> (64 - 33))
+		k2 *= h64c1
+		h2 ^= k2
+		h2 = (h2 << 31) | (h2 >> (64 - 31))
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+	}
+	k1, k2 = 0, 0
+	tailIndex := nblocks * 16
+	switch length & 15 {
+	case 15:
+		k2 ^= uint64(key[tailIndex+14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(key[tailIndex+13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(key[tailIndex+12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(key[tailIndex+11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(key[tailIndex+10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(key[tailIndex+9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(key[tailIndex+8])
+		k2 *= h64c2
+		k2 = (k2 << 33) | (k2 >> (64 - 33))
+		k2 *= h64c1
+		h2 ^= k2
+		fallthrough
+	case 8:
+		k1 ^= uint64(key[tailIndex+7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(key[tailIndex+6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(key[tailIndex+5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(key[tailIndex+4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(key[tailIndex+3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(key[tailIndex+2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(key[tailIndex+1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(key[tailIndex])
+		k1 *= h64c1
+		k1 = (k1 << 31) | (k1 >> (64 - 31))
+		k1 *= h64c2
+		h1 ^= k1
+	}
+	h1 ^= uint64(length)
+	h2 ^= uint64(length)
+	h1 += h2
+	h2 += h1
+	h1 ^= h1 >> 33
+	h1 *= 0xff51afd7ed558ccd
+	h1 ^= h1 >> 33
+	h1 *= 0xc4ceb9fe1a85ec53
+	h1 ^= h1 >> 33
+	h2 ^= h2 >> 33
+	h2 *= 0xff51afd7ed558ccd
+	h2 ^= h2 >> 33
+	h2 *= 0xc4ceb9fe1a85ec53
+	h2 ^= h2 >> 33
+	h1 += h2
+	h2 += h1
+	binary.LittleEndian.PutUint64(ret[:], h1)
+	binary.LittleEndian.PutUint64(ret[8:], h2)
+	return ret
+}
+
+// Hash128x64 is a version of MurmurHash which is designed to run only on
+// little-endian processors.  It is considerably faster for those processors
+// than Hash128.
+func Hash128x64(key []byte) []byte {
+	length := len(key)
+	ret := make([]byte, 16)
+	if length == 0 {
+		return ret
+	}
+
+	rh := *(*reflect.SliceHeader)(unsafe.Pointer(&ret))
+
+	nblocks := length / 16
+	var h1, h2, k1, k2 uint64
+
+	h := *(*reflect.SliceHeader)(unsafe.Pointer(&key))
+	h.Len = nblocks * 2
+	b := *(*[]uint64)(unsafe.Pointer(&h))
+	for i := 0; i < len(b); i += 2 {
+		k1, k2 = b[i], b[i+1]
+		k1 *= h64c1
+		k1 = (k1 << 31) | (k1 >> (64 - 31))
+		k1 *= h64c2
+		h1 ^= k1
+		h1 = (h1 << 27) | (h1 >> (64 - 27))
+		h1 += h2
+		h1 = h1*5 + 0x52dce729
+		k2 *= h64c2
+		k2 = (k2 << 33) | (k2 >> (64 - 33))
+		k2 *= h64c1
+		h2 ^= k2
+		h2 = (h2 << 31) | (h2 >> (64 - 31))
+		h2 += h1
+		h2 = h2*5 + 0x38495ab5
+	}
+	h.Len = length
+
+	k1, k2 = 0, 0
+	tailIndex := nblocks * 16
+	switch length & 15 {
+	case 15:
+		k2 ^= uint64(key[tailIndex+14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(key[tailIndex+13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(key[tailIndex+12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(key[tailIndex+11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(key[tailIndex+10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(key[tailIndex+9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(key[tailIndex+8])
+		k2 *= h64c2
+		k2 = (k2 << 33) | (k2 >> (64 - 33))
+		k2 *= h64c1
+		h2 ^= k2
+		fallthrough
+	case 8:
+		k1 ^= uint64(key[tailIndex+7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(key[tailIndex+6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(key[tailIndex+5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(key[tailIndex+4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(key[tailIndex+3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(key[tailIndex+2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(key[tailIndex+1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(key[tailIndex])
+		k1 *= h64c1
+		k1 = (k1 << 31) | (k1 >> (64 - 31))
+		k1 *= h64c2
+		h1 ^= k1
+	}
+	h1 ^= uint64(length)
+	h2 ^= uint64(length)
+	h1 += h2
+	h2 += h1
+	h1 ^= h1 >> 33
+	h1 *= 0xff51afd7ed558ccd
+	h1 ^= h1 >> 33
+	h1 *= 0xc4ceb9fe1a85ec53
+	h1 ^= h1 >> 33
+	h2 ^= h2 >> 33
+	h2 *= 0xff51afd7ed558ccd
+	h2 ^= h2 >> 33
+	h2 *= 0xc4ceb9fe1a85ec53
+	h2 ^= h2 >> 33
+	h1 += h2
+	h2 += h1
+
+	rh.Len = 2
+	b = *(*[]uint64)(unsafe.Pointer(&rh))
+	b[0] = h1
+	b[1] = h2
+	rh.Len = 16
+	return ret
+}
+
+type HashWriter128 struct {
+	buf     [16]byte
+	h1, h2  uint64
+	index   int
+	written int64
+}
+
+func (hw *HashWriter128) Reset() {
+	hw.buf = [16]byte{}
+	hw.h1 = 0
+	hw.h2 = 0
+	hw.index = 0
+	hw.written = 0
+}
+
+func (hw *HashWriter128) Size() int {
+	return 16
+}
+
+func (hw *HashWriter128) BlockSize() int {
+	return 16
+}
+
+func (hw *HashWriter128) Write(b []byte) (int, error) {
+	total := 0
+	// fill the buffer, then update the internal state
+	// of this hash
+	for len(b) != 0 {
+		n := copy(hw.buf[hw.index:], b)
+		total += n
+		b = b[n:]
+		hw.index += n
+		if hw.index != 16 {
+			hw.written += int64(total)
+			return total, nil
+		}
+		hw.updateState()
+	}
+	hw.written += int64(total)
+	return total, nil
+}
+
+func (hw *HashWriter128) WriteString(s string) (int, error) {
+	total := 0
+	// fill the buffer, then update the internal state
+	// of this hash
+	for len(s) != 0 {
+		n := copy(hw.buf[hw.index:], s)
+		total += n
+		s = s[n:]
+		hw.index += n
+		if hw.index != 16 {
+			hw.written += int64(total)
+			return total, nil
+		}
+		hw.updateState()
+	}
+	hw.written += int64(total)
+	return total, nil
+
+}
+
+func (hw *HashWriter128) updateState() {
+	hw.index = 0
+	k1 := binary.LittleEndian.Uint64(hw.buf[:])
+	k2 := binary.LittleEndian.Uint64(hw.buf[8:])
+	h1 := hw.h1
+	h2 := hw.h2
+
+	k1 *= h64c1
+	k1 = (k1 << 31) | (k1 >> (64 - 31))
+	k1 *= h64c2
+	h1 ^= k1
+	h1 = (h1 << 27) | (h1 >> (64 - 27))
+	h1 += h2
+	h1 = h1*5 + 0x52dce729
+	k2 *= h64c2
+	k2 = (k2 << 33) | (k2 >> (64 - 33))
+	k2 *= h64c1
+	h2 ^= k2
+	h2 = (h2 << 31) | (h2 >> (64 - 31))
+	h2 += h1
+	h2 = h2*5 + 0x38495ab5
+
+	hw.h1 = h1
+	hw.h2 = h2
+}
+
+func (hw *HashWriter128) Sum(b []byte) []byte {
+	k1 := uint64(0)
+	k2 := uint64(0)
+	h1 := hw.h1
+	h2 := hw.h2
+	switch hw.index {
+	case 15:
+		k2 ^= uint64(hw.buf[14]) << 48
+		fallthrough
+	case 14:
+		k2 ^= uint64(hw.buf[13]) << 40
+		fallthrough
+	case 13:
+		k2 ^= uint64(hw.buf[12]) << 32
+		fallthrough
+	case 12:
+		k2 ^= uint64(hw.buf[11]) << 24
+		fallthrough
+	case 11:
+		k2 ^= uint64(hw.buf[10]) << 16
+		fallthrough
+	case 10:
+		k2 ^= uint64(hw.buf[9]) << 8
+		fallthrough
+	case 9:
+		k2 ^= uint64(hw.buf[8])
+		k2 *= h64c2
+		k2 = (k2 << 33) | (k2 >> (64 - 33))
+		k2 *= h64c1
+		h2 ^= k2
+		fallthrough
+	case 8:
+		k1 ^= uint64(hw.buf[7]) << 56
+		fallthrough
+	case 7:
+		k1 ^= uint64(hw.buf[6]) << 48
+		fallthrough
+	case 6:
+		k1 ^= uint64(hw.buf[5]) << 40
+		fallthrough
+	case 5:
+		k1 ^= uint64(hw.buf[4]) << 32
+		fallthrough
+	case 4:
+		k1 ^= uint64(hw.buf[3]) << 24
+		fallthrough
+	case 3:
+		k1 ^= uint64(hw.buf[2]) << 16
+		fallthrough
+	case 2:
+		k1 ^= uint64(hw.buf[1]) << 8
+		fallthrough
+	case 1:
+		k1 ^= uint64(hw.buf[0])
+		k1 *= h64c1
+		k1 = (k1 << 31) | (k1 >> (64 - 31))
+		k1 *= h64c2
+		h1 ^= k1
+	}
+	h1 ^= uint64(hw.written)
+	h2 ^= uint64(hw.written)
+	h1 += h2
+	h2 += h1
+	h1 ^= h1 >> 33
+	h1 *= 0xff51afd7ed558ccd
+	h1 ^= h1 >> 33
+	h1 *= 0xc4ceb9fe1a85ec53
+	h1 ^= h1 >> 33
+	h2 ^= h2 >> 33
+	h2 *= 0xff51afd7ed558ccd
+	h2 ^= h2 >> 33
+	h2 *= 0xc4ceb9fe1a85ec53
+	h2 ^= h2 >> 33
+	h1 += h2
+	h2 += h1
+	var retbuf [8]byte
+	binary.LittleEndian.PutUint64(retbuf[:], h1)
+	b = append(b, retbuf[:]...)
+	binary.LittleEndian.PutUint64(retbuf[:], h2)
+	b = append(b, retbuf[:]...)
+	return b
+}

--- a/vendor/github.com/dgryski/go-farm/LICENSE
+++ b/vendor/github.com/dgryski/go-farm/LICENSE
@@ -1,0 +1,23 @@
+As this is a highly derivative work, I have placed it under the same license as the original implementation:
+
+Copyright (c) 2014-2017 Damian Gryski
+Copyright (c) 2016-2017 Nicola Asuni - Tecnick.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/vendor/github.com/dgryski/go-farm/basics.go
+++ b/vendor/github.com/dgryski/go-farm/basics.go
@@ -1,0 +1,30 @@
+package farm
+
+// Some primes between 2^63 and 2^64 for various uses.
+const k0 uint64 = 0xc3a5c85c97cb3127
+const k1 uint64 = 0xb492b66fbe98f273
+const k2 uint64 = 0x9ae16a3b2f90404f
+
+// Magic numbers for 32-bit hashing.  Copied from Murmur3.
+const c1 uint32 = 0xcc9e2d51
+const c2 uint32 = 0x1b873593
+
+// A 32-bit to 32-bit integer hash copied from Murmur3.
+func fmix(h uint32) uint32 {
+	h ^= h >> 16
+	h *= 0x85ebca6b
+	h ^= h >> 13
+	h *= 0xc2b2ae35
+	h ^= h >> 16
+	return h
+}
+
+func mur(a, h uint32) uint32 {
+	// Helper from Murmur3 for combining two 32-bit values.
+	a *= c1
+	a = rotate32(a, 17)
+	a *= c2
+	h ^= a
+	h = rotate32(h, 19)
+	return h*5 + 0xe6546b64
+}

--- a/vendor/github.com/dgryski/go-farm/farmhashcc.go
+++ b/vendor/github.com/dgryski/go-farm/farmhashcc.go
@@ -1,0 +1,199 @@
+package farm
+
+// This file provides a 32-bit hash equivalent to CityHash32 (v1.1.1)
+// and a 128-bit hash equivalent to CityHash128 (v1.1.1).  It also provides
+// a seeded 32-bit hash function similar to CityHash32.
+
+func hash32Len13to24Seed(s []byte, seed uint32) uint32 {
+	slen := len(s)
+	a := fetch32(s, -4+(slen>>1))
+	b := fetch32(s, 4)
+	c := fetch32(s, slen-8)
+	d := fetch32(s, (slen >> 1))
+	e := fetch32(s, 0)
+	f := fetch32(s, slen-4)
+	h := d*c1 + uint32(slen) + seed
+	a = rotate32(a, 12) + f
+	h = mur(c, h) + a
+	a = rotate32(a, 3) + c
+	h = mur(e, h) + a
+	a = rotate32(a+f, 12) + d
+	h = mur(b^seed, h) + a
+	return fmix(h)
+}
+
+func hash32Len0to4(s []byte, seed uint32) uint32 {
+	slen := len(s)
+	b := seed
+	c := uint32(9)
+	for i := 0; i < slen; i++ {
+		v := int8(s[i])
+		b = (b * c1) + uint32(v)
+		c ^= b
+	}
+	return fmix(mur(b, mur(uint32(slen), c)))
+}
+
+func hash128to64(x uint128) uint64 {
+	// Murmur-inspired hashing.
+	const mul uint64 = 0x9ddfea08eb382d69
+	a := (x.lo ^ x.hi) * mul
+	a ^= (a >> 47)
+	b := (x.hi ^ a) * mul
+	b ^= (b >> 47)
+	b *= mul
+	return b
+}
+
+type uint128 struct {
+	lo uint64
+	hi uint64
+}
+
+// A subroutine for CityHash128().  Returns a decent 128-bit hash for strings
+// of any length representable in signed long.  Based on City and Murmur.
+func cityMurmur(s []byte, seed uint128) uint128 {
+	slen := len(s)
+	a := seed.lo
+	b := seed.hi
+	var c uint64
+	var d uint64
+	l := slen - 16
+	if l <= 0 { // len <= 16
+		a = shiftMix(a*k1) * k1
+		c = b*k1 + hashLen0to16(s)
+		if slen >= 8 {
+			d = shiftMix(a + fetch64(s, 0))
+		} else {
+			d = shiftMix(a + c)
+		}
+	} else { // len > 16
+		c = hashLen16(fetch64(s, slen-8)+k1, a)
+		d = hashLen16(b+uint64(slen), c+fetch64(s, slen-16))
+		a += d
+		for {
+			a ^= shiftMix(fetch64(s, 0)*k1) * k1
+			a *= k1
+			b ^= a
+			c ^= shiftMix(fetch64(s, 8)*k1) * k1
+			c *= k1
+			d ^= c
+			s = s[16:]
+			l -= 16
+			if l <= 0 {
+				break
+			}
+		}
+	}
+	a = hashLen16(a, c)
+	b = hashLen16(d, b)
+	return uint128{a ^ b, hashLen16(b, a)}
+}
+
+func cityHash128WithSeed(s []byte, seed uint128) uint128 {
+	slen := len(s)
+	if slen < 128 {
+		return cityMurmur(s, seed)
+	}
+
+	endIdx := ((slen - 1) / 128) * 128
+	lastBlockIdx := endIdx + ((slen - 1) & 127) - 127
+	last := s[lastBlockIdx:]
+
+	// We expect len >= 128 to be the common case.  Keep 56 bytes of state:
+	// v, w, x, y, and z.
+	var v1, v2 uint64
+	var w1, w2 uint64
+	x := seed.lo
+	y := seed.hi
+	z := uint64(slen) * k1
+	v1 = rotate64(y^k1, 49)*k1 + fetch64(s, 0)
+	v2 = rotate64(v1, 42)*k1 + fetch64(s, 8)
+	w1 = rotate64(y+z, 35)*k1 + x
+	w2 = rotate64(x+fetch64(s, 88), 53) * k1
+
+	// This is the same inner loop as CityHash64(), manually unrolled.
+	for {
+		x = rotate64(x+y+v1+fetch64(s, 8), 37) * k1
+		y = rotate64(y+v2+fetch64(s, 48), 42) * k1
+		x ^= w2
+		y += v1 + fetch64(s, 40)
+		z = rotate64(z+w1, 33) * k1
+		v1, v2 = weakHashLen32WithSeeds(s, v2*k1, x+w1)
+		w1, w2 = weakHashLen32WithSeeds(s[32:], z+w2, y+fetch64(s, 16))
+		z, x = x, z
+		s = s[64:]
+		x = rotate64(x+y+v1+fetch64(s, 8), 37) * k1
+		y = rotate64(y+v2+fetch64(s, 48), 42) * k1
+		x ^= w2
+		y += v1 + fetch64(s, 40)
+		z = rotate64(z+w1, 33) * k1
+		v1, v2 = weakHashLen32WithSeeds(s, v2*k1, x+w1)
+		w1, w2 = weakHashLen32WithSeeds(s[32:], z+w2, y+fetch64(s, 16))
+		z, x = x, z
+		s = s[64:]
+		slen -= 128
+		if slen < 128 {
+			break
+		}
+	}
+	x += rotate64(v1+z, 49) * k0
+	y = y*k0 + rotate64(w2, 37)
+	z = z*k0 + rotate64(w1, 27)
+	w1 *= 9
+	v1 *= k0
+	// If 0 < len < 128, hash up to 4 chunks of 32 bytes each from the end of s.
+	for tailDone := 0; tailDone < slen; {
+		tailDone += 32
+		y = rotate64(x+y, 42)*k0 + v2
+		w1 += fetch64(last, 128-tailDone+16)
+		x = x*k0 + w1
+		z += w2 + fetch64(last, 128-tailDone)
+		w2 += v1
+		v1, v2 = weakHashLen32WithSeeds(last[128-tailDone:], v1+z, v2)
+		v1 *= k0
+	}
+
+	// At this point our 56 bytes of state should contain more than
+	// enough information for a strong 128-bit hash.  We use two
+	// different 56-byte-to-8-byte hashes to get a 16-byte final result.
+	x = hashLen16(x, v1)
+	y = hashLen16(y+z, w1)
+	return uint128{hashLen16(x+v2, w2) + y,
+		hashLen16(x+w2, y+v2)}
+}
+
+func cityHash128(s []byte) uint128 {
+	slen := len(s)
+	if slen >= 16 {
+		return cityHash128WithSeed(s[16:], uint128{fetch64(s, 0), fetch64(s, 8) + k0})
+	}
+	return cityHash128WithSeed(s, uint128{k0, k1})
+}
+
+// Fingerprint128 is a 128-bit fingerprint function for byte-slices
+func Fingerprint128(s []byte) (lo, hi uint64) {
+	h := cityHash128(s)
+	return h.lo, h.hi
+}
+
+// Fingerprint64 is a 64-bit fingerprint function for byte-slices
+func Fingerprint64(s []byte) uint64 {
+	return naHash64(s)
+}
+
+// Fingerprint32 is a 32-bit fingerprint function for byte-slices
+func Fingerprint32(s []byte) uint32 {
+	return Hash32(s)
+}
+
+// Hash128 is a 128-bit hash function for byte-slices
+func Hash128(s []byte) (lo, hi uint64) {
+	return Fingerprint128(s)
+}
+
+// Hash128WithSeed is a 128-bit hash function for byte-slices and a 128-bit seed
+func Hash128WithSeed(s []byte, seed0, seed1 uint64) (lo, hi uint64) {
+	h := cityHash128WithSeed(s, uint128{seed0, seed1})
+	return h.lo, h.hi
+}

--- a/vendor/github.com/dgryski/go-farm/farmhashmk.go
+++ b/vendor/github.com/dgryski/go-farm/farmhashmk.go
@@ -1,0 +1,102 @@
+package farm
+
+func hash32Len5to12(s []byte, seed uint32) uint32 {
+	slen := len(s)
+	a := uint32(len(s))
+	b := uint32(len(s) * 5)
+	c := uint32(9)
+	d := b + seed
+	a += fetch32(s, 0)
+	b += fetch32(s, slen-4)
+	c += fetch32(s, ((slen >> 1) & 4))
+	return fmix(seed ^ mur(c, mur(b, mur(a, d))))
+}
+
+// Hash32 hashes a byte slice and returns a uint32 hash value
+func Hash32(s []byte) uint32 {
+
+	slen := len(s)
+
+	if slen <= 24 {
+		if slen <= 12 {
+			if slen <= 4 {
+				return hash32Len0to4(s, 0)
+			}
+			return hash32Len5to12(s, 0)
+		}
+		return hash32Len13to24Seed(s, 0)
+	}
+
+	// len > 24
+	h := uint32(slen)
+	g := c1 * uint32(slen)
+	f := g
+	a0 := rotate32(fetch32(s, slen-4)*c1, 17) * c2
+	a1 := rotate32(fetch32(s, slen-8)*c1, 17) * c2
+	a2 := rotate32(fetch32(s, slen-16)*c1, 17) * c2
+	a3 := rotate32(fetch32(s, slen-12)*c1, 17) * c2
+	a4 := rotate32(fetch32(s, slen-20)*c1, 17) * c2
+	h ^= a0
+	h = rotate32(h, 19)
+	h = h*5 + 0xe6546b64
+	h ^= a2
+	h = rotate32(h, 19)
+	h = h*5 + 0xe6546b64
+	g ^= a1
+	g = rotate32(g, 19)
+	g = g*5 + 0xe6546b64
+	g ^= a3
+	g = rotate32(g, 19)
+	g = g*5 + 0xe6546b64
+	f += a4
+	f = rotate32(f, 19) + 113
+	iters := (slen - 1) / 20
+	for {
+		a := fetch32(s, 0)
+		b := fetch32(s, 4)
+		c := fetch32(s, 8)
+		d := fetch32(s, 12)
+		e := fetch32(s, 16)
+		h += a
+		g += b
+		f += c
+		h = mur(d, h) + e
+		g = mur(c, g) + a
+		f = mur(b+e*c1, f) + d
+		f += g
+		g += f
+		s = s[20:]
+		iters--
+		if iters == 0 {
+			break
+		}
+	}
+	g = rotate32(g, 11) * c1
+	g = rotate32(g, 17) * c1
+	f = rotate32(f, 11) * c1
+	f = rotate32(f, 17) * c1
+	h = rotate32(h+g, 19)
+	h = h*5 + 0xe6546b64
+	h = rotate32(h, 17) * c1
+	h = rotate32(h+f, 19)
+	h = h*5 + 0xe6546b64
+	h = rotate32(h, 17) * c1
+	return h
+}
+
+// Hash32WithSeed hashes a byte slice and a uint32 seed and returns a uint32 hash value
+func Hash32WithSeed(s []byte, seed uint32) uint32 {
+	slen := len(s)
+
+	if slen <= 24 {
+		if slen >= 13 {
+			return hash32Len13to24Seed(s, seed*c1)
+		}
+		if slen >= 5 {
+			return hash32Len5to12(s, seed)
+		}
+		return hash32Len0to4(s, seed)
+	}
+	h := hash32Len13to24Seed(s[:24], seed^uint32(slen))
+	return mur(Hash32(s[24:])+seed, h)
+}

--- a/vendor/github.com/dgryski/go-farm/farmhashna.go
+++ b/vendor/github.com/dgryski/go-farm/farmhashna.go
@@ -1,0 +1,156 @@
+package farm
+
+func shiftMix(val uint64) uint64 {
+	return val ^ (val >> 47)
+}
+
+func hashLen16(u, v uint64) uint64 {
+	return hash128to64(uint128{u, v})
+}
+
+func hashLen16Mul(u, v, mul uint64) uint64 {
+	// Murmur-inspired hashing.
+	a := (u ^ v) * mul
+	a ^= (a >> 47)
+	b := (v ^ a) * mul
+	b ^= (b >> 47)
+	b *= mul
+	return b
+}
+
+func hashLen0to16(s []byte) uint64 {
+	slen := uint64(len(s))
+	if slen >= 8 {
+		mul := k2 + slen*2
+		a := fetch64(s, 0) + k2
+		b := fetch64(s, int(slen-8))
+		c := rotate64(b, 37)*mul + a
+		d := (rotate64(a, 25) + b) * mul
+		return hashLen16Mul(c, d, mul)
+	}
+
+	if slen >= 4 {
+		mul := k2 + slen*2
+		a := fetch32(s, 0)
+		return hashLen16Mul(slen+(uint64(a)<<3), uint64(fetch32(s, int(slen-4))), mul)
+	}
+	if slen > 0 {
+		a := s[0]
+		b := s[slen>>1]
+		c := s[slen-1]
+		y := uint32(a) + (uint32(b) << 8)
+		z := uint32(slen) + (uint32(c) << 2)
+		return shiftMix(uint64(y)*k2^uint64(z)*k0) * k2
+	}
+	return k2
+}
+
+// This probably works well for 16-byte strings as well, but it may be overkill
+// in that case.
+func hashLen17to32(s []byte) uint64 {
+	slen := len(s)
+	mul := k2 + uint64(slen*2)
+	a := fetch64(s, 0) * k1
+	b := fetch64(s, 8)
+	c := fetch64(s, slen-8) * mul
+	d := fetch64(s, slen-16) * k2
+	return hashLen16Mul(rotate64(a+b, 43)+rotate64(c, 30)+d, a+rotate64(b+k2, 18)+c, mul)
+}
+
+// Return a 16-byte hash for 48 bytes.  Quick and dirty.
+// Callers do best to use "random-looking" values for a and b.
+func weakHashLen32WithSeedsWords(w, x, y, z, a, b uint64) (uint64, uint64) {
+	a += w
+	b = rotate64(b+a+z, 21)
+	c := a
+	a += x
+	a += y
+	b += rotate64(a, 44)
+	return a + z, b + c
+}
+
+// Return a 16-byte hash for s[0] ... s[31], a, and b.  Quick and dirty.
+func weakHashLen32WithSeeds(s []byte, a, b uint64) (uint64, uint64) {
+	return weakHashLen32WithSeedsWords(fetch64(s, 0),
+		fetch64(s, 8),
+		fetch64(s, 16),
+		fetch64(s, 24),
+		a,
+		b)
+}
+
+// Return an 8-byte hash for 33 to 64 bytes.
+func hashLen33to64(s []byte) uint64 {
+	slen := len(s)
+	mul := k2 + uint64(slen)*2
+	a := fetch64(s, 0) * k2
+	b := fetch64(s, 8)
+	c := fetch64(s, slen-8) * mul
+	d := fetch64(s, slen-16) * k2
+	y := rotate64(a+b, 43) + rotate64(c, 30) + d
+	z := hashLen16Mul(y, a+rotate64(b+k2, 18)+c, mul)
+	e := fetch64(s, 16) * mul
+	f := fetch64(s, 24)
+	g := (y + fetch64(s, slen-32)) * mul
+	h := (z + fetch64(s, slen-24)) * mul
+	return hashLen16Mul(rotate64(e+f, 43)+rotate64(g, 30)+h, e+rotate64(f+a, 18)+g, mul)
+}
+
+func naHash64(s []byte) uint64 {
+	slen := len(s)
+	var seed uint64 = 81
+	if slen <= 32 {
+		if slen <= 16 {
+			return hashLen0to16(s)
+		}
+		return hashLen17to32(s)
+	}
+	if slen <= 64 {
+		return hashLen33to64(s)
+	}
+	// For strings over 64 bytes we loop.
+	// Internal state consists of 56 bytes: v, w, x, y, and z.
+	v := uint128{0, 0}
+	w := uint128{0, 0}
+	x := seed*k2 + fetch64(s, 0)
+	y := seed*k1 + 113
+	z := shiftMix(y*k2+113) * k2
+	// Set end so that after the loop we have 1 to 64 bytes left to process.
+	endIdx := ((slen - 1) / 64) * 64
+	last64Idx := endIdx + ((slen - 1) & 63) - 63
+	last64 := s[last64Idx:]
+	for len(s) > 64 {
+		x = rotate64(x+y+v.lo+fetch64(s, 8), 37) * k1
+		y = rotate64(y+v.hi+fetch64(s, 48), 42) * k1
+		x ^= w.hi
+		y += v.lo + fetch64(s, 40)
+		z = rotate64(z+w.lo, 33) * k1
+		v.lo, v.hi = weakHashLen32WithSeeds(s, v.hi*k1, x+w.lo)
+		w.lo, w.hi = weakHashLen32WithSeeds(s[32:], z+w.hi, y+fetch64(s, 16))
+		x, z = z, x
+		s = s[64:]
+	}
+	mul := k1 + ((z & 0xff) << 1)
+	// Make s point to the last 64 bytes of input.
+	s = last64
+	w.lo += (uint64(slen-1) & 63)
+	v.lo += w.lo
+	w.lo += v.lo
+	x = rotate64(x+y+v.lo+fetch64(s, 8), 37) * mul
+	y = rotate64(y+v.hi+fetch64(s, 48), 42) * mul
+	x ^= w.hi * 9
+	y += v.lo*9 + fetch64(s, 40)
+	z = rotate64(z+w.lo, 33) * mul
+	v.lo, v.hi = weakHashLen32WithSeeds(s, v.hi*mul, x+w.lo)
+	w.lo, w.hi = weakHashLen32WithSeeds(s[32:], z+w.hi, y+fetch64(s, 16))
+	x, z = z, x
+	return hashLen16Mul(hashLen16Mul(v.lo, w.lo, mul)+shiftMix(y)*k0+z, hashLen16Mul(v.hi, w.hi, mul)+x, mul)
+}
+
+func naHash64WithSeed(s []byte, seed uint64) uint64 {
+	return naHash64WithSeeds(s, k2, seed)
+}
+
+func naHash64WithSeeds(s []byte, seed0, seed1 uint64) uint64 {
+	return hashLen16(naHash64(s)-seed0, seed1)
+}

--- a/vendor/github.com/dgryski/go-farm/farmhashuo.go
+++ b/vendor/github.com/dgryski/go-farm/farmhashuo.go
@@ -1,0 +1,117 @@
+package farm
+
+func uoH(x, y, mul uint64, r uint) uint64 {
+	a := (x ^ y) * mul
+	a ^= (a >> 47)
+	b := (y ^ a) * mul
+	return rotate64(b, r) * mul
+}
+
+// Hash64WithSeeds hashes a byte slice and two uint64 seeds and returns a uint64 hash value
+func Hash64WithSeeds(s []byte, seed0, seed1 uint64) uint64 {
+	slen := len(s)
+	if slen <= 64 {
+		return naHash64WithSeeds(s, seed0, seed1)
+	}
+
+	// For strings over 64 bytes we loop.
+	// Internal state consists of 64 bytes: u, v, w, x, y, and z.
+	x := seed0
+	y := seed1*k2 + 113
+	z := shiftMix(y*k2) * k2
+	v := uint128{seed0, seed1}
+	var w uint128
+	u := x - z
+	x *= k2
+	mul := k2 + (u & 0x82)
+
+	// Set end so that after the loop we have 1 to 64 bytes left to process.
+	endIdx := ((slen - 1) / 64) * 64
+	last64Idx := endIdx + ((slen - 1) & 63) - 63
+	last64 := s[last64Idx:]
+
+	for len(s) > 64 {
+		a0 := fetch64(s, 0)
+		a1 := fetch64(s, 8)
+		a2 := fetch64(s, 16)
+		a3 := fetch64(s, 24)
+		a4 := fetch64(s, 32)
+		a5 := fetch64(s, 40)
+		a6 := fetch64(s, 48)
+		a7 := fetch64(s, 56)
+		x += a0 + a1
+		y += a2
+		z += a3
+		v.lo += a4
+		v.hi += a5 + a1
+		w.lo += a6
+		w.hi += a7
+
+		x = rotate64(x, 26)
+		x *= 9
+		y = rotate64(y, 29)
+		z *= mul
+		v.lo = rotate64(v.lo, 33)
+		v.hi = rotate64(v.hi, 30)
+		w.lo ^= x
+		w.lo *= 9
+		z = rotate64(z, 32)
+		z += w.hi
+		w.hi += z
+		z *= 9
+		u, y = y, u
+
+		z += a0 + a6
+		v.lo += a2
+		v.hi += a3
+		w.lo += a4
+		w.hi += a5 + a6
+		x += a1
+		y += a7
+
+		y += v.lo
+		v.lo += x - y
+		v.hi += w.lo
+		w.lo += v.hi
+		w.hi += x - y
+		x += w.hi
+		w.hi = rotate64(w.hi, 34)
+		u, z = z, u
+		s = s[64:]
+	}
+	// Make s point to the last 64 bytes of input.
+	s = last64
+	u *= 9
+	v.hi = rotate64(v.hi, 28)
+	v.lo = rotate64(v.lo, 20)
+	w.lo += (uint64(slen-1) & 63)
+	u += y
+	y += u
+	x = rotate64(y-x+v.lo+fetch64(s, 8), 37) * mul
+	y = rotate64(y^v.hi^fetch64(s, 48), 42) * mul
+	x ^= w.hi * 9
+	y += v.lo + fetch64(s, 40)
+	z = rotate64(z+w.lo, 33) * mul
+	v.lo, v.hi = weakHashLen32WithSeeds(s, v.hi*mul, x+w.lo)
+	w.lo, w.hi = weakHashLen32WithSeeds(s[32:], z+w.hi, y+fetch64(s, 16))
+	return uoH(hashLen16Mul(v.lo+x, w.lo^y, mul)+z-u,
+		uoH(v.hi+y, w.hi+z, k2, 30)^x,
+		k2,
+		31)
+}
+
+// Hash64WithSeed hashes a byte slice and a uint64 seed and returns a uint64 hash value
+func Hash64WithSeed(s []byte, seed uint64) uint64 {
+	if len(s) <= 64 {
+		return naHash64WithSeed(s, seed)
+	}
+	return Hash64WithSeeds(s, 0, seed)
+}
+
+// Hash64 hashes a byte slice and returns a uint64 hash value
+func Hash64(s []byte) uint64 {
+	if len(s) <= 64 {
+		return naHash64(s)
+	}
+	return Hash64WithSeeds(s, 81, 0)
+}

--- a/vendor/github.com/dgryski/go-farm/platform.go
+++ b/vendor/github.com/dgryski/go-farm/platform.go
@@ -1,0 +1,18 @@
+package farm
+
+func rotate32(val uint32, shift uint) uint32 {
+	return ((val >> shift) | (val << (32 - shift)))
+}
+
+func rotate64(val uint64, shift uint) uint64 {
+	return ((val >> shift) | (val << (64 - shift)))
+}
+
+func fetch32(s []byte, idx int) uint32 {
+	return uint32(s[idx+0]) | uint32(s[idx+1])<<8 | uint32(s[idx+2])<<16 | uint32(s[idx+3])<<24
+}
+
+func fetch64(s []byte, idx int) uint64 {
+	return uint64(s[idx+0]) | uint64(s[idx+1])<<8 | uint64(s[idx+2])<<16 | uint64(s[idx+3])<<24 |
+		uint64(s[idx+4])<<32 | uint64(s[idx+5])<<40 | uint64(s[idx+6])<<48 | uint64(s[idx+7])<<56
+}

--- a/vendor/github.com/mtchavez/cuckoo/LICENSE
+++ b/vendor/github.com/mtchavez/cuckoo/LICENSE
@@ -1,0 +1,20 @@
+Cuckoo Filter
+Copyright © 2017 mtchavez
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/mtchavez/cuckoo/bucket.go
+++ b/vendor/github.com/mtchavez/cuckoo/bucket.go
@@ -1,0 +1,44 @@
+package cuckoo
+
+import (
+	"bytes"
+	"math/rand"
+)
+
+type bucket []fingerprint
+
+func (b bucket) insert(fp fingerprint) bool {
+	for i, fprint := range b {
+		if fprint == nil {
+			b[i] = fp
+			return true
+		}
+	}
+	return false
+}
+
+func (b bucket) lookup(fp fingerprint) bool {
+	for _, fprint := range b {
+		if bytes.Equal(fp, fprint) {
+			return true
+		}
+	}
+	return false
+}
+
+func (b bucket) delete(fp fingerprint) bool {
+	for i, fprint := range b {
+		if bytes.Equal(fp, fprint) {
+			b[i] = nil
+			return true
+		}
+	}
+	return false
+}
+
+func (b bucket) relocate(fp fingerprint) fingerprint {
+	i := rand.Intn(len(b))
+	b[i], fp = fp, b[i]
+
+	return fp
+}

--- a/vendor/github.com/mtchavez/cuckoo/config.go
+++ b/vendor/github.com/mtchavez/cuckoo/config.go
@@ -1,0 +1,123 @@
+package cuckoo
+
+// ConfigOption ...
+//
+// Composed Filter function type used for configuring a Filter
+type ConfigOption func(*Filter)
+
+// Cuckoo Filter notation
+// e target false positive rate
+// f fingerprint length in bits
+// α load factor (0 ≤ α ≤ 1)
+// b number of entries per bucket
+// m number of buckets
+// n number of items
+// C average bits per item
+const (
+	// Entries per bucket (b)
+	defaultBucketEntries uint = 24
+	// Bucket total (m) defaults to approx. 4 million
+	defaultBucketTotal uint = 1 << 22
+	// Length of fingreprint (f) set to log(n/b) ~6 bits
+	defaultFingerprintLength uint = 6
+	// Default attempts to find empty slot on insert
+	defaultKicks uint = 500
+)
+
+// BucketEntries ...
+//
+// Number of entries per bucket denoted as b
+//
+// Example:
+//
+// New(BucketEntries(uint(42)))
+func BucketEntries(entries uint) ConfigOption {
+	return func(f *Filter) {
+		f.bucketEntries = entries
+	}
+}
+
+// BucketTotal ...
+//
+// Number of buckets in the Filter denoted as m
+//
+// Example:
+//
+// New(BucketTotal(uint(42)))
+func BucketTotal(total uint) ConfigOption {
+	return func(f *Filter) {
+		f.bucketTotal = total
+	}
+}
+
+// FingerprintLength ...
+//
+// Length of the item fingerprint denoted as f
+//
+// Example:
+//
+// New(FingerprintLength(uint(4)))
+func FingerprintLength(length uint) ConfigOption {
+	return func(f *Filter) {
+		if length > uint(16) {
+			length = uint(16)
+		}
+		f.fingerprintLength = length
+	}
+}
+
+// Kicks ...
+//
+// Maximum number of kicks to attempt when bucket collisions occur
+//
+// Example:
+//
+// New(Kicks(uint(200)))
+func Kicks(kicks uint) ConfigOption {
+	return func(f *Filter) {
+		f.kicks = kicks
+	}
+}
+
+func capacity() ConfigOption {
+	return func(f *Filter) {
+		f.capacity = nextPowerOf2(uint64(f.bucketTotal)) / f.bucketEntries
+		if f.capacity <= 0 {
+			f.capacity = 1
+		}
+	}
+}
+
+func (f *Filter) configureDefaults() {
+	if f.bucketTotal <= 0 {
+		BucketTotal(defaultBucketTotal)(f)
+	}
+
+	if f.bucketEntries <= 0 {
+		BucketEntries(defaultBucketEntries)(f)
+	}
+
+	if f.fingerprintLength <= 0 {
+		FingerprintLength(defaultFingerprintLength)(f)
+	}
+
+	if f.kicks <= 0 {
+		Kicks(defaultKicks)(f)
+	}
+
+	if f.capacity < 1 {
+		capacity()(f)
+	}
+}
+
+func nextPowerOf2(n uint64) uint {
+	n--
+	n |= n >> 1
+	n |= n >> 2
+	n |= n >> 4
+	n |= n >> 8
+	n |= n >> 16
+	n |= n >> 32
+	n++
+	return uint(n)
+}

--- a/vendor/github.com/mtchavez/cuckoo/cuckoo.go
+++ b/vendor/github.com/mtchavez/cuckoo/cuckoo.go
@@ -1,0 +1,193 @@
+package cuckoo
+
+import (
+	"encoding/binary"
+	"sync"
+
+	farm "github.com/dgryski/go-farm"
+)
+
+const magicNumber uint64 = 0x5bd1e995
+
+// Filter ...
+//
+// Cuckoo filter type
+type Filter struct {
+	sync.Mutex
+	buckets           []bucket
+	bucketEntries     uint
+	bucketTotal       uint
+	capacity          uint
+	count             uint
+	fingerprintLength uint
+	kicks             uint
+}
+
+// New ...
+//
+// Create a new Filter with an optional set of ConfigOption to configure settings.
+//
+// Example: New Filter with custom config option
+//
+// New(FingerprintLength(4))
+//
+// Example: New Filter with default config
+//
+// New()
+//
+// returns a Filter type
+func New(opts ...ConfigOption) (filter *Filter) {
+	filter = &Filter{}
+	for _, option := range opts {
+		option(filter)
+	}
+	filter.configureDefaults()
+	filter.createBuckets()
+	return
+}
+
+// Insert ...
+//
+// Add a new item of []byte to a Filter
+//
+// Example:
+//
+// filter.Insert([]byte("new-item"))
+//
+// returns a boolean of whether the item was inserted or not
+func (f *Filter) Insert(item []byte) bool {
+	fp := newFingerprint(item, f.fingerprintLength)
+	i1 := uint(farm.Hash64(item)) % f.capacity
+	i2 := f.alternateIndex(fp, i1)
+	if f.insert(fp, i1) || f.insert(fp, i2) {
+		return true
+	}
+	return f.relocationInsert(fp, i2)
+}
+
+// InsertUnique ...
+//
+// Add a new item of []byte to a Filter only if it doesn't already exist.
+// Will do a Lookup of item first.
+//
+// Example:
+//
+// filter.InsertUnique([]byte("new-item"))
+//
+// returns a boolean of whether the item was inserted or not
+func (f *Filter) InsertUnique(item []byte) bool {
+	if f.Lookup(item) {
+		return true
+	}
+	return f.Insert(item)
+}
+
+// Lookup ...
+//
+// Check if an item of []byte exists in the Filter
+//
+// Example:
+//
+// filter.Lookup([]byte("new-item"))
+//
+// returns a boolean of whether the item exists or not
+func (f *Filter) Lookup(item []byte) bool {
+	fp := newFingerprint(item, f.fingerprintLength)
+	i1 := uint(farm.Hash64(item)) % f.capacity
+	i2 := f.alternateIndex(fp, i1)
+	if f.lookup(fp, i1) || f.lookup(fp, i2) {
+		return true
+	}
+	return false
+}
+
+// Delete ...
+//
+// Delete an item of []byte if it exists in the Filter
+//
+// Example:
+//
+// filter.Delete([]byte("new-item"))
+//
+// returns a boolean of whether the item was deleted or not
+func (f *Filter) Delete(item []byte) bool {
+	fp := newFingerprint(item, f.fingerprintLength)
+	i1 := uint(farm.Hash64(item)) % f.capacity
+	i2 := f.alternateIndex(fp, i1)
+	if f.delete(fp, i1) || f.delete(fp, i2) {
+		return true
+	}
+	return false
+}
+
+// ItemCount ...
+//
+// Get an estimate of the total items in the Filter. Could be drastically off
+// if using Insert with many duplicate items. To get a more accurate total
+// using InsertUnique can be used
+//
+// Example:
+//
+// filter.ItemCount()
+//
+// returns an uint of the total items in the Filter
+func (f *Filter) ItemCount() uint {
+	return f.count
+}
+
+func (f *Filter) insert(fp fingerprint, idx uint) bool {
+	f.Lock()
+	defer f.Unlock()
+	if f.buckets[idx].insert(fp) {
+		f.count++
+		return true
+	}
+	return false
+}
+
+func (f *Filter) relocationInsert(fp fingerprint, i uint) bool {
+	f.Lock()
+	defer f.Unlock()
+	for k := uint(0); k < f.kicks; k++ {
+		f.buckets[i].relocate(fp)
+		i = f.alternateIndex(fp, i)
+		if f.buckets[i].insert(fp) {
+			f.count++
+			return true
+		}
+	}
+	return false
+}
+
+func (f *Filter) lookup(fp fingerprint, i uint) bool {
+	if f.buckets[i].lookup(fp) {
+		return true
+	}
+	return false
+}
+
+func (f *Filter) delete(fp fingerprint, idx uint) bool {
+	if f.buckets[idx].delete(fp) {
+		f.count--
+		return true
+	}
+	return false
+}
+
+func (f *Filter) createBuckets() {
+	buckets := make([]bucket, f.capacity, f.capacity)
+	for i := range buckets {
+		buckets[i] = make([]fingerprint, f.bucketEntries, f.bucketEntries)
+	}
+	f.buckets = buckets
+}
+
+func (f *Filter) alternateIndex(fp fingerprint, i uint) uint {
+	bytes := make([]byte, 64, 64)
+	for i, b := range fp {
+		bytes[i] = b
+	}
+
+	hash := binary.LittleEndian.Uint64(bytes)
+	return uint(uint64(i)^(hash*magicNumber)) % f.capacity
+}

--- a/vendor/github.com/mtchavez/cuckoo/doc.go
+++ b/vendor/github.com/mtchavez/cuckoo/doc.go
@@ -1,0 +1,5 @@
+// Package cuckoo ...
+//
+// Implements a CuckooFilter that uses cuckoo hashing to provide fast set
+// membership testing.
+package cuckoo

--- a/vendor/github.com/mtchavez/cuckoo/encoding.go
+++ b/vendor/github.com/mtchavez/cuckoo/encoding.go
@@ -1,0 +1,79 @@
+package cuckoo
+
+import (
+	"bytes"
+	"encoding/gob"
+	"os"
+)
+
+// A filter wrapper with exported fields used for marshalling
+type encodedFilter struct {
+	Buckets           []bucket
+	BucketEntries     uint
+	BucketTotal       uint
+	Capacity          uint
+	Count             uint
+	FingerprintLength uint
+	Kicks             uint
+}
+
+// MarshalBinary used to interact with gob encoding interface
+func (f *Filter) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	ef := encodedFilter{
+		Buckets:           f.buckets,
+		BucketEntries:     f.bucketEntries,
+		BucketTotal:       f.bucketTotal,
+		Capacity:          f.capacity,
+		Count:             f.count,
+		FingerprintLength: f.fingerprintLength,
+		Kicks:             f.kicks,
+	}
+	enc := gob.NewEncoder(&buf)
+	if err := enc.Encode(ef); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// UnmarshalBinary modifies the receiver so it must take a pointer receiver.
+// Used to interact with gob encoding interface
+func (f *Filter) UnmarshalBinary(data []byte) error {
+	ef := encodedFilter{}
+	buf := bytes.NewBuffer(data)
+	dec := gob.NewDecoder(buf)
+	if err := dec.Decode(&ef); err != nil {
+		return err
+	}
+	f.buckets = ef.Buckets
+	f.bucketEntries = ef.BucketEntries
+	f.bucketTotal = ef.BucketTotal
+	f.capacity = ef.Capacity
+	f.count = ef.Count
+	f.fingerprintLength = ef.FingerprintLength
+	f.kicks = ef.Kicks
+	return nil
+}
+
+// Save takes a path to a file to save an encoded filter to disk
+func (f *Filter) Save(path string) error {
+	file, err := os.Create(path)
+	defer file.Close()
+	if err == nil {
+		encoder := gob.NewEncoder(file)
+		encoder.Encode(f)
+	}
+	return err
+}
+
+// Load takes a path to a file of an encoded Filter to load into memory
+func Load(path string) (*Filter, error) {
+	f := &Filter{}
+	file, err := os.Open(path)
+	defer file.Close()
+	if err == nil {
+		decoder := gob.NewDecoder(file)
+		err = decoder.Decode(&f)
+	}
+	return f, err
+}

--- a/vendor/github.com/mtchavez/cuckoo/fingerprint.go
+++ b/vendor/github.com/mtchavez/cuckoo/fingerprint.go
@@ -1,0 +1,25 @@
+package cuckoo
+
+import (
+	"sync"
+
+	"github.com/DataDog/mmh3"
+)
+
+type fingerprint []byte
+
+var hashSync sync.Mutex
+
+func newFingerprint(item []byte, length uint) fingerprint {
+	hashedFingerprint := calculateHash(item, length)
+	fingerprinted := make(fingerprint, length, length)
+	for i := uint(0); i < length; i++ {
+		fingerprinted[i] = hashedFingerprint[i]
+	}
+	return fingerprinted
+}
+
+func calculateHash(item []byte, length uint) (hashedItem []byte) {
+	hashedItem = mmh3.Hash128(item)
+	return
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -42,6 +42,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/DataDog/mmh3",
+			"repository": "https://github.com/DataDog/mmh3",
+			"vcs": "git",
+			"revision": "2cfb68475274527a10701355c739f31dd404718c",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/a8m/mark",
 			"repository": "https://github.com/a8m/mark",
 			"vcs": "git",
@@ -103,6 +111,14 @@
 			"repository": "https://github.com/d4l3k/messagediff",
 			"vcs": "git",
 			"revision": "29f32d820d112dbd66e58492a6ffb7cc3106312b",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/dgryski/go-farm",
+			"repository": "https://github.com/dgryski/go-farm",
+			"vcs": "git",
+			"revision": "2de33835d10275975374b37b2dcfd22c9020a1f5",
 			"branch": "master",
 			"notests": true
 		},
@@ -271,6 +287,14 @@
 			"repository": "https://github.com/mitchellh/go-homedir",
 			"vcs": "git",
 			"revision": "b8bc1bf767474819792c23f32d8286a45736f1c6",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/mtchavez/cuckoo",
+			"repository": "https://github.com/mtchavez/cuckoo",
+			"vcs": "git",
+			"revision": "aed09ec84d9ddfa9689e09dc48333bcacddeb491",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
### Purpose

Instead of direcly marshalling the FileInfo for every (device,folder,file) key we instead go via a layer of indireciton that is the SHA256 of the marshalled FileInfo. We don't track usage via refcounts or similar, opting instead for a periodic GC step. This GC uses a Cuckoo filter to keep track of keys that are (probably) in use, keeping the memory usage bounded even for large sets of files. A small number of entries may be left behind due to the probabilistic nature of the filter, but this is on the order of less than a tenth of a percent for the largest file sets, less for everyone else.

### FAQ

- Why not refcounting? This is less work to track and less likely to fuck up.
- Why hash of marshalled FileInfo and not the relevant subset of attributes directly? This is more provably correct and doesn't require a database migration if the relevant set of fields changes.
- Why the Cuckoo filter? Because keeping the full set of used file hashes in RAM might exhaust RAM, and doing it with an extra accounting table in the database seems slow and annoying. This feels like a reasonable tradeoff.
- Why, at all? Much smaller DB when there are lots of remote devices. The amount of code was quite small.

### Testing

Minor new test to verify that GC happens.