### PR TITLE
lib/db: Do all update operations on a single item at once

### DIFF
--- a/lib/db/blockmap.go
+++ b/lib/db/blockmap.go
@@ -11,125 +11,14 @@ import (
 	"fmt"
 
 	"github.com/syncthing/syncthing/lib/osutil"
-	"github.com/syncthing/syncthing/lib/protocol"
 
-	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/util"
 )
 
 var blockFinder *BlockFinder
 
-const maxBatchSize = 1000
-
-type BlockMap struct {
-	db     *Lowlevel
-	folder uint32
-}
-
-func NewBlockMap(db *Lowlevel, folder string) *BlockMap {
-	return &BlockMap{
-		db:     db,
-		folder: db.folderIdx.ID([]byte(folder)),
-	}
-}
-
-// Add files to the block map, ignoring any deleted or invalid files.
-func (m *BlockMap) Add(files []protocol.FileInfo) error {
-	batch := new(leveldb.Batch)
-	buf := make([]byte, 4)
-	var key []byte
-	for _, file := range files {
-		m.checkFlush(batch)
-
-		if file.IsDirectory() || file.IsDeleted() || file.IsInvalid() {
-			continue
-		}
-
-		for i, block := range file.Blocks {
-			binary.BigEndian.PutUint32(buf, uint32(i))
-			key = m.blockKeyInto(key, block.Hash, file.Name)
-			batch.Put(key, buf)
-		}
-	}
-	return m.db.Write(batch, nil)
-}
-
-// Update block map state, removing any deleted or invalid files.
-func (m *BlockMap) Update(files []protocol.FileInfo) error {
-	batch := new(leveldb.Batch)
-	buf := make([]byte, 4)
-	var key []byte
-	for _, file := range files {
-		m.checkFlush(batch)
-
-		switch {
-		case file.IsDirectory():
-		case file.IsDeleted() || file.IsInvalid():
-			for _, block := range file.Blocks {
-				key = m.blockKeyInto(key, block.Hash, file.Name)
-				batch.Delete(key)
-			}
-		default:
-			for i, block := range file.Blocks {
-				binary.BigEndian.PutUint32(buf, uint32(i))
-				key = m.blockKeyInto(key, block.Hash, file.Name)
-				batch.Put(key, buf)
-			}
-		}
-	}
-	return m.db.Write(batch, nil)
-}
-
-// Discard block map state, removing the given files
-func (m *BlockMap) Discard(files []protocol.FileInfo) error {
-	batch := new(leveldb.Batch)
-	var key []byte
-	for _, file := range files {
-		m.checkFlush(batch)
-		m.discard(file, key, batch)
-	}
-	return m.db.Write(batch, nil)
-}
-
-func (m *BlockMap) discard(file protocol.FileInfo, key []byte, batch *leveldb.Batch) {
-	for _, block := range file.Blocks {
-		key = m.blockKeyInto(key, block.Hash, file.Name)
-		batch.Delete(key)
-	}
-}
-
-func (m *BlockMap) checkFlush(batch *leveldb.Batch) error {
-	if batch.Len() > maxBatchSize {
-		if err := m.db.Write(batch, nil); err != nil {
-			return err
-		}
-		batch.Reset()
-	}
-	return nil
-}
-
-// Drop block map, removing all entries related to this block map from the db.
-func (m *BlockMap) Drop() error {
-	batch := new(leveldb.Batch)
-	iter := m.db.NewIterator(util.BytesPrefix(m.blockKeyInto(nil, nil, "")[:keyPrefixLen+keyFolderLen]), nil)
-	defer iter.Release()
-	for iter.Next() {
-		m.checkFlush(batch)
-
-		batch.Delete(iter.Key())
-	}
-	if iter.Error() != nil {
-		return iter.Error()
-	}
-	return m.db.Write(batch, nil)
-}
-
-func (m *BlockMap) blockKeyInto(o, hash []byte, file string) []byte {
-	return blockKeyInto(o, hash, m.folder, file)
-}
-
 type BlockFinder struct {
-	db *Lowlevel
+	db *instance
 }
 
 func NewBlockFinder(db *Lowlevel) *BlockFinder {
@@ -137,11 +26,9 @@ func NewBlockFinder(db *Lowlevel) *BlockFinder {
 		return blockFinder
 	}
 
-	f := &BlockFinder{
-		db: db,
+	return &BlockFinder{
+		db: newInstance(db),
 	}
-
-	return f
 }
 
 func (f *BlockFinder) String() string {
@@ -156,13 +43,15 @@ func (f *BlockFinder) String() string {
 func (f *BlockFinder) Iterate(folders []string, hash []byte, iterFn func(string, string, int32) bool) bool {
 	var key []byte
 	for _, folder := range folders {
-		folderID := f.db.folderIdx.ID([]byte(folder))
-		key = blockKeyInto(key, hash, folderID, "")
-		iter := f.db.NewIterator(util.BytesPrefix(key), nil)
+		t := f.db.newReadOnlyTransaction()
+		defer t.close()
+
+		key = f.db.keyer.GenerateBlockMapKey(key, []byte(folder), hash, nil)
+		iter := t.NewIterator(util.BytesPrefix(key), nil)
 		defer iter.Release()
 
 		for iter.Next() && iter.Error() == nil {
-			file := blockKeyName(iter.Key())
+			file := string(f.db.keyer.NameFromBlockMapKey(iter.Key()))
 			index := int32(binary.BigEndian.Uint32(iter.Value()))
 			if iterFn(folder, osutil.NativeFilename(file), index) {
 				return true
@@ -170,36 +59,4 @@ func (f *BlockFinder) Iterate(folders []string, hash []byte, iterFn func(string,
 		}
 	}
 	return false
-}
-
-// m.blockKey returns a byte slice encoding the following information:
-//	   keyTypeBlock (1 byte)
-//	   folder (4 bytes)
-//	   block hash (32 bytes)
-//	   file name (variable size)
-func blockKeyInto(o, hash []byte, folder uint32, file string) []byte {
-	reqLen := keyPrefixLen + keyFolderLen + keyHashLen + len(file)
-	if cap(o) < reqLen {
-		o = make([]byte, reqLen)
-	} else {
-		o = o[:reqLen]
-	}
-	o[0] = KeyTypeBlock
-	binary.BigEndian.PutUint32(o[keyPrefixLen:], folder)
-	copy(o[keyPrefixLen+keyFolderLen:], hash)
-	copy(o[keyPrefixLen+keyFolderLen+keyHashLen:], []byte(file))
-	return o
-}
-
-// blockKeyName returns the file name from the block key
-func blockKeyName(data []byte) string {
-	if len(data) < keyPrefixLen+keyFolderLen+keyHashLen+1 {
-		panic("Incorrect key length")
-	}
-	if data[0] != KeyTypeBlock {
-		panic("Incorrect key type")
-	}
-
-	file := string(data[keyPrefixLen+keyFolderLen+keyHashLen:])
-	return file
 }

--- a/lib/db/blockmap_test.go
+++ b/lib/db/blockmap_test.go
@@ -7,6 +7,7 @@
 package db
 
 import (
+	"encoding/binary"
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/protocol"
@@ -48,17 +49,51 @@ func init() {
 	}
 }
 
-func setup() (*Lowlevel, *BlockFinder) {
+func setup() (*instance, *BlockFinder) {
 	// Setup
 
 	db := OpenMemory()
-	return db, NewBlockFinder(db)
+	return newInstance(db), NewBlockFinder(db)
 }
 
-func dbEmpty(db *Lowlevel) bool {
+func dbEmpty(db *instance) bool {
 	iter := db.NewIterator(util.BytesPrefix([]byte{KeyTypeBlock}), nil)
 	defer iter.Release()
 	return !iter.Next()
+}
+
+func addToBlockMap(db *instance, folder []byte, fs []protocol.FileInfo) {
+	t := db.newReadWriteTransaction()
+	defer t.close()
+
+	var keyBuf []byte
+	blockBuf := make([]byte, 4)
+	for _, f := range fs {
+		if !f.IsDirectory() && !f.IsDeleted() && !f.IsInvalid() {
+			name := []byte(f.Name)
+			for i, block := range f.Blocks {
+				binary.BigEndian.PutUint32(blockBuf, uint32(i))
+				keyBuf = t.db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
+				t.Put(keyBuf, blockBuf)
+			}
+		}
+	}
+}
+
+func discardFromBlockMap(db *instance, folder []byte, fs []protocol.FileInfo) {
+	t := db.newReadWriteTransaction()
+	defer t.close()
+
+	var keyBuf []byte
+	for _, ef := range fs {
+		if !ef.IsDirectory() && !ef.IsDeleted() && !ef.IsInvalid() {
+			name := []byte(ef.Name)
+			for _, block := range ef.Blocks {
+				keyBuf = t.db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
+				t.Delete(keyBuf)
+			}
+		}
+	}
 }
 
 func TestBlockMapAddUpdateWipe(t *testing.T) {
@@ -68,14 +103,11 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 		t.Fatal("db not empty")
 	}
 
-	m := NewBlockMap(db, "folder1")
+	folder := []byte("folder1")
 
 	f3.Type = protocol.FileInfoTypeDirectory
 
-	err := m.Add([]protocol.FileInfo{f1, f2, f3})
-	if err != nil {
-		t.Fatal(err)
-	}
+	addToBlockMap(db, folder, []protocol.FileInfo{f1, f2, f3})
 
 	f.Iterate(folders, f1.Blocks[0].Hash, func(folder, file string, index int32) bool {
 		if folder != "folder1" || file != "f1" || index != 0 {
@@ -96,14 +128,12 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 		return true
 	})
 
+	discardFromBlockMap(db, folder, []protocol.FileInfo{f1, f2, f3})
+
 	f1.Deleted = true
 	f2.LocalFlags = protocol.FlagLocalMustRescan // one of the invalid markers
 
-	// Should remove
-	err = m.Update([]protocol.FileInfo{f1, f2, f3})
-	if err != nil {
-		t.Fatal(err)
-	}
+	addToBlockMap(db, folder, []protocol.FileInfo{f1, f2, f3})
 
 	f.Iterate(folders, f1.Blocks[0].Hash, func(folder, file string, index int32) bool {
 		t.Fatal("Unexpected block")
@@ -122,20 +152,14 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 		return true
 	})
 
-	err = m.Drop()
-	if err != nil {
-		t.Fatal(err)
-	}
+	db.dropFolder(folder)
 
 	if !dbEmpty(db) {
 		t.Fatal("db not empty")
 	}
 
 	// Should not add
-	err = m.Add([]protocol.FileInfo{f1, f2})
-	if err != nil {
-		t.Fatal(err)
-	}
+	addToBlockMap(db, folder, []protocol.FileInfo{f1, f2})
 
 	if !dbEmpty(db) {
 		t.Fatal("db not empty")
@@ -152,17 +176,11 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 func TestBlockFinderLookup(t *testing.T) {
 	db, f := setup()
 
-	m1 := NewBlockMap(db, "folder1")
-	m2 := NewBlockMap(db, "folder2")
+	folder1 := []byte("folder1")
+	folder2 := []byte("folder2")
 
-	err := m1.Add([]protocol.FileInfo{f1})
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = m2.Add([]protocol.FileInfo{f1})
-	if err != nil {
-		t.Fatal(err)
-	}
+	addToBlockMap(db, folder1, []protocol.FileInfo{f1})
+	addToBlockMap(db, folder2, []protocol.FileInfo{f1})
 
 	counter := 0
 	f.Iterate(folders, f1.Blocks[0].Hash, func(folder, file string, index int32) bool {
@@ -186,12 +204,11 @@ func TestBlockFinderLookup(t *testing.T) {
 		t.Fatal("Incorrect count", counter)
 	}
 
+	discardFromBlockMap(db, folder1, []protocol.FileInfo{f1})
+
 	f1.Deleted = true
 
-	err = m1.Update([]protocol.FileInfo{f1})
-	if err != nil {
-		t.Fatal(err)
-	}
+	addToBlockMap(db, folder1, []protocol.FileInfo{f1})
 
 	counter = 0
 	f.Iterate(folders, f1.Blocks[0].Hash, func(folder, file string, index int32) bool {


### PR DESCRIPTION
### Purpose

This is a successor to https://github.com/syncthing/syncthing/pull/5394 and has the same goal, but with less moving parts. By integrating `BlockMap` into `instance`/`keyer` all operations can now be done in `instance.updateLocalFiles` sequentially. Meaning the batch will only be flushed to db in a state, where all "update operations" for the contained items are done.

### Testing

None.