### PR TITLE
all: Event.Data: interface{} -> map[string]interface{} (fixes #5270)

### DIFF
--- a/cmd/syncthing/auditservice_test.go
+++ b/cmd/syncthing/auditservice_test.go
@@ -20,13 +20,13 @@ func TestAuditService(t *testing.T) {
 	service := newAuditService(buf)
 
 	// Event sent before start, will not be logged
-	events.Default.Log(events.ConfigSaved, "the first event")
+	events.Default.Log(events.ConfigSaved, map[string]interface{}{"": "the first event"})
 
 	go service.Serve()
 	service.WaitForStart()
 
 	// Event that should end up in the audit log
-	events.Default.Log(events.ConfigSaved, "the second event")
+	events.Default.Log(events.ConfigSaved, map[string]interface{}{"": "the second event"})
 
 	// We need to give the events time to arrive, since the channels are buffered etc.
 	time.Sleep(10 * time.Millisecond)
@@ -35,7 +35,7 @@ func TestAuditService(t *testing.T) {
 	service.WaitForStop()
 
 	// This event should not be logged, since we have stopped.
-	events.Default.Log(events.ConfigSaved, "the third event")
+	events.Default.Log(events.ConfigSaved, map[string]interface{}{"": "the third event"})
 
 	result := string(buf.Bytes())
 	t.Log(result)

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -658,7 +658,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	// Emit the Starting event, now that we know who we are.
 
-	events.Default.Log(events.Starting, map[string]string{
+	events.Default.Log(events.Starting, map[string]interface{}{
 		"home": baseDirs["config"],
 		"myID": myID.String(),
 	})
@@ -902,7 +902,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		l.Warnln("Syncthing should not run as a privileged or system user. Please consider using a normal user account.")
 	}
 
-	events.Default.Log(events.StartupComplete, map[string]string{
+	events.Default.Log(events.StartupComplete, map[string]interface{}{
 		"myID": myID.String(),
 	})
 
@@ -1199,11 +1199,10 @@ func autoUpgrade(cfg *config.Wrapper) {
 	for {
 		select {
 		case event := <-sub.C():
-			data, ok := event.Data.(map[string]string)
-			if !ok || data["clientName"] != "syncthing" || upgrade.CompareVersions(data["clientVersion"], Version) != upgrade.Newer {
+			if event.Data["clientName"] != "syncthing" || upgrade.CompareVersions(event.Data["clientVersion"].(string), Version) != upgrade.Newer {
 				continue
 			}
-			l.Infof("Connected to device %s with a newer version (current %q < remote %q). Checking for upgrades.", data["id"], Version, data["clientVersion"])
+			l.Infof("Connected to device %s with a newer version (current %q < remote %q). Checking for upgrades.", event.Data["id"], Version, event.Data["clientVersion"])
 		case <-timer.C:
 		}
 

--- a/cmd/syncthing/summaryservice.go
+++ b/cmd/syncthing/summaryservice.go
@@ -74,8 +74,7 @@ func (c *folderSummaryService) listenForUpdates() {
 				// When a device connects we schedule a refresh of all
 				// folders shared with that device.
 
-				data := ev.Data.(map[string]string)
-				deviceID, _ := protocol.DeviceIDFromString(data["id"])
+				deviceID, _ := protocol.DeviceIDFromString(ev.Data["id"].(string))
 
 				c.foldersMut.Lock()
 			nextFolder:
@@ -96,12 +95,11 @@ func (c *folderSummaryService) listenForUpdates() {
 			// affect. Whenever the local or remote index is updated for a
 			// given folder we make a note of it.
 
-			data := ev.Data.(map[string]interface{})
-			folder := data["folder"].(string)
+			folder := ev.Data["folder"].(string)
 
 			switch ev.Type {
 			case events.StateChanged:
-				if data["to"].(string) == "idle" && data["from"].(string) == "syncing" {
+				if ev.Data["to"].(string) == "idle" && ev.Data["from"].(string) == "syncing" {
 					// The folder changed to idle from syncing. We should do an
 					// immediate refresh to update the GUI. The send to
 					// c.immediate must be nonblocking so that we can continue

--- a/cmd/syncthing/verboseservice.go
+++ b/cmd/syncthing/verboseservice.go
@@ -71,85 +71,71 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 		return ""
 
 	case events.Starting:
-		return fmt.Sprintf("Starting up (%s)", ev.Data.(map[string]string)["home"])
+		return fmt.Sprintf("Starting up (%s)", ev.Data["home"])
 
 	case events.StartupComplete:
 		return "Startup complete"
 
 	case events.DeviceDiscovered:
-		data := ev.Data.(map[string]interface{})
-		return fmt.Sprintf("Discovered device %v at %v", data["device"], data["addrs"])
+		return fmt.Sprintf("Discovered device %v at %v", ev.Data["device"], ev.Data["addrs"])
 
 	case events.DeviceConnected:
-		data := ev.Data.(map[string]string)
-		return fmt.Sprintf("Connected to device %v at %v (type %s)", data["id"], data["addr"], data["type"])
+		return fmt.Sprintf("Connected to device %v at %v (type %s)", ev.Data["id"], ev.Data["addr"], ev.Data["type"])
 
 	case events.DeviceDisconnected:
-		data := ev.Data.(map[string]string)
-		return fmt.Sprintf("Disconnected from device %v", data["id"])
+		return fmt.Sprintf("Disconnected from device %v", ev.Data["id"])
 
 	case events.StateChanged:
-		data := ev.Data.(map[string]interface{})
-		return fmt.Sprintf("Folder %q is now %v", data["folder"], data["to"])
+		return fmt.Sprintf("Folder %q is now %v", ev.Data["folder"], ev.Data["to"])
 
 	case events.LocalChangeDetected:
-		data := ev.Data.(map[string]string)
-		return fmt.Sprintf("Local change detected in folder %q: %s %s %s", data["folder"], data["action"], data["type"], data["path"])
+		return fmt.Sprintf("Local change detected in folder %q: %s %s %s", ev.Data["folder"], ev.Data["action"], ev.Data["type"], ev.Data["path"])
 
 	case events.RemoteChangeDetected:
-		data := ev.Data.(map[string]string)
-		return fmt.Sprintf("Remote change detected in folder %q: %s %s %s", data["folder"], data["action"], data["type"], data["path"])
+		return fmt.Sprintf("Remote change detected in folder %q: %s %s %s", ev.Data["folder"], ev.Data["action"], ev.Data["type"], ev.Data["path"])
 
 	case events.RemoteIndexUpdated:
-		data := ev.Data.(map[string]interface{})
-		return fmt.Sprintf("Device %v sent an index update for %q with %d items", data["device"], data["folder"], data["items"])
+		return fmt.Sprintf("Device %v sent an index update for %q with %d items", ev.Data["device"], ev.Data["folder"], ev.Data["items"])
 
 	case events.DeviceRejected:
-		data := ev.Data.(map[string]interface{})
-		return fmt.Sprintf("Rejected connection from device %v at %v", data["device"], data["address"])
+		return fmt.Sprintf("Rejected connection from device %v at %v", ev.Data["device"], ev.Data["address"])
 
 	case events.FolderRejected:
-		data := ev.Data.(map[string]string)
-		return fmt.Sprintf("Rejected unshared folder %q from device %v", data["folder"], data["device"])
+		return fmt.Sprintf("Rejected unshared folder %q from device %v", ev.Data["folder"], ev.Data["device"])
 
 	case events.ItemStarted:
-		data := ev.Data.(map[string]string)
-		return fmt.Sprintf("Started syncing %q / %q (%v %v)", data["folder"], data["item"], data["action"], data["type"])
+		return fmt.Sprintf("Started syncing %q / %q (%v %v)", ev.Data["folder"], ev.Data["item"], ev.Data["action"], ev.Data["type"])
 
 	case events.ItemFinished:
-		data := ev.Data.(map[string]interface{})
-		if err, ok := data["error"].(*string); ok && err != nil {
+		if err, ok := ev.Data["error"].(*string); ok && err != nil {
 			// If the err interface{} is not nil, it is a string pointer.
 			// Dereference it to get the actual error or Sprintf will print
 			// the pointer value....
-			return fmt.Sprintf("Finished syncing %q / %q (%v %v): %v", data["folder"], data["item"], data["action"], data["type"], *err)
+			return fmt.Sprintf("Finished syncing %q / %q (%v %v): %v", ev.Data["folder"], ev.Data["item"], ev.Data["action"], ev.Data["type"], *err)
 		}
-		return fmt.Sprintf("Finished syncing %q / %q (%v %v): Success", data["folder"], data["item"], data["action"], data["type"])
+		return fmt.Sprintf("Finished syncing %q / %q (%v %v): Success", ev.Data["folder"], ev.Data["item"], ev.Data["action"], ev.Data["type"])
 
 	case events.ConfigSaved:
 		return "Configuration was saved"
 
 	case events.FolderCompletion:
-		data := ev.Data.(map[string]interface{})
-		return fmt.Sprintf("Completion for folder %q on device %v is %v%%", data["folder"], data["device"], data["completion"])
+		return fmt.Sprintf("Completion for folder %q on device %v is %v%%", ev.Data["folder"], ev.Data["device"], ev.Data["completion"])
 
 	case events.FolderSummary:
-		data := ev.Data.(map[string]interface{})
 		sum := make(map[string]interface{})
-		for k, v := range data["summary"].(map[string]interface{}) {
+		for k, v := range ev.Data["summary"].(map[string]interface{}) {
 			if k == "invalid" || k == "ignorePatterns" || k == "stateChanged" {
 				continue
 			}
 			sum[k] = v
 		}
-		return fmt.Sprintf("Summary for folder %q is %v", data["folder"], sum)
+		return fmt.Sprintf("Summary for folder %q is %v", ev.Data["folder"], sum)
 
 	case events.FolderScanProgress:
-		data := ev.Data.(map[string]interface{})
-		folder := data["folder"].(string)
-		current := data["current"].(int64)
-		total := data["total"].(int64)
-		rate := data["rate"].(float64) / 1024 / 1024
+		folder := ev.Data["folder"].(string)
+		current := ev.Data["current"].(int64)
+		total := ev.Data["total"].(int64)
+		rate := ev.Data["rate"].(float64) / 1024 / 1024
 		var pct int64
 		if total > 0 {
 			pct = 100 * current / total
@@ -157,39 +143,33 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Scanning folder %q, %d%% done (%.01f MiB/s)", folder, pct, rate)
 
 	case events.DevicePaused:
-		data := ev.Data.(map[string]string)
-		device := data["device"]
+		device := ev.Data["device"]
 		return fmt.Sprintf("Device %v was paused", device)
 
 	case events.DeviceResumed:
-		data := ev.Data.(map[string]string)
-		device := data["device"]
+		device := ev.Data["device"]
 		return fmt.Sprintf("Device %v was resumed", device)
 
 	case events.FolderPaused:
-		data := ev.Data.(map[string]string)
-		id := data["id"]
-		label := data["label"]
+		id := ev.Data["id"]
+		label := ev.Data["label"]
 		return fmt.Sprintf("Folder %v (%v) was paused", id, label)
 
 	case events.FolderResumed:
-		data := ev.Data.(map[string]string)
-		id := data["id"]
-		label := data["label"]
+		id := ev.Data["id"]
+		label := ev.Data["label"]
 		return fmt.Sprintf("Folder %v (%v) was resumed", id, label)
 
 	case events.ListenAddressesChanged:
-		data := ev.Data.(map[string]interface{})
-		address := data["address"]
-		lan := data["lan"]
-		wan := data["wan"]
+		address := ev.Data["address"]
+		lan := ev.Data["lan"]
+		wan := ev.Data["wan"]
 		return fmt.Sprintf("Listen address %s resolution has changed: lan addresses: %s wan addresses: %s", address, lan, wan)
 
 	case events.LoginAttempt:
-		data := ev.Data.(map[string]interface{})
-		username := data["username"].(string)
+		username := ev.Data["username"].(string)
 		var success string
-		if data["success"].(bool) {
+		if ev.Data["success"].(bool) {
 			success = "successful"
 		} else {
 			success = "failed"

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -397,7 +397,7 @@ func (w *Wrapper) Save() error {
 		return err
 	}
 
-	events.Default.Log(events.ConfigSaved, w.cfg)
+	events.Default.Log(events.ConfigSaved, map[string]interface{}{"config": w.cfg})
 	return nil
 }
 

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -211,10 +211,10 @@ type Event struct {
 	// Per-subscription sequential event ID. Named "id" for backwards compatibility with the REST API
 	SubscriptionID int `json:"id"`
 	// Global ID of the event across all subscriptions
-	GlobalID int         `json:"globalID"`
-	Time     time.Time   `json:"time"`
-	Type     EventType   `json:"type"`
-	Data     interface{} `json:"data"`
+	GlobalID int                    `json:"globalID"`
+	Time     time.Time              `json:"time"`
+	Type     EventType              `json:"type"`
+	Data     map[string]interface{} `json:"data"`
 }
 
 type Subscription struct {
@@ -243,7 +243,7 @@ func NewLogger() *Logger {
 	return l
 }
 
-func (l *Logger) Log(t EventType, data interface{}) {
+func (l *Logger) Log(t EventType, data map[string]interface{}) {
 	l.mutex.Lock()
 	l.nextGlobalID++
 	dl.Debugln("log", l.nextGlobalID, t, data)

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -538,7 +538,7 @@ func (f *sendReceiveFolder) handleDir(file protocol.FileInfo, dbUpdateChan chan<
 	// care not declare another err.
 	var err error
 
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   file.Name,
 		"type":   "dir",
@@ -665,7 +665,7 @@ func (f *sendReceiveFolder) handleSymlink(file protocol.FileInfo, dbUpdateChan c
 	// care not declare another err.
 	var err error
 
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   file.Name,
 		"type":   "symlink",
@@ -725,7 +725,7 @@ func (f *sendReceiveFolder) handleDeleteDir(file protocol.FileInfo, ignores *ign
 	// care not declare another err.
 	var err error
 
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   file.Name,
 		"type":   "dir",
@@ -756,7 +756,7 @@ func (f *sendReceiveFolder) deleteFile(file protocol.FileInfo, scanChan chan<- s
 	// care not declare another err.
 	var err error
 
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   file.Name,
 		"type":   "file",
@@ -821,13 +821,13 @@ func (f *sendReceiveFolder) renameFile(cur, source, target protocol.FileInfo, db
 	// care not declare another err.
 	var err error
 
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   source.Name,
 		"type":   "file",
 		"action": "delete",
 	})
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   target.Name,
 		"type":   "file",
@@ -1029,7 +1029,7 @@ func (f *sendReceiveFolder) handleFile(file protocol.FileInfo, copyChan chan<- c
 		blocks[i], blocks[j] = blocks[j], blocks[i]
 	}
 
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   file.Name,
 		"type":   "file",
@@ -1110,7 +1110,7 @@ func populateOffsets(blocks []protocol.BlockInfo) {
 func (f *sendReceiveFolder) shortcutFile(file, curFile protocol.FileInfo, dbUpdateChan chan<- dbUpdateJob) {
 	l.Debugln(f, "taking shortcut on", file.Name)
 
-	events.Default.Log(events.ItemStarted, map[string]string{
+	events.Default.Log(events.ItemStarted, map[string]interface{}{
 		"folder": f.folderID,
 		"item":   file.Name,
 		"type":   "file",

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -492,7 +492,7 @@ func TestDeregisterOnFailInCopy(t *testing.T) {
 
 		if ev, err := s.Poll(timeout); err != nil {
 			t.Fatal("Got error waiting for ItemFinished event:", err)
-		} else if n := ev.Data.(map[string]interface{})["item"]; n != state.file.Name {
+		} else if n := ev.Data["item"]; n != state.file.Name {
 			t.Fatal("Got ItemFinished event for wrong file:", n)
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -567,7 +567,7 @@ func TestDeregisterOnFailInPull(t *testing.T) {
 
 		if ev, err := s.Poll(timeout); err != nil {
 			t.Fatal("Got error waiting for ItemFinished event:", err)
-		} else if n := ev.Data.(map[string]interface{})["item"]; n != state.file.Name {
+		} else if n := ev.Data["item"]; n != state.file.Name {
 			t.Fatal("Got ItemFinished event for wrong file:", n)
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -954,7 +954,7 @@ func (m *Model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 				continue
 			}
 			m.cfg.AddOrUpdatePendingFolder(folder.ID, folder.Label, deviceID)
-			events.Default.Log(events.FolderRejected, map[string]string{
+			events.Default.Log(events.FolderRejected, map[string]interface{}{
 				"folder":      folder.ID,
 				"folderLabel": folder.Label,
 				"device":      deviceID.String(),
@@ -1291,7 +1291,7 @@ func (m *Model) Closed(conn protocol.Connection, err error) {
 	m.pmut.Unlock()
 
 	l.Infof("Connection to %s at %s closed: %v", device, conn.Name(), err)
-	events.Default.Log(events.DeviceDisconnected, map[string]string{
+	events.Default.Log(events.DeviceDisconnected, map[string]interface{}{
 		"id":    device.String(),
 		"error": err.Error(),
 	})
@@ -1561,7 +1561,7 @@ func (m *Model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protoco
 	cfg, ok := m.cfg.Device(remoteID)
 	if !ok {
 		m.cfg.AddOrUpdatePendingDevice(remoteID, hello.DeviceName, addr.String())
-		events.Default.Log(events.DeviceRejected, map[string]string{
+		events.Default.Log(events.DeviceRejected, map[string]interface{}{
 			"name":    hello.DeviceName,
 			"device":  remoteID.String(),
 			"address": addr.String(),
@@ -1622,7 +1622,7 @@ func (m *Model) AddConnection(conn connections.Connection, hello protocol.HelloR
 
 	m.helloMessages[deviceID] = hello
 
-	event := map[string]string{
+	event := map[string]interface{}{
 		"id":            deviceID.String(),
 		"deviceName":    hello.DeviceName,
 		"clientName":    hello.ClientName,
@@ -1901,7 +1901,7 @@ func (m *Model) diskChangeDetected(folderCfg config.FolderConfiguration, files [
 		}
 
 		// Two different events can be fired here based on what EventType is passed into function
-		events.Default.Log(typeOfEvent, map[string]string{
+		events.Default.Log(typeOfEvent, map[string]interface{}{
 			"folder":     folderCfg.ID,
 			"folderID":   folderCfg.ID, // incorrect, deprecated, kept for historical compliance
 			"label":      folderCfg.Label,
@@ -2738,7 +2738,7 @@ func (m *Model) CommitConfiguration(from, to config.Configuration) bool {
 			if toCfg.Paused {
 				eventType = events.FolderPaused
 			}
-			events.Default.Log(eventType, map[string]string{"id": toCfg.ID, "label": toCfg.Label})
+			events.Default.Log(eventType, map[string]interface{}{"id": toCfg.ID, "label": toCfg.Label})
 		}
 	}
 
@@ -2766,9 +2766,9 @@ func (m *Model) CommitConfiguration(from, to config.Configuration) bool {
 		if toCfg.Paused {
 			l.Infoln("Pausing", deviceID)
 			m.close(deviceID)
-			events.Default.Log(events.DevicePaused, map[string]string{"device": deviceID.String()})
+			events.Default.Log(events.DevicePaused, map[string]interface{}{"device": deviceID.String()})
 		} else {
-			events.Default.Log(events.DeviceResumed, map[string]string{"device": deviceID.String()})
+			events.Default.Log(events.DeviceResumed, map[string]interface{}{"device": deviceID.String()})
 		}
 	}
 

--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -91,12 +91,12 @@ func (t *ProgressEmitter) Serve() {
 
 func (t *ProgressEmitter) sendDownloadProgressEvent() {
 	// registry lock already held
-	output := make(map[string]map[string]*pullerProgress)
+	output := make(map[string]interface{})
 	for _, puller := range t.registry {
 		if output[puller.folder] == nil {
 			output[puller.folder] = make(map[string]*pullerProgress)
 		}
-		output[puller.folder][puller.file.Name] = puller.Progress()
+		output[puller.folder].(map[string]*pullerProgress)[puller.file.Name] = puller.Progress()
 	}
 	events.Default.Log(events.DownloadProgress, output)
 	l.Debugf("progress emitter: emitting %#v", output)

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -38,7 +38,7 @@ func expectEvent(w *events.Subscription, t *testing.T, size int) {
 	if event.Type != events.DownloadProgress {
 		t.Fatal("Unexpected event:", event, "at", caller(1))
 	}
-	data := event.Data.(map[string]map[string]*pullerProgress)
+	data := event.Data
 	if len(data) != size {
 		t.Fatal("Unexpected event data size:", data, "at", caller(1))
 	}

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -680,7 +680,7 @@ func TestRequestSymlinkWindows(t *testing.T) {
 	for {
 		select {
 		case ev := <-sub.C():
-			switch data := ev.Data.(map[string]interface{}); {
+			switch data := ev.Data; {
 			case ev.Type == events.LocalIndexUpdated:
 				t.Fatalf("Local index was updated unexpectedly: %v", data)
 			case ev.Type == events.StateChanged:

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -437,10 +437,10 @@ func (a *aggregator) updateConfig(folderCfg config.FolderConfiguration) {
 
 func updateInProgressSet(event events.Event, inProgress map[string]struct{}) {
 	if event.Type == events.ItemStarted {
-		path := event.Data.(map[string]string)["item"]
+		path := event.Data["item"].(string)
 		inProgress[path] = struct{}{}
 	} else if event.Type == events.ItemFinished {
-		path := event.Data.(map[string]interface{})["item"].(string)
+		path := event.Data["item"].(string)
 		delete(inProgress, path)
 	}
 }

--- a/lib/watchaggregator/aggregator_test.go
+++ b/lib/watchaggregator/aggregator_test.go
@@ -124,7 +124,7 @@ func TestAggregate(t *testing.T) {
 // TestInProgress checks that ignoring files currently edited by Syncthing works
 func TestInProgress(t *testing.T) {
 	testCase := func(c chan<- fs.Event) {
-		events.Default.Log(events.ItemStarted, map[string]string{
+		events.Default.Log(events.ItemStarted, map[string]interface{}{
 			"item": "inprogress",
 		})
 		sleepMs(100)


### PR DESCRIPTION
### Purpose

Instead of just fixing the one issue (see https://github.com/syncthing/syncthing/issues/5270#issuecomment-429669744), I removed one level of interfaces/ambiguity. To be really consequent, all events should be structs, thus preventing any potential for false type assertions, but that's also very cumbersome. I like `map[string]interface{}` better than `interface` for `event.Data`, but if you don't (or just can't stand this ugly diff), just tell me and the fix will become a one line diff.

### Testing

Manual testing: Doesn't panic anymore on rejected folder with `-verbose` and verbose logging still works as far as I observed.