### PR TITLE
gui: 'Select/Deselect All' tick box when adding new folder/device or editing folder/device(#fixes 4000)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1371,6 +1371,20 @@ angular.module('syncthing.core')
             $('#editDevice').modal();
         };
 
+        $scope.selectAllFolders = function() {
+            Object.entries($scope.folders).forEach(entry =>{
+                let id = entry[1].id;
+                $scope.currentDevice.selectedFolders[id] = true;
+            });
+        };
+
+        $scope.deSelectAllFolders = function() {
+            Object.entries($scope.folders).forEach(entry =>{
+                let id = entry[1].id;
+                $scope.currentDevice.selectedFolders[id] = false;
+            });
+        };
+
         $scope.addDevice = function (deviceID, name) {
             return $http.get(urlbase + '/system/discovery')
                 .success(function (registry) {
@@ -1692,6 +1706,20 @@ angular.module('syncthing.core')
                 });
 
             $scope.editFolderModal();
+        };
+
+        $scope.selectAllDevices = function() {
+            var devices = $scope.otherDevices();
+            for (var i = 0; i < devices.length; i++){
+                $scope.currentFolder.selectedDevices[devices[i].deviceID] = true;
+            }
+        };
+
+        $scope.deSelectAllDevices = function() {
+            var devices = $scope.otherDevices();
+            for (var i = 0; i < devices.length; i++){
+                $scope.currentFolder.selectedDevices[devices[i].deviceID] = false;
+            }
         };
 
         $scope.addFolder = function () {

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -69,7 +69,8 @@
                 <label translate for="folders">Share Folders With Device</label>
                 <p class="help-block">
                   <span translate>Select the folders to share with this device.</span>&emsp;
-                  <small><a ng-click="selectAllFolders()" translate>Select All</a> - <a ng-click="deSelectAllFolders()" translate>Deselect All</a></small>
+                  <small><a href="#" ng-click="selectAllFolders()" translate>Select All</a>&emsp;
+                    <a href="#" ng-click="deSelectAllFolders()" translate>Deselect All</a></small>
                 </p>
                 <div class="row">
                   <div class="col-md-4" ng-repeat="folder in folderList()">

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -67,7 +67,10 @@
             <div class="col-md-12">
               <div class="form-group">
                 <label translate for="folders">Share Folders With Device</label>
-                <p translate class="help-block">Select the folders to share with this device.</p>
+                <p class="help-block">
+                  <span translate>Select the folders to share with this device.</span>&emsp;
+                  <small><a ng-click="selectAllFolders()" translate>Select All</a> - <a ng-click="deSelectAllFolders()" translate>Deselect All</a></small>
+                </p>
                 <div class="row">
                   <div class="col-md-4" ng-repeat="folder in folderList()">
                     <div class="checkbox">

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -42,7 +42,10 @@
           </div>
           <div class="form-group">
             <label translate for="devices">Share With Devices</label>
-            <p translate class="help-block">Select the devices to share this folder with.</p>
+            <p class="help-block">
+              <span translate>Select the devices to share this folder with.</span>&emsp;
+              <small><a ng-click="selectAllDevices()" translate>Select All</a> - <a ng-click="deSelectAllDevices()" translate>Deselect All</a></small>
+            </p>
             <div class="row">
               <div class="col-md-4" ng-repeat="device in otherDevices()">
                 <div class="checkbox">

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -44,7 +44,8 @@
             <label translate for="devices">Share With Devices</label>
             <p class="help-block">
               <span translate>Select the devices to share this folder with.</span>&emsp;
-              <small><a ng-click="selectAllDevices()" translate>Select All</a> - <a ng-click="deSelectAllDevices()" translate>Deselect All</a></small>
+              <small><a href="#" ng-click="selectAllDevices()" translate>Select All</a>&emsp;
+                <a href="#" ng-click="deSelectAllDevices()" translate>Deselect All</a></small>
             </p>
             <div class="row">
               <div class="col-md-4" ng-repeat="device in otherDevices()">


### PR DESCRIPTION
### Purpose

To allow **selecting or if all selected let deselecting all tick boxes** (toggle) when adding new folder (`Add Folder`), new device (`Add Remote Device`) or using `Edit` button on folder (under 'Folders') and device (under 'Remote Devices').

### Screenshots

- **`Select All`**

<img width="726" alt="screen shot 2018-11-04 at 15 51 55" src="https://user-images.githubusercontent.com/29825419/47964344-98b74600-e030-11e8-8e81-5ff0c3f67abe.png">

- **`Deselect All`**

<img width="713" alt="screen shot 2018-11-04 at 15 52 01" src="https://user-images.githubusercontent.com/29825419/47964345-98b74600-e030-11e8-8406-fc37b552dcbb.png">

### Documentation

No need.




