### PR TITLE
lib/ignore Have a nice treeview for handling ignores - Next Gen Ignores

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1569,16 +1569,16 @@ angular.module('syncthing.core')
             });
         };
 
-	$scope.syncedFiles = {
-	    parseable: false,
-	    all: false,
-	    files: [],
-	    reset: function() {
-		$scope.syncedFiles.parseable = false;
-		$scope.syncedFiles.all = false;
-		$scope.syncedFiles.files = [];
-	    }
-	};
+        $scope.syncedFiles = {
+            parseable: false,
+            all: false,
+            files: [],
+            reset: function() {
+                $scope.syncedFiles.parseable = false;
+                $scope.syncedFiles.all = false;
+                $scope.syncedFiles.files = [];
+            }
+        };
 
         $scope.editFolder = function (folderCfg) {
             $scope.editingExisting = true;
@@ -1626,70 +1626,70 @@ angular.module('syncthing.core')
 
             function enableBasicRules(enable) {
                 if (enable) {
-		    console.log('enabling basic rules');
+                    console.log('enabling basic rules');
                     $('#folder-ignores #folderIgnoresTree').removeAttr('disabled');
                     //$('#folder-ignores #folderIgnoresTree').show();
                 } else {
-		    console.log('disabling basic rules');
+                    console.log('disabling basic rules');
                     $('#folder-ignores #folderIgnoresTree').attr('disabled', 'disabled');
                     //$('#folder-ignores #folderIgnoresTree').hide();
                 }
             }
 
             function writeAdvancedRules() {
-		console.log('writeAdvancedRules');
-		if ($scope.syncedFiles.all) {
+                console.log('writeAdvancedRules');
+                if ($scope.syncedFiles.all) {
                     $('#folder-ignores textarea').val('');
-		    return;
-		}
+                    return;
+                }
 
                 var rules = ['*'];
-		$scope.syncedFiles.files.forEach(function (file) {
-		    console.log('file', file);
-		    var fileSplit = file.split('/');
-		    var fileDir = fileSplit.slice(0, fileSplit.length - 1).join('/');
-		    rules.push('!/' + file);
-		    if (fileDir === '') {
-			rules.push('*');
-		    } else {
-			rules.push('/' + fileDir + '/*');
-		    }
-		});
+                $scope.syncedFiles.files.forEach(function (file) {
+                    console.log('file', file);
+                    var fileSplit = file.split('/');
+                    var fileDir = fileSplit.slice(0, fileSplit.length - 1).join('/');
+                    rules.push('!/' + file);
+                    if (fileDir === '') {
+                        rules.push('*');
+                    } else {
+                        rules.push('/' + fileDir + '/*');
+                    }
+                });
 
-		rules = rules.sort(function(a, b) {
-		    var a_toSort = a;
-		    if (a_toSort.startsWith('!')) {
-			a_toSort = a_toSort.slice(1, a_toSort.length).concat('1');
-		    } else {
-			a_toSort = a_toSort.concat('2');
-		    }
+                rules = rules.sort(function(a, b) {
+                    var a_toSort = a;
+                    if (a_toSort.startsWith('!')) {
+                        a_toSort = a_toSort.slice(1, a_toSort.length).concat('1');
+                    } else {
+                        a_toSort = a_toSort.concat('2');
+                    }
 
-		    var b_toSort = b;
-		    if (b_toSort.startsWith('!')) {
-			b_toSort = b_toSort.slice(1, b_toSort.length).concat('1');
-		    } else {
-			b_toSort = b_toSort.concat('2');
-		    }
+                    var b_toSort = b;
+                    if (b_toSort.startsWith('!')) {
+                        b_toSort = b_toSort.slice(1, b_toSort.length).concat('1');
+                    } else {
+                        b_toSort = b_toSort.concat('2');
+                    }
 
-		    return a_toSort <= b_toSort;
-		}).filter(function(value, index, self) {
-		    return self.indexOf(value) === index
-		});
+                    return a_toSort <= b_toSort;
+                }).filter(function(value, index, self) {
+                    return self.indexOf(value) === index
+                });
 
-		console.log('writeAdvancedRules - rules:', rules);
-		$('#folder-ignores textarea').val(rules.join('\n'));
+                console.log('writeAdvancedRules - rules:', rules);
+                $('#folder-ignores textarea').val(rules.join('\n'));
             }
 
             function parseAdvancedRules() {
-		/*
+                /*
                  * parse:
                  *
-		 *    !/c/c
-		 *    !/c/a
-		 *    /c/*
-		 *    !/b
-		 *    !/a
-		 *    *
+                 *    !/c/c
+                 *    !/c/a
+                 *    /c/*
+                 *    !/b
+                 *    !/a
+                 *    *
                  *
                  * into object with:
                  *
@@ -1699,60 +1699,60 @@ angular.module('syncthing.core')
                  *     files: ['/c/c', '/c/a', '/b', '/a'],
                  *    }
                  *
-		 */
-		console.log('parseAdvancedRules');
-		var rules = $('#folder-ignores textarea').val().split('\n');
+                 */
+                console.log('parseAdvancedRules');
+                var rules = $('#folder-ignores textarea').val().split('\n');
                 $scope.syncedFiles.reset();
-		$scope.syncedFiles.parseable = true;
-		$scope.syncedFiles.all = true;
+                $scope.syncedFiles.parseable = true;
+                $scope.syncedFiles.all = true;
 
                 var prevRule = null;
                 for (const rule of rules) {
-		    console.log('rule', rule, 'prevRule', prevRule);
+                    console.log('rule', rule, 'prevRule', prevRule);
                     if (rule === '') {
                         continue;
                     } else {
-			$scope.syncedFiles.all = false;
-		    }
+                        $scope.syncedFiles.all = false;
+                    }
 
-		    // TODO: handles cases with multiple prevRule and one rule (multiple files in same dir)
-		    if (rule === '*') {
-			continue;
-		    } else if (prevRule === null) {
-			if (!rule.startsWith('!')) {
-			    console.log('not start with !')
+                    // TODO: handles cases with multiple prevRule and one rule (multiple files in same dir)
+                    if (rule === '*') {
+                        continue;
+                    } else if (prevRule === null) {
+                        if (!rule.startsWith('!')) {
+                            console.log('not start with !')
                             $scope.syncedFiles.parseable = false;
-			    console.log('parseAdvancedRules - syncedFiles:', $scope.syncedFiles);
+                            console.log('parseAdvancedRules - syncedFiles:', $scope.syncedFiles);
                             return;
                         } else {
-			    prevRule = rule;
-			}
+                            prevRule = rule;
+                        }
                     } else {
-			var prevRuleSplit = prevRule.split('/');
-			//var prevRulePath = ([prevRuleSplit[0].slice(1, prevRuleSplit[0].length)].concat(prevRuleSplit.slice(1, prevRuleSplit.length - 1))).join('/');
-			// Remove leading ! and basename
-			var prevRulePath = prevRuleSplit.slice(0, prevRuleSplit.length - 1).join('/');
-			// Remove leading !
-			var rulePathWithBasename = prevRule.slice(1, prevRule.length);
-			// Remove last *
-			var ruleSplit = rule.split('/');
-			var rulePath = ruleSplit.slice(0, prevRuleSplit.length - 1).join('/');
-			console.log('prevRulePath', prevRulePath, 'rulePath', rulePath)
+                        var prevRuleSplit = prevRule.split('/');
+                        //var prevRulePath = ([prevRuleSplit[0].slice(1, prevRuleSplit[0].length)].concat(prevRuleSplit.slice(1, prevRuleSplit.length - 1))).join('/');
+                        // Remove leading ! and basename
+                        var prevRulePath = prevRuleSplit.slice(0, prevRuleSplit.length - 1).join('/');
+                        // Remove leading !
+                        var rulePathWithBasename = prevRule.slice(1, prevRule.length);
+                        // Remove last *
+                        var ruleSplit = rule.split('/');
+                        var rulePath = ruleSplit.slice(0, prevRuleSplit.length - 1).join('/');
+                        console.log('prevRulePath', prevRulePath, 'rulePath', rulePath)
 
-			if (prevRulePath !== rulePath) {
-			    console.log('prevRulePath !== rulePath')
+                        if (prevRulePath !== rulePath) {
+                            console.log('prevRulePath !== rulePath')
                             $scope.syncedFiles.parseable = false;
-			    console.log('parseAdvancedRules - syncedFiles:', $scope.syncedFiles);
+                            console.log('parseAdvancedRules - syncedFiles:', $scope.syncedFiles);
                             return;
-			} else {
-			    console.log(rulePathWithBasename)
-			    $scope.syncedFiles.files.push(rulePathWithBasename);
-			    prevRule = null;
-			}
-		    }
+                        } else {
+                            console.log(rulePathWithBasename)
+                            $scope.syncedFiles.files.push(rulePathWithBasename);
+                            prevRule = null;
+                        }
+                    }
                 }
 
-		console.log('parseAdvancedRules - syncedFiles:', $scope.syncedFiles);
+                console.log('parseAdvancedRules - syncedFiles:', $scope.syncedFiles);
             }
 
             enableBasicRules(false);
