### PR TITLE
docs: Correct Docker README (#5480)

### DIFF
--- a/README-Docker.md
+++ b/README-Docker.md
@@ -1,39 +1,30 @@
 # Docker Container for Syncthing
 
 Use the Dockerfile in this repo, or pull the `syncthing/syncthing` image
-from Docker Hub. Use volumes to have the synchronized files available on the
-host.
+from Docker Hub.
 
-The exposed volumes are by default:
-
-    /var/syncthing/config   - the configuration and index directory into the Container
-    /var/syncthing          - the default sync folder into the Container
-
-You can add more folders and map them as you prefer.
+Use the `/var/syncthing` volume to have the synchronized files available on the
+host. You can add more folders and map them as you prefer.
 
 Note that Syncthing runs as UID 1000 and GID 1000 by default. These may be
 altered with the ``PUID`` and ``PGID`` environment variables.
 
-Example usage:
+## Example Usage
 
 ```
 $ docker pull syncthing/syncthing
 $ docker run -p 8384:8384 -p 22000:22000 \
-    -v /wherever/st-cfg:/var/syncthing/config \
     -v /wherever/st-sync:/var/syncthing \
     syncthing/syncthing:latest
 ```
 
-Note that local device discovery will not work with the above command resulting
-in poor local transfer rates if local device addresses are not manually
-configured.
+Note that local device discovery will not work with the above command, resulting in poor local transfer rates if local device addresses are not manually configured.
 
 To allow local discovery, the docker host network can be used instead:
 
 ```
 $ docker pull syncthing/syncthing
 $ docker run --network=host \
-    -v /wherever/st-cfg:/var/syncthing/config \
     -v /wherever/st-sync:/var/syncthing \
     syncthing/syncthing:latest
 ```


### PR DESCRIPTION
Plus some formatting.
If you rather wish to add a `VOLUME` tag to the Dockerfile, feel free to close this alternative solution.