### PR TITLE
Multiarch for Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,28 +1,26 @@
-FROM golang:1.11 AS builder
-
-WORKDIR /go/src/github.com/syncthing/syncthing
-COPY . .
+### Build ###
+FROM golang:1.11-alpine AS builder
 
 ENV CGO_ENABLED=0
 ENV BUILD_HOST=syncthing.net
 ENV BUILD_USER=docker
-RUN rm -f syncthing && go run build.go -no-upgrade build syncthing
 
+WORKDIR /go/src/github.com/syncthing/syncthing
+COPY . .
+RUN go run build.go -no-upgrade build
+
+### Serve ###
 FROM alpine
 
+ENV PUID=1000 PGID=1000
 EXPOSE 8384 22000 21027/udp
-
 VOLUME ["/var/syncthing"]
 
-RUN apk add --no-cache ca-certificates su-exec
-
+RUN apk add --update --no-cache ca-certificates su-exec
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
-
-ENV PUID=1000 PGID=1000
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z localhost 8384 || exit 1
-
 ENTRYPOINT \
   chown "${PUID}:${PGID}" /var/syncthing \
   && su-exec "${PUID}:${PGID}" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,24 @@
+# Syncthing Docker
+
+## Build Args
+
+### Supported
+
+|BUILD_GOOS|BUILD_GOARCH|SERVE_U|SERVE_R|QEMUARCH|
+|-|-|-|-|-|
+|linux|386|i386|alpine|i386|
+|linux|amd64|amd64|alpine|amd64|
+|linux|arm|arm32v6|alpine|arm|
+|linux|arm64|arm64v8|alpine|aarch64|
+|linux|ppc64le|ppc64le|alpine|ppc64le|
+|linux|s390x|s390x|alpine|s390x|
+
+### Unsupported (no base image available)
+
+|BUILD_GOOS|BUILD_GOARCH|SERVE_U|SERVE_R|QEMUARCH|
+|-|-|-|-|-|
+|linux|mips|!|!|mips|
+|linux|mips64|!|!|mips64|
+|linux|mips64le|!|!|mips64el|
+|linux|mipsle|!|!|mipsel|
+|linux|ppc64|!|!|ppc64|

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -12,24 +12,24 @@ AUTHTOKEN=$(cat ~/.dockercfg | jq '.["https://index.docker.io/v1/"] .auth')
 echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\": $AUTHTOKEN}},\"experimental\": \"enabled\"}" > ~/.docker/config.json
 ### -------------------- ###
 
-MULTIARCH_DOCKERFILE_PATH=$(echo "$DOCKERFILE_PATH" | sed "s/Dockerfile/multiarch.Dockerfile/")
+MULTIARCH_DOCKERFILE_PATH="${DOCKERFILE_PATH/Dockerfile/multiarch.Dockerfile}"
 
 # register qemu modules
 docker run --rm --privileged multiarch/qemu-user-static:register
 
 # remove MULTIARCH line and build default image
 sed "/__MULTIARCH_/d" "$MULTIARCH_DOCKERFILE_PATH" > "$DOCKERFILE_PATH"
-docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="amd64" --build-arg SERVE_U="amd64" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="amd64" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/") .
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="amd64" --build-arg SERVE_U="amd64" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="amd64" -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME/:latest/:amd64-latest}" .
 
 # enable MULTIARCH line and build multiarch images
 sed "s/__MULTIARCH_//g" "$MULTIARCH_DOCKERFILE_PATH" > "$DOCKERFILE_PATH"
 curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-i386-static.tar.gz" | tar xz
-docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="386" --build-arg SERVE_U="i386" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="i386" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/") .
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="386" --build-arg SERVE_U="i386" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="i386" -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME/:latest/:i386-latest}" .
 curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-arm-static.tar.gz" | tar xz
-docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="arm" --build-arg SERVE_U="arm32v6" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="arm" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/") .
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="arm" --build-arg SERVE_U="arm32v6" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="arm" -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME/:latest/:arm-latest}" .
 curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-aarch64-static.tar.gz" | tar xz
-docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="arm64" --build-arg SERVE_U="arm64v8" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="aarch64" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/") .
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="arm64" --build-arg SERVE_U="arm64v8" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="aarch64" -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME/:latest/:aarch64-latest}" .
 curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-ppc64le-static.tar.gz" | tar xz
-docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="ppc64le" --build-arg SERVE_U="ppc64le" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="ppc64le" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/") .
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="ppc64le" --build-arg SERVE_U="ppc64le" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="ppc64le" -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME/:latest/:ppc64le-latest}" .
 curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-s390x-static.tar.gz" | tar xz
-docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="s390x" --build-arg SERVE_U="s390x" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="s390x" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/") .
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="s390x" --build-arg SERVE_U="s390x" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="s390x" -f "$DOCKERFILE_PATH" -t "${IMAGE_NAME/:latest/:s390x-latest}" .

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# navigate from Dockerfile folder to project root
+cd ..
+
+### upgrade to Docker 18 ###
+docker --version
+apt-get update && apt-get dist-upgrade -y && apt-get install jq -y
+docker --version
+mkdir ~/.docker
+AUTHTOKEN=$(cat ~/.dockercfg | jq '.["https://index.docker.io/v1/"] .auth')
+echo "{\"auths\":{\"https://index.docker.io/v1/\":{\"auth\": $AUTHTOKEN}},\"experimental\": \"enabled\"}" > ~/.docker/config.json
+### -------------------- ###
+
+MULTIARCH_DOCKERFILE_PATH=$(echo "$DOCKERFILE_PATH" | sed "s/Dockerfile/multiarch.Dockerfile/")
+
+# register qemu modules
+docker run --rm --privileged multiarch/qemu-user-static:register
+
+# remove MULTIARCH line and build default image
+sed "/__MULTIARCH_/d" "$MULTIARCH_DOCKERFILE_PATH" > "$DOCKERFILE_PATH"
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="amd64" --build-arg SERVE_U="amd64" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="amd64" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/") .
+
+# enable MULTIARCH line and build multiarch images
+sed "s/__MULTIARCH_//g" "$MULTIARCH_DOCKERFILE_PATH" > "$DOCKERFILE_PATH"
+curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-i386-static.tar.gz" | tar xz
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="386" --build-arg SERVE_U="i386" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="i386" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/") .
+curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-arm-static.tar.gz" | tar xz
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="arm" --build-arg SERVE_U="arm32v6" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="arm" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/") .
+curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-aarch64-static.tar.gz" | tar xz
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="arm64" --build-arg SERVE_U="arm64v8" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="aarch64" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/") .
+curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-ppc64le-static.tar.gz" | tar xz
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="ppc64le" --build-arg SERVE_U="ppc64le" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="ppc64le" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/") .
+curl -L "https://github.com/multiarch/qemu-user-static/releases/download/v3.1.0-2/x86_64_qemu-s390x-static.tar.gz" | tar xz
+docker build --build-arg BUILD_GOOS="linux" --build-arg BUILD_GOARCH="s390x" --build-arg SERVE_U="s390x" --build-arg SERVE_R="alpine" --build-arg QEMUARCH="s390x" -f "$DOCKERFILE_PATH" -t $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/") .

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,23 +1,23 @@
 #!/bin/bash
 
 # push individual tags
-docker push $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/")
-docker push $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/")
-docker push $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/")
-docker push $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/")
-docker push $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/")
-docker push $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/")
+docker push "${IMAGE_NAME/:latest/:i386-latest}"
+docker push "${IMAGE_NAME/:latest/:amd64-latest}"
+docker push "${IMAGE_NAME/:latest/:arm-latest}"
+docker push "${IMAGE_NAME/:latest/:aarch64-latest}"
+docker push "${IMAGE_NAME/:latest/:ppc64le-latest}"
+docker push "${IMAGE_NAME/:latest/:s390x-latest}"
 
 # create manifest
-docker manifest create $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/")
+docker manifest create $IMAGE_NAME "${IMAGE_NAME/:latest/:i386-latest}" "${IMAGE_NAME/:latest/:amd64-latest}" "${IMAGE_NAME/:latest/:arm-latest}" "${IMAGE_NAME/:latest/:aarch64-latest}" "${IMAGE_NAME/:latest/:ppc64le-latest}" "${IMAGE_NAME/:latest/:s390x-latest}"
 
 # annotate manifest
-docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/") --os linux --arch 386
-docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/") --os linux --arch amd64
-docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/") --os linux --arch arm
-docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/") --os linux --arch arm64 --variant armv8
-docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/") --os linux --arch ppc64le
-docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/") --os linux --arch s390x
+docker manifest annotate $IMAGE_NAME "${IMAGE_NAME/:latest/:i386-latest}" --os linux --arch 386
+docker manifest annotate $IMAGE_NAME "${IMAGE_NAME/:latest/:amd64-latest}" --os linux --arch amd64
+docker manifest annotate $IMAGE_NAME "${IMAGE_NAME/:latest/:arm-latest}" --os linux --arch arm
+docker manifest annotate $IMAGE_NAME "${IMAGE_NAME/:latest/:aarch64-latest}" --os linux --arch arm64 --variant armv8
+docker manifest annotate $IMAGE_NAME "${IMAGE_NAME/:latest/:ppc64le-latest}" --os linux --arch ppc64le
+docker manifest annotate $IMAGE_NAME "${IMAGE_NAME/:latest/:s390x-latest}" --os linux --arch s390x
 
 # push manifest
 docker manifest push $IMAGE_NAME

--- a/docker/hooks/push
+++ b/docker/hooks/push
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# push individual tags
+docker push $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/")
+docker push $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/")
+docker push $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/")
+docker push $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/")
+docker push $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/")
+docker push $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/")
+
+# create manifest
+docker manifest create $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/") $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/")
+
+# annotate manifest
+docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:i386-latest/") --os linux --arch 386
+docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:amd64-latest/") --os linux --arch amd64
+docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:arm-latest/") --os linux --arch arm
+docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:aarch64-latest/") --os linux --arch arm64 --variant armv8
+docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:ppc64le-latest/") --os linux --arch ppc64le
+docker manifest annotate $IMAGE_NAME $(echo $IMAGE_NAME | sed "s/:latest/:s390x-latest/") --os linux --arch s390x
+
+# push manifest
+docker manifest push $IMAGE_NAME

--- a/docker/multiarch.Dockerfile
+++ b/docker/multiarch.Dockerfile
@@ -24,6 +24,7 @@ VOLUME ["/var/syncthing"]
 
 __MULTIARCH_COPY qemu-${QEMUARCH}-static /usr/bin/
 RUN apk add --update --no-cache ca-certificates su-exec
+RUN rm /usr/bin/qemu-${QEMUARCH}-static
 COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
 
 HEALTHCHECK --interval=1m --timeout=10s \

--- a/docker/multiarch.Dockerfile
+++ b/docker/multiarch.Dockerfile
@@ -1,0 +1,37 @@
+ARG SERVE_U=amd64
+ARG SERVE_R=alpine
+
+### Build ###
+FROM golang:1.11-alpine AS builder
+
+ARG BUILD_GOOS=linux
+ARG BUILD_GOARCH=amd64
+ENV CGO_ENABLED=0
+ENV BUILD_HOST=syncthing.net
+ENV BUILD_USER=docker
+
+WORKDIR /go/src/github.com/syncthing/syncthing
+COPY . .
+RUN go run build.go -no-upgrade -goos=$BUILD_GOOS -goarch=$BUILD_GOARCH build
+
+### Serve ###
+FROM $SERVE_U/$SERVE_R
+
+ARG QEMUARCH=amd64
+ENV PUID=1000 PGID=1000
+EXPOSE 8384 22000 21027/udp
+VOLUME ["/var/syncthing"]
+
+__MULTIARCH_COPY qemu-${QEMUARCH}-static /usr/bin/
+RUN apk add --update --no-cache ca-certificates su-exec
+COPY --from=builder /go/src/github.com/syncthing/syncthing/syncthing /bin/syncthing
+
+HEALTHCHECK --interval=1m --timeout=10s \
+  CMD nc -z localhost 8384 || exit 1
+ENTRYPOINT \
+  chown "${PUID}:${PGID}" /var/syncthing \
+  && su-exec "${PUID}:${PGID}" \
+     env HOME=/var/syncthing \
+     /bin/syncthing \
+       -home /var/syncthing/config \
+       -gui-address 0.0.0.0:8384


### PR DESCRIPTION
### Purpose

This refactors the Dockerfile into a multiarch.Dockerfile, that is provided along with build hook scripts to push a manifest from DockerHub to DockerHub. Fixes #5436.

### Testing

My fork builds successfully on DockerHub. See [cloud](https://cloud.docker.com/repository/registry-1.docker.io/dargmuesli/syncthing/builds/4f7112fe-0482-42d9-b367-b1c8414f7c13) (I'm not sure if someone else can) or [hub](https://hub.docker.com/r/dargmuesli/syncthing)

### Documentation

There are no documentation changes necessary as Docker manifests make it possible to pull the correct image automatically and thus remove the architecture (tag) selection step.