### PR TITLE
build, script: Localize .desktop files (fixes #5535)

### DIFF
--- a/build.go
+++ b/build.go
@@ -762,6 +762,7 @@ func translate() {
 func transifex() {
 	os.Chdir("gui/default/assets/lang")
 	runPrint(goCmd, "run", "../../../../script/transifexdl.go")
+	runPrint(goCmd, "run", "../../../../script/update-desktop-translations.go", "../../../../etc/linux-desktop/", "./")
 }
 
 func ldflags() string {

--- a/script/translate.go
+++ b/script/translate.go
@@ -129,19 +129,19 @@ func parseDesktop(filename string) {
 		}
 
 		switch value := strings.SplitN(line, "=", 2); value[0] {
-			case "Name", "GenericName", "Comment":
-				if len(value[1]) == 0 {
+		case "Name", "GenericName", "Comment":
+			if len(value[1]) == 0 {
+				continue
+			}
+			translation(value[1])
+		case "Keywords":
+			words := strings.Split(value[1], ";")
+			for _, word := range words {
+				if len(word) == 0 {
 					continue
 				}
-				translation(value[1])
-			case "Keywords":
-				words := strings.Split(value[1], ";")
-				for _, word := range words {
-					if len(word) == 0 {
-						continue
-					}
-					translation(word)
-				}
+				translation(word)
+			}
 		}
 	}
 }

--- a/script/translate.go
+++ b/script/translate.go
@@ -93,6 +93,7 @@ func inTranslate(n *html.Node, filename string) {
 	}
 }
 
+// parseDesktop gets lines for translation from a .desktop file
 func parseDesktop(filename string) {
 	fd, err := os.Open(filename)
 	if err != nil {
@@ -105,36 +106,41 @@ func parseDesktop(filename string) {
 		log.Fatal(err)
 	}
 
-	lines := strings.Split(string(bs), "\n")
+	lines := strings.Split(string(bs), "\n") // this is .desktop file line by line
 
-	in := false
+	in := false // will only look in [Desktop Entry] section
 
 	for _, line := range lines {
+
+		// this line starts [Desktop Entry] section, will process the lines below
 		if groupRe.MatchString(line) {
 			in = true
 			continue
 		}
 
+		// this line starts some other section, will not process the lines below
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 			in = false
 			continue
 		}
 
+		// this line is not inside [Desktop Entry], will disregard it
 		if !in {
 			continue
 		}
 
+		// this line is not one of localestrings, will disregard it
 		if !(locRe.MatchString(line)) {
 			continue
 		}
 
 		switch value := strings.SplitN(line, "=", 2); value[0] {
-		case "Name", "GenericName", "Comment":
+		case "Name", "GenericName", "Comment": // these are submitted for translation
 			if len(value[1]) == 0 {
 				continue
 			}
 			translation(value[1])
-		case "Keywords":
+		case "Keywords": // this line is submitted value by value
 			words := strings.Split(value[1], ";")
 			for _, word := range words {
 				if len(word) == 0 {

--- a/script/update-desktop-translations.go
+++ b/script/update-desktop-translations.go
@@ -1,0 +1,212 @@
+// Copyright (C) 2019 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// +build ignore
+
+package main
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var groupRe = regexp.MustCompile(`^\[Desktop Entry\]$`)
+var locRe = regexp.MustCompile(`^(Name|GenericName|Comment|Keywords)=.*\S*.*`)
+var transRe = regexp.MustCompile(`^(Name|GenericName|Comment|Keywords)\[[a-z]{2}[a-z]?(_[A-Z]{2})?(\..+)?(@\w+)?\]=`)
+var validLangRe = regexp.MustCompile(`^[a-z]{2}[a-z]?(_[A-Z]{2})?(\..+)?(@\w+)?$`)
+var badRe = regexp.MustCompile(`\n`)
+
+var langs = make([]string,0)
+
+func main() {
+	err := filepath.Walk(os.Args[2], walkerLanguages)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = filepath.Walk(os.Args[1], walkerDesktop)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func walkerLanguages(file string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if filepath.Ext(file) == ".json" && filepath.Base(file)[0:5] == "lang-" && info.Mode().IsRegular() {
+		lang := strings.TrimSuffix(filepath.Base(file)[5:], ".json")
+		for i := 2; i < 4; i++ {
+			lang = replaceAtIndex(lang, '-', '_', i)
+		}
+		if validLangRe.MatchString(lang) {
+			langs = append(langs, lang)
+		}
+	}
+
+	return nil
+}
+
+func replaceAtIndex(in string, f rune, r rune, i int) string {
+	out := []rune(in)
+	if len(out) > i && out[i] == f {
+		out[i] = r
+	}
+	return string(out)
+}
+
+func walkerDesktop(file string, info os.FileInfo, err error) error {
+	if err != nil {
+		return err
+	}
+
+	if filepath.Ext(file) == ".desktop" && info.Mode().IsRegular() {
+		fd, err := os.Open(file)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		defer fd.Close()
+
+		bs, err := ioutil.ReadAll(fd)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		lines := strings.Split(string(bs), "\n")
+		linesNew := []string{}
+
+		in := false
+
+		for _, line := range lines {
+			if in && transRe.MatchString(line) {
+				continue
+			}
+
+			linesNew = append(linesNew, line)
+
+		if groupRe.MatchString(line) {
+			in = true
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			in = false
+			continue
+		}
+
+			if in && locRe.MatchString(line) {
+				trans := translate(line)
+				linesNew = append(linesNew, trans...)
+			}
+		}
+
+		lNew := strings.Join(linesNew, "\n")
+
+		out, err := os.Create(file)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer out.Close()
+
+		_, err = out.WriteString(lNew)
+		if err != nil {
+			log.Fatal(err)
+		}
+		err = out.Sync()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+	}
+
+	return(nil)
+}
+
+func translate(line string) []string {
+	translated := []string{}
+	values := strings.SplitN(line, "=", 2)
+	trans := make(map[string]string)
+	if values[0] == "Keywords" {
+		trans = getKeywordTrans(values[1])
+	} else {
+		trans = getTrans(values[1])
+	}
+	for lang, tran := range trans {
+		newLine := values[0] + "[" + lang + "]" + "=" + tran
+		translated = append(translated, newLine)
+	}
+	return translated
+}
+
+func getTrans(line string) map[string]string {
+	trans := make(map[string]string)
+	for _, lang := range langs {
+		translation := getTranslation(lang, line)
+		if translation != "" {
+			trans[lang] = translation
+		}
+	}
+	return trans
+}
+
+func getTranslation(lang string, line string) string {
+	for i := 2; i < 4; i++ {
+		lang = replaceAtIndex(lang, '_', '-', i)
+	}
+	langFile := "lang-" + lang + ".json"
+	langFile = filepath.Join(os.Args[2], langFile)
+
+	fd, err := os.Open(langFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	trans := make(map[string]string)
+	err = json.NewDecoder(fd).Decode(&trans)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fd.Close()
+
+	line = strings.TrimSpace(line)
+
+	// This check is probably redundant depending on how Tansifex really works,
+	// but "\n" would really damage our files, so we'll have this check just in case.
+	if badRe.MatchString(line) {
+		line = ""
+	}
+
+	return trans[line]
+}
+
+func getKeywordTrans(line string) map[string]string {
+	trans := make(map[string]string)
+	words := strings.Split(line, ";")
+	for _, lang := range langs {
+		tr := []string{}
+		tl := ""
+		for _, word := range words {
+			translation := getTranslation(lang, word)
+			if translation != "" {
+				tr = append(tr, translation)
+			}
+		}
+		for _, tran := range tr {
+			tl = tl + tran + ";"
+		}
+		if tl != "" {
+			trans[lang] = tl
+		}
+	}
+	return trans
+}

--- a/script/update-desktop-translations.go
+++ b/script/update-desktop-translations.go
@@ -48,16 +48,23 @@ func main() {
 	}
 }
 
+// walkerLanguages is for translation directory. It just looks at filenames and builds our list of available languages.
 func walkerLanguages(file string, info os.FileInfo, err error) error {
 	if err != nil {
 		return err
 	}
 
 	if filepath.Ext(file) == ".json" && filepath.Base(file)[0:5] == "lang-" && info.Mode().IsRegular() {
+
+		// Our filenames are lang-LANGUAGE.json. We only need the LANGUAGE part.
 		lang := strings.TrimSuffix(filepath.Base(file)[5:], ".json")
+
+		// Transifex LANGUAGE format differs from spec (es-ES instead of es_ES), so convert.
 		for i := 2; i < 4; i++ {
 			lang = replaceAtIndex(lang, '-', '_', i)
 		}
+
+		// If the resulting LANGUAGE looks spec-conforming, it goes to the list.
 		if validLangRe.MatchString(lang) {
 			langs = append(langs, lang)
 		}
@@ -66,6 +73,7 @@ func walkerLanguages(file string, info os.FileInfo, err error) error {
 	return nil
 }
 
+// replaceAtIndex replaces f for r in string in position i, otherwise returns unmodified string.
 func replaceAtIndex(in string, f rune, r rune, i int) string {
 	out := []rune(in)
 	if len(out) > i && out[i] == f {
@@ -74,6 +82,7 @@ func replaceAtIndex(in string, f rune, r rune, i int) string {
 	return string(out)
 }
 
+// walkerDesktop is for .desktop files directory. It looks for .desktop files and processes them in place.
 func walkerDesktop(file string, info os.FileInfo, err error) error {
 	if err != nil {
 		return err
@@ -84,7 +93,6 @@ func walkerDesktop(file string, info os.FileInfo, err error) error {
 		if err != nil {
 			log.Fatal(err)
 		}
-
 		defer fd.Close()
 
 		bs, err := ioutil.ReadAll(fd)
@@ -92,35 +100,43 @@ func walkerDesktop(file string, info os.FileInfo, err error) error {
 			log.Fatal(err)
 		}
 
-		lines := strings.Split(string(bs), "\n")
-		linesNew := []string{}
+		lines := strings.Split(string(bs), "\n") // this is what's in out .desktop file, line by line
+		linesNew := []string{}                   // and this will be what we write in its stead when done
 
+		// We only will process [Desktop Entry] section. Spec explicitly requires us to leave any other section alone.
 		in := false
 
 		for _, line := range lines {
+
+			// This is an already translated line. We discard it.
 			if in && transRe.MatchString(line) {
 				continue
 			}
 
+			// All other lines need to be kept verbatim.
 			linesNew = append(linesNew, line)
 
+			// This is "[Desktop Entry]" line. We will process the lines below it.
 			if groupRe.MatchString(line) {
 				in = true
 				continue
 			}
 
+			// This line starts another section. We don't process the lines below it.
 			if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 				in = false
 				continue
 			}
 
+			// This is one of our lines that need to be translated. We append its translations to our output.
 			if in && locRe.MatchString(line) {
 				trans := translate(line)
 				linesNew = append(linesNew, trans...)
 			}
 		}
 
-		lNew := strings.Join(linesNew, "\n")
+		// Now we take the result of our work and write it to .desktop file.
+		lNew := strings.Join(linesNew, "\n") // this way we avoid appending trailing newline to the file
 
 		out, err := os.Create(file)
 		if err != nil {
@@ -142,24 +158,31 @@ func walkerDesktop(file string, info os.FileInfo, err error) error {
 	return (nil)
 }
 
+// translate takes "Key=Value" and returns []"Key[language]=Translated value"
 func translate(line string) []string {
 	translated := []string{}
-	values := strings.SplitN(line, "=", 2)
-	trans := make(map[string]string)
+	values := strings.SplitN(line, "=", 2) // as values may by spec contain "=" symbols, too
+	trans := make(map[string]string)       // trans["language"] = "Translated value"
+
+	// One special case is Keywords, as there can be many of them, and each gets translated separately
 	if values[0] == "Keywords" {
 		trans = getKeywordTrans(values[1])
 	} else {
 		trans = getTrans(values[1])
 	}
+
+	// Construct whole lines to return
 	for lang, tran := range trans {
 		newLine := values[0] + "[" + lang + "]" + "=" + tran
 		translated = append(translated, newLine)
 	}
+
 	return translated
 }
 
+//getTrans takes "phrase" and returns map["language"]"translation of phrase" with only valid translations
 func getTrans(line string) map[string]string {
-	trans := make(map[string]string)
+	trans := make(map[string]string) // trans["language"] = "Translated value"
 	for _, lang := range langs {
 		translation := getTranslation(lang, line)
 		if translation != "" {
@@ -169,7 +192,41 @@ func getTrans(line string) map[string]string {
 	return trans
 }
 
+//getKeywordTrans is like getTrans, but for multi-values lines
+func getKeywordTrans(line string) map[string]string {
+	trans := make(map[string]string) // trans["language"] = "Translated value;another one;yet another"
+	words := strings.Split(line, ";")
+
+	// for each language we have
+	for _, lang := range langs {
+		tr := []string{} // translations for individual words
+		tl := ""         // "Translated value;another one;yet another"
+
+		// translate each word separately
+		for _, word := range words {
+			translation := getTranslation(lang, word)
+			if translation != "" {
+				tr = append(tr, translation)
+			}
+		}
+
+		// now concatenate into one line
+		for _, tran := range tr {
+			tl = tl + tran + ";"
+		}
+
+		// and add to the list of good translations
+		if tl != "" {
+			trans[lang] = tl
+		}
+	}
+	return trans
+}
+
+//getTranslation returns translation of line in lang, returns "" if it is not available
 func getTranslation(lang string, line string) string {
+
+	// change our LANGUAGE format from .desktop to Transifex and look in the corresponding file
 	for i := 2; i < 4; i++ {
 		lang = replaceAtIndex(lang, '_', '-', i)
 	}
@@ -181,42 +238,20 @@ func getTranslation(lang string, line string) string {
 		log.Fatal(err)
 	}
 
-	trans := make(map[string]string)
+	trans := make(map[string]string) // all the translations in the language file
 	err = json.NewDecoder(fd).Decode(&trans)
 	if err != nil {
 		log.Fatal(err)
 	}
 	fd.Close()
 
-	line = strings.TrimSpace(line)
+	line = strings.TrimSpace(line) // that's how the line was written to Transifex, so we look it up the same way
 
 	// This check is probably redundant depending on how Tansifex really works,
-	// but "\n" would really damage our files, so we'll have this check just in case.
-	if badRe.MatchString(line) {
-		line = ""
+	// but "\n" would really damage our files (and is illegal), so we'll have this check just in case.
+	if badRe.MatchString(trans[line]) {
+		return ""
 	}
 
 	return trans[line]
-}
-
-func getKeywordTrans(line string) map[string]string {
-	trans := make(map[string]string)
-	words := strings.Split(line, ";")
-	for _, lang := range langs {
-		tr := []string{}
-		tl := ""
-		for _, word := range words {
-			translation := getTranslation(lang, word)
-			if translation != "" {
-				tr = append(tr, translation)
-			}
-		}
-		for _, tran := range tr {
-			tl = tl + tran + ";"
-		}
-		if tl != "" {
-			trans[lang] = tl
-		}
-	}
-	return trans
 }

--- a/script/update-desktop-translations.go
+++ b/script/update-desktop-translations.go
@@ -24,7 +24,7 @@ var transRe = regexp.MustCompile(`^(Name|GenericName|Comment|Keywords)\[[a-z]{2}
 var validLangRe = regexp.MustCompile(`^[a-z]{2}[a-z]?(_[A-Z]{2})?(\..+)?(@\w+)?$`)
 var badRe = regexp.MustCompile(`\n`)
 
-var langs = make([]string,0)
+var langs = make([]string, 0)
 
 func main() {
 	err := filepath.Walk(os.Args[2], walkerLanguages)
@@ -94,15 +94,15 @@ func walkerDesktop(file string, info os.FileInfo, err error) error {
 
 			linesNew = append(linesNew, line)
 
-		if groupRe.MatchString(line) {
-			in = true
-			continue
-		}
+			if groupRe.MatchString(line) {
+				in = true
+				continue
+			}
 
-		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
-			in = false
-			continue
-		}
+			if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+				in = false
+				continue
+			}
 
 			if in && locRe.MatchString(line) {
 				trans := translate(line)
@@ -129,7 +129,7 @@ func walkerDesktop(file string, info os.FileInfo, err error) error {
 
 	}
 
-	return(nil)
+	return (nil)
 }
 
 func translate(line string) []string {


### PR DESCRIPTION
Pick up lines that support translations from `.desktop` files and feed them to Transifex. When translations appear, put them back into corresponding `.desktop` files.

Tested manually.