### PR TITLE
lib/scanner, vendor: Update github.com/chmduquesne/rollinghash (fixes #5334)

### DIFF
--- a/lib/scanner/blocks_test.go
+++ b/lib/scanner/blocks_test.go
@@ -144,14 +144,13 @@ func TestAdler32Variants(t *testing.T) {
 
 	windowSize := 128
 
-	hf2.Reset()
-
 	hf3 := rollingAdler32.New()
 	hf3.Write(data[:windowSize])
 
 	for i := windowSize; i < len(data); i++ {
 		if i%windowSize == 0 {
 			// let the reference function catch up
+			hf2.Reset()
 			hf2.Write(data[i-windowSize : i])
 
 			// verify that they are in sync with the rolling function

--- a/vendor/github.com/chmduquesne/rollinghash/adler32/adler32.go
+++ b/vendor/github.com/chmduquesne/rollinghash/adler32/adler32.go
@@ -18,23 +18,24 @@ const (
 // It implements the adler32 algorithm https://en.wikipedia.org/wiki/Adler-32
 type Adler32 struct {
 	a, b uint32
+	n    uint32
 
 	// window is treated like a circular buffer, where the oldest element
 	// is indicated by d.oldest
 	window []byte
 	oldest int
-	n      uint32
 
 	vanilla hash.Hash32
 }
 
 // Reset resets the digest to its initial state.
 func (d *Adler32) Reset() {
-	d.window = d.window[:1] // Reset the size but don't reallocate
-	d.window[0] = 0
+	d.window = d.window[:0] // Reset the size but don't reallocate
+	d.oldest = 0
 	d.a = 1
 	d.b = 0
-	d.oldest = 0
+	d.n = 0
+	d.vanilla.Reset()
 }
 
 // New returns a new Adler32 digest
@@ -42,7 +43,8 @@ func New() *Adler32 {
 	return &Adler32{
 		a:       1,
 		b:       0,
-		window:  make([]byte, 1, rollinghash.DefaultWindowCap),
+		n:       0,
+		window:  make([]byte, 0, rollinghash.DefaultWindowCap),
 		oldest:  0,
 		vanilla: vanilla.New(),
 	}
@@ -54,30 +56,30 @@ func (d *Adler32) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Adler32) BlockSize() int { return 1 }
 
-// Write (re)initializes the rolling window with the input byte slice and
-// adds its data to the digest.
-func (d *Adler32) Write(p []byte) (int, error) {
-	// Copy the window, avoiding allocations where possible
-	l := len(p)
+// Write appends data to the rolling window and updates the digest.
+func (d *Adler32) Write(data []byte) (int, error) {
+	l := len(data)
 	if l == 0 {
-		l = 1
+		return 0, nil
 	}
-	if len(d.window) != l {
-		if cap(d.window) >= l {
-			d.window = d.window[:l]
-		} else {
-			d.window = make([]byte, len(p))
-		}
+	// Re-arrange the window so that the leftmost element is at index 0
+	n := len(d.window)
+	if d.oldest != 0 {
+		tmp := make([]byte, d.oldest)
+		copy(tmp, d.window[:d.oldest])
+		copy(d.window, d.window[d.oldest:])
+		copy(d.window[n-d.oldest:], tmp)
+		d.oldest = 0
 	}
-	copy(d.window, p)
+	d.window = append(d.window, data...)
 
 	// Piggy-back on the core implementation
 	d.vanilla.Reset()
-	d.vanilla.Write(p)
+	d.vanilla.Write(d.window)
 	s := d.vanilla.Sum32()
 	d.a, d.b = s&0xffff, s>>16
-	d.n = uint32(len(p)) % Mod
-	return len(d.window), nil
+	d.n = uint32(len(d.window)) % Mod
+	return len(data), nil
 }
 
 // Sum32 returns the hash as a uint32
@@ -94,6 +96,12 @@ func (d *Adler32) Sum(b []byte) []byte {
 // Roll updates the checksum of the window from the entering byte. You
 // MUST initialize a window with Write() before calling this method.
 func (d *Adler32) Roll(b byte) {
+	// This check costs 10-15% performance. If we disable it, we crash
+	// when the window is empty. If we enable it, we are always correct
+	// (an empty window never changes no matter how much you roll it).
+	//if len(d.window) == 0 {
+	//	return
+	//}
 	// extract the entering/leaving bytes and update the circular buffer.
 	enter := uint32(b)
 	leave := uint32(d.window[d.oldest])

--- a/vendor/github.com/chmduquesne/rollinghash/buzhash64/buzhash64.go
+++ b/vendor/github.com/chmduquesne/rollinghash/buzhash64/buzhash64.go
@@ -65,7 +65,7 @@ func New() *Buzhash64 {
 func NewFromUint64Array(b [256]uint64) *Buzhash64 {
 	return &Buzhash64{
 		sum:      0,
-		window:   make([]byte, 1, rollinghash.DefaultWindowCap),
+		window:   make([]byte, 0, rollinghash.DefaultWindowCap),
 		oldest:   0,
 		bytehash: b,
 	}
@@ -77,30 +77,32 @@ func (d *Buzhash64) Size() int { return Size }
 // BlockSize is 1 byte
 func (d *Buzhash64) BlockSize() int { return 1 }
 
-// Write (re)initializes the rolling window with the input byte slice and
-// adds its data to the digest.
+// Write appends data to the rolling window and updates the digest. It
+// never returns an error.
 func (d *Buzhash64) Write(data []byte) (int, error) {
-	// Copy the window, avoiding allocations where possible
 	l := len(data)
 	if l == 0 {
-		l = 1
+		return 0, nil
 	}
-	if len(d.window) != l {
-		if cap(d.window) >= l {
-			d.window = d.window[:l]
-		} else {
-			d.window = make([]byte, l)
-		}
+	// Re-arrange the window so that the leftmost element is at index 0
+	n := len(d.window)
+	if d.oldest != 0 {
+		tmp := make([]byte, d.oldest)
+		copy(tmp, d.window[:d.oldest])
+		copy(d.window, d.window[d.oldest:])
+		copy(d.window[n-d.oldest:], tmp)
+		d.oldest = 0
 	}
-	copy(d.window, data)
+	d.window = append(d.window, data...)
 
+	d.sum = 0
 	for _, c := range d.window {
 		d.sum = d.sum<<1 | d.sum>>63
 		d.sum ^= d.bytehash[int(c)]
 	}
 	d.nRotate = uint(len(d.window)) % 64
 	d.nRotateComplement = 64 - d.nRotate
-	return len(d.window), nil
+	return len(data), nil
 }
 
 // Sum64 returns the hash as a uint64
@@ -117,6 +119,13 @@ func (d *Buzhash64) Sum(b []byte) []byte {
 // Roll updates the checksum of the window from the entering byte. You
 // MUST initialize a window with Write() before calling this method.
 func (d *Buzhash64) Roll(c byte) {
+	// This check costs 10-15% performance. If we disable it, we crash
+	// when the window is empty. If we enable it, we are always correct
+	// (an empty window never changes no matter how much you roll it).
+	//if len(d.window) == 0 {
+	//	return
+	//}
+
 	// extract the entering/leaving bytes and update the circular buffer.
 	hn := d.bytehash[int(c)]
 	h0 := d.bytehash[int(d.window[d.oldest])]

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -94,7 +94,7 @@
 			"importpath": "github.com/chmduquesne/rollinghash",
 			"repository": "https://github.com/chmduquesne/rollinghash",
 			"vcs": "git",
-			"revision": "abb8cbaf9915e48ee20cae94bcd94221b61707a2",
+			"revision": "a60f8e7142b536ea61bb5d84014171189eeaaa81",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Updates the package and fixes a test that depended on the old behavior
of Write() being equivalent to Reset()+Write() which is no longer the
case. The scanner already did resets after each block write, so this is
fine.