@@ -1783,54 +1783,54 @@ angular.module('syncthing.core')
                 }
             });
 
-	    function updateBasicRulesFromSyncedFiles() {
-		console.log('updateBasicRulesFromSyncedFiles');
-		enableBasicRules($scope.syncedFiles.parseable);
+            function updateBasicRulesFromSyncedFiles() {
+                console.log('updateBasicRulesFromSyncedFiles');
+                enableBasicRules($scope.syncedFiles.parseable);
 
-		if ($scope.syncedFiles.all === true) {
-		    $('#folder-ignores #folderIgnoresTree').fancytree('getTree').rootNode.children[0].setSelected(true);
-		} else {
-		    $('#folder-ignores #folderIgnoresTree').fancytree('getTree').visit(function(node) {
-			if ($scope.syncedFiles.files.includes(node.key)) {
-			    node.setSelected(true);
-			}
-		    });
-		}
-	    }
+                if ($scope.syncedFiles.all === true) {
+                    $('#folder-ignores #folderIgnoresTree').fancytree('getTree').rootNode.children[0].setSelected(true);
+                } else {
+                    $('#folder-ignores #folderIgnoresTree').fancytree('getTree').visit(function(node) {
+                        if ($scope.syncedFiles.files.includes(node.key)) {
+                            node.setSelected(true);
+                        }
+                    });
+                }
+            }
 
