### PR TITLE
Update golint import path

### DIFF
--- a/build.go
+++ b/build.go
@@ -361,7 +361,7 @@ func setup() {
 		"github.com/AlekSi/gocov-xml",
 		"github.com/axw/gocov/gocov",
 		"github.com/FiloSottile/gvt",
-		"github.com/golang/lint/golint",
+		"golang.org/x/lint/golint",
 		"github.com/gordonklaus/ineffassign",
 		"github.com/mdempsky/unconvert",
 		"github.com/mitchellh/go-wordwrap",


### PR DESCRIPTION
Heya :wave: ,

A small update for the golint import path as this has been changed last February. 

### Purpose
Fixes error "code in directory GOPATH/src/github.com/golang/lint/golint expects import golang.org/x/lint/golint" while running the
`go run build.go setup` command.

### Testing

1. Check out the master branch. 
1. Run `go run build.go setup`
1. Acknowledge the error when the setup is trying to go get github.com/golang/lint/golint
1. Checkout this PR
1. Retry `go run build.go setup`
1. Acknowledge that the error is fixed
1. Run `go run build.go lint` to confirm that the linter still works

Have a nice day :tada: 
