### PR TITLE
lib/model: Fixes on receive-only test setup and pulling

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -7,6 +7,8 @@
 package model
 
 import (
+	"bytes"
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -16,6 +18,7 @@ import (
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/scanner"
 )
 
 func TestRecvOnlyRevertDeletes(t *testing.T) {
@@ -244,6 +247,7 @@ func setupKnownFiles(t *testing.T, data []byte) []protocol.FileInfo {
 	if err != nil {
 		t.Fatal(err)
 	}
+	blocks, _ := scanner.Blocks(context.TODO(), bytes.NewReader(data), protocol.BlockSize(int64(len(data))), int64(len(data)), nil, true)
 	knownFiles := []protocol.FileInfo{
 		{
 			Name:        "knownDir",
@@ -261,6 +265,7 @@ func setupKnownFiles(t *testing.T, data []byte) []protocol.FileInfo {
 			ModifiedNs:  int32(fi.ModTime().UnixNano() % 1e9),
 			Version:     protocol.Vector{Counters: []protocol.Counter{{ID: 42, Value: 42}}},
 			Sequence:    42,
+			Blocks:      blocks,
 		},
 	}
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -455,6 +455,7 @@ nextFile:
 		}
 
 		if !f.checkParent(fi.Name, scanChan) {
+			f.queue.Done(fileName)
 			continue
 		}
 


### PR DESCRIPTION
### Purpose

For some weird reason receive-only tests do show failures occurring during pulling. By `TestReceiveOnlyRevertNeeds` repeatedly I can consistently get the following issue:

```
2018/08/19 22:57:21.466474 progressemitter.go:196: DEBUG: progress emitter: updated interval 1s
2018/08/19 22:57:21.467116 set.go:78: INFO: No stored folder metadata for "ro": recalculating
2018/08/19 22:57:21.467529 progressemitter.go:62: DEBUG: progress emitter: timer - looking after 0
2018/08/19 22:57:21.467594 progressemitter.go:81: DEBUG: progress emitter: nothing new
2018/08/19 22:57:21.467630 model.go:849: DEBUG: Index (in): AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR / "ro": 2 files
2018/08/19 22:57:21.468473 events.go:249: DEBUG: log 1 RemoteIndexUpdated map[items:2 version:42 device:AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR folder:ro]
2018/08/19 22:57:21.469264 events.go:249: DEBUG: log 2 LocalIndexUpdated map[items:2 filenames:[knownDir knownDir/knownFile] version:2 folder:ro]
2018/08/19 22:57:21.469367 events.go:249: DEBUG: log 3 LocalChangeDetected map[type:dir path:knownDir modifiedBy: folder:ro folderID:ro label:receive only test action:modified]
2018/08/19 22:57:21.469498 events.go:249: DEBUG: log 4 LocalChangeDetected map[type:file path:knownDir/knownFile modifiedBy: folder:ro folderID:ro label:receive only test action:modified]
2018/08/19 22:57:21.469996 model.go:193: INFO: Ready to synchronize "receive only test" (ro) (receiveonly)
2018/08/19 22:57:21.470146 folder.go:92: DEBUG: receiveonly/ro@0xc4200e2580 starting
2018/08/19 22:57:21.470801 folder.go:156: DEBUG: receiveonly/ro@0xc4200e2580 Scanning subdirectories
2018/08/19 22:57:21.471124 events.go:249: DEBUG: log 5 StateChanged map[folder:ro to:scanning from:idle]
2018/08/19 22:57:21.473492 events.go:249: DEBUG: log 6 StateChanged map[folder:ro to:idle from:scanning duration:0.002362771]
2018/08/19 22:57:21.473573 folder.go:286: INFO: Completed initial scan of receiveonly folder "receive only test" (ro)
2018/08/19 22:57:21.473643 folder.go:228: DEBUG: receiveonly/ro@0xc4200e2580 next rescan in 25h18m25.770538387s
2018/08/19 22:57:21.474175 events.go:249: DEBUG: log 7 StateChanged map[from:idle duration:0.000724283 folder:ro to:scanning]
2018/08/19 22:57:21.476281 events.go:249: DEBUG: log 8 StateChanged map[duration:0.002104469 folder:ro to:idle from:scanning]
2018/08/19 22:57:21.476488 progressemitter.go:240: DEBUG: progress emitter: bytes completed for ro: 0
2018/08/19 22:57:21.476710 model.go:725: DEBUG: model@0xc4200e0240 NeedSize("ro"): {0 0 0 0 0 0 [] 0}
2018/08/19 22:57:21.477181 events.go:249: DEBUG: log 9 StateChanged map[folder:ro to:scanning from:idle duration:0.000899655]
2018/08/19 22:57:21.480281 events.go:249: DEBUG: log 10 LocalIndexUpdated map[version:3 folder:ro items:1 filenames:[knownDir/knownFile]]
2018/08/19 22:57:21.480828 events.go:249: DEBUG: log 11 StateChanged map[to:idle from:scanning duration:0.003647366 folder:ro]
2018/08/19 22:57:21.481239 progressemitter.go:240: DEBUG: progress emitter: bytes completed for ro: 0
2018/08/19 22:57:21.481327 model.go:725: DEBUG: model@0xc4200e0240 NeedSize("ro"): {0 0 0 0 0 0 [] 0}
2018/08/19 22:57:21.481446 events.go:249: DEBUG: log 12 StateChanged map[folder:ro to:scanning from:idle duration:0.000597264]
2018/08/19 22:57:21.482546 events.go:249: DEBUG: log 13 LocalIndexUpdated map[items:1 filenames:[knownDir/knownFile] version:4 folder:ro]
2018/08/19 22:57:21.482655 events.go:249: DEBUG: log 14 LocalChangeDetected map[action:modified type:file path:knownDir/knownFile modifiedBy:7777777 folder:ro folderID:ro label:receive only test]
2018/08/19 22:57:21.482758 events.go:249: DEBUG: log 15 StateChanged map[duration:0.001320583 folder:ro to:idle from:scanning]
2018/08/19 22:57:21.483054 progressemitter.go:240: DEBUG: progress emitter: bytes completed for ro: 0
2018/08/19 22:57:21.483146 model.go:725: DEBUG: model@0xc4200e0240 NeedSize("ro"): {1 0 0 0 6 0 [] 0}
2018/08/19 22:57:21.483487 folder_sendrecv.go:166: DEBUG: receiveonly/ro@0xc4200e2580 pulling (ignoresChanged=true)
2018/08/19 22:57:21.483595 events.go:249: DEBUG: log 16 StateChanged map[duration:0.000827127 folder:ro to:syncing from:idle]
2018/08/19 22:57:21.483819 folder_sendrecv.go:239: DEBUG: receiveonly/ro@0xc4200e2580 copiers: 2 pullerPendingKiB: 32768
2018/08/19 22:57:21.484776 folder_sendrecv.go:661: DEBUG: receiveonly/ro@0xc4200e2580 parent not missing knownDir/knownFile
2018/08/19 22:57:21.484885 events.go:249: DEBUG: log 17 StateChanged map[folder:ro to:idle from:syncing duration:0.001297632]
2018/08/19 22:57:21.484938 asm_amd64.s:573: DEBUG: receiveonly/ro@0xc4200e2580 exiting
panic: runtime error: index out of range

goroutine 26 [running]:
github.com/syncthing/syncthing/lib/model.(*sendReceiveFolder).processNeeded(0xc4200e2580, 0xc4201a8120, 0xc4201c60a0, 0xc42033e120, 0xc42033e060, 0xc42033e0c0, 0xc4202a5f80, 0xdcc280, 0xc420027330, 0xc4201c3848, ...)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/model/folder_sendrecv.go:468 +0x205f
github.com/syncthing/syncthing/lib/model.(*sendReceiveFolder).pullerIteration(0xc4200e2580, 0xc4201a8120, 0xc4201c60a0, 0xc4200e2501, 0xc4202a5f80, 0x2)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/model/folder_sendrecv.go:271 +0x77d
github.com/syncthing/syncthing/lib/model.(*sendReceiveFolder).pull(0xc4200e2580, 0xc42008e600)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/model/folder_sendrecv.go:185 +0x90b
github.com/syncthing/syncthing/lib/model.(*folder).Serve(0xc4200e2580)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/model/folder.go:123 +0xefb
github.com/syncthing/syncthing/vendor/github.com/calmh/suture.(*Supervisor).runService.func1(0xc4201b81e0, 0xc400000000, 0x7f01911e4ca8, 0xc420238000)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/vendor/github.com/calmh/suture/supervisor.go:537 +0x6c
created by github.com/syncthing/syncthing/vendor/github.com/calmh/suture.(*Supervisor).runService
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/vendor/github.com/calmh/suture/supervisor.go:525 +0x69
exit status 2
FAIL	github.com/syncthing/syncthing/lib/model	0.440s
```

The problem is, that test file infos are generated without blocks and at this point in the puller, that results in an index out of range:
```
key := string(fi.Blocks[0].Hash)
```
https://github.com/syncthing/syncthing/blob/master/lib/model/folder_sendrecv.go#L463  

In production that can never happen, because the file infos are checked for consistency (at least one block if undeleted and regular).

The second small fix is that a file wasn't marked as done in the queue, if there was an error with it's parent directory.

As one if these issue is solely testing and the other is tiny, I don't believe this merits a changelog entry.

### Testing

Running `TestReceiveOnlyRevertNeeds` 50x without this error.