### PR TITLE
lib/db: Flush batch based on size and refactor (fixes #5531)

### DIFF
--- a/lib/db/blockmap_test.go
+++ b/lib/db/blockmap_test.go
@@ -73,7 +73,7 @@ func addToBlockMap(db *instance, folder []byte, fs []protocol.FileInfo) {
 			name := []byte(f.Name)
 			for i, block := range f.Blocks {
 				binary.BigEndian.PutUint32(blockBuf, uint32(i))
-				keyBuf = t.db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
+				keyBuf = t.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
 				t.Put(keyBuf, blockBuf)
 			}
 		}
@@ -89,7 +89,7 @@ func discardFromBlockMap(db *instance, folder []byte, fs []protocol.FileInfo) {
 		if !ef.IsDirectory() && !ef.IsDeleted() && !ef.IsInvalid() {
 			name := []byte(ef.Name)
 			for _, block := range ef.Blocks {
-				keyBuf = t.db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
+				keyBuf = t.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
 				t.Delete(keyBuf)
 			}
 		}

--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -80,7 +80,7 @@ func (db *instance) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		if ok {
 			if !ef.IsDirectory() && !ef.IsDeleted() && !ef.IsInvalid() {
 				for _, block := range ef.Blocks {
-					keyBuf = t.db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
+					keyBuf = db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
 					t.Delete(keyBuf)
 				}
 			}
@@ -100,7 +100,7 @@ func (db *instance) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		l.Debugf("insert (local); folder=%q %v", folder, f)
 		t.Put(dk, mustMarshal(&f))
 
-		gk = t.db.keyer.GenerateGlobalVersionKey(gk, folder, []byte(f.Name))
+		gk = db.keyer.GenerateGlobalVersionKey(gk, folder, []byte(f.Name))
 		keyBuf, _ = t.updateGlobal(gk, keyBuf, folder, protocol.LocalDeviceID[:], f, meta)
 
 		keyBuf = db.keyer.GenerateSequenceKey(keyBuf, folder, f.Sequence)
@@ -110,7 +110,7 @@ func (db *instance) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		if !f.IsDirectory() && !f.IsDeleted() && !f.IsInvalid() {
 			for i, block := range f.Blocks {
 				binary.BigEndian.PutUint32(blockBuf, uint32(i))
-				keyBuf = t.db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
+				keyBuf = db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
 				t.Put(keyBuf, blockBuf)
 			}
 		}

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -19,7 +19,8 @@ import (
 
 const (
 	dbMaxOpenFiles = 100
-	dbWriteBuffer  = 4 << 20
+	dbWriteBuffer  = 16 << 20
+	dbFlushBatch   = dbWriteBuffer / 4 // Some leeway for any leveldb in-memory optimizations
 )
 
 // Lowlevel is the lowest level database interface. It has a very simple
@@ -126,4 +127,30 @@ func leveldbIsCorrupted(err error) bool {
 	}
 
 	return false
+}
+
+type batch struct {
+	*leveldb.Batch
+	db *Lowlevel
+}
+
+func (db *Lowlevel) newBatch() *batch {
+	return &batch{
+		Batch: new(leveldb.Batch),
+		db:    db,
+	}
+}
+
+// checkFlush flushes and resets the batch if its size exceeds dbFlushBatch.
+func (b *batch) checkFlush() {
+	if len(b.Dump()) > dbFlushBatch {
+		b.flush()
+		b.Reset()
+	}
+}
+
+func (b *batch) flush() {
+	if err := b.db.Write(b.Batch, nil); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
Flush the batch when exceeding a certain size, instead of when reaching a number
of batched operations.
Move batch to lowlevel to be able to use it in NamespacedKV.
Increase the leveldb memory buffer from 4 to 16 MiB.

See discussion in #5531.