### PR TITLE
all: Fix some linter errors

### DIFF
--- a/cmd/syncthing/auditservice.go
+++ b/cmd/syncthing/auditservice.go
@@ -44,7 +44,7 @@ func (s *auditService) Serve() {
 	for {
 		select {
 		case ev := <-sub.C():
-			enc.Encode(ev)
+			_ = enc.Encode(ev)
 		case <-s.stop:
 			return
 		}

--- a/cmd/syncthing/cpuusage_unix.go
+++ b/cmd/syncthing/cpuusage_unix.go
@@ -13,6 +13,6 @@ import "time"
 
 func cpuUsage() time.Duration {
 	var rusage syscall.Rusage
-	syscall.Getrusage(syscall.RUSAGE_SELF, &rusage)
+	_ = syscall.Getrusage(syscall.RUSAGE_SELF, &rusage)
 	return time.Duration(rusage.Utime.Nano() + rusage.Stime.Nano())
 }

--- a/cmd/syncthing/gui_auth.go
+++ b/cmd/syncthing/gui_auth.go
@@ -20,7 +20,7 @@ import (
 	"github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/sync"
 	"golang.org/x/crypto/bcrypt"
-	"gopkg.in/ldap.v2"
+	ldap "gopkg.in/ldap.v2"
 )
 
 var (
@@ -80,11 +80,10 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 			return
 		}
 
-		authOk := false
 		username := string(fields[0])
 		password := string(fields[1])
 
-		authOk = auth(username, password, guiCfg, ldapCfg)
+		authOk := auth(username, password, guiCfg, ldapCfg)
 		if !authOk {
 			usernameIso := string(iso88591ToUTF8([]byte(username)))
 			passwordIso := string(iso88591ToUTF8([]byte(password)))

--- a/cmd/syncthing/gui_statics.go
+++ b/cmd/syncthing/gui_statics.go
@@ -160,7 +160,7 @@ func (s *staticsServer) serveAsset(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(bs)))
 
-	w.Write(bs)
+	_, _ = w.Write(bs)
 }
 
 func (s *staticsServer) serveThemes(w http.ResponseWriter, r *http.Request) {

--- a/cmd/syncthing/gui_test.go
+++ b/cmd/syncthing/gui_test.go
@@ -114,13 +114,13 @@ func TestAssetsDir(t *testing.T) {
 	// The asset map contains compressed assets, so create a couple of gzip compressed assets here.
 	buf := new(bytes.Buffer)
 	gw := gzip.NewWriter(buf)
-	gw.Write([]byte("default"))
+	_, _ = gw.Write([]byte("default"))
 	gw.Close()
 	def := buf.Bytes()
 
 	buf = new(bytes.Buffer)
 	gw = gzip.NewWriter(buf)
-	gw.Write([]byte("foo"))
+	_, _ = gw.Write([]byte("foo"))
 	gw.Close()
 	foo := buf.Bytes()
 

--- a/cmd/syncthing/mocked_config_test.go
+++ b/cmd/syncthing/mocked_config_test.go
@@ -30,7 +30,7 @@ func (c *mockedConfig) LDAP() config.LDAPConfiguration {
 
 func (c *mockedConfig) RawCopy() config.Configuration {
 	cfg := config.Configuration{}
-	util.SetDefaults(&cfg.Options)
+	_ = util.SetDefaults(&cfg.Options)
 	return cfg
 }
 

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -127,13 +127,13 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 		select {
 		case s := <-stopSign:
 			l.Infof("Signal %d received; exiting", s)
-			cmd.Process.Signal(sigTerm)
+			_ = cmd.Process.Signal(sigTerm)
 			<-exit
 			return
 
 		case s := <-restartSign:
 			l.Infof("Signal %d received; restarting", s)
-			cmd.Process.Signal(sigHup)
+			_ = cmd.Process.Signal(sigHup)
 			err = <-exit
 
 		case err = <-exit:
@@ -179,7 +179,7 @@ func copyStderr(stderr io.Reader, dst io.Writer) {
 		}
 
 		if panicFd == nil {
-			dst.Write([]byte(line))
+			_, _ = dst.Write([]byte(line))
 
 			if strings.Contains(line, "SIGILL") {
 				l.Warnln(`
@@ -226,20 +226,20 @@ func copyStderr(stderr io.Reader, dst io.Writer) {
 
 				stdoutMut.Lock()
 				for _, line := range stdoutFirstLines {
-					panicFd.WriteString(line)
+					_, _ = panicFd.WriteString(line)
 				}
-				panicFd.WriteString("...\n")
+				_, _ = panicFd.WriteString("...\n")
 				for _, line := range stdoutLastLines {
-					panicFd.WriteString(line)
+					_, _ = panicFd.WriteString(line)
 				}
 				stdoutMut.Unlock()
 			}
 
-			panicFd.WriteString("Panic at " + time.Now().Format(time.RFC3339) + "\n")
+			_, _ = panicFd.WriteString("Panic at " + time.Now().Format(time.RFC3339) + "\n")
 		}
 
 		if panicFd != nil {
-			panicFd.WriteString(line)
+			_, _ = panicFd.WriteString(line)
 		}
 	}
 }
@@ -263,7 +263,7 @@ func copyStdout(stdout io.Reader, dst io.Writer) {
 		}
 		stdoutMut.Unlock()
 
-		dst.Write([]byte(line))
+		_, _ = dst.Write([]byte(line))
 	}
 }
 

--- a/cmd/syncthing/monitor_test.go
+++ b/cmd/syncthing/monitor_test.go
@@ -17,7 +17,7 @@ import (
 func TestAutoClosedFile(t *testing.T) {
 	os.RemoveAll("_autoclose")
 	defer os.RemoveAll("_autoclose")
-	os.Mkdir("_autoclose", 0755)
+	_ = os.Mkdir("_autoclose", 0755)
 	file := filepath.FromSlash("_autoclose/tmp")
 	data := []byte("hello, world\n")
 

--- a/cmd/syncthing/perfstats_unix.go
+++ b/cmd/syncthing/perfstats_unix.go
@@ -38,7 +38,10 @@ func savePerfStats(file string) {
 
 	t0 := time.Now()
 	for t := range time.NewTicker(250 * time.Millisecond).C {
-		syscall.Getrusage(syscall.RUSAGE_SELF, &rusage)
+		if err := syscall.Getrusage(syscall.RUSAGE_SELF, &rusage); err != nil {
+			continue
+		}
+
 		curTime := time.Now().UnixNano()
 		timeDiff := curTime - prevTime
 		curUsage := rusage.Utime.Nano() + rusage.Stime.Nano()

--- a/cmd/syncthing/usage.go
+++ b/cmd/syncthing/usage.go
@@ -19,11 +19,11 @@ func optionTable(w io.Writer, rows [][]string) {
 	for _, row := range rows {
 		for i, cell := range row {
 			if i > 0 {
-				tw.Write([]byte("\t"))
+				_, _ = tw.Write([]byte("\t"))
 			}
-			tw.Write([]byte(cell))
+			_, _ = tw.Write([]byte(cell))
 		}
-		tw.Write([]byte("\n"))
+		_, _ = tw.Write([]byte("\n"))
 	}
 	tw.Flush()
 }

--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -348,7 +348,9 @@ func newUsageReportingService(cfg *config.Wrapper, model *model.Model, connectio
 func (s *usageReportingService) sendUsageReport() error {
 	d := reportData(s.cfg, s.model, s.connectionsService, s.cfg.Options().URAccepted, false)
 	var b bytes.Buffer
-	json.NewEncoder(&b).Encode(d)
+	if err := json.NewEncoder(&b).Encode(d); err != nil {
+		return err
+	}
 
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -417,7 +419,7 @@ func (s *usageReportingService) Stop() {
 	s.stopMut.RUnlock()
 }
 
-func (usageReportingService) String() string {
+func (*usageReportingService) String() string {
 	return "usageReportingService"
 }
 
@@ -425,7 +427,7 @@ func (usageReportingService) String() string {
 func cpuBench(iterations int, duration time.Duration, useWeakHash bool) float64 {
 	dataSize := 16 * protocol.MinBlockSize
 	bs := make([]byte, dataSize)
-	rand.Reader.Read(bs)
+	_, _ = rand.Reader.Read(bs)
 
 	var perf float64
 	for i := 0; i < iterations; i++ {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -258,9 +258,9 @@ func (m *Model) startFolderLocked(folder string) config.FolderType {
 	ffs := fs.MtimeFS()
 
 	// These are our metadata files, and they should always be hidden.
-	ffs.Hide(config.DefaultMarkerName)
-	ffs.Hide(".stversions")
-	ffs.Hide(".stignore")
+	_ = ffs.Hide(config.DefaultMarkerName)
+	_ = ffs.Hide(".stversions")
+	_ = ffs.Hide(".stignore")
 
 	p := folderFactory(m, cfg, ver, ffs)
 
@@ -338,7 +338,7 @@ func (m *Model) RemoveFolder(cfg config.FolderConfiguration) {
 	m.fmut.Lock()
 	m.pmut.Lock()
 	// Delete syncthing specific files
-	cfg.Filesystem().RemoveAll(config.DefaultMarkerName)
+	_ = cfg.Filesystem().RemoveAll(config.DefaultMarkerName)
 
 	m.tearDownFolderLocked(cfg, fmt.Errorf("removing folder %v", cfg.Description()))
 	// Remove it from the database
@@ -362,7 +362,7 @@ func (m *Model) tearDownFolderLocked(cfg config.FolderConfiguration, err error) 
 	m.pmut.Unlock()
 	m.fmut.Unlock()
 	for _, id := range tokens {
-		m.RemoveAndWait(id, 0)
+		_ = m.RemoveAndWait(id, 0)
 	}
 	m.fmut.Lock()
 	m.pmut.Lock()
@@ -1189,7 +1189,7 @@ func (m *Model) handleIntroductions(introducerCfg config.DeviceConfiguration, cm
 		}
 
 		if changed {
-			m.cfg.SetFolder(fcfg)
+			_, _ = m.cfg.SetFolder(fcfg)
 		}
 	}
 
@@ -1246,7 +1246,7 @@ func (m *Model) handleDeintroductions(introducerCfg config.DeviceConfiguration, 
 		cfg := m.cfg.RawCopy()
 		cfg.Folders = folders
 		cfg.Devices = devices
-		m.cfg.Replace(cfg)
+		_, _ = m.cfg.Replace(cfg)
 	}
 
 	return changed
@@ -1325,7 +1325,7 @@ func (m *Model) introduceDevice(device protocol.Device, introducerCfg config.Dev
 		newDeviceCfg.SkipIntroductionRemovals = device.SkipIntroductionRemovals
 	}
 
-	m.cfg.SetDevice(newDeviceCfg)
+	_, _ = m.cfg.SetDevice(newDeviceCfg)
 }
 
 // Closed is called when a connection has been closed
@@ -1776,8 +1776,8 @@ func (m *Model) AddConnection(conn connections.Connection, hello protocol.HelloR
 
 	if (device.Name == "" || m.cfg.Options().OverwriteRemoteDevNames) && hello.DeviceName != "" {
 		device.Name = hello.DeviceName
-		m.cfg.SetDevice(device)
-		m.cfg.Save()
+		_, _ = m.cfg.SetDevice(device)
+		_ = m.cfg.Save()
 	}
 
 	m.deviceWasSeen(deviceID)
@@ -1864,7 +1864,7 @@ func sendIndexes(conn protocol.Connection, folder string, fs *db.FileSet, ignore
 		// local index may update for other folders than the one we are
 		// sending for.
 		if fs.Sequence(protocol.LocalDeviceID) <= prevSequence {
-			sub.Poll(time.Minute)
+			_, _ = sub.Poll(time.Minute)
 			continue
 		}
 
@@ -2484,7 +2484,7 @@ func (m *Model) RestoreFolderVersions(folder string, versions map[string]time.Ti
 			}
 		}
 
-		filesystem.MkdirAll(filepath.Dir(target), 0755)
+		_ = filesystem.MkdirAll(filepath.Dir(target), 0755)
 		if err == nil {
 			err = osutil.Copy(filesystem, source, target)
 		}
@@ -2732,17 +2732,6 @@ func getChunk(data []string, skip, get int) ([]string, int, int) {
 		return data[skip:l], 0, get - (l - skip)
 	}
 	return data[skip : skip+get], 0, 0
-}
-
-func stringSliceWithout(ss []string, s string) []string {
-	for i := range ss {
-		if ss[i] == s {
-			copy(ss[i:], ss[i+1:])
-			ss = ss[:len(ss)-1]
-			return ss
-		}
-	}
-	return ss
 }
 
 func readOffsetIntoBuf(fs fs.Filesystem, file string, offset int64, buf []byte) error {

--- a/lib/nat/interface.go
+++ b/lib/nat/interface.go
@@ -15,7 +15,7 @@ type Protocol string
 
 const (
 	TCP Protocol = "TCP"
-	UDP          = "UDP"
+	UDP Protocol = "UDP"
 )
 
 type Device interface {

--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -92,7 +92,7 @@ func (s *Service) process() int {
 			toRenew = append(toRenew, mapping)
 		} else {
 			toUpdate = append(toUpdate, mapping)
-			mappingRenewIn := mapping.expires.Sub(time.Now())
+			mappingRenewIn := time.Until(mapping.expires)
 			if mappingRenewIn < renewIn {
 				renewIn = mappingRenewIn
 			}
@@ -328,6 +328,6 @@ findIP:
 
 func hash(input string) int64 {
 	h := fnv.New64a()
-	h.Write([]byte(input))
+	_, _ = h.Write([]byte(input))
 	return int64(h.Sum64())
 }

--- a/lib/protocol/hello.go
+++ b/lib/protocol/hello.go
@@ -77,12 +77,7 @@ func readHello(c io.Reader) (HelloResult, error) {
 		if err := hello.Unmarshal(buf); err != nil {
 			return HelloResult{}, err
 		}
-		res := HelloResult{
-			DeviceName:    hello.DeviceName,
-			ClientName:    hello.ClientName,
-			ClientVersion: hello.ClientVersion,
-		}
-		return res, nil
+		return HelloResult(hello), nil
 
 	case 0x00010001, 0x00010000, Version13HelloMagic:
 		// This is the first word of an older cluster config message or an

--- a/lib/upgrade/upgrade_common.go
+++ b/lib/upgrade/upgrade_common.go
@@ -83,10 +83,10 @@ type Relation int
 
 const (
 	MajorOlder Relation = -2 // Older by a major version (x in x.y.z or 0.x.y).
-	Older               = -1 // Older by a minor version (y or z in x.y.z, or y in 0.x.y)
-	Equal               = 0  // Versions are semantically equal
-	Newer               = 1  // Newer by a minor version (y or z in x.y.z, or y in 0.x.y)
-	MajorNewer          = 2  // Newer by a major version (x in x.y.z or 0.x.y).
+	Older      Relation = -1 // Older by a minor version (y or z in x.y.z, or y in 0.x.y)
+	Equal      Relation = 0  // Versions are semantically equal
+	Newer      Relation = 1  // Newer by a minor version (y or z in x.y.z, or y in 0.x.y)
+	MajorNewer Relation = 2  // Newer by a major version (x in x.y.z or 0.x.y).
 )
 
 // CompareVersions returns a relation describing how a compares to b.


### PR DESCRIPTION
I'm working through linter complaints, these are some fixes. Broad
categories:

1) Ignore errors where we can ignore errors: add "_ = ..." construct.
you can argue that this is annoying noise, but apart from silencing the
linter it *does* serve the purpose of highlighting that an error is
being ignored. I think this is OK, because the linter highlighted some
error cases I wasn't aware of (starting CPU profiles, for example).

2) Untyped constants where we though we had set the type.

3) A real bug where we ineffectually assigned to a shadowed err.

4) Some dead code removed.

There'll be more of these, because not all packages are fixed, but the
diff was already large enough.

In the end I intend to enable the golang-ci cloud service that runs these linter checks on changed lines on pull requests.