### PR TITLE
cmd/syncthing, gui: Settings dialog upgrades/reporting for candidates (fixes #4216)

### DIFF
--- a/cmd/syncthing/gui.go
+++ b/cmd/syncthing/gui.go
@@ -609,12 +609,15 @@ func (s *apiService) getJSMetadata(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *apiService) getSystemVersion(w http.ResponseWriter, r *http.Request) {
-	sendJSON(w, map[string]string{
+	sendJSON(w, map[string]interface{}{
 		"version":     Version,
 		"codename":    Codename,
 		"longVersion": LongVersion,
 		"os":          runtime.GOOS,
 		"arch":        runtime.GOARCH,
+		"isBeta":      IsBeta,
+		"isCandidate": IsCandidate,
+		"isRelease":   IsRelease,
 	})
 }
 

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -30,7 +30,7 @@
 
 <body>
   <script type="text/javascript" src="syncthing/development/logbar.js"></script>
-  <div ng-if="version.isDevelopmentVersion" ng-include="'syncthing/development/logbar.html'"></div>
+  <div ng-if="version.isBeta" ng-include="'syncthing/development/logbar.html'"></div>
   <!-- Top bar -->
 
   <nav class="navbar navbar-top navbar-default" role="navigation">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -124,6 +124,7 @@ angular.module('syncthing.core')
             refreshThemes();
 
             $http.get(urlbase + '/system/version').success(function (data) {
+                console.log("version", data);
                 if ($scope.version.version && $scope.version.version !== data.version) {
                     // We already have a version response, but it differs from
                     // the new one. Reload the full GUI in case it's changed.
@@ -131,7 +132,6 @@ angular.module('syncthing.core')
                 }
 
                 $scope.version = data;
-                $scope.version.isDevelopmentVersion = data.version.indexOf('-') > 0;
             }).error($scope.emitHTTPError);
 
             $http.get(urlbase + '/svc/report').success(function (data) {

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -70,7 +70,7 @@
             <div class="col-md-6">
               <div class="form-group">
                 <label translate for="urVersion">Anonymous Usage Reporting</label> (<a href="" translate data-toggle="modal" data-target="#urPreview">Preview</a>)
-                <div ng-if="tmpOptions.upgrades != 'candidate'">
+                <div ng-if="tmpOptions.upgrades != 'candidate' && !version.isCandidate">
                   <select class="form-control" id="urVersion" ng-model="tmpOptions._urAcceptedStr">
                     <option ng-repeat="n in urVersions()" value="{{n}}">{{'Version' | translate}} {{n}}</option>
                     <!-- 1 does not exist, as we did not support incremental formats back then. -->
@@ -78,7 +78,7 @@
                     <option value="-1" translate>Disabled</option>
                   </select>
                 </div>
-                <p class="help-block" ng-if="tmpOptions.upgrades == 'candidate'">
+                <p class="help-block" ng-if="tmpOptions.upgrades == 'candidate' || version.isCandidate"">
                   <span translate>Usage reporting is always enabled for candidate releases.</span>
                 </p>
               </div>
@@ -87,12 +87,15 @@
               <div class="form-group">
                 <label translate>Automatic upgrades</label>&emsp;<a href="https://docs.syncthing.net/users/releases.html" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
                 <select class="form-control" ng-model="tmpOptions.upgrades" ng-if="upgradeInfo">
-                  <option value="none" translate>No upgrades</option>
+                  <option ng-if="!version.isCandidate" value="none" translate>No upgrades</option>
                   <option value="stable" translate>Stable releases only</option>
                   <option value="candidate" translate>Stable releases and release candidates</option>
                 </select>
                 <p class="help-block" ng-if="!upgradeInfo">
                   <span translate>Unavailable/Disabled by administrator or maintainer</span>
+                </p>
+                <p class="help-block" ng-if="version.isCandidate"">
+                  <span translate>Automatic upgrades are always enabled for candidate releases.</span>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
### Purpose

This adds booleans to the /system/version response to advice the GUI whether the running version is a candidate release or not. (We could parse it from the version string, but why duplicate the logic.)

Additionally the settings dialog locks down the upgrade and usage reporting options on candidate releases. This matches the current behavior, it just makes it obvious what actually *can* be chosen.

The usage reporting settings locks down 1) when on a candidate version 2) when on a non-candidate version and selecting candidate upgrades. The latter isn't strictly necessary but it's what was already happening, and it also illustrates that the choice will be taken from you if you do upgrade to a candidate so I think this is fine.

### Testing

Manual

### Screenshots

On candidate:

<img width="931" alt="screen shot 2019-01-14 at 18 09 05" src="https://user-images.githubusercontent.com/125426/51128298-cc300100-1827-11e9-9b4c-43425fa44798.png">

<img width="950" alt="screen shot 2019-01-14 at 18 09 36" src="https://user-images.githubusercontent.com/125426/51128304-cf2af180-1827-11e9-94c9-57a7854a9562.png">

On release:

<img width="946" alt="screen shot 2019-01-14 at 18 10 24" src="https://user-images.githubusercontent.com/125426/51128312-d4883c00-1827-11e9-875a-ef6318aee5b7.png">
