### PR TITLE
lib/db: Defer unlock to avoid hangup on panic

### DIFF
--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -113,6 +113,8 @@ func (m *metadataTracker) addFile(dev protocol.DeviceID, f FileIntf) {
 	}
 
 	m.mut.Lock()
+	defer m.mut.Unlock()
+
 	m.dirty = true
 
 	if flags := f.FileLocalFlags(); flags == 0 {
@@ -124,8 +126,6 @@ func (m *metadataTracker) addFile(dev protocol.DeviceID, f FileIntf) {
 			m.addFileLocked(dev, flag, f)
 		})
 	}
-
-	m.mut.Unlock()
 }
 
 func (m *metadataTracker) addFileLocked(dev protocol.DeviceID, flags uint32, f FileIntf) {
@@ -156,6 +156,8 @@ func (m *metadataTracker) removeFile(dev protocol.DeviceID, f FileIntf) {
 	}
 
 	m.mut.Lock()
+	defer m.mut.Unlock()
+
 	m.dirty = true
 
 	if flags := f.FileLocalFlags(); flags == 0 {
@@ -167,8 +169,6 @@ func (m *metadataTracker) removeFile(dev protocol.DeviceID, f FileIntf) {
 			m.removeFileLocked(dev, flag, f)
 		})
 	}
-
-	m.mut.Unlock()
 }
 
 func (m *metadataTracker) removeFileLocked(dev protocol.DeviceID, flags uint32, f FileIntf) {


### PR DESCRIPTION
As discussed and explained by @calmh in https://forum.syncthing.net/t/hanging-panics-in-integration-tests/12574/6. Does not change anything, because there is no reason to panic there, but it's still more correct this way (and I get to add debug panics without additional hassle)