### PR TITLE
lib/db: Consistent use of buffers

### DIFF
--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -53,7 +53,7 @@ func (db *instance) updateFiles(folder, device []byte, fs []protocol.FileInfo, m
 		t.insertFile(dk, folder, device, f)
 
 		gk = db.keyer.GenerateGlobalVersionKey(gk, folder, name)
-		t.updateGlobal(gk, keyBuf, folder, device, f, meta)
+		keyBuf, _ = t.updateGlobal(gk, keyBuf, folder, device, f, meta)
 
 		// Write out and reuse the batch every few records, to avoid the batch
 		// growing too large and thus allocating unnecessarily much memory.

--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -34,7 +34,7 @@ func (db *instance) updateFiles(folder, device []byte, fs []protocol.FileInfo, m
 	t := db.newReadWriteTransaction()
 	defer t.close()
 
-	var dk, gk []byte
+	var dk, gk, keyBuf []byte
 	devID := protocol.DeviceIDFromBytes(device)
 	for _, f := range fs {
 		name := []byte(f.Name)
@@ -53,7 +53,7 @@ func (db *instance) updateFiles(folder, device []byte, fs []protocol.FileInfo, m
 		t.insertFile(dk, folder, device, f)
 
 		gk = db.keyer.GenerateGlobalVersionKey(gk, folder, name)
-		t.updateGlobal(gk, folder, device, f, meta)
+		t.updateGlobal(gk, keyBuf, folder, device, f, meta)
 
 		// Write out and reuse the batch every few records, to avoid the batch
 		// growing too large and thus allocating unnecessarily much memory.
@@ -156,7 +156,7 @@ func (db *instance) withAllFolderTruncated(folder []byte, fn func(device []byte,
 	dbi := t.NewIterator(util.BytesPrefix(db.keyer.GenerateDeviceFileKey(nil, folder, nil, nil).WithoutNameAndDevice()), nil)
 	defer dbi.Release()
 
-	var gk []byte
+	var gk, buf []byte
 	for dbi.Next() {
 		device, ok := db.keyer.DeviceFromDeviceFileKey(dbi.Key())
 		if !ok {
@@ -181,7 +181,7 @@ func (db *instance) withAllFolderTruncated(folder []byte, fn func(device []byte,
 			l.Infof("Dropping invalid filename %q from database", f.Name)
 			name := []byte(f.Name)
 			gk = db.keyer.GenerateGlobalVersionKey(gk, folder, name)
-			t.removeFromGlobal(gk, folder, device, name, nil)
+			buf = t.removeFromGlobal(gk, buf, folder, device, name, nil)
 			t.Delete(dbi.Key())
 			t.checkFlush()
 			continue
@@ -202,8 +202,7 @@ func (db *instance) getFileDirty(folder, device, file []byte) (protocol.FileInfo
 func (db *instance) getGlobalDirty(folder, file []byte, truncate bool) (FileIntf, bool) {
 	t := db.newReadOnlyTransaction()
 	defer t.close()
-
-	_, _, f, ok := t.getGlobalInto(nil, nil, folder, file, truncate)
+	_, f, ok := t.getGlobal(nil, folder, file, truncate)
 	return f, ok
 }
 
@@ -219,7 +218,7 @@ func (db *instance) withGlobal(folder, prefix []byte, truncate bool, fn Iterator
 			prefix = append(prefix, '/')
 		}
 
-		if _, _, f, ok := t.getGlobalInto(nil, nil, folder, unslashedPrefix, truncate); ok && !fn(f) {
+		if _, f, ok := t.getGlobal(nil, folder, unslashedPrefix, truncate); ok && !fn(f) {
 			return
 		}
 	}
@@ -363,11 +362,11 @@ func (db *instance) withNeedLocal(folder []byte, truncate bool, fn Iterator) {
 	dbi := t.NewIterator(util.BytesPrefix(db.keyer.GenerateNeedFileKey(nil, folder, nil).WithoutName()), nil)
 	defer dbi.Release()
 
-	var gk, dk []byte
+	var buf []byte
 	var f FileIntf
 	var ok bool
 	for dbi.Next() {
-		gk, dk, f, ok = t.getGlobalInto(gk, dk, folder, db.keyer.NameFromGlobalVersionKey(dbi.Key()), truncate)
+		buf, f, ok = t.getGlobal(buf, folder, db.keyer.NameFromGlobalVersionKey(dbi.Key()), truncate)
 		if !ok {
 			continue
 		}
@@ -402,13 +401,12 @@ func (db *instance) dropDeviceFolder(device, folder []byte, meta *metadataTracke
 	dbi := t.NewIterator(util.BytesPrefix(db.keyer.GenerateDeviceFileKey(nil, folder, device, nil)), nil)
 	defer dbi.Release()
 
-	var gk []byte
+	var gk, buf []byte
 	for dbi.Next() {
-		key := dbi.Key()
-		name := db.keyer.NameFromDeviceFileKey(key)
+		name := db.keyer.NameFromDeviceFileKey(dbi.Key())
 		gk = db.keyer.GenerateGlobalVersionKey(gk, folder, name)
-		t.removeFromGlobal(gk, folder, device, name, meta)
-		t.Delete(key)
+		buf = t.removeFromGlobal(gk, buf, folder, device, name, meta)
+		t.Delete(dbi.Key())
 		t.checkFlush()
 	}
 }

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -101,7 +101,7 @@ func (db *schemaUpdater) updateSchema0to1() {
 	changedFolders := make(map[string]struct{})
 	ignAdded := 0
 	meta := newMetadataTracker() // dummy metadata tracker
-	var gk []byte
+	var gk, buf []byte
 
 	for dbi.Next() {
 		folder, ok := db.keyer.FolderFromDeviceFileKey(dbi.Key())
@@ -126,7 +126,7 @@ func (db *schemaUpdater) updateSchema0to1() {
 				changedFolders[string(folder)] = struct{}{}
 			}
 			gk = db.keyer.GenerateGlobalVersionKey(gk, folder, name)
-			t.removeFromGlobal(gk, folder, device, nil, nil)
+			buf = t.removeFromGlobal(gk, buf, folder, device, nil, nil)
 			t.Delete(dbi.Key())
 			t.checkFlush()
 			continue
@@ -156,8 +156,8 @@ func (db *schemaUpdater) updateSchema0to1() {
 		// Add invalid files to global list
 		if f.IsInvalid() {
 			gk = db.keyer.GenerateGlobalVersionKey(gk, folder, name)
-			if t.updateGlobal(gk, folder, device, f, meta) {
-				if _, ok := changedFolders[string(folder)]; !ok {
+			if buf, ok = t.updateGlobal(gk, buf, folder, device, f, meta); ok {
+				if _, ok = changedFolders[string(folder)]; !ok {
 					changedFolders[string(folder)] = struct{}{}
 				}
 				ignAdded++

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -65,24 +65,24 @@ func (t readOnlyTransaction) getFileTrunc(key []byte, trunc bool) (FileIntf, boo
 }
 
 func (t readOnlyTransaction) getGlobal(buf, folder, file []byte, truncate bool) ([]byte, FileIntf, bool) {
-	buf = t.db.keyer.GenerateGlobalVersionKey(buf, folder, file)
+	var key []byte = t.db.keyer.GenerateGlobalVersionKey(buf, folder, file)
 
-	bs, err := t.Get(buf, nil)
+	bs, err := t.Get(key, nil)
 	if err != nil {
-		return buf, nil, false
+		return key, nil, false
 	}
 
 	vl, ok := unmarshalVersionList(bs)
 	if !ok {
-		return buf, nil, false
+		return key, nil, false
 	}
 
-	buf = t.db.keyer.GenerateDeviceFileKey(buf, folder, vl.Versions[0].Device, file)
-	if fi, ok := t.getFileTrunc(buf, truncate); ok {
-		return buf, fi, true
+	key = t.db.keyer.GenerateDeviceFileKey(key, folder, vl.Versions[0].Device, file)
+	if fi, ok := t.getFileTrunc(key, truncate); ok {
+		return key, fi, true
 	}
 
-	return buf, nil, false
+	return key, nil, false
 }
 
 // A readWriteTransaction is a readOnlyTransaction plus a batch for writes.


### PR DESCRIPTION
Second to last PR :)

In some places we do use/share byte buffers for keys, in some we don't. In this PR the use is made consistent such that buffers are used for all "normal" operations. Normal in the sense that they aren't part of some kind of "special" operation, but happen often (every loop of update, drop, ...).