### PR TITLE
lib/model: Don't check folder health if there is nothing to pull (fixes #2497)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -141,11 +141,6 @@ func (f *sendReceiveFolder) pull() bool {
 		return true
 	}
 
-	if err := f.CheckHealth(); err != nil {
-		l.Debugln("Skipping pull of", f.Description(), "due to folder error:", err)
-		return true
-	}
-
 	f.model.fmut.RLock()
 	curIgnores := f.model.folderIgnores[f.folderID]
 	folderFiles := f.model.folderFiles[f.folderID]
@@ -158,6 +153,11 @@ func (f *sendReceiveFolder) pull() bool {
 		return false
 	})
 	if abort {
+		return true
+	}
+
+	if err := f.CheckHealth(); err != nil {
+		l.Debugln("Skipping pull of", f.Description(), "due to folder error:", err)
 		return true
 	}
 


### PR DESCRIPTION
### Purpose

Just exchange the two checks before pulling: Do the one without accessing the folder root first.

### Testing

None. The specific fixed issue might have already been solved before, but this solves it for sure.