### PR TITLE
gui: Sort folders and devices on status (#fixes 5044)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -299,7 +299,7 @@
       <div class="col-md-6" aria-labelledby="folder_list" role="region" >
         <h3 id="folder_list" translate>Folders</h3>
         <div class="panel-group" id="folders">
-          <div class="panel panel-default" ng-repeat="folder in folderList()">
+          <div class="panel panel-default" ng-repeat="folder in guiShowFolderList()">
             <button class="btn panel-heading" data-toggle="collapse" data-parent="#folders" data-target="#folder-{{$index}}" aria-expanded="false">
               <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id) | percent}}"></div>
               <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id) | percent}}"></div>
@@ -627,7 +627,7 @@
         <!-- Remote devices -->
         <h3 translate>Remote Devices</h3>
         <div class="panel-group" id="devices">
-          <div class="panel panel-default" ng-repeat="deviceCfg in otherDevices()">
+          <div class="panel panel-default" ng-repeat="deviceCfg in guiShowOtherDevices()">
             <button class="btn panel-heading" data-toggle="collapse" data-parent="#devices" data-target="#device-{{$index}}" aria-expanded="false">
               <div class="panel-progress" ng-show="deviceStatus(deviceCfg) == 'syncing'" ng-attr-style="width: {{completion[deviceCfg.deviceID]._total | percent}}"></div>
               <h4 class="panel-title">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1514,6 +1514,54 @@ angular.module('syncthing.core')
             });
         };
 
+        $scope.statusOtherDevices = function () {
+            var unknownArray = [], unusedArray = [], pausedArray = [], insyncArray = [], disconnectedArray = [], defaultArray =[];
+
+            // loop through all devices
+            var devices = $scope.otherDevices();
+            var deviceLength = devices.length;
+            for (var i = 0; i < deviceLength; i++) {
+                var status = $scope.deviceStatus({
+                    deviceID:$scope.devices[i].deviceID
+                });
+
+                switch (status){
+                    case 'unused':
+                        unusedArray.push(devices[i]);
+                        break;
+
+                    case 'unknown':
+                        unknownArray.push(devices[i]);
+                        break;
+
+                    case 'paused':
+                        pausedArray.push(devices[i]);
+                        break;
+
+                    case 'insync' || 'syncing':
+                        insyncArray.push(devices[i]);
+                        break;
+
+                    case 'disconnected':
+                        disconnectedArray.push(devices[i]);
+                        break;
+
+                    default:
+                        defaultArray.push(devices[i]);
+                }
+            };
+
+            return unknownArray.concat(insyncArray, disconnectedArray, pausedArray, unusedArray, defaultArray);
+        };
+
+        $scope.guiShowOtherDevices = function () {
+            var statusSort = $scope.config.options.sortFolderDeviceByStatus;
+            if (statusSort){
+                return $scope.statusOtherDevices();
+            }
+            return $scope.otherDevices();
+        };
+
         $scope.thisDevice = function () {
             return $scope.thisDeviceIn($scope.devices);
         }
