### PR TITLE
lib/db: Update item by item and strict sequence increase

### DIFF
--- a/lib/db/blockmap_test.go
+++ b/lib/db/blockmap_test.go
@@ -100,10 +100,7 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 	f2.LocalFlags = protocol.FlagLocalMustRescan // one of the invalid markers
 
 	// Should remove
-	err = m.Update([]protocol.FileInfo{f1, f2, f3})
-	if err != nil {
-		t.Fatal(err)
-	}
+	m.Update([]protocol.FileInfo{f1, f2, f3})
 
 	f.Iterate(folders, f1.Blocks[0].Hash, func(folder, file string, index int32) bool {
 		t.Fatal("Unexpected block")
@@ -188,10 +185,7 @@ func TestBlockFinderLookup(t *testing.T) {
 
 	f1.Deleted = true
 
-	err = m1.Update([]protocol.FileInfo{f1})
-	if err != nil {
-		t.Fatal(err)
-	}
+	m1.Update([]protocol.FileInfo{f1})
 
 	counter = 0
 	f.Iterate(folders, f1.Blocks[0].Hash, func(folder, file string, index int32) bool {

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -274,13 +274,6 @@ func (m *metadataTracker) Counts(dev protocol.DeviceID, flag uint32) Counts {
 	return m.counts.Counts[idx]
 }
 
-func (m *metadataTracker) seq(dev protocol.DeviceID) int64 {
-	m.mut.Lock()
-	defer m.mut.Unlock()
-
-	return m.countsPtr(dev, 0).Sequence
-}
-
 // devices returns the list of devices tracked, excluding the local device
 // (which we don't know the ID of)
 func (m *metadataTracker) devices() []protocol.DeviceID {

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -140,6 +140,8 @@ func (m *metadataTracker) updateSeqLocked(dev protocol.DeviceID, f FileIntf) {
 	if dev == protocol.GlobalDeviceID {
 		return
 	}
+	// Incoming updates aren't necessarily ordered by SeqNo (only ordered
+	// for local regular updates, not for meta recalcs and remote updates).
 	if cp := m.countsPtr(dev, 0); f.SequenceNo() > cp.Sequence {
 		cp.Sequence = f.SequenceNo()
 	}
@@ -272,14 +274,11 @@ func (m *metadataTracker) Counts(dev protocol.DeviceID, flag uint32) Counts {
 	return m.counts.Counts[idx]
 }
 
-// nextSeq allocates a new sequence number for the given device
-func (m *metadataTracker) nextSeq(dev protocol.DeviceID) int64 {
+func (m *metadataTracker) seq(dev protocol.DeviceID) int64 {
 	m.mut.Lock()
 	defer m.mut.Unlock()
 
-	c := m.countsPtr(dev, 0)
-	c.Sequence++
-	return c.Sequence
+	return m.countsPtr(dev, 0).Sequence
 }
 
 // devices returns the list of devices tracked, excluding the local device

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -156,7 +156,7 @@ func (db *schemaUpdater) updateSchema0to1() {
 		// Add invalid files to global list
 		if f.IsInvalid() {
 			gk = db.keyer.GenerateGlobalVersionKey(gk, folder, name)
-			if t.updateGlobal(gk, folder, device, f, meta) {
+			if t.updateGlobal(gk, folder, protocol.DeviceIDFromBytes(device), f, meta) {
 				if _, ok := changedFolders[string(folder)]; !ok {
 					changedFolders[string(folder)] = struct{}{}
 				}

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -162,6 +162,7 @@ func (s *FileSet) Update(device protocol.DeviceID, fs []protocol.FileInfo) {
 	oldFs := fs
 	fs = fs[:0]
 	var dk []byte
+	seq := s.meta.seq(protocol.LocalDeviceID)
 	folder := []byte(s.folder)
 	for _, nf := range oldFs {
 		dk = s.db.keyer.GenerateDeviceFileKey(dk, folder, device[:], []byte(osutil.NormalizedFilename(nf.Name)))
@@ -170,7 +171,8 @@ func (s *FileSet) Update(device protocol.DeviceID, fs []protocol.FileInfo) {
 			continue
 		}
 
-		nf.Sequence = s.meta.nextSeq(protocol.LocalDeviceID)
+		seq++
+		nf.Sequence = seq
 		fs = append(fs, nf)
 
 		if ok {


### PR DESCRIPTION
### Purpose

I don't have a smoking gun, that it's related to #5340, but it's motivated by it:  
Currently updates happens by passing multiple slices of fileinfos around to several functions that update the db in various places. This has recently be significantly improved by @calmh, but I still don't like it in principle: It uses more memory and I think it's also more fragile (e.g. when process is interrupted mid-update). Another related issue is how sequences are stored and updated (also see https://forum.syncthing.net/t/question-about-metadata-buckets-and-sequence/12579). This PR does not change how they are saved (lacyness), but the update now happens in only one place and in a dedicated function for consistency. <strike>I also added a panic to prevent the sequence from ever decreasing. Maybe that panic should be hidden behind `shouldDebug`.</strike> Undid that, see next post.

Also I recommend looking at it commit by commit. The first is purely cosmetic to make further diffs smaller, the latter contain the main changes explained above. It might even make sense to commit them separately to master in the end.

### Testing

Unit and integration testing, no production testing. <strike>One unit test that depends on stored db data fails, because the db data is erroneous (we didn't care about sequences in testing back then). I can fix that if this change meets favorable opinions, it's just cumbersome, so I skipped it for now.</strike> See below.