### PR TITLE
lib/model: Don't pull if ignores failed to load and cleanup

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -197,7 +197,7 @@ func (f *folder) DelayScan(next time.Duration) {
 	f.Delay(next)
 }
 
-func (f *folder) IgnoresUpdated() {
+func (f *folder) ignoresUpdated() {
 	if f.FSWatcherEnabled {
 		f.scheduleWatchRestart()
 	}
@@ -310,8 +310,9 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 	oldHash := ignores.Hash()
 	defer func() {
 		if ignores.Hash() != oldHash {
-			l.Debugln("Folder", f.ID, "ignore patterns changed; triggering puller")
-			f.IgnoresUpdated()
+			l.Debugln("Folder", f.Description(), "ignore patterns change detected while scanning; triggering puller")
+			f.ignoresUpdated()
+			f.SchedulePull()
 		}
 	}()
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -58,7 +58,6 @@ type service interface {
 	Override(*db.FileSet, func([]protocol.FileInfo))
 	Revert(*db.FileSet, func([]protocol.FileInfo))
 	DelayScan(d time.Duration)
-	IgnoresUpdated()            // ignore matcher was updated notification
 	SchedulePull()              // something relevant changed, we should try a pull
 	Jobs() ([]string, []string) // In progress, Queued
 	Scan(subs []string) error


### PR DESCRIPTION
### Purpose

https://forum.syncthing.net/t/stop-folder-when-loading-ignores-fails/12612

Currently on pulling we don't reload the ignores, we just check the hash of what the model has against the previously seen hash. That means if loading ignores  fails, pulling will still happen and potentially creating a whole lot of previously ignored data.

Now the ignore patterns are loaded from file before pulling, aborting it if it fails. This means the previous hash doesn't need to be tracked anymore

Doing this revealed some cruft laying around: `ignoresChanged` was still passed to `pullerIteration` but not used anywhere in there (a wonder go didn't complain, usually it's very thorough on that kind of stuff). `IgnoresChanged` is not used outside of folder services anymore, therefore I removed it from the interface and unexported it. And for an unknown reason no pull was triggered when a change of ignores was detected on scanning.

@calmh Is this internal enough to go through without an issue? :) 

### Testing

None