### PR TITLE
lib: Introduce fs.IsParent (fixes #5324)

### DIFF
--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -199,12 +199,11 @@ func NewFilesystem(fsType FilesystemType, uri string) Filesystem {
 func IsInternal(file string) bool {
 	// fs cannot import config, so we hard code .stfolder here (config.DefaultMarkerName)
 	internals := []string{".stfolder", ".stignore", ".stversions"}
-	pathSep := string(PathSeparator)
 	for _, internal := range internals {
 		if file == internal {
 			return true
 		}
-		if strings.HasPrefix(file, internal+pathSep) {
+		if IsParent(file, internal) {
 			return true
 		}
 	}

--- a/lib/fs/util.go
+++ b/lib/fs/util.go
@@ -79,6 +79,11 @@ func WindowsInvalidFilename(name string) bool {
 }
 
 func IsParent(path, parent string) bool {
+	if len(parent) == 0 {
+		// The empty string is the parent of everything except the empty
+		// string. (Avoids panic in the next step.)
+		return len(path) > 0
+	}
 	if parent[len(parent)-1] != PathSeparator {
 		parent += string(PathSeparator)
 	}

--- a/lib/fs/util.go
+++ b/lib/fs/util.go
@@ -77,3 +77,10 @@ func WindowsInvalidFilename(name string) bool {
 	// The path must not contain any disallowed characters
 	return strings.ContainsAny(name, windowsDisallowedCharacters)
 }
+
+func IsParent(path, parent string) bool {
+	if parent[len(parent)-1] != PathSeparator {
+		parent += string(PathSeparator)
+	}
+	return strings.HasPrefix(path, parent)
+}

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -336,7 +336,7 @@ func loadParseIncludeFile(filesystem fs.Filesystem, file string, cd ChangeDetect
 	if filesystem.Type() == fs.FilesystemTypeBasic {
 		uri := filesystem.URI()
 		joined := filepath.Join(uri, file)
-		if !strings.HasPrefix(joined, uri) {
+		if !fs.IsParent(joined, uri) {
 			filesystem = fs.NewFilesystem(filesystem.Type(), filepath.Dir(joined))
 			file = filepath.Base(joined)
 		}

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -699,7 +699,7 @@ func (f *folder) clearScanErrors(subDirs []string) {
 outer:
 	for _, fe := range f.scanErrors {
 		for _, sub := range subDirs {
-			if fs.IsParent(fe.Path, sub) {
+			if fe.Path == sub || fs.IsParent(fe.Path, sub) {
 				continue outer
 			}
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -288,7 +288,7 @@ func (m *Model) warnAboutOverwritingProtectedFiles(folder string) {
 	var filesAtRisk []string
 	for _, protectedFilePath := range m.protectedFiles {
 		// check if file is synced in this folder
-		if !strings.HasPrefix(protectedFilePath, folderLocation) {
+		if !fs.IsParent(protectedFilePath, folderLocation) {
 			continue
 		}
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -288,7 +288,7 @@ func (m *Model) warnAboutOverwritingProtectedFiles(folder string) {
 	var filesAtRisk []string
 	for _, protectedFilePath := range m.protectedFiles {
 		// check if file is synced in this folder
-		if !fs.IsParent(protectedFilePath, folderLocation) {
+		if protectedFilePath != folderLocation && !fs.IsParent(protectedFilePath, folderLocation) {
 			continue
 		}
 

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -250,7 +250,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 				return skip
 			}
 			// If the parent wasn't ignored already, set this path as the "highest" ignored parent
-			if info.IsDir() && (ignoredParent == "" || !strings.HasPrefix(path, ignoredParent+string(fs.PathSeparator))) {
+			if info.IsDir() && (ignoredParent == "" || !fs.IsParent(path, ignoredParent)) {
 				ignoredParent = path
 			}
 			return nil


### PR DESCRIPTION
https://github.com/syncthing/syncthing/issues/5324#issuecomment-438179326 by @calmh :
> Path prefixes are Hard™ :)

Make it harder to mess prefixes up by replacing the `strings.HasPrefix(..., ...+pathSeparator)` dance with `fs.IsParent(..., ...)`.