### PR TITLE
etc: Add keywords to .desktop files (fixes #5365)

### DIFF
--- a/etc/linux-desktop/syncthing-start.desktop
+++ b/etc/linux-desktop/syncthing-start.desktop
@@ -6,4 +6,5 @@ Exec=/usr/bin/syncthing -no-browser
 Icon=syncthing
 Terminal=false
 Type=Application
+Keywords=synchronization;daemon;
 Categories=Network;FileTransfer;P2P

--- a/etc/linux-desktop/syncthing-ui.desktop
+++ b/etc/linux-desktop/syncthing-ui.desktop
@@ -6,4 +6,5 @@ Exec=/usr/bin/syncthing -browser-only
 Icon=syncthing
 Terminal=false
 Type=Application
+Keywords=synchronization;interface;
 Categories=Network;FileTransfer;P2P


### PR DESCRIPTION
### Purpose

Make .deb builds more pleasing to the Debian package linter.

### Testing

Frankly, none.
