### PR TITLE
cmd/syncthing: Correct type assertion in verboseService (fixes #5270)

### DIFF
--- a/cmd/syncthing/verboseservice.go
+++ b/cmd/syncthing/verboseservice.go
@@ -105,7 +105,7 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Device %v sent an index update for %q with %d items", data["device"], data["folder"], data["items"])
 
 	case events.DeviceRejected:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]string)
 		return fmt.Sprintf("Rejected connection from device %v at %v", data["device"], data["address"])
 
 	case events.FolderRejected:


### PR DESCRIPTION
### Purpose

#5270

### Testing

None. Any unit test that checks if the assertions are correct would have to generate the data sent to `events.Logger.Log` itself, which does not guarantee that the actual data sent somewhere in the code corresponds to that. This is an intrinsic flaw of working with interfaces here, but it makes life much easier - trade-offs...