### PR TITLE
lib/model: Improve TestIssue5063

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"sync"
@@ -1122,8 +1123,9 @@ func TestIssue5063(t *testing.T) {
 	wcfg, m := newState(defaultAutoAcceptCfg)
 	defer testOs.Remove(wcfg.ConfigPath())
 
-	addAndVerify := func(wg *sync.WaitGroup) {
-		id := srand.String(8)
+	wg := sync.WaitGroup{}
+
+	addAndVerify := func(id string) {
 		m.ClusterConfig(device1, protocol.ClusterConfig{
 			Folders: []protocol.Folder{
 				{
@@ -1132,20 +1134,37 @@ func TestIssue5063(t *testing.T) {
 				},
 			},
 		})
-		testOs.RemoveAll(id)
-		wg.Done()
 		if fcfg, ok := wcfg.Folder(id); !ok || !fcfg.SharedWith(device1) {
 			t.Error("expected shared", id)
 		}
+		wg.Done()
 	}
 
-	wg := &sync.WaitGroup{}
-	for i := 0; i <= 10; i++ {
+	reps := 10
+	ids := make([]string, reps)
+	for i := 0; i < reps; i++ {
 		wg.Add(1)
-		go addAndVerify(wg)
+		ids[i] = srand.String(8)
+		go addAndVerify(ids[i])
 	}
+	defer func() {
+		for _, id := range ids {
+			testOs.RemoveAll(id)
+		}
+	}()
+	defer m.Stop()
 
-	wg.Wait()
+	finished := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(finished)
+	}()
+	select {
+	case <-finished:
+	case <-time.After(10 * time.Second):
+		pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		t.Fatal("Timed out before all devices were added")
+	}
 }
 
 func TestAutoAcceptRejected(t *testing.T) {


### PR DESCRIPTION
This lets the test time out after 10s instead of triggering the global timeout and panicking when failing. It also does some shuffling around of cleanup and waitgroup to prevent `directory not empty` errors from `os.RemoveAll` on openbsd.

This is one of a few unit test related PRs resulting from https://forum.syncthing.net/t/openbsd-test-debugging/12799