### PR TITLE
lib/model: Check folder context before setting error state

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -653,6 +653,12 @@ func (f *folder) startWatchAsync(ctx context.Context, ignores *ignore.Matcher) {
 }
 
 func (f *folder) setError(err error) {
+	select {
+	case <-f.ctx.Done():
+		return
+	default:
+	}
+
 	_, _, oldErr := f.getState()
 	if (err != nil && oldErr != nil && oldErr.Error() == err.Error()) || (err == nil && oldErr == nil) {
 		return


### PR DESCRIPTION
### Purpose

https://forum.syncthing.net/t/error-on-folder-myfolder-myfolder-context-canceled/12611

If the folder is stopped (restarted, paused, ...) we should not set its error state and thus display a warning in the weg UI.

### Testing

None.