### PR TITLE
lib/config: Add context to the home disk out of space error

### DIFF
--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -499,8 +500,11 @@ func (w *Wrapper) AddOrUpdatePendingFolder(id, label string, device protocol.Dev
 // CheckHomeFreeSpace returns nil if the home disk has the required amount of
 // free space, or if home disk free space checking is disabled.
 func (w *Wrapper) CheckHomeFreeSpace() error {
-	if usage, err := fs.NewFilesystem(fs.FilesystemTypeBasic, filepath.Dir(w.ConfigPath())).Usage("."); err == nil {
-		return checkFreeSpace(w.Options().MinHomeDiskFree, usage)
+	path := filepath.Dir(w.ConfigPath())
+	if usage, err := fs.NewFilesystem(fs.FilesystemTypeBasic, path).Usage("."); err == nil {
+		if err = checkFreeSpace(w.Options().MinHomeDiskFree, usage); err != nil {
+			return fmt.Errorf("insufficient space on home disk (%v): %v", path, err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
https://forum.syncthing.net/t/folder-stopped-error-0-193170-1/12256

Currently the error for the home disk is so minimal that it is simply cryptic: "*actual space* < *required space*", there is no context about where the space is missing (in case of folder out of space, this context is already added).