### PR TITLE
build: Add -cc argument that is not used by build.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -46,6 +46,7 @@ var (
 	extraTags     string
 	installSuffix string
 	pkgdir        string
+	cc            string
 	debugBinary   bool
 	timeout       = "120s"
 )
@@ -329,6 +330,7 @@ func parseFlags() {
 	flag.StringVar(&extraTags, "tags", extraTags, "Extra tags, space separated")
 	flag.StringVar(&installSuffix, "installsuffix", installSuffix, "Install suffix, optional")
 	flag.StringVar(&pkgdir, "pkgdir", "", "Set -pkgdir parameter for `go build`")
+	flag.StringVar(&cc, "cc", os.Getenv("CC"), "Set CC environment variable for `go build`")
 	flag.BoolVar(&debugBinary, "debug-binary", debugBinary, "Create unoptimized binary to use with delve, set -gcflags='-N -l' and omit -ldflags")
 	flag.Parse()
 }
@@ -398,6 +400,7 @@ func install(target target, tags []string) {
 
 	os.Setenv("GOOS", goos)
 	os.Setenv("GOARCH", goarch)
+	os.Setenv("CC", cc)
 
 	// On Windows generate a special file which the Go compiler will
 	// automatically use when generating Windows binaries to set things like
@@ -425,6 +428,7 @@ func build(target target, tags []string) {
 
 	os.Setenv("GOOS", goos)
 	os.Setenv("GOARCH", goarch)
+	os.Setenv("CC", cc)
 
 	// On Windows generate a special file which the Go compiler will
 	// automatically use when generating Windows binaries to set things like


### PR DESCRIPTION
Seems that `CGO_ENABLED=1 CC=foo go run build.go` actually tries to compile build.go with an android compiler and link against local non-android system headers which obviously does not work.

Also, CGO_ENABLED=1 should also probably be -cgo-enabled, but that's not a problem for now.

I guess prior to Go 1.10, it worked somehow differently?