### PR TITLE
lib/model: Don't use LocalDeviceID as normal id in tests

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -337,7 +337,7 @@ func setupKnownFiles(t *testing.T, data []byte) []protocol.FileInfo {
 }
 
 func setupROFolder() *Model {
-	fcfg := config.NewFolderConfiguration(protocol.LocalDeviceID, "ro", "receive only test", fs.FilesystemTypeBasic, "_recvonly")
+	fcfg := config.NewFolderConfiguration(myID, "ro", "receive only test", fs.FilesystemTypeBasic, "_recvonly")
 	fcfg.Type = config.FolderTypeReceiveOnly
 	fcfg.Devices = []config.FolderDeviceConfiguration{{DeviceID: device1}}
 	fcfg.FSWatcherEnabled = false
@@ -349,7 +349,7 @@ func setupROFolder() *Model {
 	wrp := config.Wrap("/dev/null", cfg)
 
 	db := db.OpenMemory()
-	m := NewModel(wrp, protocol.LocalDeviceID, "syncthing", "dev", db, nil)
+	m := NewModel(wrp, myID, "syncthing", "dev", db, nil)
 
 	m.ServeBackground()
 	m.AddFolder(fcfg)

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -77,7 +77,7 @@ func setUpFile(filename string, blockNumbers []int) protocol.FileInfo {
 
 func setUpModel(files ...protocol.FileInfo) *Model {
 	db := db.OpenMemory()
-	model := NewModel(defaultCfgWrapper, protocol.LocalDeviceID, "syncthing", "dev", db, nil)
+	model := NewModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
 	model.AddFolder(defaultFolderConfig)
 	// Update index
 	model.updateLocalsFromScanning("default", files)
@@ -408,7 +408,7 @@ func TestCopierCleanup(t *testing.T) {
 	m := setUpModel(file)
 
 	file.Blocks = []protocol.BlockInfo{blocks[1]}
-	file.Version = file.Version.Update(protocol.LocalDeviceID.Short())
+	file.Version = file.Version.Update(myID.Short())
 	// Update index (removing old blocks)
 	m.updateLocalsFromScanning("default", []protocol.FileInfo{file})
 
@@ -421,7 +421,7 @@ func TestCopierCleanup(t *testing.T) {
 	}
 
 	file.Blocks = []protocol.BlockInfo{blocks[0]}
-	file.Version = file.Version.Update(protocol.LocalDeviceID.Short())
+	file.Version = file.Version.Update(myID.Short())
 	// Update index (removing old blocks)
 	m.updateLocalsFromScanning("default", []protocol.FileInfo{file})
 
@@ -442,7 +442,7 @@ func TestDeregisterOnFailInCopy(t *testing.T) {
 
 	db := db.OpenMemory()
 
-	m := NewModel(defaultCfgWrapper, protocol.LocalDeviceID, "syncthing", "dev", db, nil)
+	m := NewModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
 	m.AddFolder(defaultFolderConfig)
 
 	// Set up our evet subscription early
@@ -535,7 +535,7 @@ func TestDeregisterOnFailInPull(t *testing.T) {
 	defer testOs.Remove("testdata/" + fs.TempName("filex"))
 
 	db := db.OpenMemory()
-	m := NewModel(defaultCfgWrapper, protocol.LocalDeviceID, "syncthing", "dev", db, nil)
+	m := NewModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
 	m.AddFolder(defaultFolderConfig)
 
 	// Set up our evet subscription early


### PR DESCRIPTION
Currently throughout model tests we use a mix of `device1` and `protocol.LocalDeviceID` for the "local device-id". In this PR I add another device-id called `myID` which should always be used for the local id, e.g. when passed to `NewModel`. Any additional remote devices are then `device1` and `device2`.

This is one of a few unit test related PRs resulting from https://forum.syncthing.net/t/openbsd-test-debugging/12799