### PR TITLE
all: Get rid of fatal logging

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -462,11 +462,11 @@ func generate(generateDir string) error {
 	} else {
 		cert, err = tlsutil.NewCertificate(certFile, keyFile, tlsDefaultCommonName)
 		if err != nil {
-			return errors.Wrap(err, "Create certificate")
+			return errors.Wrap(err, "create certificate")
 		}
 		myID = protocol.NewDeviceID(cert.Certificate[0])
 		if err != nil {
-			return errors.Wrap(err, "Load certificate")
+			return errors.Wrap(err, "load certificate")
 		}
 		if err == nil {
 			l.Infoln("Device ID:", protocol.NewDeviceID(cert.Certificate[0]))
@@ -484,7 +484,7 @@ func generate(generateDir string) error {
 	}
 	err = cfg.Save()
 	if err != nil {
-		return errors.Wrap(err, "Save config")
+		return errors.Wrap(err, "save config")
 	}
 	return nil
 }
@@ -973,23 +973,23 @@ func loadConfigAtStartup() (*config.Wrapper, error) {
 	if os.IsNotExist(err) {
 		cfg, err = defaultConfig(cfgFile)
 		if err != nil {
-			return nil, errors.Wrap(err, "Failed to generate default config")
+			return nil, errors.Wrap(err, "failed to generate default config")
 		}
 		err = cfg.Save()
 		if err != nil {
-			return nil, errors.Wrap(err, "Failed to save default config")
+			return nil, errors.Wrap(err, "failed to save default config")
 		}
 		l.Infof("Default config saved. Edit %s to taste (with Syncthing stopped) or use the GUI", cfg.ConfigPath())
 	} else if err == io.EOF {
 		return nil, errors.New("Failed to load config: unexpected end of file. Truncated or empty configuration?")
 	} else if err != nil {
-		return nil, errors.Wrap(err, "Failed to load config")
+		return nil, errors.Wrap(err, "failed to load config")
 	}
 
 	if cfg.RawCopy().OriginalVersion != config.CurrentVersion {
 		err = archiveAndSaveConfig(cfg)
 		if err != nil {
-			return nil, errors.Wrap(err, "Config archive")
+			return nil, errors.Wrap(err, "config archive")
 		}
 	}
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -1079,10 +1079,14 @@ func setupGUI(mainService *suture.Supervisor, cfg *config.Wrapper, m *model.Mode
 	cfg.Subscribe(api)
 	mainService.Add(api)
 
+	if err := api.WaitForStart(); err != nil {
+		l.Warnln("Failed starting API:", err)
+		os.Exit(exitError)
+	}
+
 	if cfg.Options().StartBrowser && !runtimeOptions.noBrowser && !runtimeOptions.stRestarting {
 		// Can potentially block if the utility we are invoking doesn't
 		// fork, and just execs, hence keep it in its own routine.
-		<-api.startedOnce
 		go func() { _ = openURL(guiCfg.URL()) }()
 	}
 }

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -85,18 +85,18 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 
 		stderr, err := cmd.StderrPipe()
 		if err != nil {
-			l.Fatalln("stderr:", err)
+			panic(err)
 		}
 
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
-			l.Fatalln("stdout:", err)
+			panic(err)
 		}
 
 		l.Infoln("Starting syncthing")
 		err = cmd.Start()
 		if err != nil {
-			l.Fatalln(err)
+			panic(err)
 		}
 
 		stdoutMut.Lock()

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -84,18 +84,18 @@ func New(myID protocol.DeviceID) Configuration {
 	return cfg
 }
 
-func NewWithFreePorts(myID protocol.DeviceID) Configuration {
+func NewWithFreePorts(myID protocol.DeviceID) (Configuration, error) {
 	cfg := New(myID)
 
 	port, err := getFreePort("127.0.0.1", DefaultGUIPort)
 	if err != nil {
-		l.Fatalln("get free port (GUI):", err)
+		return Configuration{}, fmt.Errorf("get free port (GUI): %v", err)
 	}
 	cfg.GUI.RawAddress = fmt.Sprintf("127.0.0.1:%d", port)
 
 	port, err = getFreePort("0.0.0.0", DefaultTCPPort)
 	if err != nil {
-		l.Fatalln("get free port (BEP):", err)
+		return Configuration{}, fmt.Errorf("get free port (BEP): %v", err)
 	}
 	if port == DefaultTCPPort {
 		cfg.Options.ListenAddresses = []string{"default"}
@@ -106,7 +106,7 @@ func NewWithFreePorts(myID protocol.DeviceID) Configuration {
 		}
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 func ReadXML(r io.Reader, myID protocol.DeviceID) (Configuration, error) {

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -106,7 +106,7 @@ func (f FolderConfiguration) Versioner() versioner.Versioner {
 	}
 	versionerFactory, ok := versioner.Factories[f.Versioning.Type]
 	if !ok {
-		l.Fatalf("Requested versioning type %q that does not exist", f.Versioning.Type)
+		panic(fmt.Sprintf("Requested versioning type %q that does not exist", f.Versioning.Type))
 	}
 
 	return versionerFactory(f.ID, f.Filesystem(), f.Versioning.Params)

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -25,7 +25,6 @@ const (
 	LevelVerbose
 	LevelInfo
 	LevelWarn
-	LevelFatal
 	NumLevels
 )
 
@@ -49,8 +48,6 @@ type Logger interface {
 	Infof(format string, vals ...interface{})
 	Warnln(vals ...interface{})
 	Warnf(format string, vals ...interface{})
-	Fatalln(vals ...interface{})
-	Fatalf(format string, vals ...interface{})
 	ShouldDebug(facility string) bool
 	SetDebug(facility string, enabled bool)
 	Facilities() map[string]string
@@ -188,28 +185,6 @@ func (l *logger) Warnf(format string, vals ...interface{}) {
 	defer l.mut.Unlock()
 	l.logger.Output(2, "WARNING: "+s)
 	l.callHandlers(LevelWarn, s)
-}
-
-// Fatalln logs a line with a FATAL prefix and exits the process with exit
-// code 1.
-func (l *logger) Fatalln(vals ...interface{}) {
-	s := fmt.Sprintln(vals...)
-	l.mut.Lock()
-	defer l.mut.Unlock()
-	l.logger.Output(2, "FATAL: "+s)
-	l.callHandlers(LevelFatal, s)
-	os.Exit(1)
-}
-
-// Fatalf logs a formatted line with a FATAL prefix and exits the process with
-// exit code 1.
-func (l *logger) Fatalf(format string, vals ...interface{}) {
-	s := fmt.Sprintf(format, vals...)
-	l.mut.Lock()
-	defer l.mut.Unlock()
-	l.logger.Output(2, "FATAL: "+s)
-	l.callHandlers(LevelFatal, s)
-	os.Exit(1)
 }
 
 // ShouldDebug returns true if the given facility has debugging enabled.

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -923,7 +923,7 @@ func (m *Model) handleIndex(deviceID protocol.DeviceID, folder string, fs []prot
 	m.fmut.RUnlock()
 
 	if !existing {
-		l.Fatalf("%v for nonexistent folder %q", op, folder)
+		panic(fmt.Sprintf("%v for nonexistent folder %q", op, folder))
 	}
 
 	if running {
@@ -931,7 +931,7 @@ func (m *Model) handleIndex(deviceID protocol.DeviceID, folder string, fs []prot
 	} else if update {
 		// Runner may legitimately not be set if this is the "cleanup" Index
 		// message at startup.
-		l.Fatalf("%v for not running folder %q", op, folder)
+		panic(fmt.Sprintf("%v for not running folder %q", op, folder))
 	}
 
 	m.pmut.RLock()


### PR DESCRIPTION
### Purpose

A package/library has no business calling `os.Exit` ever, but that's what `logger.Fatal...` does. Solution: Panic on errors that just must not happen or bubble errors up until they reach `cmd/syncthing` (or whoever calls) and let them decide on what's to do.

### Testing

Tests pass and test setup starts and GUI reacts to input.