### PR TITLE
lib/config: Add omitempty to DeprecatedMinHomeDiskFreePct (fixes #5482)

### DIFF
--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -58,7 +58,7 @@ type OptionsConfiguration struct {
 	DeprecatedUPnPRenewalM       int      `xml:"upnpRenewalMinutes,omitempty" json:"-"`
 	DeprecatedUPnPTimeoutS       int      `xml:"upnpTimeoutSeconds,omitempty" json:"-"`
 	DeprecatedRelayServers       []string `xml:"relayServer,omitempty" json:"-"`
-	DeprecatedMinHomeDiskFreePct float64  `xml:"minHomeDiskFreePct" json:"-"`
+	DeprecatedMinHomeDiskFreePct float64  `xml:"minHomeDiskFreePct,omitempty" json:"-"`
 }
 
 func (orig OptionsConfiguration) Copy() OptionsConfiguration {


### PR DESCRIPTION
> when I start syncthing on a fresh installation it creates the config on first launch. There, "minHomeDiskFree" and "minHomeDiskFreePct" tags are both present in the generated xml while "minHomeDiskFreePct" is deprecated and unused. Relevant PR was #4087 .

> It's missing omitempty