### PR TITLE
lib/model: Always release the lock

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1308,8 +1308,6 @@ func (m *Model) Request(deviceID protocol.DeviceID, folder, name string, offset 
 		return protocol.ErrInvalid
 	}
 
-	m.fmut.RLock()
-
 	if cfg, ok := m.cfg.Folder(folder); !ok || !cfg.SharedWith(deviceID) {
 		l.Warnf("Request from %s for file %s in unshared folder %q", deviceID, name, folder)
 		return protocol.ErrNoSuchFile
@@ -1318,10 +1316,16 @@ func (m *Model) Request(deviceID protocol.DeviceID, folder, name string, offset 
 		return protocol.ErrInvalid
 	}
 
-	folderCfg := m.folderCfgs[folder]
+	m.fmut.RLock()
+	folderCfg, ok := m.folderCfgs[folder]
 	folderIgnores := m.folderIgnores[folder]
-
 	m.fmut.RUnlock()
+	if !ok {
+		// The folder might be already unpaused in the config, but not yet
+		// in the model.
+		l.Debugf("Request from %s for file %s in unstarted folder %q", deviceID, name, folder)
+		return protocol.ErrInvalid
+	}
 
 	// Make sure the path is valid and in canonical form
 	var err error


### PR DESCRIPTION
This is a regression from #4974 and thus affecting v0.14.49. Discovered thanks to this report:
https://forum.syncthing.net/t/panic-deadlock-detected-at-fmut/11976  
The regression being present in v0.14.49 makes this no v0.14.50 RC material. However as it is pretty bad, I'd propose to make an exception and include it anyway.

Not that it makes it any better, but the reason for including the config stuff in the `fmut` lock was probably the edge case I now handled by checking that `m.folderCfgs[folder]` is really present.