### PR TITLE
gui: Display ETA while syncing (fixes #899)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -325,7 +325,11 @@
                   <span ng-switch-when="idle"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="syncing">
                     <span class="hidden-xs" translate>Syncing</span>
-                    <span ng-show="syncRemaining(folder.id)">({{syncPercentage(folder.id) | percent}}, {{syncRemaining(folder.id) | binary}}B)</span>
+                    <span ng-show="syncRemaining(folder.id)">
+                      ({{syncPercentage(folder.id) | percent}}, {{syncRemaining(folder.id) | binary}}B)
+                      <small style="display:block;text-align:right;"><span class="far fa-clock"></span> {{syncFolderETA(folder) | duration}}</small>
+                      <!-- #TODO external css #TODO hide eta on small displays #TODO alternative: move size to second line -->
+                    </span>
                   </span>
                   <span ng-switch-when="outofsync"><span class="hidden-xs" translate>Out of Sync</span><span class="visible-xs">&#9724;</span></span>
                 </div>
@@ -650,7 +654,8 @@
                   <span ng-switch-when="insync"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="syncing">
                     <span class="hidden-xs" translate>Syncing</span> ({{completion[deviceCfg.deviceID]._total | percent}}, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
-                  </span>
+                    <small style="display:block;text-align:right;"><span class="far fa-clock"></span> {{syncDeviceETA(deviceCfg.deviceID) | duration}}</small>
+                  </span><!-- #TODO external css #TODO hide eta on small displays #TODO alternative: move size to second line  -->
                   <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="disconnected"><span class="hidden-xs" translate>Disconnected</span><span class="visible-xs">&#9724;</span></span>
                   <span ng-switch-when="unused"><span class="hidden-xs" translate>Unused</span><span class="visible-xs">&#9724;</span></span>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -813,6 +813,39 @@ angular.module('syncthing.core')
             return bytes;
         };
 
+        // Show ETA #TODO icon, duration format, &infin;  if not set or longer than 30 days  #TODO alternative: display only largest duration unit, e.g. 1d, then 23h, then 59m  #TODO two lines or one?
+        $scope.showETA = function (bytes, rate) {
+            if (bytes == 0 || rate == 0) {
+                return 0;  //#TODO undefined?
+            }
+            return Math.floor(bytes / rate);
+        };
+
+        // ETA for device #TODO testing
+        $scope.syncDeviceETA = function (deviceID) {
+
+            // Output
+            return $scope.showETA($scope.completion[deviceID]._needBytes, $scope.connections[deviceID].outbps);
+        };
+
+        // ETA for folder #TODO testing
+        $scope.syncFolderETA = function (folder) {
+
+            // Read download rates from all devices that share this folder, use fastest one for calculation
+            var rates = [];
+            folder.devices.forEach(function (device) {
+                if (device.deviceID !== $scope.myID) {
+                    rates.push($scope.connections[device.deviceID].inbps);
+                }
+            });
+            var maxrate = Math.max.apply(null, rates);
+            console.log(rates); //#TODO delete
+            console.log('max: ' + maxrate);  //#TODO delete
+
+            // Output
+            return $scope.showETA($scope.syncRemaining(folder.id), maxrate);
+        };
+
         $scope.scanPercentage = function (folder) {
             if (!$scope.scanProgress[folder]) {
                 return undefined;


### PR DESCRIPTION
Display ETA while syncing

- [x] ETA for device
- [ ] ETA for folder
- [ ] CSS styling (two lines for status - see [idea](https://github.com/syncthing/syncthing/pull/3928#issuecomment-274993674))

-wip, do not merge-