### PR TITLE
test, lib/rc: Integration test fixes and polish

### DIFF
--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -126,12 +126,10 @@ func (p *Process) wait() {
 // AwaitStartup waits for the Syncthing process to start and perform initial
 // scans of all folders.
 func (p *Process) AwaitStartup() {
-	fmt.Println("awaiting startup")
 	select {
 	case <-p.startComplete:
 	case <-p.stopped:
 	}
-	fmt.Println("awaited startup")
 }
 
 // Stop stops the running Syncthing process. If the process was logging to a
@@ -320,6 +318,7 @@ func InSync(folder string, ps ...*Process) bool {
 		// If our latest FolderSummary didn't report 100%, then we are not done.
 
 		if !ps[i].done[folder] {
+			l.Debugf("done = ps[%d].done[%q] = false", i, folder)
 			return false
 		}
 

--- a/test/override_test.go
+++ b/test/override_test.go
@@ -28,8 +28,8 @@ func TestOverride(t *testing.T) {
 	fld := cfg.Folders()["default"]
 	fld.Type = config.FolderTypeSendOnly
 	cfg.SetFolder(fld)
-	t.Log(os.Rename("h1/config.xml", "h1/config.xml.orig"))
-	defer t.Log(os.Rename("h1/config.xml.orig", "h1/config.xml"))
+	os.Rename("h1/config.xml", "h1/config.xml.orig")
+	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
 	cfg.Save()
 
 	log.Println("Cleaning...")


### PR DESCRIPTION
Integration tests failed consistently locally. Apparently the renames wrapped in `t.Log` for some reason didn't take effect, thus ensuing tests failed. The rest is minor stuff that I noticed while debugging the above.

In addition on CI the integration tests currently fail due to gomodules. I wanted to try and fix it, but apparently I don't have the permissions.