### PR TITLE
lib/fs: Use os.FileMode.String for fs.FileMode

### DIFF
--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -79,6 +79,10 @@ type FileInfo interface {
 // FileMode is similar to os.FileMode
 type FileMode uint32
 
+func (fm FileMode) String() string {
+	return os.FileMode(fm).String()
+}
+
 // Usage represents filesystem space usage
 type Usage struct {
 	Free  int64

--- a/lib/fs/filesystem_test.go
+++ b/lib/fs/filesystem_test.go
@@ -98,3 +98,11 @@ func TestCanonicalize(t *testing.T) {
 		}
 	}
 }
+
+func TestFileModeString(t *testing.T) {
+	var fm FileMode = 0777
+	exp := "-rwxrwxrwx"
+	if fm.String() != exp {
+		t.Fatalf("Got %v, expected %v", fm.String(), exp)
+	}
+}


### PR DESCRIPTION
Just makes logged permissions a bit easier to read.