### PR TITLE
build.go: avoid rebuilding cgo.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -450,7 +450,7 @@ func build(target target, tags []string) {
 
 	rmr(target.BinaryName())
 
-	args := []string{"build", "-i", "-v"}
+	args := []string{"build", "-v"}
 	args = appendParameters(args, tags, target)
 
 	os.Setenv("GOOS", goos)


### PR DESCRIPTION
### Purpose

Fix permission problem when building syncthing from a system-wide toolchain.

Also see https://github.com/golang/go/issues/24674
and https://github.com/NixOS/nixpkgs/issues/51825

### Testing

build is wip

### Documentation

not required

## Authorship

ok
