### PR TITLE
lib/logger: Strip control characters from log output (fixes #5428)

### DIFF
--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -390,6 +390,7 @@ func (s controlStripper) Write(data []byte) (int, error) {
 			continue
 		}
 		if b < 32 {
+			// Characters below 32 are control characters
 			data[i] = ' '
 		}
 	}

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -70,7 +70,7 @@ type logger struct {
 var DefaultLogger = New()
 
 func New() Logger {
-	return newLogger(os.Stdout)
+	return newLogger(controlStripper{os.Stdout})
 }
 
 func newLogger(w io.Writer) Logger {
@@ -375,4 +375,23 @@ func (r *recorder) append(l LogLevel, msg string) {
 	if len(r.lines) == r.initial {
 		r.lines = append(r.lines, Line{time.Now(), "...", l})
 	}
+}
+
+// controlStripper is a Writer that replaces control characters
+// with spaces.
+type controlStripper struct {
+	io.Writer
+}
+
+func (s controlStripper) Write(data []byte) (int, error) {
+	for i, b := range data {
+		if b == '\n' || b == '\r' {
+			// Newlines are OK
+			continue
+		}
+		if b < 32 {
+			data[i] = ' '
+		}
+	}
+	return s.Writer.Write(data)
 }

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -6,6 +6,7 @@ package logger
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"strings"
 	"testing"
@@ -165,4 +166,44 @@ func TestStackLevel(t *testing.T) {
 		t.Logf("%q", res)
 		t.Error("Should identify this file as the source (bad level?)")
 	}
+}
+
+func TestControlStripper(t *testing.T) {
+	b := new(bytes.Buffer)
+	l := newLogger(controlStripper{b})
+
+	l.Infoln("testing\x07testing\ntesting")
+	res := b.String()
+
+	if !strings.Contains(res, "testing testing\ntesting") {
+		t.Logf("%q", res)
+		t.Error("Control character should become space")
+	}
+	if strings.Contains(res, "\x07") {
+		t.Logf("%q", res)
+		t.Error("Control character should be removed")
+	}
+}
+
+func BenchmarkLog(b *testing.B) {
+	l := newLogger(controlStripper{ioutil.Discard})
+	benchmarkLogger(b, l)
+}
+
+func BenchmarkLogNoStripper(b *testing.B) {
+	l := newLogger(ioutil.Discard)
+	benchmarkLogger(b, l)
+}
+
+func benchmarkLogger(b *testing.B, l Logger) {
+	l.SetFlags(log.Lshortfile | log.Lmicroseconds)
+	l.SetPrefix("ABCDEFG")
+
+	for i := 0; i < b.N; i++ {
+		l.Infoln("This is a somewhat representative log line")
+		l.Infof("This is a log line with a couple of formatted things: %d %q", 42, "a file name maybe, who knows?")
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(1)
 }

--- a/lib/logger/logger_test.go
+++ b/lib/logger/logger_test.go
@@ -205,5 +205,5 @@ func benchmarkLogger(b *testing.B, l Logger) {
 	}
 
 	b.ReportAllocs()
-	b.SetBytes(1)
+	b.SetBytes(2) // log entries per iteration
 }


### PR DESCRIPTION
### Purpose

Less odd stuff on the console, including beeps.

### Testing

Unit. Also, benchmarks:

```
pkg: github.com/syncthing/syncthing/lib/logger
BenchmarkLog-4             	  300000	      3461 ns/op	   0.58 MB/s	     352 B/op	       6 allocs/op
BenchmarkLogNoStripper-4   	  500000	      3241 ns/op	   0.62 MB/s	     352 B/op	       6 allocs/op
PASS
```

I think the penalty is fine. (Those "MB/s" are in fact "Mlogentries/s".)

In comparison to the previous PR, doing it at the Writer level avoids both having to deal with runes or code points which means it's faster (UTF-8 bytes behave the way we need), and avoids whatever was the deal with the stack level stuff on old Go.