-	    function updateSyncedFilesFromBasicRules() {
-		console.log('updateSyncedFilesFromBasicRules');
-		$scope.syncedFiles.reset();
-		$scope.syncedFiles.parseable = true;
+            function updateSyncedFilesFromBasicRules() {
+                console.log('updateSyncedFilesFromBasicRules');
+                $scope.syncedFiles.reset();
+                $scope.syncedFiles.parseable = true;
 
-		$('#folder-ignores #folderIgnoresTree').fancytree('getTree').visit(function(node) {
-		    if (node.isSelected()) {
-			if (node.key === '') {
-			    // If we include the whole tree, no need
-			    // for any rule so we break now
-			    $scope.syncedFiles.all = true;
-			    return false;
-			} else if (!node.parent.isSelected()) {
-			    $scope.syncedFiles.files.push(node.key);
-			}
-		    }
-		    return true;
-		});
+                $('#folder-ignores #folderIgnoresTree').fancytree('getTree').visit(function(node) {
+                    if (node.isSelected()) {
+                        if (node.key === '') {
+                            // If we include the whole tree, no need
+                            // for any rule so we break now
+                            $scope.syncedFiles.all = true;
+                            return false;
+                        } else if (!node.parent.isSelected()) {
+                            $scope.syncedFiles.files.push(node.key);
+                        }
+                    }
+                    return true;
+                });
 
-	    }
+            }
 
             // When switching to the Basic tab, parse the current ignore
             // rules and either disable the tree if the rules are too
             // complicated or pre-check the currently not-ignored files
             // and folders.
             $('#folder-ignores .nav-tabs a').on('shown.bs.tab', function(event) {
-		console.log('change tab', event);
+                console.log('change tab', event);
                 if (event.target.getAttribute('href') === '#folder-ignores-basic') {
-		    parseAdvancedRules();
-		    updateBasicRulesFromSyncedFiles();
+                    parseAdvancedRules();
+                    updateBasicRulesFromSyncedFiles();
                 } else {
-		    updateSyncedFilesFromBasicRules();
-		    writeAdvancedRules();
+                    updateSyncedFilesFromBasicRules();
+                    writeAdvancedRules();
                 }
             });
 

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -116,21 +116,33 @@
           </div>
         </div>
         <div id="folder-ignores" class="tab-pane">
