### PR TITLE
Fix comments according to best practices by effective go

### DIFF
--- a/cmd/stdisco/main.go
+++ b/cmd/stdisco/main.go
@@ -61,7 +61,7 @@ func runbeacon(bc beacon.Interface, fake bool) {
 	}
 }
 
-// receives and prints discovery announcements
+// recv receives and prints discovery announcements
 func recv(bc beacon.Interface) {
 	seen := make(map[string]bool)
 	for {
@@ -104,7 +104,7 @@ func send(bc beacon.Interface) {
 	}
 }
 
-// returns a random but recognizable device ID
+// randomDeviceID returns a random but recognizable device ID
 func randomDeviceID() protocol.DeviceID {
 	var id protocol.DeviceID
 	copy(id[:], randomPrefix)

--- a/cmd/strelaypoolsrv/stats.go
+++ b/cmd/strelaypoolsrv/stats.go
@@ -230,7 +230,7 @@ func deleteMetrics(host string) {
 	delete(lastStats, host)
 }
 
-// Due to some unexplainable behaviour, some of the numbers sometimes travel slightly backwards (by less than 1%)
+// mergeStats; Due to some unexplainable behaviour, some of the numbers sometimes travel slightly backwards (by less than 1%)
 // This happens between scrapes, which is 30s, so this can't be a race.
 // This causes prometheus to assume a "rate reset", hence causes phenomenal spikes.
 // One of the number that moves backwards is BytesProxied, which atomically increments a counter with numeric value

--- a/cmd/stvanity/main.go
+++ b/cmd/stvanity/main.go
@@ -68,7 +68,7 @@ func main() {
 	fmt.Println("Saved to cert.pem, key.pem")
 }
 
-// Try certificates until one is found that has the prefix at the start of
+// generatePrefixed; Try certificates until one is found that has the prefix at the start of
 // the resulting device ID. Increments count atomically, sends the result to
 // found, returns when stop is closed.
 func generatePrefixed(prefix string, count *int64, found chan<- result, stop <-chan struct{}) {

--- a/cmd/syncthing/gui_auth.go
+++ b/cmd/syncthing/gui_auth.go
@@ -163,7 +163,7 @@ func authLDAP(username string, password string, cfg config.LDAPConfiguration) bo
 	return true
 }
 
-// Convert an ISO-8859-1 encoded byte string to UTF-8. Works by the
+// iso88591ToUTF8; Convert an ISO-8859-1 encoded byte string to UTF-8. Works by the
 // principle that ISO-8859-1 bytes are equivalent to unicode code points,
 // that a rune slice is a list of code points, and that stringifying a slice
 // of runes generates UTF-8 in Go.

--- a/cmd/syncthing/gui_csrf.go
+++ b/cmd/syncthing/gui_csrf.go
@@ -29,7 +29,7 @@ var csrfMut = sync.NewMutex()
 
 const maxCsrfTokens = 25
 
-// Check for CSRF token on /rest/ URLs. If a correct one is not given, reject
+// csrfMiddleware; Check for CSRF token on /rest/ URLs. If a correct one is not given, reject
 // the request with 403. For / and /index.html, set a new CSRF cookie if none
 // is currently set.
 func csrfMiddleware(unique string, prefix string, cfg config.GUIConfiguration, next http.Handler) http.Handler {

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -368,7 +368,7 @@ func (f *autoclosedFile) Close() error {
 	return nil
 }
 
-// Must be called with f.mut held!
+// ensureOpen; Must be called with f.mut held!
 func (f *autoclosedFile) ensureOpen() error {
 	if f.fd != nil {
 		// File is already open
@@ -414,7 +414,7 @@ func (f *autoclosedFile) closerLoop() {
 	}
 }
 
-// Returns the desired child environment, properly filtered and added to.
+// childEnv returns the desired child environment, properly filtered and added to.
 func childEnv() []string {
 	var env []string
 	for _, str := range os.Environ() {

--- a/cmd/ursrv/analytics.go
+++ b/cmd/ursrv/analytics.go
@@ -40,7 +40,7 @@ func (l analyticList) Len() int {
 	return len(l)
 }
 
-// Returns a list of frequency analytics for a given list of strings.
+// analyticsFor returns a list of frequency analytics for a given list of strings.
 func analyticsFor(ss []string, cutoff int) []analytic {
 	m := make(map[string]int)
 	t := 0
@@ -75,7 +75,7 @@ func analyticsFor(ss []string, cutoff int) []analytic {
 	return l
 }
 
-// Find the points at which certain penetration levels are met
+// penetrationLevels; Find the points at which certain penetration levels are met
 func penetrationLevels(as []analytic, points []float64) []analytic {
 	sort.Slice(as, func(a, b int) bool {
 		return versionLess(as[b].Key, as[a].Key)
@@ -216,7 +216,7 @@ func versionLess(a, b string) bool {
 	return false
 }
 
-// Split a version as returned from transformVersion into parts.
+// versionParts; Split a version as returned from transformVersion into parts.
 // "1.2.3-beta.2" -> []int{1, 2, 3}, "beta.2"}
 func versionParts(v string) ([]int, string) {
 	parts := strings.SplitN(v[1:], " ", 2) // " (+dev)" versions

--- a/lib/connections/limiter.go
+++ b/lib/connections/limiter.go
@@ -52,7 +52,7 @@ func newLimiter(cfg *config.Wrapper) *limiter {
 	return l
 }
 
-// This function sets limiters according to corresponding DeviceConfiguration
+// setLimitsLocked sets limiters according to corresponding DeviceConfiguration
 func (lim *limiter) setLimitsLocked(device config.DeviceConfiguration) bool {
 	readLimiter := lim.getReadLimiterLocked(device.DeviceID)
 	writeLimiter := lim.getWriteLimiterLocked(device.DeviceID)
@@ -79,7 +79,7 @@ func (lim *limiter) setLimitsLocked(device config.DeviceConfiguration) bool {
 	return true
 }
 
-// This function handles removing, adding and updating of device limiters.
+// processDevicesConfigurationLocked handles removing, adding and updating of device limiters.
 func (lim *limiter) processDevicesConfigurationLocked(from, to config.Configuration) {
 	seen := make(map[protocol.DeviceID]struct{})
 

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -49,7 +49,7 @@ func (m *metadataTracker) Unmarshal(bs []byte) error {
 	return nil
 }
 
-// Unmarshal returns the protobuf representation of the metadataTracker
+// Marshal returns the protobuf representation of the metadataTracker
 func (m *metadataTracker) Marshal() ([]byte, error) {
 	return m.counts.Marshal()
 }

--- a/lib/db/namespaced.go
+++ b/lib/db/namespaced.go
@@ -173,7 +173,7 @@ func NewFolderStatisticsNamespace(db *Lowlevel, folder string) *NamespacedKV {
 	return NewNamespacedKV(db, string(KeyTypeFolderStatistic)+folder)
 }
 
-// NewMiscDateNamespace creates a KV namespace for miscellaneous metadata.
+// NewMiscDataNamespace creates a KV namespace for miscellaneous metadata.
 func NewMiscDataNamespace(db *Lowlevel) *NamespacedKV {
 	return NewNamespacedKV(db, string(KeyTypeMiscData))
 }

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -221,7 +221,7 @@ func (s *FileSet) WithHaveSequence(startSeq int64, fn Iterator) {
 	s.db.withHaveSequence([]byte(s.folder), startSeq, nativeFileIterator(fn))
 }
 
-// Except for an item with a path equal to prefix, only children of prefix are iterated.
+// WithPrefixedHaveTruncated; Except for an item with a path equal to prefix, only children of prefix are iterated.
 // E.g. for prefix "dir", "dir/file" is iterated, but "dir.file" is not.
 func (s *FileSet) WithPrefixedHaveTruncated(device protocol.DeviceID, prefix string, fn Iterator) {
 	l.Debugf(`%s WithPrefixedHaveTruncated(%v, "%v")`, s.folder, device, prefix)
@@ -237,7 +237,7 @@ func (s *FileSet) WithGlobalTruncated(fn Iterator) {
 	s.db.withGlobal([]byte(s.folder), nil, true, nativeFileIterator(fn))
 }
 
-// Except for an item with a path equal to prefix, only children of prefix are iterated.
+// WithPrefixedGlobalTruncated; Except for an item with a path equal to prefix, only children of prefix are iterated.
 // E.g. for prefix "dir", "dir/file" is iterated, but "dir.file" is not.
 func (s *FileSet) WithPrefixedGlobalTruncated(prefix string, fn Iterator) {
 	l.Debugf(`%s WithPrefixedGlobalTruncated("%v")`, s.folder, prefix)

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -140,7 +140,7 @@ func (t readWriteTransaction) updateGlobal(gk, folder, device []byte, file proto
 	return true
 }
 
-// updateLocalNeeds checks whether the given file is still needed on the local
+// updateLocalNeed checks whether the given file is still needed on the local
 // device according to the version list and global FileInfo given and updates
 // the db accordingly.
 func (t readWriteTransaction) updateLocalNeed(folder, name []byte, fl VersionList, global protocol.FileInfo) {

--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -83,7 +83,7 @@ func dialWithFallback(proxyDialFunc dialFunc, fallbackDialFunc dialFunc, network
 	return conn, err
 }
 
-// This is a rip off of proxy.FromURL for "socks" URL scheme
+// socksDialerFunction is a rip off of proxy.FromURL for "socks" URL scheme
 func socksDialerFunction(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
 	var auth *proxy.Auth
 	if u.User != nil {
@@ -97,7 +97,7 @@ func socksDialerFunction(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error)
 	return proxy.SOCKS5("tcp", u.Host, auth, forward)
 }
 
-// This is a rip off of proxy.FromEnvironment with a custom forward dialer
+// getDialer is a rip off of proxy.FromEnvironment with a custom forward dialer
 func getDialer(forward proxy.Dialer) proxy.Dialer {
 	allProxy := os.Getenv("all_proxy")
 	if len(allProxy) == 0 {

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -33,7 +33,7 @@ func (BasicFilesystem) CreateSymlink(target, name string) error {
 	return errNotSupported
 }
 
-// Required due to https://github.com/golang/go/issues/10900
+// mkdirAll; Required due to https://github.com/golang/go/issues/10900
 func (f *BasicFilesystem) mkdirAll(path string, perm os.FileMode) error {
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
 	dir, err := os.Stat(path)

--- a/lib/fs/lstat_broken.go
+++ b/lib/fs/lstat_broken.go
@@ -14,7 +14,7 @@ import (
 	"time"
 )
 
-// Lstat is like os.Lstat, except lobotomized for Android. See
+// underlyingLstat is like os.Lstat, except lobotomized for Android. See
 // https://forum.syncthing.net/t/2395
 func underlyingLstat(name string) (fi os.FileInfo, err error) {
 	for i := 0; i < 10; i++ { // We have to draw the line somewhere

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -90,12 +90,12 @@ func (l *logger) AddHandler(level LogLevel, h MessageHandler) {
 	l.handlers[level] = append(l.handlers[level], h)
 }
 
-// See log.SetFlags
+// SetFlags; See log.SetFlags
 func (l *logger) SetFlags(flag int) {
 	l.logger.SetFlags(flag)
 }
 
-// See log.SetPrefix
+// SetPrefix; See log.SetPrefix
 func (l *logger) SetPrefix(prefix string) {
 	l.logger.SetPrefix(prefix)
 }
@@ -132,7 +132,7 @@ func (l *logger) debugf(level int, format string, vals ...interface{}) {
 	l.callHandlers(LevelDebug, s)
 }
 
-// Infoln logs a line with a VERBOSE prefix.
+// Verboseln; Infoln logs a line with a VERBOSE prefix.
 func (l *logger) Verboseln(vals ...interface{}) {
 	s := fmt.Sprintln(vals...)
 	l.mut.Lock()
@@ -141,7 +141,7 @@ func (l *logger) Verboseln(vals ...interface{}) {
 	l.callHandlers(LevelVerbose, s)
 }
 
-// Infof logs a formatted line with a VERBOSE prefix.
+// Verbosef; Infof logs a formatted line with a VERBOSE prefix.
 func (l *logger) Verbosef(format string, vals ...interface{}) {
 	s := fmt.Sprintf(format, vals...)
 	l.mut.Lock()

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -721,7 +721,7 @@ func (f *folder) Errors() []FileError {
 	return append([]FileError{}, f.scanErrors...)
 }
 
-// The exists function is expected to return true for all known paths
+// unifySubs; The exists function is expected to return true for all known paths
 // (excluding "" and ".")
 func unifySubs(dirs []string, exists func(dir string) bool) []string {
 	if len(dirs) == 0 {

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1570,7 +1570,7 @@ func (f *sendReceiveFolder) finisherRoutine(ignores *ignore.Matcher, in <-chan *
 	}
 }
 
-// Moves the given filename to the front of the job queue
+// BringToFront moves the given filename to the front of the job queue
 func (f *sendReceiveFolder) BringToFront(filename string) {
 	f.queue.BringToFront(filename)
 }

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -400,7 +400,7 @@ func TestWeakHash(t *testing.T) {
 	}
 }
 
-// Test that updating a file removes its old blocks from the blockmap
+// TestCopierCleanup tests that updating a file removes its old blocks from the blockmap
 func TestCopierCleanup(t *testing.T) {
 	iterFn := func(folder, file string, index int32) bool {
 		return true

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1536,7 +1536,7 @@ type cFiler struct {
 	r string
 }
 
-// Implements scanner.CurrentFiler
+// CurrentFile implements scanner.CurrentFiler
 func (cf cFiler) CurrentFile(file string) (protocol.FileInfo, bool) {
 	return cf.m.CurrentFolderFile(cf.r, file)
 }
@@ -2618,7 +2618,7 @@ func (m *Model) checkFolderRunningLocked(folder string) error {
 	return errFolderNotRunning
 }
 
-// checkFolderDeviceStatusLocked first checks the folder and then whether the
+// checkDeviceFolderConnectedLocked first checks the folder and then whether the
 // given device is connected and shares this folder.
 // Need to hold (read) lock on both m.fmut and m.pmut when calling this.
 func (m *Model) checkDeviceFolderConnectedLocked(device protocol.DeviceID, folder string) error {
@@ -2662,7 +2662,7 @@ func mapDevices(devices []protocol.DeviceID) map[protocol.DeviceID]struct{} {
 	return m
 }
 
-// Skips `skip` elements and retrieves up to `get` elements from a given slice.
+// getChunk skips `skip` elements and retrieves up to `get` elements from a given slice.
 // Returns the resulting slice, plus how much elements are left to skip or
 // copy to satisfy the values which were provided, given the slice is not
 // big enough.

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -305,7 +305,7 @@ func TestPullInvalidIgnoredSR(t *testing.T) {
 	pullInvalidIgnored(t, config.FolderTypeSendReceive)
 }
 
-// This test checks that (un-)ignored/invalid/deleted files are treated as expected.
+// pullInvalidIgnored checks that (un-)ignored/invalid/deleted files are treated as expected.
 func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 	t.Helper()
 

--- a/lib/model/sharedpullerstate_test.go
+++ b/lib/model/sharedpullerstate_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/syncthing/syncthing/lib/sync"
 )
 
-// Test creating temporary file inside read-only directory
+// TestReadOnlyDir tests creating temporary file inside read-only directory
 func TestReadOnlyDir(t *testing.T) {
 	// Create a read only directory, clean it up afterwards.
 	os.Mkdir("testdata/read_only_dir", 0555)

--- a/lib/nat/structs.go
+++ b/lib/nat/structs.go
@@ -107,7 +107,7 @@ func (m *Mapping) GoString() string {
 	return m.String()
 }
 
-// Checks if the mappings local IP address matches the IP address of the gateway
+// validGateway checks if the mappings local IP address matches the IP address of the gateway
 // For example, if we are explicitly listening on 192.168.0.12, there is no
 // point trying to acquire a mapping on a gateway to which the local IP is
 // 10.0.0.1. Fallback to true if any of the IPs is not there.

--- a/lib/osutil/osutil.go
+++ b/lib/osutil/osutil.go
@@ -88,7 +88,7 @@ func InWritableDir(fn func(string) error, fs fs.Filesystem, path string) error {
 	return fn(path)
 }
 
-// Tries hard to succeed on various systems by temporarily tweaking directory
+// withPreparedTarget tries hard to succeed on various systems by temporarily tweaking directory
 // permissions and removing the destination file when necessary.
 func withPreparedTarget(filesystem fs.Filesystem, from, to string, f func() error) error {
 	// Make sure the destination directory is writeable

--- a/lib/protocol/benchmark_test.go
+++ b/lib/protocol/benchmark_test.go
@@ -101,7 +101,7 @@ func benchmarkRequestsConnPair(b *testing.B, conn0, conn1 net.Conn) {
 	}
 }
 
-// returns the two endpoints of a TCP connection over lo0
+// getTCPConnectionPair returns the two endpoints of a TCP connection over lo0
 func getTCPConnectionPair() (net.Conn, net.Conn, error) {
 	lst, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -819,7 +819,7 @@ func (c *rawConnection) close(err error) {
 	})
 }
 
-// The pingSender makes sure that we've sent a message within the last
+// pingSender makes sure that we've sent a message within the last
 // PingSendInterval. If we already have something sent in the last
 // PingSendInterval/2, we do nothing. Otherwise we send a ping message. This
 // results in an effecting ping interval of somewhere between
@@ -846,7 +846,7 @@ func (c *rawConnection) pingSender() {
 	}
 }
 
-// The pingReceiver checks that we've received a message (any message will do,
+// pingReceiver checks that we've received a message (any message will do,
 // but we expect pings in the absence of other messages) within the last
 // ReceiveTimeout. If not, we close the connection with an ErrTimeout.
 func (c *rawConnection) pingReceiver() {

--- a/lib/signature/signature.go
+++ b/lib/signature/signature.go
@@ -174,7 +174,7 @@ type signature struct {
 	R, S *big.Int
 }
 
-// marhalSignature returns ASN.1 encoded bytes for the given integers,
+// marshalSignature returns ASN.1 encoded bytes for the given integers,
 // suitable for PEM encoding.
 func marshalSignature(r, s *big.Int) ([]byte, error) {
 	sig := signature{

--- a/lib/upgrade/upgrade_common.go
+++ b/lib/upgrade/upgrade_common.go
@@ -190,7 +190,7 @@ func CompareVersions(a, b string) Relation {
 	return Equal
 }
 
-// Split a version into parts.
+// versionParts; Split a version into parts.
 // "1.2.3-beta.2" -> []int{1, 2, 3}, []interface{}{"beta", 2}
 func versionParts(v string) ([]int, []interface{}) {
 	if strings.HasPrefix(v, "v") || strings.HasPrefix(v, "V") {

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -133,7 +133,7 @@ nextResult:
 	return results
 }
 
-// Search for UPnP InternetGatewayDevices for <timeout> seconds, ignoring responses from any devices listed in knownDevices.
+// discover; Search for UPnP InternetGatewayDevices for <timeout> seconds, ignoring responses from any devices listed in knownDevices.
 // The order in which the devices appear in the result list is not deterministic
 func discover(intf *net.Interface, deviceType string, timeout time.Duration, results chan<- nat.Device) {
 	ssdp := &net.UDPAddr{IP: []byte{239, 255, 255, 250}, Port: 1900}

--- a/lib/versioner/empty_dir_tracker.go
+++ b/lib/versioner/empty_dir_tracker.go
@@ -22,7 +22,7 @@ func (t emptyDirTracker) addDir(path string) {
 	t[path] = struct{}{}
 }
 
-// Remove all dirs from the path to the file
+// addFile; Remove all dirs from the path to the file
 func (t emptyDirTracker) addFile(path string) {
 	dir := filepath.Dir(path)
 	for dir != "." {

--- a/lib/versioner/util.go
+++ b/lib/versioner/util.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 )
 
-// Inserts ~tag just before the extension of the filename.
+// TagFilename inserts ~tag just before the extension of the filename.
 func TagFilename(name, tag string) string {
 	dir, file := filepath.Dir(name), filepath.Base(name)
 	ext := filepath.Ext(file)
@@ -22,7 +22,7 @@ func TagFilename(name, tag string) string {
 
 var tagExp = regexp.MustCompile(`.*~([^~.]+)(?:\.[^.]+)?$`)
 
-// Returns the tag from a filename, whether at the end or middle.
+// ExtractTag returns the tag from a filename, whether at the end or middle.
 func ExtractTag(path string) string {
 	match := tagExp.FindStringSubmatch(path)
 	// match is []string{"whole match", "submatch"} when successful

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -322,7 +322,7 @@ func (a *aggregator) actOnTimer(out chan<- []string) {
 	go a.notify(oldEvents, out)
 }
 
-// Schedule scan for given events dispatching deletes last and reset notification
+// notify; Schedule scan for given events dispatching deletes last and reset notification
 // afterwards to set up for the next scan scheduling.
 func (a *aggregator) notify(oldEvents map[string]*aggregatedEvent, out chan<- []string) {
 	timeBeforeSending := time.Now()
@@ -360,7 +360,7 @@ func (a *aggregator) notify(oldEvents map[string]*aggregatedEvent, out chan<- []
 	}
 }
 
-// popOldEvents finds events that should be scheduled for scanning recursively in dirs,
+// popOldEventsTo finds events that should be scheduled for scanning recursively in dirs,
 // removes those events and empty eventDirs and returns a map with all the removed
 // events referenced by their filesystem path
 func (a *aggregator) popOldEventsTo(to map[string]*aggregatedEvent, dir *eventDir, dirPath string, currTime time.Time, delayRem bool) {

--- a/script/authors.go
+++ b/script/authors.go
@@ -180,7 +180,7 @@ func readAll(path string) []byte {
 	return bs
 }
 
-// Add number of commits per author to the author list.
+// getContributions; Add number of commits per author to the author list.
 func getContributions(authors []author) {
 	buf := new(bytes.Buffer)
 	cmd := exec.Command("git", "log", "--pretty=format:%ae")
@@ -251,7 +251,7 @@ type byContributions []author
 
 func (l byContributions) Len() int { return len(l) }
 
-// Sort first by log10(commits), then by name. This means that we first get
+// Less; Sort first by log10(commits), then by name. This means that we first get
 // an alphabetic list of people with >= 1000 commits, then a list of people
 // with >= 100 commits, and so on.
 func (l byContributions) Less(a, b int) bool {


### PR DESCRIPTION
Use [CodeLingo](https://codelingo.io) to automatically fix function comments following the
[effective go guidelines](https://golang.org/doc/effective_go.html#commentary) in [3.3. Contribution Guidelines - Syncthing v0.14 documentation](https://docs.syncthing.net/dev/contributing.html).

This patch was generated by running the CodeLingo Rewrite Flow over the "[comment-first-word-as-subject](https://github.com/codelingo/codelingo/blob/master/tenets/codelingo/effective-go/comment-first-word-as-subject/codelingo.yaml)" Tenet. Note: the same Tenet can be used to automate PR reviews and generate contributor docs by [Installing](https://github.com/apps/codelingo) the CodeLingo GitHub app. Learn more at [codelingo.io](https://codelingo.io).