### PR TITLE
lib/scanner: Check ignore patterns before reporting error (fixes #5397)

### DIFF
--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -252,6 +252,7 @@ func TestNormalization(t *testing.T) {
 
 func TestIssue1507(t *testing.T) {
 	w := &walker{}
+	w.Matcher = ignore.New(w.Filesystem)
 	h := make(chan protocol.FileInfo, 100)
 	f := make(chan ScanResult, 100)
 	fn := w.walkAndHashFiles(context.TODO(), h, f)


### PR DESCRIPTION
### Purpose

Fix #5397 introduced in #5215:  
Move UTF8 validity check to the front and report regardless of filesystem errors. Then check for ign/temp/internal before reporting filesystem errors. An argument could be made that errors on temporary files should be reported, as the reason for the error might cause the temporary file to not be removed. However we didn't report above debug level before #5215, so that's a separate issue in my opinion.

### Testing

None.
