### PR TITLE
lib/connections: Don't panic on removed device (fixes #5299)

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -245,7 +245,9 @@ next:
 
 		deviceCfg, ok := s.cfg.Device(remoteID)
 		if !ok {
-			panic("bug: unknown device should already have been rejected")
+			l.Infof("Device %s removed from config during connection attempt at %s", remoteID, c)
+			c.Close()
+			continue
 		}
 
 		// Verify the name on the certificate. By default we set it to


### PR DESCRIPTION
#5299 

The device config is queried from the wrapper multiple times during the connection process. Therefore it may happen that a device exists in the beginning of the attempt, and is removed at the point changed in this PR. The underlying problem is this inherent racyness of the current config system (#5298). Until that's fixed, lets not panic here and just drop the connection attempt.