### PR TITLE
Switch "Upgrade To" to style used in every translated file

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -334,7 +334,7 @@
    "Up to Date": "Up to Date",
    "Updated": "Updated",
    "Upgrade": "Upgrade",
-   "Upgrade To {%version%}": "Upgrade To {{version}}",
+   "Upgrade To {%version%}": "Upgrade to {{version}}",
    "Upgrading": "Upgrading",
    "Upload Rate": "Upload Rate",
    "Uptime": "Uptime",


### PR DESCRIPTION
Note: This is really a stupid PR, but the visual appearance just makes me frown.

It's quite a good way to notify users about the update, but optically it doesn't look right to me:

![image](https://user-images.githubusercontent.com/8825439/45897005-2ec34400-bdd6-11e8-9b6d-d5405c36ccb2.png)
 
"To" itself with the upcase is really annoying in there to my eyes. I tried to look up even how to remove the `v` from `v0.14.50` but without success.

![image](https://user-images.githubusercontent.com/8825439/45897251-e5bfbf80-bdd6-11e8-9a03-1423f29540a2.png)

additionally highlighting the version is also better for optically separating it, so that it doesn't appear like one word or "Tov"/"Tor" and similar stuff.

![image](https://user-images.githubusercontent.com/8825439/45905446-a8682b80-bdf0-11e8-9207-c521993bc140.png)

If this change is welcome, please point me to something that would help me removing "v" from the version. Most likely even adding `<b>` tag to the version string alone could be a quick fix instead of rewriting the .JSON translations. Unless the version string is used anywhere else as a condition or something.