### PR TITLE
lib/config, lib/model: Use path from locations to check disk space for db

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -278,7 +278,7 @@ func (f *FolderConfiguration) CheckAvailableSpace(req int64) error {
 	}
 	usage.Free -= req
 	if usage.Free > 0 {
-		if err := checkFreeSpace(f.MinDiskFree, usage); err == nil {
+		if err := CheckFreeSpace(f.MinDiskFree, usage); err == nil {
 			return nil
 		}
 	}

--- a/lib/config/size.go
+++ b/lib/config/size.go
@@ -78,7 +78,7 @@ func (s *Size) ParseDefault(str string) error {
 	return err
 }
 
-func checkFreeSpace(req Size, usage fs.Usage) error {
+func CheckFreeSpace(req Size, usage fs.Usage) error {
 	val := req.BaseValue()
 	if val <= 0 {
 		return nil

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -7,14 +7,11 @@
 package config
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 	"sync/atomic"
 	"time"
 
 	"github.com/syncthing/syncthing/lib/events"
-	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
@@ -487,16 +484,4 @@ func (w *Wrapper) AddOrUpdatePendingFolder(id, label string, device protocol.Dev
 	}
 
 	panic("bug: adding pending folder for non-existing device")
-}
-
-// CheckHomeFreeSpace returns nil if the home disk has the required amount of
-// free space, or if home disk free space checking is disabled.
-func (w *Wrapper) CheckHomeFreeSpace() error {
-	path := filepath.Dir(w.ConfigPath())
-	if usage, err := fs.NewFilesystem(fs.FilesystemTypeBasic, path).Usage("."); err == nil {
-		if err = checkFreeSpace(w.Options().MinHomeDiskFree, usage); err != nil {
-			return fmt.Errorf("insufficient space on home disk (%v): %v", path, err)
-		}
-	}
-	return nil
 }

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -21,6 +21,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
+	"github.com/syncthing/syncthing/lib/locations"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/scanner"
@@ -269,8 +270,11 @@ func (f *folder) getHealthError() error {
 		return err
 	}
 
-	if err := f.model.cfg.CheckHomeFreeSpace(); err != nil {
-		return err
+	dbPath := locations.Get(locations.Database)
+	if usage, err := fs.NewFilesystem(fs.FilesystemTypeBasic, dbPath).Usage("."); err == nil {
+		if err = config.CheckFreeSpace(f.model.cfg.Options().MinHomeDiskFree, usage); err != nil {
+			return fmt.Errorf("insufficient space on disk for database (%v): %v", dbPath, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Currently we check disk space at the path passed to `config.Wrapper`, which works for `cmd/syncthing` as the database is at the same place, but it's not right in general. Now the check is done at `locations.Get(locations.Database)`.