### PR TITLE
all: Skip fewer tests due to symlinks on windows (fixes #4887)

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/d4l3k/messagediff"
 	"github.com/syncthing/syncthing/lib/fs"
-	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
@@ -429,6 +428,8 @@ func TestFolderCheckPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	fs.DebugSymlinkForTestsOnly(t, filepath.Join(n, "dir"), filepath.Join(n, "link"))
+
 	testcases := []struct {
 		path string
 		err  error
@@ -445,21 +446,10 @@ func TestFolderCheckPath(t *testing.T) {
 			path: "dir",
 			err:  nil,
 		},
-	}
-
-	err = osutil.DebugSymlinkForTestsOnly(filepath.Join(n, "dir"), filepath.Join(n, "link"))
-	if err == nil {
-		t.Log("running with symlink check")
-		testcases = append(testcases, struct {
-			path string
-			err  error
-		}{
+		{
 			path: "link",
 			err:  nil,
-		})
-	} else if runtime.GOOS != "windows" {
-		t.Log("running without symlink check")
-		t.Fatal(err)
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -710,7 +700,7 @@ func TestV14ListenAddressesMigration(t *testing.T) {
 		// config to start with...
 		{
 			{"tcp://0.0.0.0:22000"}, // old listen addrs
-			{""}, // old relay addrs
+			{""},                    // old relay addrs
 			{"tcp://0.0.0.0:22000"}, // new listen addrs
 		},
 		// Default listen plus non-default relays gets copied verbatim

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -253,10 +253,6 @@ func TestWatchErrorLinuxInterpretation(t *testing.T) {
 }
 
 func TestWatchSymlinkedRoot(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Involves symlinks")
-	}
-
 	name := "symlinkedRoot"
 	if err := testFs.MkdirAll(name, 0755); err != nil {
 		panic(fmt.Sprintf("Failed to create directory %s: %s", name, err))
@@ -269,9 +265,7 @@ func TestWatchSymlinkedRoot(t *testing.T) {
 	}
 	link := filepath.Join(name, "link")
 
-	if err := testFs.CreateSymlink(filepath.Join(testFs.URI(), root), link); err != nil {
-		panic(err)
-	}
+	DebugSymlinkForTestsOnly(t, filepath.Join(testFs.URI(), root), filepath.Join(testFs.URI(), link))
 
 	linkedFs := NewFilesystem(FilesystemTypeBasic, filepath.Join(testFs.URI(), link))
 

--- a/lib/fs/debug_symlink.go
+++ b/lib/fs/debug_symlink.go
@@ -6,16 +6,20 @@
 
 // +build !windows
 
-package osutil
+package fs
 
 import (
 	"os"
+	"testing"
 )
 
 // DebugSymlinkForTestsOnly is not and should not be used in Syncthing code,
 // hence the cumbersome name to make it obvious if this ever leaks. Its
 // reason for existence is the Windows version, which allows creating
 // symlinks when non-elevated.
-func DebugSymlinkForTestsOnly(oldname, newname string) error {
-	return os.Symlink(oldname, newname)
+func DebugSymlinkForTestsOnly(t *testing.T, oldname, newname string) {
+	t.Helper()
+	if err := os.Symlink(oldname, newname); err != nil {
+		t.Fatal(err)
+	}
 }

--- a/lib/fs/debug_symlink_windows.go
+++ b/lib/fs/debug_symlink_windows.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
+	"testing"
 )
 
 // DebugSymlinkForTestsOnly is os.Symlink from Go1.11 onwards, falling back to

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3116,9 +3116,7 @@ func TestIssue2571(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := osutil.DebugSymlinkForTestsOnly(filepath.Join(testFs.URI(), "linkTarget"), filepath.Join(testFs.URI(), "toLink")); err != nil {
-		t.Fatal(err)
-	}
+	fs.DebugSymlinkForTestsOnly(t, filepath.Join(testFs.URI(), "linkTarget"), filepath.Join(testFs.URI(), "toLink"))
 
 	m.ScanFolder("default")
 

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -62,13 +62,8 @@ func TestRequestSimple(t *testing.T) {
 	}
 }
 
+// TestSymlinkTraversalRead verifies that a symlink can not be traversed for reading.
 func TestSymlinkTraversalRead(t *testing.T) {
-	// Verify that a symlink can not be traversed for reading.
-
-	if runtime.GOOS == "windows" {
-		t.Skip("no symlink support on CI")
-		return
-	}
 
 	m, fc, tmpDir, w := setupModelWithConnection()
 	defer func() {

--- a/lib/osutil/osutil_test.go
+++ b/lib/osutil/osutil_test.go
@@ -251,12 +251,7 @@ func TestIsDeleted(t *testing.T) {
 		}
 	}
 	for _, n := range []string{"Dir", "File", "Del"} {
-		if err := osutil.DebugSymlinkForTestsOnly(filepath.Join(testFs.URI(), strings.ToLower(n)), filepath.Join(testFs.URI(), "linkTo"+n)); err != nil {
-			if runtime.GOOS == "windows" {
-				t.Skip("Symlinks aren't working")
-			}
-			t.Fatal(err)
-		}
+		fs.DebugSymlinkForTestsOnly(t, filepath.Join(testFs.URI(), strings.ToLower(n)), filepath.Join(testFs.URI(), "linkTo"+n))
 	}
 
 	for _, c := range cases {

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/d4l3k/messagediff"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
-	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sha256"
 	"golang.org/x/text/unicode/norm"
@@ -284,7 +283,7 @@ func TestWalkSymlinkUnix(t *testing.T) {
 
 func TestWalkSymlinkWindows(t *testing.T) {
 	if runtime.GOOS != "windows" {
-		t.Skip("skipping unsupported symlink test")
+		t.Skip("windows specific test")
 	}
 
 	// Create a folder with a symlink in it
@@ -292,11 +291,10 @@ func TestWalkSymlinkWindows(t *testing.T) {
 	os.RemoveAll(name)
 	os.Mkdir(name, 0755)
 	defer os.RemoveAll(name)
+
+	fs.DebugSymlinkForTestsOnly(t, "../testdata", "_symlinks/link")
+
 	fs := fs.NewFilesystem(fs.FilesystemTypeBasic, name)
-	if err := osutil.DebugSymlinkForTestsOnly("../testdata", "_symlinks/link"); err != nil {
-		// Probably we require permissions we don't have.
-		t.Skip(err)
-	}
 
 	for _, path := range []string{".", "link"} {
 		// Scan it
@@ -319,14 +317,7 @@ func TestWalkRootSymlink(t *testing.T) {
 
 	link := tmp + "/link"
 	dest, _ := filepath.Abs("testdata/dir1")
-	if err := osutil.DebugSymlinkForTestsOnly(dest, link); err != nil {
-		if runtime.GOOS == "windows" {
-			// Probably we require permissions we don't have.
-			t.Skip("Need admin permissions or developer mode to run symlink test on Windows: " + err.Error())
-		} else {
-			t.Fatal(err)
-		}
-	}
+	fs.DebugSymlinkForTestsOnly(t, dest, link)
 
 	// Scan it
 	files := walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, link), ".", nil, nil, 0)


### PR DESCRIPTION
### Purpose

This only concerns tests, see #4887.  
The only test that could be "un-skipped" was `TestWatchSymlinkedRoot`, all other skipped tests concern scanning or pulling, which we do not support (regardless of what `os` supports). All the other changes are either due to `DebugSymlinkForTestsOnly` being moved to the `fs` package (due to cyclic imports) or handling test cancellation in that function too (thus prohibiting it's use outside of testing). I left the hack in  `DebugSymlinkForTestsOnly` as a fallback if `os.CreateSymlink` still doesn't work (e.g. on old Go or Windows versions).

### Testing

Still pass on linux, pass on windows too, except for the known go1.11 failures which are being addressed in another PR.