### PR TITLE
cmd/syncthing: Pass SIGTERM on in monitor (fixes #5493)

### DIFF
--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -127,7 +127,7 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 		select {
 		case s := <-stopSign:
 			l.Infof("Signal %d received; exiting", s)
-			cmd.Process.Kill()
+			cmd.Process.Signal(sigTerm)
 			<-exit
 			return
 


### PR DESCRIPTION
Tested manually.