### PR TITLE
lib/model: In tests disable watching for changes by default (fixes #5246)

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -50,6 +50,7 @@ func init() {
 
 	defaultFolderConfig = config.NewFolderConfiguration(protocol.LocalDeviceID, "default", "default", fs.FilesystemTypeBasic, "testdata")
 	defaultFolderConfig.Devices = []config.FolderDeviceConfiguration{{DeviceID: device1}}
+	defaultFolderConfig.FSWatcherEnabled = false
 	defaultCfg = config.Configuration{
 		Version: config.CurrentVersion,
 		Folders: []config.FolderConfiguration{defaultFolderConfig},

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -718,6 +718,7 @@ func setupModelWithConnection() (*Model, *fakeConnection, string, *config.Wrappe
 	cfg := defaultCfgWrapper.RawCopy()
 	cfg.Devices = append(cfg.Devices, config.NewDeviceConfiguration(device2, "device2"))
 	cfg.Folders[0] = config.NewFolderConfiguration(protocol.LocalDeviceID, "default", "default", fs.FilesystemTypeBasic, tmpDir)
+	cfg.Folders[0].FSWatcherEnabled = false
 	cfg.Folders[0].Devices = []config.FolderDeviceConfiguration{
 		{DeviceID: device1},
 		{DeviceID: device2},


### PR DESCRIPTION
Many model tests depend on a specific order of scans/pulls/... The by default enabled watching for changes can interfere with this pattern and thus change the tested scenario, which can make tests fail randomly, thus disable it explicitly.