### PR TITLE
lib/model: Prevent repeat db update

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -916,8 +916,6 @@ func (f *sendReceiveFolder) renameFile(cur, source, target protocol.FileInfo, db
 		if err = f.performFinish(nil, target, curTarget, true, tempName, dbUpdateChan, scanChan); err != nil {
 			return
 		}
-
-		dbUpdateChan <- dbUpdateJob{target, dbUpdateHandleFile}
 	} else {
 		// We failed the rename so we have a source file that we still need to
 		// get rid of. Attempt to delete it instead so that we make *some*


### PR DESCRIPTION
### Purpose

This fixes a bug introduced in #5195, which isn't released yet. `performFinish` already does a db update if appropriate, therefore the one in `renameFile` is redundant.

### Testing

Running model tests with `STTRACE=model` enables some additional checks. Before this PR these checks resulted in panics, now they don't. (Ideally, these checks should always be enabled when testing).