### PR TITLE
etc: Remove unnecessary quotes in .desktop

### DIFF
--- a/etc/linux-desktop/syncthing-ui.desktop
+++ b/etc/linux-desktop/syncthing-ui.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Syncthing Web UI
 GenericName=File synchronization UI
-Comment="Opens Syncthing's Web UI in the default browser (Syncthing must already be started)."
+Comment=Opens Syncthing's Web UI in the default browser (Syncthing must already be started).
 Exec=/usr/bin/syncthing -browser-only
 Icon=syncthing
 Terminal=false


### PR DESCRIPTION
### Purpose

Spec says nothing about using double-quotes here. They don't get stripped when line is used by DEs, resulting in inconsistent experience.
![screenshot_20190215_102405](https://user-images.githubusercontent.com/1515080/52840952-eb160180-310b-11e9-99e3-4b568b465e1e.png)


### Testing

Tested manually on KDE and XFCE.