### PR TITLE
gui: Don't fail if pendingFolders is undefined (fixes #5190)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -973,7 +973,7 @@ angular.module('syncthing.core')
                         deviceCount--;
                         break;
                 }
-                pendingFolders += $scope.devices[i].pendingFolders.length;
+                pendingFolders += $scope.sizeOf($scope.devices[i].pendingFolders);
             }
 
             // enumerate notifications


### PR DESCRIPTION
#5190 

Manual testing.