### PR TITLE
WIP: Add GOARM handling

### DIFF
--- a/build.go
+++ b/build.go
@@ -35,6 +35,7 @@ import (
 
 var (
 	versionRe     = regexp.MustCompile(`-[0-9]{1,3}-g[0-9a-f]{5,10}`)
+	goarm         string
 	goarch        string
 	goos          string
 	noupgrade     bool
@@ -321,6 +322,7 @@ func runCommand(cmd string, target target) {
 }
 
 func parseFlags() {
+	flag.StringVar(&goarm, "goarm", os.Getenv("GOARM"), "GOARM")
 	flag.StringVar(&goarch, "goarch", runtime.GOARCH, "GOARCH")
 	flag.StringVar(&goos, "goos", runtime.GOOS, "GOOS")
 	flag.StringVar(&goCmd, "gocmd", "go", "Specify `go` command")
@@ -400,6 +402,7 @@ func install(target target, tags []string) {
 
 	os.Setenv("GOOS", goos)
 	os.Setenv("GOARCH", goarch)
+	os.Setenv("GOARM", goarm)
 	os.Setenv("CC", cc)
 
 	// On Windows generate a special file which the Go compiler will
@@ -428,6 +431,7 @@ func build(target target, tags []string) {
 
 	os.Setenv("GOOS", goos)
 	os.Setenv("GOARCH", goarch)
+	os.Setenv("GOARM", goarm)
 	os.Setenv("CC", cc)
 
 	// On Windows generate a special file which the Go compiler will
@@ -961,6 +965,11 @@ func buildArch() string {
 	if os == "darwin" {
 		os = "macos"
 	}
+
+	if "arm" == goarch && "" != goarm {
+		return fmt.Sprintf("%s-%s-%s", os, goarch, goarm)
+	}
+
 	return fmt.Sprintf("%s-%s", os, goarch)
 }
 

--- a/build.sh
+++ b/build.sh
@@ -68,24 +68,39 @@ case "${1:-default}" in
 		;;
 
 	all)
-		platforms=(
+		platforms=( # format: GOOS-GOARCH[-GOARM]
+			# Amd64 architecture
 			darwin-amd64 dragonfly-amd64 freebsd-amd64 linux-amd64 netbsd-amd64 openbsd-amd64 solaris-amd64 windows-amd64
+
+			# 386 architecture
 			freebsd-386 linux-386 netbsd-386 openbsd-386 windows-386
-			linux-arm linux-arm64 linux-ppc64 linux-ppc64le
+
+			# ARM architecture
+			linux-arm linux-arm-5 linux-arm-6 linux-arm-7 linux-arm64
+
+			# PPC64 Architecture
+			linux-ppc64 linux-ppc64le
 		)
 
 		for plat in "${platforms[@]}"; do
 			echo Building "$plat"
 
-			goos="${plat%-*}"
-			goarch="${plat#*-}"
-			dist="tar"
+			goos="${plat%%-*}"
+			goarm="${plat#$goos-}"
+			goarch="${goarm%%-*}"
+			goarm="${goarm#$goarch-}"
+			build_params="-goos $goos -goarch $goarch"
 
+			if [[ $goarch == "arm" && $goarm != "arm" ]]; then
+				build_params="$build_params -goarm $goarm"
+			fi
+
+			dist="tar"
 			if [[ $goos == "windows" ]]; then
 				dist="zip"
 			fi
 
-			build -goos "$goos" -goarch "$goarch" "$dist"
+			build "$build_params" "$dist"
 			echo
 		done
 		;;


### PR DESCRIPTION
### Purpose

Allow building ARM specific binaries given by specifying the `goarm` parameter

Looks like the GOARM configuration is not specified nowhere in the code, this changes keeps the current behavior while allowing the GOARM parameter to be configured and used at build time.

Related issues:
- #5305 

The reason for this MR: I'd like to directly run Syncthing on my RaspberryPI without compiling from sources on that (very limited) hardware.
