### PR TITLE
lib/db: Add "dirty" function terminology to getGlobal (ref #5462)

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -250,7 +250,7 @@ func (s *FileSet) Get(device protocol.DeviceID, file string) (protocol.FileInfo,
 }
 
 func (s *FileSet) GetGlobal(file string) (protocol.FileInfo, bool) {
-	fi, ok := s.db.getGlobal([]byte(s.folder), []byte(osutil.NormalizedFilename(file)), false)
+	fi, ok := s.db.getGlobalDirty([]byte(s.folder), []byte(osutil.NormalizedFilename(file)), false)
 	if !ok {
 		return protocol.FileInfo{}, false
 	}
@@ -260,7 +260,7 @@ func (s *FileSet) GetGlobal(file string) (protocol.FileInfo, bool) {
 }
 
 func (s *FileSet) GetGlobalTruncated(file string) (FileInfoTruncated, bool) {
-	fi, ok := s.db.getGlobal([]byte(s.folder), []byte(osutil.NormalizedFilename(file)), true)
+	fi, ok := s.db.getGlobalDirty([]byte(s.folder), []byte(osutil.NormalizedFilename(file)), true)
 	if !ok {
 		return FileInfoTruncated{}, false
 	}


### PR DESCRIPTION
This does similar renaming as in #5462, just on getGlobal* instead of getFile*. 

Despite my previous comment this is definitely not RC material, it's solely for somewhat better naming consistency with #5462.