### PR TITLE
Improve messages when free space is running out

### DIFF
--- a/lib/config/size.go
+++ b/lib/config/size.go
@@ -85,10 +85,10 @@ func checkFreeSpace(req Size, usage fs.Usage) error {
 	if req.Percentage() {
 		freePct := (float64(usage.Free) / float64(usage.Total)) * 100
 		if freePct < val {
-			return fmt.Errorf("%f %% < %v", freePct, req)
+			return fmt.Errorf("not enough free space, %f %% < %v", freePct, req)
 		}
 	} else if float64(usage.Free) < val {
-		return fmt.Errorf("%v < %v", usage.Free, req)
+		return fmt.Errorf("not enough free space, %v < %v", usage.Free, req)
 	}
 
 	return nil


### PR DESCRIPTION
### Purpose

Use a better error message when disk space is running low. Without this PR, the user gets the error `error on folder XXX: 0.578253 % < 1 %`, which is not helpful. With this PR, the error becomes

    error on folder XXX: not enough free space, 0.578253 % < 1 %

### Testing

I successfully checked that all the tests ran by `go test` pass.

### Documentation

N/A

## Authorship

Maurizio Tomasi <ziotom78@gmail.com>
