### PR TITLE
lib/logger: Strip control characters from log output (fixes #5428)

### DIFF
--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -4,7 +4,9 @@
 package logger
 
 import (
+	"bytes"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -149,5 +151,22 @@ func TestRecorder(t *testing.T) {
 	if lines[0].Message != "hah" {
 		t.Errorf("incorrect line: %s", lines[0].Message)
 	}
+}
 
+func TestControlStripper(t *testing.T) {
+	b := new(bytes.Buffer)
+	l := newLogger(b)
+
+	l.SetFlags(log.Lshortfile)
+	l.Infoln("testing\x07testing\ntesting")
+
+	if !strings.Contains(b.String(), "logger_test.go:") {
+		t.Error("Should identify this file as the source (bad level?)")
+	}
+	if !strings.Contains(b.String(), "testing testing\ntesting") {
+		t.Error("Control character should become space")
+	}
+	if strings.Contains(b.String(), "\x07") {
+		t.Error("Control character should be removed")
+	}
 }

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -162,13 +162,15 @@ func TestControlStripper(t *testing.T) {
 	res := b.String()
 
 	if !strings.Contains(res, "logger_test.go:") {
-		t.Log(res)
+		t.Logf("%q", res)
 		t.Error("Should identify this file as the source (bad level?)")
 	}
 	if !strings.Contains(res, "testing testing\ntesting") {
+		t.Logf("%q", res)
 		t.Error("Control character should become space")
 	}
 	if strings.Contains(res, "\x07") {
+		t.Logf("%q", res)
 		t.Error("Control character should be removed")
 	}
 }

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -159,14 +159,16 @@ func TestControlStripper(t *testing.T) {
 
 	l.SetFlags(log.Lshortfile)
 	l.Infoln("testing\x07testing\ntesting")
+	res := b.String()
 
-	if !strings.Contains(b.String(), "logger_test.go:") {
+	if !strings.Contains(res, "logger_test.go:") {
+		t.Log(res)
 		t.Error("Should identify this file as the source (bad level?)")
 	}
-	if !strings.Contains(b.String(), "testing testing\ntesting") {
+	if !strings.Contains(res, "testing testing\ntesting") {
 		t.Error("Control character should become space")
 	}
-	if strings.Contains(b.String(), "\x07") {
+	if strings.Contains(res, "\x07") {
 		t.Error("Control character should be removed")
 	}
 }

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -6,6 +6,7 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"strings"
 	"testing"
@@ -182,4 +183,32 @@ func TestControlStripper(t *testing.T) {
 		t.Logf("%q", res)
 		t.Error("Control character should be removed")
 	}
+}
+
+func BenchmarkLog(b *testing.B) {
+	l := newLogger(ioutil.Discard)
+
+	benchmarkLogger(b, l)
+}
+
+func BenchmarkLogNoStripper(b *testing.B) {
+	l := newLogger(ioutil.Discard)
+	// Reach in and grab the destination behind the controlStripper, thus
+	// bypassing it.
+	l.logger = l.logger.(controlStripper).lowlevel
+
+	benchmarkLogger(b, l)
+}
+
+func benchmarkLogger(b *testing.B, l Logger) {
+	l.SetFlags(log.Lshortfile | log.Lmicroseconds)
+	l.SetPrefix("ABCDEFG")
+
+	for i := 0; i < b.N; i++ {
+		l.Infoln("This is a somewhat representative log line")
+		l.Infof("This is a log line with a couple of formatted things: %d %q", 42, "a file name maybe, who knows?")
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(1)
 }


### PR DESCRIPTION
### Purpose

Don't randomly beep

### Testing

Bask in the glory of my unit test