### PR TITLE
ldap auth mode

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -343,7 +343,7 @@ func (s *apiService) Serve() {
 	handler = withDetailsMiddleware(s.id, handler)
 
 	// Wrap everything in basic auth, if user/password is set.
-	if len(guiCfg.User) > 0 && len(guiCfg.Password) > 0 {
+	if guiCfg.IsAuthEnabled() {
 		handler = basicAuthAndSessionMiddleware("sessionid-"+s.id.String()[:5], guiCfg, handler)
 	}
 

--- a/cmd/syncthing/gui_auth_test.go
+++ b/cmd/syncthing/gui_auth_test.go
@@ -1,0 +1,43 @@
+// Copyright (C) 2014 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"testing"
+	"golang.org/x/crypto/bcrypt"
+
+    "github.com/syncthing/syncthing/cmd/syncthing"
+
+)
+
+func TestSimpleAuthOK(t *testing.T) {
+    passwordHashBytes, _ := bcrypt.GenerateFromPassword([]byte("pass"), 14)
+    ok, username := main.AuthSimple("user", "pass", "user", string(passwordHashBytes))
+    if !ok {
+        t.Fatalf("should pass auth")
+    }
+    if username != "user" {
+        t.Fatalf(username)
+    }
+}
+
+func TestSimpleAuthUsernameFail(t *testing.T) {
+    passwordHashBytes, _ := bcrypt.GenerateFromPassword([]byte("pass"), 14)
+    ok, _ := main.AuthSimple("userWRONG", "pass", "user", string(passwordHashBytes))
+    if ok {
+        t.Fatalf("should fail auth")
+    }
+}
+
+func TestSimpleAuthPasswordFail(t *testing.T) {
+    passwordHashBytes, _ := bcrypt.GenerateFromPassword([]byte("passWRONG"), 14)
+    ok, _ := main.AuthSimple("user", "pass", "user", string(passwordHashBytes))
+    if ok {
+        t.Fatalf("should fail auth")
+    }
+}
+

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -17,6 +17,10 @@ type GUIConfiguration struct {
 	RawAddress                string `xml:"address" json:"address" default:"127.0.0.1:8384"`
 	User                      string `xml:"user,omitempty" json:"user"`
 	Password                  string `xml:"password,omitempty" json:"password"`
+	AuthMode                  string `xml:"authMode,omitempty" json:"authMode"`
+	LdapServer                string `xml:"ldapServer,omitempty" json:"ldapServer"`
+	LdapPort                  int    `xml:"ldapPort,omitempty" json:"ldapPort"`
+	LdapBindDn                string `xml:"ldapBindDn,omitempty" json:"ldapBindDn"`
 	RawUseTLS                 bool   `xml:"tls,attr" json:"useTLS"`
 	APIKey                    string `xml:"apikey,omitempty" json:"apiKey"`
 	InsecureAdminAccess       bool   `xml:"insecureAdminAccess,omitempty" json:"insecureAdminAccess"`
@@ -24,6 +28,18 @@ type GUIConfiguration struct {
 	Debugging                 bool   `xml:"debugging,attr" json:"debugging"`
 	InsecureSkipHostCheck     bool   `xml:"insecureSkipHostcheck,omitempty" json:"insecureSkipHostcheck"`
 	InsecureAllowFrameLoading bool   `xml:"insecureAllowFrameLoading,omitempty" json:"insecureAllowFrameLoading"`
+}
+
+func (c GUIConfiguration) IsAuthEnabled() bool {
+    return c.IsAuthModeSimple() || c.IsAuthModeLdap()
+}
+
+func (c GUIConfiguration) IsAuthModeLdap() bool {
+    return c.AuthMode == "ldap"
+}
+
+func (c GUIConfiguration) IsAuthModeSimple() bool {
+    return (len(c.User) > 0 && len(c.Password) > 0)
 }
 
 func (c GUIConfiguration) Address() string {


### PR DESCRIPTION
### Purpose

Allows gui to authenticate against ldap using simple bind approach.

Additional config section:

    <authMode>ldap</authMode>
    <ldapServer>localhost</ldapServer>
    <ldapPort>389</ldapPort>
    <ldapBindDn>cn=%s,ou=users,dc=syncloud,dc=org</ldapBindDn>

Existing user/password authentication is preserved and can be used as before if authMode is not present or not equals to ldap.

### Testing

Few mising unit tests are added for existing auth.
No unit tests for ldap, although integration tests are available in Syncloud project:
https://github.com/syncloud/syncthing/blob/master/integration/verify.py#L99

## Authorship

Boris Rybalkin (ribalkin@gmail.com)

