### PR TITLE
lib/fs: Try EvalSymlinks without '\\?\' prefix on failure (fixes #5226)

### DIFF
--- a/lib/fs/basicfs_unix.go
+++ b/lib/fs/basicfs_unix.go
@@ -11,6 +11,7 @@ package fs
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -73,3 +74,5 @@ func (f *BasicFilesystem) unrootedChecked(absPath, root string) string {
 func rel(path, prefix string) string {
 	return strings.TrimPrefix(strings.TrimPrefix(path, prefix), string(PathSeparator))
 }
+
+var evalSymlinks = filepath.EvalSymlinks

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
-	"runtime"
 
 	"github.com/syncthing/notify"
 )
@@ -23,12 +22,9 @@ import (
 var backendBuffer = 500
 
 func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, error) {
-	evalRoot, err := filepath.EvalSymlinks(f.root)
+	evalRoot, err := evalSymlinks(f.root)
 	if err != nil {
 		return nil, err
-	}
-	if runtime.GOOS == "windows" {
-		evalRoot = longFilenameSupport(evalRoot)
 	}
 
 	absName, err := rooted(name, evalRoot)

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 		panic("Cannot get absolute path to working dir")
 	}
 
-	dir, err = filepath.EvalSymlinks(dir)
+	dir, err = evalSymlinks(dir)
 	if err != nil {
 		panic("Cannot get real path to working dir")
 	}

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -210,3 +210,15 @@ func isMaybeWin83(absPath string) bool {
 	}
 	return strings.Contains(strings.TrimPrefix(filepath.Base(absPath), WindowsTempPrefix), "~")
 }
+
+func evalSymlinks(in string) (string, error) {
+	out, err := filepath.EvalSymlinks(in)
+	if err != nil && strings.HasPrefix(in, `\\?\`) {
+		// Try again without the `\\?\` prefix
+		out, err = filepath.EvalSymlinks(in[4:])
+	}
+	if err != nil {
+		return "", err
+	}
+	return longFilenameSupport(out), nil
+}


### PR DESCRIPTION
See #5226 and  https://forum.syncthing.net/t/findfirstfile-error/12140/18:  
Apparently `filepath.EvalSymlinks` may fail in special circumstances (e.g. confirmed with ramdisk with IMDisk driver). This is potentially an upstream issue, as they do seem to support `\\?` prefixes, but given it's only reproducible in one very specific case, I doubt that's going to be fixed. Therefore I added a workaround by wrapping `filepath.EvalSymlinks` in `evalSymlinks`, which retries the call without the prefix on windows on failure.