### PR TITLE
lib/db: Deduplicate comparing old and new items

### DIFF
--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -48,7 +48,7 @@ func (db *instance) updateFiles(folder, device []byte, fs []protocol.FileInfo, m
 			err = ef.Unmarshal(bs)
 		}
 
-		if unchanged(f, ef, err == nil) {
+		if err == nil && unchanged(f, ef) {
 			continue
 		}
 
@@ -565,6 +565,6 @@ func (e errorSuggestion) Error() string {
 // unchanged checks if two files are the same and thus don't need to be updated.
 // Local flags or the invalid bit might change without the version
 // being bumped. The IsInvalid() method handles both.
-func unchanged(nf, ef FileIntf, efOk bool) bool {
-	return efOk && ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid()
+func unchanged(nf, ef FileIntf) bool {
+	return ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid()
 }

--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -48,9 +48,7 @@ func (db *instance) updateFiles(folder, device []byte, fs []protocol.FileInfo, m
 			err = ef.Unmarshal(bs)
 		}
 
-		// Local flags or the invalid bit might change without the version
-		// being bumped. The IsInvalid() method handles both.
-		if err == nil && ef.Version.Equal(f.Version) && ef.IsInvalid() == f.IsInvalid() {
+		if unchanged(f, ef, err == nil) {
 			continue
 		}
 
@@ -562,4 +560,11 @@ type errorSuggestion struct {
 
 func (e errorSuggestion) Error() string {
 	return fmt.Sprintf("%s (%s)", e.inner.Error(), e.suggestion)
+}
+
+// unchanged checks if two files are the same and thus don't need to be updated.
+// Local flags or the invalid bit might change without the version
+// being bumped. The IsInvalid() method handles both.
+func unchanged(nf, ef FileIntf, efOk bool) bool {
+	return efOk && ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid()
 }

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -164,7 +164,7 @@ func (s *FileSet) Update(device protocol.DeviceID, fs []protocol.FileInfo) {
 	folder := []byte(s.folder)
 	for _, nf := range oldFs {
 		ef, ok := s.db.getFileDirty(folder, device[:], []byte(osutil.NormalizedFilename(nf.Name)))
-		if ok && ef.Version.Equal(nf.Version) && ef.IsInvalid() == nf.IsInvalid() {
+		if unchanged(nf, ef, ok) {
 			continue
 		}
 

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -164,7 +164,7 @@ func (s *FileSet) Update(device protocol.DeviceID, fs []protocol.FileInfo) {
 	folder := []byte(s.folder)
 	for _, nf := range oldFs {
 		ef, ok := s.db.getFileDirty(folder, device[:], []byte(osutil.NormalizedFilename(nf.Name)))
-		if unchanged(nf, ef, ok) {
+		if ok && unchanged(nf, ef) {
 			continue
 		}
 


### PR DESCRIPTION
Add a utility function `unchanged` that determines whether two `FileIntf` are the same from a database perspective (i.e. whether or not the update needs to happen).