### PR TITLE
gui: css: use lining nums for Raleway font

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -15,6 +15,7 @@ body {
 h1, h2, h3, h4, h5 {
     font-family: "Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;
     line-height: 1.25;
+    font-variant-numeric: lining-nums;
 }
 
 ul+h5 {


### PR DESCRIPTION
The "old-style" numerals have ascenders and descenders that break the horizontal text alignment.
Nice for fancy magazine text, not so nice for matter-of-fact information-dense interfaces like syncthing web.
Solution: Use lining numerals via css font property.

### Purpose

Improve readability for web interface with Raleway font.

### Testing

View the change in the web interface.

### Screenshots

Old-style numerals(note the "9" and "3" in particular): 
![syncthing-oldstyle](https://user-images.githubusercontent.com/10212877/49334653-4c353b00-f5db-11e8-9687-0dbff13de952.png)
Lining numerals:
![syncthing-lining](https://user-images.githubusercontent.com/10212877/49334650-43dd0000-f5db-11e8-8ac0-95910e97d5bd.png)

### Documentation
---

## Authorship
ix5