-          <p translate>Enter ignore patterns, one per line.</p>
-          <textarea class="form-control" rows="5"></textarea>
-          <hr/>
-          <p class="small"><span translate>Quick guide to supported patterns</span> (<a href="https://docs.syncthing.net/users/ignoring.html" target="_blank" translate>full documentation</a>):</p>
-          <dl class="dl-horizontal dl-narrow small">
-            <dt><code>(?d)</code></dt> <dd><b><span translate>Prefix indicating that the file can be deleted if preventing directory removal</span></b></dd>
-            <dt><code>(?i)</code></dt> <dd><span translate>Prefix indicating that the pattern should be matched without case sensitivity</span></dd>
-            <dt><code>!</code></dt> <dd><span translate>Inversion of the given condition (i.e. do not exclude)</span></dd>
-            <dt><code>*</code></dt> <dd><span translate>Single level wildcard (matches within a directory only)</span></dd>
-            <dt><code>**</code></dt> <dd><span translate>Multi level wildcard (matches multiple directory levels)</span></dd>
-            <dt><code>//</code></dt> <dd><span translate>Comment, when used at the start of a line</span></dd>
-          </dl>
-          <hr/>
-          <div class="pull-left" ng-show="editingExisting"><span translate translate-value-path="{{currentFolder.path}}{{system.pathSeparator}}.stignore">Editing {%path%}.</span></div>
-          <div class="pull-left" ng-show="!editingExisting"><span translate translate-value-path="{{currentFolder.path}}{{system.pathSeparator}}.stignore">Creating ignore patterns, overwriting an existing file at {%path%}.</span></div>
+          <ul class="nav nav-tabs">
+              <li class="active"><a data-toggle="tab" href="#folder-ignores-basic"><span class="fas fa-filter-basic"></span> <span translate>Basic</span></a></li>
+              <li><a data-toggle="tab" href="#folder-ignores-advanced"><span class="fas fa-filter-advanced"></span> <span translate>Advanced</span></a></li>
+          </ul>
+          <div class="tab-content">
+            <div id="folder-ignores-basic" class="tab-pane in active">
+              <p translate>Select files and folders to sync.</p>
+              <div id="folderIgnoresTree"></div>
+            </div>
+            <div id="folder-ignores-advanced" class="tab-pane">
+              <p translate>Enter patterns, one per line.</p>
+              <textarea class="form-control" rows="5"></textarea>
+              <hr/>
+              <p class="small"><span translate>Quick guide to supported patterns</span> (<a href="https://docs.syncthing.net/users/ignoring.html" target="_blank" translate>full documentation</a>):</p>
+              <dl class="dl-horizontal dl-narrow small">
+                <dt><code>(?d)</code></dt> <dd><b><span translate>Prefix indicating that the file can be deleted if preventing directory removal</span></b></dd>
+                <dt><code>(?i)</code></dt> <dd><span translate>Prefix indicating that the pattern should be matched without case sensitivity</span></dd>
+                <dt><code>!</code></dt> <dd><span translate>Inversion of the given condition (i.e. do not exclude)</span></dd>
+                <dt><code>*</code></dt> <dd><span translate>Single level wildcard (matches within a directory only)</span></dd>
+                <dt><code>**</code></dt> <dd><span translate>Multi level wildcard (matches multiple directory levels)</span></dd>
+                <dt><code>//</code></dt> <dd><span translate>Comment, when used at the start of a line</span></dd>
+              </dl>
+              <hr/>
+              <div class="pull-left" ng-show="editingExisting"><span translate translate-value-path="{{currentFolder.path}}{{system.pathSeparator}}.stignore">Editing {%path%}.</span></div>
+              <div class="pull-left" ng-show="!editingExisting"><span translate translate-value-path="{{currentFolder.path}}{{system.pathSeparator}}.stignore">Creating ignore patterns, overwriting an existing file at {%path%}.</span></div>
+            </div>
+          </div>
         </div>
         <div id="folder-advanced" class="tab-pane">
           <div class="row form-group" ng-class="{'has-error': folderEditor.rescanIntervalS.$invalid && folderEditor.rescanIntervalS.$dirty}">


