### PR TITLE
cmd/syncthing, lib/config: Update default config creation

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -47,6 +47,7 @@ var (
 		util.Address("tcp", net.JoinHostPort("0.0.0.0", strconv.Itoa(DefaultTCPPort))),
 		"dynamic+https://relays.syncthing.net/endpoint",
 	}
+	DefaultGUIPort = 8384
 	// DefaultDiscoveryServersV4 should be substituted when the configuration
 	// contains <globalAnnounceServer>default-v4</globalAnnounceServer>.
 	DefaultDiscoveryServersV4 = []string{
@@ -78,6 +79,31 @@ func New(myID protocol.DeviceID) Configuration {
 	// Can't happen.
 	if err := cfg.prepare(myID); err != nil {
 		panic("bug: error in preparing new folder: " + err.Error())
+	}
+
+	return cfg
+}
+
+func NewWithFreePorts(myID protocol.DeviceID) Configuration {
+	cfg := New(myID)
+
+	port, err := getFreePort("127.0.0.1", DefaultGUIPort)
+	if err != nil {
+		l.Fatalln("get free port (GUI):", err)
+	}
+	cfg.GUI.RawAddress = fmt.Sprintf("127.0.0.1:%d", port)
+
+	port, err = getFreePort("0.0.0.0", DefaultTCPPort)
+	if err != nil {
+		l.Fatalln("get free port (BEP):", err)
+	}
+	if port == DefaultTCPPort {
+		cfg.Options.ListenAddresses = []string{"default"}
+	} else {
+		cfg.Options.ListenAddresses = []string{
+			fmt.Sprintf("tcp://%s", net.JoinHostPort("0.0.0.0", strconv.Itoa(port))),
+			"dynamic+https://relays.syncthing.net/endpoint",
+		}
 	}
 
 	return cfg
@@ -839,4 +865,24 @@ func filterURLSchemePrefix(addrs []string, prefix string) []string {
 		}
 	}
 	return addrs
+}
+
+// tried in succession and the first to succeed is returned. If none succeed,
+// a random high port is returned.
+func getFreePort(host string, ports ...int) (int, error) {
+	for _, port := range ports {
+		c, err := net.Listen("tcp", fmt.Sprintf("%s:%d", host, port))
+		if err == nil {
+			c.Close()
+			return port, nil
+		}
+	}
+
+	c, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		return 0, err
+	}
+	addr := c.Addr().(*net.TCPAddr)
+	c.Close()
+	return addr.Port, nil
 }

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -64,7 +64,6 @@ type Wrapper struct {
 
 	deviceMap map[protocol.DeviceID]DeviceConfiguration
 	folderMap map[string]FolderConfiguration
-	replaces  chan Configuration
 	subs      []Committer
 	mut       sync.Mutex
 
@@ -79,7 +78,6 @@ func Wrap(path string, cfg Configuration) *Wrapper {
 		path: path,
 		mut:  sync.NewMutex(),
 	}
-	w.replaces = make(chan Configuration)
 	return w
 }
 
@@ -102,12 +100,6 @@ func Load(path string, myID protocol.DeviceID) (*Wrapper, error) {
 
 func (w *Wrapper) ConfigPath() string {
 	return w.path
-}
-
-// Stop stops the Serve() loop. Set and Replace operations will panic after a
-// Stop.
-func (w *Wrapper) Stop() {
-	close(w.replaces)
 }
 
 // Subscribe registers the given handler to be called on any future


### PR DESCRIPTION
A lot of things that are done in main are obsolete, as the config generation already takes care of it. In addition I moved ensuring free ports to the config package and removed some dead code from the config wrapper.