### PR TITLE
lib/model: Don't flake out on shortcutting files (ref #5258, #5257, #5234)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -968,6 +968,7 @@ func (f *sendReceiveFolder) handleFile(file protocol.FileInfo, copyChan chan<- c
 		// are only updating metadata, so we don't actually *need* to make the
 		// copy.
 		f.shortcutFile(file, curFile, dbUpdateChan)
+		return
 	}
 
 	tempName := fs.TempName(file.Name)


### PR DESCRIPTION
In a recent change (#5201) this return disappeared. The effect is that
we first shortcut the file and then also treat it normally. This results
in to database updates after each other, which are bound to end up in
the same batch. This means we remove one sequence entry and add two.

Not marking the issues as fixed, because I need to do more testing and
there are other discrepancies...

