### PR TITLE
lib/model: Fix regressions detecting deletes/ignores (fixes #5125, fixes #5127)

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -45,6 +45,7 @@ type FileIntf interface {
 	MustRescan() bool
 	IsDirectory() bool
 	IsSymlink() bool
+	ShouldConflict() bool
 	HasPermissionBits() bool
 	SequenceNo() int64
 	BlockSize() int

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -69,6 +69,10 @@ func (f FileInfoTruncated) IsSymlink() bool {
 	}
 }
 
+func (f FileInfoTruncated) ShouldConflict() bool {
+	return f.LocalFlags&protocol.LocalConflictFlags != 0
+}
+
 func (f FileInfoTruncated) HasPermissionBits() bool {
 	return !f.NoPermissions
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2157,8 +2157,8 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 				// Successfully scanned items are already un-ignored during
 				// the scan, so check whether it is deleted.
 				fallthrough
-			case !f.IsIgnored() && !f.IsDeleted():
-				// The file is not ignored and not deleted. Lets check if
+			case !f.IsIgnored() && !f.IsDeleted() && !f.IsUnsupported():
+				// The file is not ignored, deleted or unsupported. Lets check if
 				// it's still here. Simply stat:ing it wont do as there are
 				// tons of corner cases (e.g. parent dir->symlink, missing
 				// permissions)
@@ -2186,7 +2186,7 @@ func (m *Model) internalScanFolderSubdirs(ctx context.Context, folder string, su
 				// counter makes sure we are in conflict with any
 				// other existing versions, which will be resolved
 				// by the normal pulling mechanisms.
-				if f.IsIgnored() {
+				if f.ShouldConflict() {
 					nf.Version = nf.Version.DropOthers(m.shortID)
 				}
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3813,6 +3813,23 @@ func TestIssue5002(t *testing.T) {
 	m.recheckFile(protocol.LocalDeviceID, defaultFolderConfig.Filesystem(), "default", "foo", nBlocks+1, []byte{1, 2, 3, 4})
 }
 
+func TestParentOfUnignored(t *testing.T) {
+	wcfg, m := newState(defaultCfg)
+	defer func() {
+		m.Stop()
+		defaultFolderConfig.Filesystem().Remove(".stignore")
+		os.Remove(wcfg.ConfigPath())
+	}()
+
+	m.SetIgnores("default", []string{"!quux", "*"})
+
+	if parent, ok := m.CurrentFolderFile("default", "baz"); !ok {
+		t.Errorf(`Directory "baz" missing in db`)
+	} else if parent.IsIgnored() {
+		t.Errorf(`Directory "baz" is ignored`)
+	}
+}
+
 func addFakeConn(m *Model, dev protocol.DeviceID) *fakeConnection {
 	fc := &fakeConnection{id: dev, model: m}
 	m.AddConnection(fc, protocol.HelloResult{})

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -631,6 +631,74 @@ func TestParentDeletion(t *testing.T) {
 	}
 }
 
+// TestRequestSymlinkWindows checks that symlinks aren't marked as deleted on windows
+// Issue: https://github.com/syncthing/syncthing/issues/5125
+func TestRequestSymlinkWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows specific test")
+	}
+
+	m, fc, tmpDir, w := setupModelWithConnection()
+	defer func() {
+		m.Stop()
+		os.RemoveAll(tmpDir)
+		os.Remove(w.ConfigPath())
+	}()
+
+	first := make(chan struct{})
+	second := make(chan []protocol.FileInfo)
+	fc.mut.Lock()
+	i := 0
+	fc.indexFn = func(folder string, fs []protocol.FileInfo) {
+		// unexpected second index
+		if i != 0 {
+			second <- fs
+			return
+		}
+		// expected first index
+		if len(fs) != 1 {
+			t.Fatalf("Expected just one file in index, got %v", fs)
+		}
+		f := fs[0]
+		if f.Name != "link" {
+			t.Fatalf(`Got file info with path "%v", expected "link"`, f.Name)
+		}
+		if !f.IsInvalid() {
+			t.Errorf(`File info was not marked as invalid`)
+		}
+		i++
+		close(first)
+	}
+	fc.mut.Unlock()
+
+	fc.addFile("link", 0644, protocol.FileInfoTypeSymlink, nil)
+	fc.sendIndexUpdate()
+
+	select {
+	case <-first:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out before pull was finished")
+	}
+
+	sub := events.Default.Subscribe(events.StateChanged)
+	defer events.Default.Unsubscribe(sub)
+
+	m.ScanFolder("default")
+
+	for {
+		select {
+		case ev := <-sub.C():
+			if ev.Data.(map[string]interface{})["from"] == "scanning" {
+				return
+			}
+		case fs := <-second:
+			t.Fatalf("Received unexpected second index %v", fs)
+		case <-time.After(5 * time.Second):
+			t.Fatalf("Timed out before scan finished")
+		}
+	}
+}
+
 func setupModelWithConnection() (*Model, *fakeConnection, string, *config.Wrapper) {
 	tmpDir := createTmpDir()
 	cfg := defaultCfgWrapper.RawCopy()


### PR DESCRIPTION
Ready for review - windows only test was verified to work and fix is now in place.  
<strike>**Do not merge**. This does not yet contain the fix for #5125, only the unit test that should reproduce it (<strike>i.e. if the new windows test passes, that's a failure</strike> it fails :) ).</strike>

### Purpose

When recurse unignoring (#4811), not only the scanner side of things should have been adapted, the model side of things (detecting ignores and deletes) as well.  
When adding more fine grained control over invalid files via local flags (#4952), the existing `IsIgnored` condition isn't enough anymore to filter files before checking whether they were deleted.

### Testing

Unit tests for both issues.