### PR TITLE
gui: Show usage reporting title regardless of RC

### DIFF
--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -69,8 +69,8 @@
           <div class="row">
             <div class="col-md-6">
               <div class="form-group">
+                <label translate for="urVersion">Anonymous Usage Reporting</label> (<a href="" translate data-toggle="modal" data-target="#urPreview">Preview</a>)
                 <div ng-if="tmpOptions.upgrades != 'candidate'">
-                  <label translate for="urVersion">Anonymous Usage Reporting</label> (<a href="" translate data-toggle="modal" data-target="#urPreview">Preview</a>)
                   <select class="form-control" id="urVersion" ng-model="tmpOptions._urAcceptedStr">
                     <option ng-repeat="n in urVersions()" value="{{n}}">{{'Version' | translate}} {{n}}</option>
                     <!-- 1 does not exist, as we did not support incremental formats back then. -->
@@ -79,7 +79,7 @@
                   </select>
                 </div>
                 <p class="help-block" ng-if="tmpOptions.upgrades == 'candidate'">
-                  <span translate>Usage reporting is always enabled for candidate releases.</span> (<a href="" translate data-toggle="modal" data-target="#urPreview">Preview</a>)
+                  <span translate>Usage reporting is always enabled for candidate releases.</span>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
When seeing a [screenshot of the settings in the forum](https://forum.syncthing.net/t/usage-reporting/12337/4?u=imsodin) I considered it a bit weird that UR is the only thing without a title. Turned out, the title is conditional on whether it's an RC or not. This makes the title unconditional:

![screenshot_2018-10-22_15-00-14](https://user-images.githubusercontent.com/15955093/47293953-ef258d00-d60b-11e8-8ef9-8c3dca4c235b.png)