### PR TITLE
cmd/syncthing: Don't rewrite config on startup unless necessary

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -840,13 +840,16 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	if opts := cfg.Options(); IsCandidate {
 		l.Infoln("Anonymous usage reporting is always enabled for candidate releases.")
-		opts.URAccepted = usageReportVersion
-		cfg.SetOptions(opts)
-		cfg.Save()
-		// Unique ID will be set and config saved below if necessary.
+		if opts.URAccepted != usageReportVersion {
+			opts.URAccepted = usageReportVersion
+			cfg.SetOptions(opts)
+			cfg.Save()
+			// Unique ID will be set and config saved below if necessary.
+		}
 	}
 
-	if opts := cfg.Options(); opts.URUniqueID == "" {
+	// If we are going to do usdage reporting, ensure we have a valid unique ID.
+	if opts := cfg.Options(); opts.URAccepted > 0 && opts.URUniqueID == "" {
 		opts.URUniqueID = rand.String(8)
 		cfg.SetOptions(opts)
 		cfg.Save()


### PR DESCRIPTION
### Purpose

On release candidate builds we'd always do a `cfg.Save()` on startup. This hides that behind an `if` so we only do it if required.

(This save generally doesn't hurt, but in rare cases it does - people who do ansible deployed configs that are equivalent but differently indented, for example, see odd results.)

### Testing

I ran it manually on a config with comments and whitespace and verified it did not get overwritten. If the usage reporting version is low, it does still get correctly resaved.