### PR TITLE
lib/db: Properly remove FileInfos when dropping folder

### DIFF
--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -442,7 +442,7 @@ func (db *instance) dropFolder(folder []byte) {
 
 	for _, key := range [][]byte{
 		// Remove all items related to the given folder from the device->file bucket
-		db.keyer.GenerateDeviceFileKey(nil, folder, nil, nil).WithoutName(),
+		db.keyer.GenerateDeviceFileKey(nil, folder, nil, nil).WithoutNameAndDevice(),
 		// Remove all sequences related to the folder
 		db.keyer.GenerateSequenceKey(nil, []byte(folder), 0).WithoutSequence(),
 		// Remove all items related to the given folder from the global bucket

--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -171,7 +171,7 @@ func (db *instance) withAllFolderTruncated(folder []byte, fn func(device []byte,
 	t := db.newReadWriteTransaction()
 	defer t.close()
 
-	dbi := t.NewIterator(util.BytesPrefix(db.keyer.GenerateDeviceFileKey(nil, folder, nil, nil).WithoutName()), nil)
+	dbi := t.NewIterator(util.BytesPrefix(db.keyer.GenerateDeviceFileKey(nil, folder, nil, nil).WithoutNameAndDevice()), nil)
 	defer dbi.Release()
 
 	var gk []byte

--- a/lib/db/keyer.go
+++ b/lib/db/keyer.go
@@ -82,10 +82,6 @@ func newDefaultKeyer(folderIdx, deviceIdx *smallIndex) defaultKeyer {
 
 type deviceFileKey []byte
 
-func (k deviceFileKey) WithoutName() []byte {
-	return k[:keyPrefixLen+keyFolderLen+keyDeviceLen]
-}
-
 func (k deviceFileKey) WithoutNameAndDevice() []byte {
 	return k[:keyPrefixLen+keyFolderLen]
 }

--- a/lib/db/keyer.go
+++ b/lib/db/keyer.go
@@ -86,6 +86,10 @@ func (k deviceFileKey) WithoutName() []byte {
 	return k[:keyPrefixLen+keyFolderLen+keyDeviceLen]
 }
 
+func (k deviceFileKey) WithoutNameAndDevice() []byte {
+	return k[:keyPrefixLen+keyFolderLen]
+}
+
 func (k defaultKeyer) GenerateDeviceFileKey(key, folder, device, name []byte) deviceFileKey {
 	key = resize(key, keyPrefixLen+keyFolderLen+keyDeviceLen+len(name))
 	key[0] = KeyTypeDevice


### PR DESCRIPTION
This doesn't cause any catastrophic issues other than FileInfos
lingering in the database forever... But the prefix here was wrong
(including a nil device ID) resulting in this cleanup being a no-op.
