### PR TITLE
 lib/db: Fix sequence updating for remote invalid items

### DIFF
--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -107,15 +107,17 @@ func (m *metadataTracker) countsPtr(dev protocol.DeviceID, flags uint32) *Counts
 // addFile adds a file to the counts, adjusting the sequence number as
 // appropriate
 func (m *metadataTracker) addFile(dev protocol.DeviceID, f FileIntf) {
-	if f.IsInvalid() && f.FileLocalFlags() == 0 {
-		// This is a remote invalid file; it does not count.
-		return
-	}
-
 	m.mut.Lock()
 	defer m.mut.Unlock()
 
 	m.dirty = true
+
+	m.updateSeqLocked(dev, f)
+
+	if f.IsInvalid() && f.FileLocalFlags() == 0 {
+		// This is a remote invalid file; it does not count.
+		return
+	}
 
 	if flags := f.FileLocalFlags(); flags == 0 {
 		// Account regular files in the zero-flags bucket.
@@ -125,6 +127,21 @@ func (m *metadataTracker) addFile(dev protocol.DeviceID, f FileIntf) {
 		eachFlagBit(flags, func(flag uint32) {
 			m.addFileLocked(dev, flag, f)
 		})
+	}
+}
+
+func (m *metadataTracker) Sequence(dev protocol.DeviceID) int64 {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+	return m.countsPtr(dev, 0).Sequence
+}
+
+func (m *metadataTracker) updateSeqLocked(dev protocol.DeviceID, f FileIntf) {
+	if dev == protocol.GlobalDeviceID {
+		return
+	}
+	if cp := m.countsPtr(dev, 0); f.SequenceNo() > cp.Sequence {
+		cp.Sequence = f.SequenceNo()
 	}
 }
 
@@ -142,10 +159,6 @@ func (m *metadataTracker) addFileLocked(dev protocol.DeviceID, flags uint32, f F
 		cp.Files++
 	}
 	cp.Bytes += f.FileSize()
-
-	if seq := f.SequenceNo(); seq > cp.Sequence {
-		cp.Sequence = seq
-	}
 }
 
 // removeFile removes a file from the counts

--- a/lib/db/meta_test.go
+++ b/lib/db/meta_test.go
@@ -94,10 +94,10 @@ func TestMetaSequences(t *testing.T) {
 	meta.addFile(protocol.LocalDeviceID, protocol.FileInfo{Sequence: 3, LocalFlags: 1})
 	meta.addFile(protocol.LocalDeviceID, protocol.FileInfo{Sequence: 4, LocalFlags: 2})
 
-	if seq := meta.countsPtr(d1, 0).Sequence; seq != 4 {
+	if seq := meta.Sequence(d1); seq != 4 {
 		t.Error("sequence of first device should be 4, not", seq)
 	}
-	if seq := meta.countsPtr(protocol.LocalDeviceID, 0).Sequence; seq != 4 {
+	if seq := meta.Sequence(protocol.LocalDeviceID); seq != 4 {
 		t.Error("sequence of first device should be 4, not", seq)
 	}
 }

--- a/lib/db/meta_test.go
+++ b/lib/db/meta_test.go
@@ -80,3 +80,24 @@ func TestMetaDevices(t *testing.T) {
 		t.Error("second device should be d2")
 	}
 }
+
+func TestMetaSequences(t *testing.T) {
+	d1 := protocol.DeviceID{1}
+	meta := newMetadataTracker()
+
+	meta.addFile(d1, protocol.FileInfo{Sequence: 1})
+	meta.addFile(d1, protocol.FileInfo{Sequence: 2, RawInvalid: true})
+	meta.addFile(d1, protocol.FileInfo{Sequence: 3})
+	meta.addFile(d1, protocol.FileInfo{Sequence: 4, RawInvalid: true})
+	meta.addFile(protocol.LocalDeviceID, protocol.FileInfo{Sequence: 1})
+	meta.addFile(protocol.LocalDeviceID, protocol.FileInfo{Sequence: 2})
+	meta.addFile(protocol.LocalDeviceID, protocol.FileInfo{Sequence: 3, LocalFlags: 1})
+	meta.addFile(protocol.LocalDeviceID, protocol.FileInfo{Sequence: 4, LocalFlags: 2})
+
+	if seq := meta.countsPtr(d1, 0).Sequence; seq != 4 {
+		t.Error("sequence of first device should be 4, not", seq)
+	}
+	if seq := meta.countsPtr(protocol.LocalDeviceID, 0).Sequence; seq != 4 {
+		t.Error("sequence of first device should be 4, not", seq)
+	}
+}

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -276,7 +276,7 @@ func (s *FileSet) Availability(file string) []protocol.DeviceID {
 }
 
 func (s *FileSet) Sequence(device protocol.DeviceID) int64 {
-	return s.meta.Counts(device, 0).Sequence
+	return s.meta.Sequence(device)
 }
 
 func (s *FileSet) LocalSize() Counts {


### PR DESCRIPTION
### Purpose

This is a followup to (or a part of) #5394, to get the less disruptive changes in.  
The main change is illustrated by the unit test: The device sequence number is now also updated for invalid files. And it is not updated for the global device. These are the only two changes in functionality. The entire blockmap change is just polish, and most changes around meta are intended to make sequence handling more obvious/robust. Meaning introducing functions to access and update the device sequence number (hiding the zero bucket aspect).

### Testing

New unit test `TestMetaSequences`.