### PR TITLE
lib/scanner: Don't report error on missing items (fixes #5385)

### DIFF
--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -535,7 +535,12 @@ func (w *walker) updateFileInfo(file, curFile protocol.FileInfo) protocol.FileIn
 	file.LocalFlags = w.LocalFlags
 	return file
 }
+
 func (w *walker) handleError(ctx context.Context, context, path string, err error, finishedChan chan<- ScanResult) {
+	// Ignore missing items, as deletions are not handled by the scanner.
+	if fs.IsNotExist(err) {
+		return
+	}
 	l.Infof("Scanner (folder %s, file %q): %s: %v", w.Folder, path, context, err)
 	select {
 	case finishedChan <- ScanResult{

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -738,6 +738,23 @@ func TestIssue4841(t *testing.T) {
 	}
 }
 
+// TestNotExistingError reproduces https://github.com/syncthing/syncthing/issues/5385
+func TestNotExistingError(t *testing.T) {
+	sub := "notExisting"
+	if _, err := testFs.Lstat(sub); !fs.IsNotExist(err) {
+		t.Fatalf("Lstat returned error %v, while nothing should exist there.", err)
+	}
+
+	fchan := Walk(context.TODO(), Config{
+		Filesystem: testFs,
+		Subs:       []string{sub},
+		Hashers:    2,
+	})
+	for f := range fchan {
+		t.Fatalf("Expected no result from scan, got %v", f)
+	}
+}
+
 // Verify returns nil or an error describing the mismatch between the block
 // list and actual reader contents
 func verify(r io.Reader, blocksize int, blocks []protocol.BlockInfo) error {


### PR DESCRIPTION
Fixes and adds unit test for #5385.