### PR TITLE
lib/scanner: Centralise protocol.FileInfo creation

### DIFF
--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -330,7 +330,7 @@ func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileIn
 	}
 
 	f, _ := CreateFileInfo(info, relPath, nil)
-	f = w.updateFileInfo(f, curFile, hasCurFile)
+	f = w.updateFileInfo(f, curFile)
 	f.NoPermissions = w.IgnorePerms
 	f.RawBlockSize = int32(blockSize)
 
@@ -364,7 +364,7 @@ func (w *walker) walkDir(ctx context.Context, relPath string, info fs.FileInfo, 
 	curFile, hasCurFile := w.CurrentFiler.CurrentFile(relPath)
 
 	f, _ := CreateFileInfo(info, relPath, nil)
-	f = w.updateFileInfo(f, curFile, hasCurFile)
+	f = w.updateFileInfo(f, curFile)
 	f.NoPermissions = w.IgnorePerms
 
 	if hasCurFile {
@@ -420,7 +420,7 @@ func (w *walker) walkSymlink(ctx context.Context, relPath string, dchan chan pro
 		NoPermissions: true, // Symlinks don't have permissions of their own
 		SymlinkTarget: target,
 	}
-	f = w.updateFileInfo(f, curFile, hasCurFile)
+	f = w.updateFileInfo(f, curFile)
 
 	if hasCurFile {
 		if curFile.IsEquivalentOptional(f, w.IgnorePerms, true, w.LocalFlags) {
@@ -510,9 +510,9 @@ func (w *walker) normalizePath(path string, info fs.FileInfo) (normPath string, 
 	return normPath, false
 }
 
-// updateFileInfo updates walker specific members of protocol.FileInfo
-func (w *walker) updateFileInfo(file, curFile protocol.FileInfo, hasCurFile bool) protocol.FileInfo {
-	if hasCurFile && file.Type == protocol.FileInfoTypeFile && runtime.GOOS == "windows" {
+// updateFileInfo updates walker specific members of protocol.FileInfo that do not depend on type
+func (w *walker) updateFileInfo(file, curFile protocol.FileInfo) protocol.FileInfo {
+	if file.Type == protocol.FileInfoTypeFile && runtime.GOOS == "windows" {
 		// If we have an existing index entry, copy the executable bits
 		// from there.
 		file.Permissions |= (curFile.Permissions & 0111)


### PR DESCRIPTION
Mostly just refactoring to have less redundancy. Also there is a small fix to `scanner.CreateFileInfo`: Before it did set the `Permissions` and time fields of `FileInfo` for symlinks, which we do not actually want to record.