### PR TITLE
dockerfile: Improve UID/GID handling (fixes #5180)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 AS builder
+FROM golang:1.11 AS builder
 
 WORKDIR /go/src/github.com/syncthing/syncthing
 COPY . .
@@ -6,7 +6,7 @@ COPY . .
 ENV CGO_ENABLED=0
 ENV BUILD_HOST=syncthing.net
 ENV BUILD_USER=docker
-RUN rm -f syncthing && go run build.go build syncthing
+RUN rm -f syncthing && go run build.go -no-upgrade build syncthing
 
 FROM alpine
 
@@ -18,27 +18,15 @@ RUN apk add --no-cache ca-certificates su-exec
 
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
 
-ENV STNOUPGRADE=1 PUSR=syncthing PUID=1000 PGRP=syncthing PGID=1000
+ENV PUID=1000 PGID=1000
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z localhost 8384 || exit 1
 
-ENTRYPOINT true \
- && ( getent group "${PGRP}" >/dev/null \
-      || addgroup \
-          -g "${PGID}" \
-          "${PGRP}" \
-    ) \
- && ( getent passwd "${PUSR}" >/dev/null \
-      || adduser \
-          -h /var/syncthing \
-          -G "${PGRP}" \
-          -u "${PUID}" \
-          "${PUSR}" \
-    ) \
- && chown "${PUSR}:${PGRP}" /var/syncthing \
- && su-exec "${PUSR}:${PGRP}" \
+ENTRYPOINT \
+  chown "${PUID}:${PGID}" /var/syncthing \
+  && su-exec "${PUID}:${PGID}" \
+     env HOME=/var/syncthing \
      /bin/syncthing \
        -home /var/syncthing/config \
-       -gui-address 0.0.0.0:8384 \
- && true
+       -gui-address 0.0.0.0:8384


### PR DESCRIPTION
### Purpose

This removes the user and group juggling, which would fail when given
for example a PGID that already existed as the "syncthing" group could
then not be created with that PGID. It's not reasonable to expect the
user to know which group/user names/IDs are already present in the
Docker image.

Instead we now just launch under the specified IDs, while manually
setting the HOME env var to give us a home directory - the only thing we
needed the user entry for anyway.

Also updates to Go 1.11 and building without upgrades instead of
disabling by env var.

### Testing

I've ran it manually under existing and non-existing IDs, and it works for me; previously it didn't.

```
$ docker run -it --rm -e PUID=2 -e PGID=2 syncthing
$ docker run -it --rm -e PUID=12345 -e PGID=12345 syncthing
```
