### PR TITLE
Suggest setting up auth on initial startup (fixes #4703)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -122,6 +122,38 @@
       </div>
     </div>
 
+    <!-- Panel: GUI Authentication Notification-->
+
+    <div ng-if="noAuth" class="row">
+      <div class="col-md-12">
+        <div class="panel panel-info fade in collapse" id="auth">
+          <div class="panel-heading">
+            <h3 class="panel-title">
+              <div class="panel-icon">
+                <span class="fas fa-user-circle-o"></span>
+              </div>
+              <span translate>GUI Authentication, Set User and Password</span>
+            </h3>
+          </div>
+          <div class="panel-body">
+            <p>
+            <span translate>Username/Password has not been set for the GUI authentication. Please consider setting it up.</span>
+            <b><span>(Settings --> GUI)</span></b>
+            </p>
+          </div>
+          <div class="panel-footer">
+            <button type="button" class="btn btn-sm btn-default pull-right" ng-click="editSettings()">
+              <span class="fas fa-cog"></span>&nbsp;<span translate>Settings</span>
+            </button>
+            <button type="button" class="btn btn-sm btn-default pull-left" data-toggle="collapse" href="#auth" ng-click="authenticationDontWant()">
+              <span class="fa fa-check-circle"></span>&nbsp;<span translate>OK</span>
+            </button>
+            <div class="clearfix"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Panel: Restart Needed -->
 
     <div ng-if="!configInSync" class="row">


### PR DESCRIPTION
### Purpose

Suggest user for setting `User` and `Password` in GUI Authentication, if not set. 
Suggest setting up auth on initial startup (fixes #4703)

### Testing
None

### Screenshots

If `User` and `Password` not set, initial startup this information panel shows up.

<img width="1204" alt="screen shot 2018-09-21 at 20 01 06" src="https://user-images.githubusercontent.com/29825419/45895190-0892a980-bdc0-11e8-838a-0f1c962e3eed.png">

Clicking: - `OK` closes panel. And panel will shows up again 1 weeks later in loading (if user and password not set).
               - `Settings` opens settings for setting relevant boxes.
After setting user and password, panel will shows off. Except cleaning user and password, panel never shows up again.

Localstroge key `authWarningDismissed` holds `true` and `false` and `authWarningDismissed` holds expiration time when it set clicking `OK` button. 

### Documentation

Not needed.



