### PR TITLE
lib/model: Check if files from queue are invalid (fixes #5291)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -448,7 +448,7 @@ nextFile:
 			continue
 		}
 
-		if fi.IsDeleted() || fi.Type != protocol.FileInfoTypeFile {
+		if fi.IsDeleted() || fi.IsInvalid() || fi.Type != protocol.FileInfoTypeFile {
 			// The item has changed type or status in the index while we
 			// were processing directories above.
 			f.queue.Done(fileName)


### PR DESCRIPTION
Once scenario where #5291 can happen: A valid file exists on a remote -> put in the queue. While other stuff in the queue is processed, that file vanishes/gets invalidated/..., such that there are now only invalid files in the global list. Therefore when the file is processed from the queue and the global file queried, it is now invalid -> check for that (like we already check for deletion, file type, ...).
