### PR TITLE
fix socket path and do not run syncthing as root

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -9,6 +9,7 @@ ExecStart=/usr/bin/syncthing -no-browser -no-restart -logflags=0
 Restart=on-failure
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
+RuntimeDirectory=syncthing
 
 [Install]
 WantedBy=multi-user.target

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Syncthing - Open Source Continuous File Synchronization
+ConditionUser=!@system
 Documentation=man:syncthing(1)
 
 [Service]

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -7,6 +7,7 @@ ExecStart=/usr/bin/syncthing -no-browser -no-restart -logflags=0
 Restart=on-failure
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
+RuntimeDirectory=syncthing
 
 [Install]
 WantedBy=default.target

--- a/man/syncthing.1
+++ b/man/syncthing.1
@@ -84,7 +84,7 @@ Generate key and config in specified dir, then exit.
 .TP
 .B \-gui\-address=<address>
 Override GUI listen address. Set this to an address (\fB0.0.0.0:8384\fP)
-or file path (\fB/var/run/st.sock\fP, for UNIX sockets).
+or file path (\fB/run/syncthing/st.sock\fP, for UNIX sockets).
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
### Purpose

The documentation currently mentions /var/run/st.sock as a suggested location
for the socket file which has a couple of problems:

 - /var/run has been deprecated in favour of /run for a long time (both still
   work as most distributions set up a symlink)
 - when running as a system instance as a given user, the user will most likely
   not have permissions to write directly to /run

So we change the suggested socket path to /run/syncthing/st.sock and have the
systemd units take care of creating the directory. Further to #3616.

Secondly, it is possible to tell systemd to enable a unit for all users in one go which
will configure *user* services for every user:
systemctl --global enable syncthing.service

The problem with that is that root or other system users will then also try to
spawn a syncthing instance on login which is probably not what you want.

Instead only enable the *user* service for normal users.

### Testing

I have been using the 2nd commit for months. The first commit doesn't change any existing behaviour and thus cannot break anything.

### Documentation

Man page is updated accordingly.