### PR TITLE
lib/model: Don't compare permissions if IgnorePerms is true

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -876,7 +876,7 @@ func (f *sendReceiveFolder) renameFile(cur, source, target protocol.FileInfo, db
 		err = errModified
 	default:
 		if fi, err := scanner.CreateFileInfo(stat, target.Name, f.fs); err == nil {
-			if !fi.IsEquivalentOptional(curTarget, false, true, protocol.LocalAllFlags) {
+			if !fi.IsEquivalentOptional(curTarget, f.IgnorePerms, true, protocol.LocalAllFlags) {
 				// Target changed
 				scanChan <- target.Name
 				err = errModified
@@ -1880,7 +1880,7 @@ func (f *sendReceiveFolder) checkToBeDeleted(cur protocol.FileInfo, scanChan cha
 	if err != nil {
 		return err
 	}
-	if !fi.IsEquivalentOptional(cur, false, true, protocol.LocalAllFlags) {
+	if !fi.IsEquivalentOptional(cur, f.IgnorePerms, true, protocol.LocalAllFlags) {
 		// File changed
 		scanChan <- cur.Name
 		return errModified


### PR DESCRIPTION
The fixed problem is likely the cause of https://forum.syncthing.net/t/0-14-52-file-deletion-issues/12436. "Likely" because I didn't reproduce (try to) myself, but the mechanism is clear: Local device ignores permissions but the remote does not, then different permissions let the consistency check fail when deleting the file and scheduls it for scanning. Scanning won't detect a change, because it does correctly ignore permissions.