### PR TITLE
lib/model: Helperize test os and remove error return value

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -310,7 +310,7 @@ func setupKnownFiles(t *testing.T, data []byte) []protocol.FileInfo {
 	t0 := time.Now().Add(-1 * time.Minute)
 	testOs.Chtimes("_recvonly/knownDir/knownFile", t0, t0)
 
-	fi, _ := testOs.Stat("_recvonly/knownDir/knownFile")
+	fi := testOs.Stat("_recvonly/knownDir/knownFile")
 	blocks, _ := scanner.Blocks(context.TODO(), bytes.NewReader(data), protocol.BlockSize(int64(len(data))), int64(len(data)), nil, true)
 	knownFiles := []protocol.FileInfo{
 		{

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -293,7 +293,7 @@ func TestWeakHash(t *testing.T) {
 	cleanup()
 	defer cleanup()
 
-	f, _ := testOs.Create("testdata/weakhash")
+	f := testOs.Create("testdata/weakhash")
 	defer f.Close()
 	_, err := io.CopyN(f, rand.Reader, size)
 	if err != nil {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1835,7 +1835,7 @@ func TestROScanRecovery(t *testing.T) {
 		return
 	}
 
-	fd, _ := testOs.Create(filepath.Join(fcfg.Path, config.DefaultMarkerName))
+	fd := testOs.Create(filepath.Join(fcfg.Path, config.DefaultMarkerName))
 	fd.Close()
 
 	if err := waitFor(""); err != nil {
@@ -1922,10 +1922,7 @@ func TestRWScanRecovery(t *testing.T) {
 		return
 	}
 
-	fd, err := testOs.Create(filepath.Join(fcfg.Path, config.DefaultMarkerName))
-	if err != nil {
-		t.Fatal(err)
-	}
+	fd := testOs.Create(filepath.Join(fcfg.Path, config.DefaultMarkerName))
 	fd.Close()
 
 	if err := waitFor(""); err != nil {
@@ -3176,7 +3173,7 @@ func TestCustomMarkerName(t *testing.T) {
 	}
 
 	testOs.Mkdir(fcfg.Path, 0700)
-	fd, _ := testOs.Create(filepath.Join(fcfg.Path, "myfile"))
+	fd := testOs.Create(filepath.Join(fcfg.Path, "myfile"))
 	fd.Close()
 
 	if err := waitFor(""); err != nil {

--- a/lib/model/testos_test.go
+++ b/lib/model/testos_test.go
@@ -14,6 +14,7 @@ import (
 // fatal is the required common interface between *testing.B and *testing.T
 type fatal interface {
 	Fatal(...interface{})
+	Helper()
 }
 
 type fatalOs struct {
@@ -21,62 +22,65 @@ type fatalOs struct {
 }
 
 func (f *fatalOs) must(fn func() error) {
+	f.Helper()
 	if err := fn(); err != nil {
 		f.Fatal(err)
 	}
 }
 
-func (f *fatalOs) Chmod(name string, mode os.FileMode) error {
+func (f *fatalOs) Chmod(name string, mode os.FileMode) {
+	f.Helper()
 	f.must(func() error { return os.Chmod(name, mode) })
-	return nil
 }
 
-func (f *fatalOs) Chtimes(name string, atime time.Time, mtime time.Time) error {
+func (f *fatalOs) Chtimes(name string, atime time.Time, mtime time.Time) {
+	f.Helper()
 	f.must(func() error { return os.Chtimes(name, atime, mtime) })
-	return nil
 }
 
-func (f *fatalOs) Create(name string) (*os.File, error) {
+func (f *fatalOs) Create(name string) *os.File {
+	f.Helper()
 	file, err := os.Create(name)
 	if err != nil {
 		f.Fatal(err)
 	}
-	return file, nil
+	return file
 }
 
-func (f *fatalOs) Mkdir(name string, perm os.FileMode) error {
+func (f *fatalOs) Mkdir(name string, perm os.FileMode) {
+	f.Helper()
 	f.must(func() error { return os.Mkdir(name, perm) })
-	return nil
 }
 
-func (f *fatalOs) MkdirAll(name string, perm os.FileMode) error {
+func (f *fatalOs) MkdirAll(name string, perm os.FileMode) {
+	f.Helper()
 	f.must(func() error { return os.MkdirAll(name, perm) })
-	return nil
 }
 
-func (f *fatalOs) Remove(name string) error {
+func (f *fatalOs) Remove(name string) {
+	f.Helper()
 	if err := os.Remove(name); err != nil && !os.IsNotExist(err) {
 		f.Fatal(err)
 	}
-	return nil
 }
 
-func (f *fatalOs) RemoveAll(name string) error {
+func (f *fatalOs) RemoveAll(name string) {
+	f.Helper()
 	if err := os.RemoveAll(name); err != nil && !os.IsNotExist(err) {
 		f.Fatal(err)
 	}
-	return nil
 }
 
-func (f *fatalOs) Rename(oldname, newname string) error {
+func (f *fatalOs) Rename(oldname, newname string) {
+	f.Helper()
 	f.must(func() error { return os.Rename(oldname, newname) })
-	return nil
 }
 
-func (f *fatalOs) Stat(name string) (os.FileInfo, error) {
+func (f *fatalOs) Stat(name string) os.FileInfo {
+	f.Helper()
 	info, err := os.Stat(name)
 	if err != nil {
 		f.Fatal(err)
 	}
-	return info, nil
+	return info
 }


### PR DESCRIPTION
Results in relevant files/line numbers on test failures.

Also our new bot indirectly detected a small slip of mine: An os that fails on errors really doesn't need to return a nil error.

This is one of a few unit test related PRs resulting from https://forum.syncthing.net/t/openbsd-test-debugging/12799
