### PR TITLE
lib/model: Introduce setupModel test utility

### DIFF
--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -740,11 +740,7 @@ func setupModelWithConnection() (*Model, *fakeConnection, string, *config.Wrappe
 }
 
 func setupModelWithConnectionFromWrapper(w *config.Wrapper) (*Model, *fakeConnection) {
-	db := db.OpenMemory()
-	m := NewModel(w, myID, "syncthing", "dev", db, nil)
-	m.AddFolder(w.FolderList()[0])
-	m.ServeBackground()
-	m.StartFolder("default")
+	m := setupModel(w)
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"


### PR DESCRIPTION
This is purely for convenience, consistency and deduplication - no functional change.

This is one of a few unit test related PRs resulting from https://forum.syncthing.net/t/openbsd-test-debugging/12799