### PR TITLE
ui: fix a translate error

### DIFF
--- a/gui/default/assets/lang/lang-zh-CN.json
+++ b/gui/default/assets/lang/lang-zh-CN.json
@@ -336,7 +336,7 @@
     "Unavailable": "无效",
     "Unavailable/Disabled by administrator or maintainer": "无效/禁用（由管理员或维护者）",
     "Undecided (will prompt)": "待定（将提示）",
-    "Unignore": "屏蔽",
+    "Unignore": "解除忽略",
     "Unknown": "未知",
     "Unshared": "未共享",
     "Unused": "未使用",


### PR DESCRIPTION
This is a fix of a translation term in `lang-zh-CN.json`.

The translation of `Unignore` is `屏蔽`, that's an error. `屏蔽` in Chinese means "shield; don't show it again; etc."

I changed it to `解除忽略`, which means "Remove Ignore" in Chinese.