@@ -1567,6 +1615,63 @@ angular.module('syncthing.core')
 
         $scope.folderList = function () {
             return folderList($scope.folders);
+        };
+
+        $scope.statusFolderList = function () {
+            var unknownArray = [], idleArray = [], pausedArray = [], syncingArray = [];
+            var stoppedArray  = [], unsharedArray = [], defaultArray = [];
+
+            // loop through all folders
+            var folders = $scope.folderList();
+            for (var i = 0; i < folders.length; i++) {
+                var status = $scope.folderStatus(folders[i]);
+
+                switch (status){
+                case 'idle':
+                    idleArray.push(folders[i]);
+                    break;
+
+                case 'paused':
+                    pausedArray.push(folders[i]);
+                    break;
+
+                case 'syncing' || 'scanning':
+                    syncingArray.push(folders[i]);
+                    break;
+
+                case 'unknown':
+                    unknownArray.push(folders[i]);
+                    break;
+
+                case 'stopped' || 'outofsync' || 'error':
+                    stoppedArray.push(folders[i]);
+                    break;
+
+                case 'unshared':
+                    unsharedArray.push(folders[i]);
+                    break;
+
+                default:
+                    defaultArray.push(folders[i]);
+                }
+            };
+
+            idleArray = folderList(idleArray)
+            pausedArray = folderList(pausedArray)
+            syncingArray = folderList(syncingArray)
+            unknownArray = folderList(unknownArray)
+            stoppedArray = folderList(stoppedArray)
+            unsharedArray = folderList(unsharedArray)
+            defaultArray = folderList(defaultArray)
+            return unknownArray.concat(idleArray, pausedArray, unsharedArray, syncingArray, stoppedArray, defaultArray);
+        };
+
+        $scope.guiShowFolderList = function (){
+            var statusSort = $scope.config.options.sortFolderDeviceByStatus;
+            if(statusSort){
+                return $scope.statusFolderList();
+            }
+                return $scope.folderList();
         };
 
         $scope.directoryList = [];

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -13,44 +13,45 @@ import (
 )
 
 type OptionsConfiguration struct {
-	ListenAddresses         []string `xml:"listenAddress" json:"listenAddresses" default:"default"`
-	GlobalAnnServers        []string `xml:"globalAnnounceServer" json:"globalAnnounceServers" json:"globalAnnounceServer" default:"default" restart:"true"`
-	GlobalAnnEnabled        bool     `xml:"globalAnnounceEnabled" json:"globalAnnounceEnabled" default:"true" restart:"true"`
-	LocalAnnEnabled         bool     `xml:"localAnnounceEnabled" json:"localAnnounceEnabled" default:"true" restart:"true"`
-	LocalAnnPort            int      `xml:"localAnnouncePort" json:"localAnnouncePort" default:"21027" restart:"true"`
-	LocalAnnMCAddr          string   `xml:"localAnnounceMCAddr" json:"localAnnounceMCAddr" default:"[ff12::8384]:21027" restart:"true"`
-	MaxSendKbps             int      `xml:"maxSendKbps" json:"maxSendKbps"`
-	MaxRecvKbps             int      `xml:"maxRecvKbps" json:"maxRecvKbps"`
-	ReconnectIntervalS      int      `xml:"reconnectionIntervalS" json:"reconnectionIntervalS" default:"60"`
-	RelaysEnabled           bool     `xml:"relaysEnabled" json:"relaysEnabled" default:"true"`
-	RelayReconnectIntervalM int      `xml:"relayReconnectIntervalM" json:"relayReconnectIntervalM" default:"10"`
-	StartBrowser            bool     `xml:"startBrowser" json:"startBrowser" default:"true"`
-	NATEnabled              bool     `xml:"natEnabled" json:"natEnabled" default:"true"`
-	NATLeaseM               int      `xml:"natLeaseMinutes" json:"natLeaseMinutes" default:"60"`
-	NATRenewalM             int      `xml:"natRenewalMinutes" json:"natRenewalMinutes" default:"30"`
-	NATTimeoutS             int      `xml:"natTimeoutSeconds" json:"natTimeoutSeconds" default:"10"`
-	URAccepted              int      `xml:"urAccepted" json:"urAccepted"` // Accepted usage reporting version; 0 for off (undecided), -1 for off (permanently)
-	URSeen                  int      `xml:"urSeen" json:"urSeen"`         // Report which the user has been prompted for.
-	URUniqueID              string   `xml:"urUniqueID" json:"urUniqueId"` // Unique ID for reporting purposes, regenerated when UR is turned on.
-	URURL                   string   `xml:"urURL" json:"urURL" default:"https://data.syncthing.net/newdata"`
-	URPostInsecurely        bool     `xml:"urPostInsecurely" json:"urPostInsecurely" default:"false"` // For testing
-	URInitialDelayS         int      `xml:"urInitialDelayS" json:"urInitialDelayS" default:"1800"`
-	RestartOnWakeup         bool     `xml:"restartOnWakeup" json:"restartOnWakeup" default:"true" restart:"true"`
-	AutoUpgradeIntervalH    int      `xml:"autoUpgradeIntervalH" json:"autoUpgradeIntervalH" default:"12" restart:"true"` // 0 for off
-	UpgradeToPreReleases    bool     `xml:"upgradeToPreReleases" json:"upgradeToPreReleases" restart:"true"`              // when auto upgrades are enabled
-	KeepTemporariesH        int      `xml:"keepTemporariesH" json:"keepTemporariesH" default:"24"`                        // 0 for off
-	CacheIgnoredFiles       bool     `xml:"cacheIgnoredFiles" json:"cacheIgnoredFiles" default:"false" restart:"true"`
-	ProgressUpdateIntervalS int      `xml:"progressUpdateIntervalS" json:"progressUpdateIntervalS" default:"5"`
-	LimitBandwidthInLan     bool     `xml:"limitBandwidthInLan" json:"limitBandwidthInLan" default:"false"`
-	MinHomeDiskFree         Size     `xml:"minHomeDiskFree" json:"minHomeDiskFree" default:"1 %"`
-	ReleasesURL             string   `xml:"releasesURL" json:"releasesURL" default:"https://upgrades.syncthing.net/meta.json" restart:"true"`
-	AlwaysLocalNets         []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
-	OverwriteRemoteDevNames bool     `xml:"overwriteRemoteDeviceNamesOnConnect" json:"overwriteRemoteDeviceNamesOnConnect" default:"false"`
-	TempIndexMinBlocks      int      `xml:"tempIndexMinBlocks" json:"tempIndexMinBlocks" default:"10"`
-	UnackedNotificationIDs  []string `xml:"unackedNotificationID" json:"unackedNotificationIDs"`
-	TrafficClass            int      `xml:"trafficClass" json:"trafficClass"`
-	DefaultFolderPath       string   `xml:"defaultFolderPath" json:"defaultFolderPath" default:"~"`
-	SetLowPriority          bool     `xml:"setLowPriority" json:"setLowPriority" default:"true"`
+	ListenAddresses          []string `xml:"listenAddress" json:"listenAddresses" default:"default"`
+	GlobalAnnServers         []string `xml:"globalAnnounceServer" json:"globalAnnounceServers" json:"globalAnnounceServer" default:"default" restart:"true"`
+	GlobalAnnEnabled         bool     `xml:"globalAnnounceEnabled" json:"globalAnnounceEnabled" default:"true" restart:"true"`
+	LocalAnnEnabled          bool     `xml:"localAnnounceEnabled" json:"localAnnounceEnabled" default:"true" restart:"true"`
+	LocalAnnPort             int      `xml:"localAnnouncePort" json:"localAnnouncePort" default:"21027" restart:"true"`
+	LocalAnnMCAddr           string   `xml:"localAnnounceMCAddr" json:"localAnnounceMCAddr" default:"[ff12::8384]:21027" restart:"true"`
+	MaxSendKbps              int      `xml:"maxSendKbps" json:"maxSendKbps"`
+	MaxRecvKbps              int      `xml:"maxRecvKbps" json:"maxRecvKbps"`
+	ReconnectIntervalS       int      `xml:"reconnectionIntervalS" json:"reconnectionIntervalS" default:"60"`
+	RelaysEnabled            bool     `xml:"relaysEnabled" json:"relaysEnabled" default:"true"`
+	RelayReconnectIntervalM  int      `xml:"relayReconnectIntervalM" json:"relayReconnectIntervalM" default:"10"`
+	StartBrowser             bool     `xml:"startBrowser" json:"startBrowser" default:"true"`
+	NATEnabled               bool     `xml:"natEnabled" json:"natEnabled" default:"true"`
+	NATLeaseM                int      `xml:"natLeaseMinutes" json:"natLeaseMinutes" default:"60"`
+	NATRenewalM              int      `xml:"natRenewalMinutes" json:"natRenewalMinutes" default:"30"`
+	NATTimeoutS              int      `xml:"natTimeoutSeconds" json:"natTimeoutSeconds" default:"10"`
+	URAccepted               int      `xml:"urAccepted" json:"urAccepted"` // Accepted usage reporting version; 0 for off (undecided), -1 for off (permanently)
+	URSeen                   int      `xml:"urSeen" json:"urSeen"`         // Report which the user has been prompted for.
+	URUniqueID               string   `xml:"urUniqueID" json:"urUniqueId"` // Unique ID for reporting purposes, regenerated when UR is turned on.
+	URURL                    string   `xml:"urURL" json:"urURL" default:"https://data.syncthing.net/newdata"`
+	URPostInsecurely         bool     `xml:"urPostInsecurely" json:"urPostInsecurely" default:"false"` // For testing
+	URInitialDelayS          int      `xml:"urInitialDelayS" json:"urInitialDelayS" default:"1800"`
+	RestartOnWakeup          bool     `xml:"restartOnWakeup" json:"restartOnWakeup" default:"true" restart:"true"`
+	AutoUpgradeIntervalH     int      `xml:"autoUpgradeIntervalH" json:"autoUpgradeIntervalH" default:"12" restart:"true"` // 0 for off
+	UpgradeToPreReleases     bool     `xml:"upgradeToPreReleases" json:"upgradeToPreReleases" restart:"true"`              // when auto upgrades are enabled
+	KeepTemporariesH         int      `xml:"keepTemporariesH" json:"keepTemporariesH" default:"24"`                        // 0 for off
+	CacheIgnoredFiles        bool     `xml:"cacheIgnoredFiles" json:"cacheIgnoredFiles" default:"false" restart:"true"`
+	ProgressUpdateIntervalS  int      `xml:"progressUpdateIntervalS" json:"progressUpdateIntervalS" default:"5"`
+	LimitBandwidthInLan      bool     `xml:"limitBandwidthInLan" json:"limitBandwidthInLan" default:"false"`
+	MinHomeDiskFree          Size     `xml:"minHomeDiskFree" json:"minHomeDiskFree" default:"1 %"`
+	ReleasesURL              string   `xml:"releasesURL" json:"releasesURL" default:"https://upgrades.syncthing.net/meta.json" restart:"true"`
+	AlwaysLocalNets          []string `xml:"alwaysLocalNet" json:"alwaysLocalNets"`
+	OverwriteRemoteDevNames  bool     `xml:"overwriteRemoteDeviceNamesOnConnect" json:"overwriteRemoteDeviceNamesOnConnect" default:"false"`
+	TempIndexMinBlocks       int      `xml:"tempIndexMinBlocks" json:"tempIndexMinBlocks" default:"10"`
+	UnackedNotificationIDs   []string `xml:"unackedNotificationID" json:"unackedNotificationIDs"`
+	TrafficClass             int      `xml:"trafficClass" json:"trafficClass"`
+	DefaultFolderPath        string   `xml:"defaultFolderPath" json:"defaultFolderPath" default:"~"`
+	SetLowPriority           bool     `xml:"setLowPriority" json:"setLowPriority" default:"true"`
+	SortFolderDeviceByStatus bool     `xml:"sortFolderDeviceByStatus,omitempty" json:"sortFolderDeviceByStatus" default:"false"`
 
 	DeprecatedUPnPEnabled        bool     `xml:"upnpEnabled,omitempty" json:"-"`
 	DeprecatedUPnPLeaseM         int      `xml:"upnpLeaseMinutes,omitempty" json:"-"`


### PR DESCRIPTION
### Purpose
Sort `folders` and `devices` on `status` instead of names. (fixes #5044).

Folders sorted by 7 and devices sorted by 6 different status.

### Screenshots
#### Select status sorting:  **Action > Advanced > Options**
<img width="491" alt="screen" src="https://user-images.githubusercontent.com/29825419/46694253-dfbe4100-cc14-11e8-8da8-0c0083da7466.png">

#### Before `status sort` (namely it is `default`):
<img width="1005" alt="screen shot 2018-10-06 at 22 39 32" src="https://user-images.githubusercontent.com/29825419/46575337-2c024a80-c9a3-11e8-8c41-a6f55f97cd97.png">

#### After `status sort`:
<img width="1020" alt="screen shot 2018-10-06 at 22 39 53" src="https://user-images.githubusercontent.com/29825419/46575346-5522db00-c9a3-11e8-8cc1-24c466ab7596.png">


#### The order of statuses can be changed.
#### Instead of under `Options`, checkbox can be under `GUI`. 

