### PR TITLE
all: Check files on disk/in db when deleting/renaming (fixes #5194)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -851,6 +851,8 @@ func (f *sendReceiveFolder) renameFile(cur, source, target protocol.FileInfo, db
 
 	// Check that source is compatible with what we have in the DB
 	if err = f.checkToBeDeleted(cur, scanChan); err != nil {
+		err = fmt.Errorf("from %s: %s", source.Name, err.Error())
+		f.newError("rename check source", target.Name, err)
 		return
 	}
 	// Check that the target corresponds to what we have in the DB
@@ -872,6 +874,8 @@ func (f *sendReceiveFolder) renameFile(cur, source, target protocol.FileInfo, db
 		err = errModified
 	}
 	if err != nil {
+		err = fmt.Errorf("from %s: %s", source.Name, err.Error())
+		f.newError("rename check target", target.Name, err)
 		return
 	}
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -435,6 +435,7 @@ func (f *fakeConnection) addFileLocked(name string, flags uint32, ftype protocol
 			Version:       version,
 			Sequence:      time.Now().UnixNano(),
 			SymlinkTarget: string(data),
+			NoPermissions: true,
 		})
 	}
 

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -740,3 +740,85 @@ func equalContents(path string, contents []byte) error {
 	}
 	return nil
 }
+
+func TestRequestRemoteRenameChanged(t *testing.T) {
+	m, fc, tmpDir, w := setupModelWithConnection()
+	defer func() {
+		m.Stop()
+		os.RemoveAll(tmpDir)
+		os.Remove(w.ConfigPath())
+	}()
+	tfs := fs.NewFilesystem(fs.FilesystemTypeBasic, tmpDir)
+
+	done := make(chan struct{})
+	fc.mut.Lock()
+	fc.indexFn = func(folder string, fs []protocol.FileInfo) {
+		if len(fs) != 2 {
+			t.Fatalf("Received index with %v indexes instead of 2", len(fs))
+		}
+		close(done)
+	}
+	fc.mut.Unlock()
+
+	// setup
+	a := "a"
+	b := "b"
+	data := map[string][]byte{
+		a: []byte("aData"),
+		b: []byte("bData"),
+	}
+	for _, n := range [2]string{a, b} {
+		fc.addFile(n, 0644, protocol.FileInfoTypeFile, data[n])
+	}
+	fc.sendIndexUpdate()
+	select {
+	case <-done:
+		done = make(chan struct{})
+		fc.mut.Lock()
+		fc.indexFn = func(folder string, fs []protocol.FileInfo) {
+			close(done)
+		}
+		fc.mut.Unlock()
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	for _, n := range [2]string{a, b} {
+		if err := equalContents(filepath.Join(tmpDir, n), data[n]); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fd, err := tfs.OpenFile(b, fs.OptReadWrite, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherData := []byte("otherData")
+	if _, err = fd.Write(otherData); err != nil {
+		t.Fatal(err)
+	}
+	fd.Close()
+
+	// rename
+	fc.deleteFile(a)
+	fc.updateFile(b, 0644, protocol.FileInfoTypeFile, data[a])
+	fc.sendIndexUpdate()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out")
+	}
+
+	// Check outcome
+	tfs.Walk(".", func(path string, info fs.FileInfo, err error) error {
+		switch {
+		case path == a:
+			t.Errorf(`File "a" was not removed`)
+		case path == b:
+			if err := equalContents(filepath.Join(tmpDir, b), otherData); err != nil {
+				t.Errorf(`Modified file "b" was overwritten`)
+			}
+		}
+		return nil
+	})
+}

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -13,7 +13,6 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/rand"
 )
 
@@ -211,26 +210,6 @@ func (f FileInfo) isEquivalent(other FileInfo, ignorePerms bool, ignoreBlocks bo
 	}
 
 	return false
-}
-
-func FromFSFileInfo(fi fs.FileInfo, name string, filesystem fs.Filesystem) FileInfo {
-	f := FileInfo{
-		Name:        name,
-		Type:        FileInfoTypeFile,
-		Permissions: uint32(fi.Mode()),
-		ModifiedS:   fi.ModTime().Unix(),
-		ModifiedNs:  int32(fi.ModTime().Nanosecond()),
-		Size:        fi.Size(),
-	}
-	switch {
-	case fi.IsDir():
-		f.Type = FileInfoTypeDirectory
-	case fi.IsSymlink():
-		f.Type = FileInfoTypeSymlink
-		target, _ := filesystem.ReadSymlink(name)
-		f.SymlinkTarget = target
-	}
-	return f
 }
 
 func PermsEqual(a, b uint32) bool {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -103,6 +103,8 @@ const (
 	// successor, due to us not having an up to date picture of its state on
 	// disk.
 	LocalConflictFlags = FlagLocalUnsupported | FlagLocalIgnored | FlagLocalReceiveOnly
+
+	LocalAllFlags = FlagLocalUnsupported | FlagLocalIgnored | FlagLocalMustRescan | FlagLocalReceiveOnly
 )
 
 var (


### PR DESCRIPTION
### Purpose

#5194 

The most relevant changes are those to `deleteFile`, `renameFile` and in the new `checkToBeDeleted` functions. The rest is just restructuring and fixes for existing tests.

### Testing

Three new unit tests.
