### PR TITLE
lib/config: Disable folder free disk check when configured (fixes #5267)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -269,6 +269,10 @@ func (f *FolderConfiguration) SharedWith(device protocol.DeviceID) bool {
 }
 
 func (f *FolderConfiguration) CheckAvailableSpace(req int64) error {
+	val := f.MinDiskFree.BaseValue()
+	if val <= 0 {
+		return nil
+	}
 	fs := f.Filesystem()
 	usage, err := fs.Usage(".")
 	if err != nil {


### PR DESCRIPTION
#5267
https://forum.syncthing.net/t/insufficient-space-error-from-v0-14-51-with-sshfs/12276

This only changes things in the corner-case where free space is smaller than the space required for the pull operation (`usage.Free - req <= 0`).