### PR TITLE
Add hardening options to syncthing systemd services (fixes #5286)

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -10,5 +10,12 @@ Restart=on-failure
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 
+# Hardening
+ProtectSystem=full
+PrivateTmp=true
+SystemCallArchitectures=native
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+
 [Install]
 WantedBy=multi-user.target

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -8,5 +8,12 @@ Restart=on-failure
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 
+# Hardening
+ProtectSystem=full
+PrivateTmp=true
+SystemCallArchitectures=native
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
This fixes #5286 by adding security options to Syncthing systemd service files.

See the related pull request for the relay service options, for the rationale on the choice of options : https://github.com/syncthing/syncthing/pull/5350#pullrequestreview-182004704

In summary :
* we want to reduce the scope of what the executable can do, because syncthing will likely run on public facing IP, so is a target for attack
* we want to restrict capabilities, but not overdo it because the service will not run as root anyway
* we can not be as restrictive as with the relay service because its uses, and particularly the paths it will read/write to are not predictible

Compared to the relay hardening options:
* we use `ProtectSystem=full` instead of the more restrictive `ReadOnlyPaths=/  ReadWritePaths=/var/lib/syncthing-relaysrv` because we don't know where syncthing may need to write
* we can not use `ProtectHome=true`, because syncthing may need to read/write files in `/home`
* we can not use `PrivateDevices=true` either, because otherwise systemd throws this error:
```
syncthing.service: Failed to drop capabilities: Operation not permitted
syncthing.service: Failed at step CAPABILITIES spawning /usr/bin/syncthing: Operation not permitted
```
I am not 100% sure, but I presume this is because the systemd user process does not have the required capabilities to setup the `/dev` mount namespace.

I have tested it in the following configurations:
* `syncthing.service`: Ubuntu 18.04, Syncthing 0.14.53
* `syncthing@.service`: Arch Linux, Syncthing 0.14.52

