### PR TITLE
lib/model: Improve errors while pulling

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -64,7 +64,7 @@ var (
 	errSymlinksUnsupported = errors.New("symlinks not supported")
 	errDirHasToBeScanned   = errors.New("directory contains unexpected files, scheduling scan")
 	errDirHasIgnored       = errors.New("directory contains ignored files (see ignore documentation for (?d) prefix)")
-	errDirNotEmpty         = errors.New("directory is not empty")
+	errDirNotEmpty         = errors.New("directory is not empty; files within are probably ignored on connected devices only")
 	errNotAvailable        = errors.New("no connected device has the required version of this file")
 	errModified            = errors.New("file modified but not rescanned; will try again later")
 )
@@ -1397,7 +1397,8 @@ func (f *sendReceiveFolder) pullBlock(state pullBlockState, out chan<- *sharedPu
 		// Fetch the block, while marking the selected device as in use so that
 		// leastBusy can select another device when someone else asks.
 		activity.using(selected)
-		buf, lastError := f.model.requestGlobal(selected.ID, f.folderID, state.file.Name, state.block.Offset, int(state.block.Size), state.block.Hash, state.block.WeakHash, selected.FromTemporary)
+		var buf []byte
+		buf, lastError = f.model.requestGlobal(selected.ID, f.folderID, state.file.Name, state.block.Offset, int(state.block.Size), state.block.Hash, state.block.WeakHash, selected.FromTemporary)
 		activity.done(selected)
 		if lastError != nil {
 			l.Debugln("request:", f.folderID, state.file.Name, state.block.Offset, state.block.Size, "returned error:", lastError)


### PR DESCRIPTION
`lastError` is declared outside of the loop and reused in the next iteration -> don't redeclare.

Until now I thought that `errDirNotEmpty` should never happen. Recent support threads on the forum made one mechanism clear, how you can end up with this error:

1.    Devices A and B have the same file at `foo/bar`, device A has ignore pattern `bar`.
2.   On A the user deletes `foo` is deleted -> Syncthing marks foo as deleted and sends that info to B - it doesn’t do anything about `foo/bar`, as it’s ignored.
 3.   B tries to get in sync, thus tries to delete `foo` but correctly realizes that there is still `foo/bar` and thus throws this error.

The new error is a bit more descriptive based on this scenario.