### PR DESCRIPTION
### Purpose

This is PR attempts to address the requirements of issue #2491 by following the rules outlined in [this comment](https://github.com/syncthing/syncthing/issues/2491#issuecomment-359889677).

This PR is in progress. I posted it [as requested](https://github.com/syncthing/syncthing/issues/2491#issuecomment-413694849). What's notably missing is advanced testing of part of it, see [this comment](https://github.com/syncthing/syncthing/issues/2491#issuecomment-413598000).

Please see commit messages for info on the implementation.

### Testing

Unfortunately testing needs to be manual.

What would be greatly needed to gain confidence in this PR is a way to unit test the new js functions. The main scary one is the function that parses the .stignore to populate the basic view. It doesn't work right now correctly. It is a pain to test manually though.

I'm less woried about the UI part - the update of the UI when a user clicks - as there is not that much going on on that front. I'm not saying it's flawless, just that it is possible to exhaustively test the behavior with manual testing.

### Screenshots

Clicking on the Ignore Patterns shows 2 tabs, the Basic one is selected by default:
<img width="888" alt="image" src="https://user-images.githubusercontent.com/1044950/44294960-c1f7df80-a254-11e8-95fa-cc203f3e66c7.png">

This shows the advanced tab:
<img width="888" alt="image" src="https://user-images.githubusercontent.com/1044950/44294963-d3d98280-a254-11e8-8adb-fd454a04c703.png">

Opening the folder asynchronously loads the contents by getting the global state from syncthing
<img width="888" alt="image" src="https://user-images.githubusercontent.com/1044950/44294972-02eff400-a255-11e8-9baf-39bfdaee39a5.png">

Selectively syncing a few files:
<img width="888" alt="image" src="https://user-images.githubusercontent.com/1044950/44294976-156a2d80-a255-11e8-9679-721d3f8737e8.png">

Corresponding advanced rules:
<img width="271" alt="image" src="https://user-images.githubusercontent.com/1044950/44294978-2155ef80-a255-11e8-812f-78cac52e95fa.png">

Another configuration:
<img width="193" alt="image" src="https://user-images.githubusercontent.com/1044950/44294981-2e72de80-a255-11e8-8a89-8829781b949e.png">

And corresponding advanced rules:
<img width="176" alt="image" src="https://user-images.githubusercontent.com/1044950/44294982-3763b000-a255-11e8-8efb-56ce5b6460e3.png">

Extreme case 1, sync all:
<img width="170" alt="image" src="https://user-images.githubusercontent.com/1044950/44294986-42b6db80-a255-11e8-9bc8-2df9a52f8652.png">

Corresponding pattern is empty:
<img width="232" alt="image" src="https://user-images.githubusercontent.com/1044950/44294993-49dde980-a255-11e8-8207-cebe67d65985.png">

Extreme case 2, ignore all:
<img width="251" alt="image" src="https://user-images.githubusercontent.com/1044950/44294997-57936f00-a255-11e8-87c4-e6ee97f731db.png">

Corresponding patterns:
<img width="225" alt="image" src="https://user-images.githubusercontent.com/1044950/44295004-64b05e00-a255-11e8-9672-6d7193c51418.png">

### Documentation

I guess we should discuss documentation later when the implementation is more solid? Although I'm totally fine to tackle this now if requested.

Disclaimer: first PR here, I don't want to waste anyone's time so feel free to just skim over it and tell me what could help you review this more easily.