### PR TITLE
Fix missing 'Close' button on remote devices' files

### DIFF
--- a/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
+++ b/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
@@ -42,4 +42,9 @@
       </div>
     </div>
   </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">
+      <span class="fas fa-times"></span>&nbsp;<span translate>Close</span>
+    </button>
+  </div>
 </modal>


### PR DESCRIPTION
The missing button means I have to tap on the really small border (~2mm wide?) around the modal to get out of it (or press "back" button and be kicked from WebView).

This change adds the `Close` button even for the list of files in the `Remote Devices` section (the one with multiple folders within modal).

Tested with Firefox on desktop, but it should be ok even for Android's WebView.

Ref: https://github.com/syncthing/syncthing/blob/c2b0d309fb4595ccc68ff2e267ef7b25fc3f4225/gui/default/syncthing/device/globalChangesModalView.html#L30