### PR TITLE
gui: Use a modern font stack inspired by Bootstrap 4

### DIFF
--- a/cmd/ursrv/static/index.html
+++ b/cmd/ursrv/static/index.html
@@ -21,7 +21,7 @@ found in the LICENSE file.
   <style type="text/css">
     body {
       margin: 40px;
-      font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     }
     tr.main td {
       font-weight: bold;

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -9,11 +9,11 @@
 
 body {
     padding-bottom: 70px;
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 h1, h2, h3, h4, h5 {
-    font-family: "Raleway", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "Raleway", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     line-height: 1.25;
 }
 


### PR DESCRIPTION
### Purpose

Modern OSes ship with high-quality fonts that can be used out of the box with a simple change. It tends to be slightly more consistent across platforms too, even though it's still not perfect (especially on the Linux side of things).

I didn't edit vendored libraries such as the date range chooser, but some of them still refer to the "old" font stack; let me know if I should edit them anyway.

See https://github.com/twbs/bootstrap/pull/19098 for more information.

### Testing

Tested in Chromium 70 on Fedora 29, Edge 17 on Windows 10 and Safari 11.1 on macOS 10.13; see screenshots below.

### Screenshots

**Chromium 70 on Fedora 29 (dark theme):**

![syncthing_system_font_linux_dark](https://user-images.githubusercontent.com/180032/50457747-5ccc9d00-095e-11e9-93ae-c19c0d3a2132.png)

**Edge 17 on Windows 10 (light theme):**

![syncthing_system_font_windows_light](https://user-images.githubusercontent.com/180032/50457749-5d653380-095e-11e9-91ea-c7386cd84e6a.png)

**Safari 11.1 on macOS 10.13 (light theme):**

![syncthing_system_font_macos_light](https://user-images.githubusercontent.com/180032/50457748-5d653380-095e-11e9-8a61-bbe16a0ebb98.png)