### PR TITLE
all: Hide implementations behind interfaces for mocked testing

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -956,7 +956,7 @@ func setupSignalHandling() {
 	}()
 }
 
-func loadOrDefaultConfig() (*config.Wrapper, error) {
+func loadOrDefaultConfig() (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, err := config.Load(cfgFile, myID)
 
@@ -967,7 +967,7 @@ func loadOrDefaultConfig() (*config.Wrapper, error) {
 	return cfg, err
 }
 
-func loadConfigAtStartup() (*config.Wrapper, error) {
+func loadConfigAtStartup() (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, err := config.Load(cfgFile, myID)
 	if os.IsNotExist(err) {
@@ -996,7 +996,7 @@ func loadConfigAtStartup() (*config.Wrapper, error) {
 	return cfg, nil
 }
 
-func archiveAndSaveConfig(cfg *config.Wrapper) error {
+func archiveAndSaveConfig(cfg config.Wrapper) error {
 	// Copy the existing config to an archive copy
 	archivePath := cfg.ConfigPath() + fmt.Sprintf(".v%d", cfg.RawCopy().OriginalVersion)
 	l.Infoln("Archiving a copy of old config file format at:", archivePath)
@@ -1061,7 +1061,7 @@ func startAuditing(mainService *suture.Supervisor, auditFile string) {
 	l.Infoln("Audit log in", auditDest)
 }
 
-func setupGUI(mainService *suture.Supervisor, cfg *config.Wrapper, m *model.Model, defaultSub, diskSub events.BufferedSubscription, discoverer discover.CachingMux, connectionsService *connections.Service, errors, systemLog logger.Recorder, runtimeOptions RuntimeOptions) {
+func setupGUI(mainService *suture.Supervisor, cfg config.Wrapper, m model.Model, defaultSub, diskSub events.BufferedSubscription, discoverer discover.CachingMux, connectionsService connections.Service, errors, systemLog logger.Recorder, runtimeOptions RuntimeOptions) {
 	guiCfg := cfg.GUI()
 
 	if !guiCfg.Enabled {
@@ -1091,7 +1091,7 @@ func setupGUI(mainService *suture.Supervisor, cfg *config.Wrapper, m *model.Mode
 	}
 }
 
-func defaultConfig(cfgFile string) (*config.Wrapper, error) {
+func defaultConfig(cfgFile string) (config.Wrapper, error) {
 	newCfg, err := config.NewWithFreePorts(myID)
 	if err != nil {
 		return nil, err
@@ -1154,7 +1154,7 @@ func standbyMonitor() {
 	}
 }
 
-func autoUpgrade(cfg *config.Wrapper) {
+func autoUpgrade(cfg config.Wrapper) {
 	timer := time.NewTimer(0)
 	sub := events.Default.Subscribe(events.DeviceConnected)
 	for {
@@ -1256,7 +1256,7 @@ func cleanConfigDirectory() {
 // checkShortIDs verifies that the configuration won't result in duplicate
 // short ID:s; that is, that the devices in the cluster all have unique
 // initial 64 bits.
-func checkShortIDs(cfg *config.Wrapper) error {
+func checkShortIDs(cfg config.Wrapper) error {
 	exists := make(map[protocol.ShortID]protocol.DeviceID)
 	for deviceID := range cfg.Devices() {
 		shortID := deviceID.Short()
@@ -1278,7 +1278,7 @@ func showPaths(options RuntimeOptions) {
 	fmt.Printf("Default sync folder directory:\n\t%s\n\n", locations.Get(locations.DefFolder))
 }
 
-func setPauseState(cfg *config.Wrapper, paused bool) {
+func setPauseState(cfg config.Wrapper, paused bool) {
 	raw := cfg.RawCopy()
 	for i := range raw.Devices {
 		raw.Devices[i].Paused = paused

--- a/cmd/syncthing/mocked_config_test.go
+++ b/cmd/syncthing/mocked_config_test.go
@@ -44,6 +44,8 @@ func (c *mockedConfig) Replace(cfg config.Configuration) (config.Waiter, error) 
 
 func (c *mockedConfig) Subscribe(cm config.Committer) {}
 
+func (c *mockedConfig) Unsubscribe(cm config.Committer) {}
+
 func (c *mockedConfig) Folders() map[string]config.FolderConfiguration {
 	return nil
 }
@@ -66,6 +68,58 @@ func (c *mockedConfig) Save() error {
 
 func (c *mockedConfig) RequiresRestart() bool {
 	return false
+}
+
+func (c *mockedConfig) AddOrUpdatePendingDevice(device protocol.DeviceID, name, address string) {}
+
+func (c *mockedConfig) AddOrUpdatePendingFolder(id, label string, device protocol.DeviceID) {}
+
+func (m *mockedConfig) MyName() string {
+	return ""
+}
+
+func (m *mockedConfig) ConfigPath() string {
+	return ""
+}
+
+func (m *mockedConfig) SetGUI(gui config.GUIConfiguration) (config.Waiter, error) {
+	return noopWaiter{}, nil
+}
+
+func (m *mockedConfig) SetOptions(opts config.OptionsConfiguration) (config.Waiter, error) {
+	return noopWaiter{}, nil
+}
+
+func (m *mockedConfig) Folder(id string) (config.FolderConfiguration, bool) {
+	return config.FolderConfiguration{}, false
+}
+
+func (m *mockedConfig) FolderList() []config.FolderConfiguration {
+	return nil
+}
+
+func (m *mockedConfig) SetFolder(fld config.FolderConfiguration) (config.Waiter, error) {
+	return noopWaiter{}, nil
+}
+
+func (m *mockedConfig) Device(id protocol.DeviceID) (config.DeviceConfiguration, bool) {
+	return config.DeviceConfiguration{}, false
+}
+
+func (m *mockedConfig) RemoveDevice(id protocol.DeviceID) (config.Waiter, error) {
+	return noopWaiter{}, nil
+}
+
+func (m *mockedConfig) IgnoredDevice(id protocol.DeviceID) bool {
+	return false
+}
+
+func (m *mockedConfig) IgnoredFolder(device protocol.DeviceID, folder string) bool {
+	return false
+}
+
+func (m *mockedConfig) GlobalDiscoveryServers() []string {
+	return nil
 }
 
 type noopWaiter struct{}

--- a/cmd/syncthing/mocked_connections_test.go
+++ b/cmd/syncthing/mocked_connections_test.go
@@ -15,3 +15,7 @@ func (m *mockedConnections) Status() map[string]interface{} {
 func (m *mockedConnections) NATType() string {
 	return ""
 }
+
+func (m *mockedConnections) Serve() {}
+
+func (m *mockedConnections) Stop() {}

--- a/cmd/syncthing/mocked_model_test.go
+++ b/cmd/syncthing/mocked_model_test.go
@@ -7,8 +7,10 @@
 package main
 
 import (
+	"net"
 	"time"
 
+	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/connections"
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/model"
@@ -150,3 +152,38 @@ func (m *mockedModel) WatchError(folder string) error {
 func (m *mockedModel) LocalChangedFiles(folder string, page, perpage int) []db.FileInfoTruncated {
 	return nil
 }
+
+func (m *mockedModel) Serve()                                                                     {}
+func (m *mockedModel) Stop()                                                                      {}
+func (m *mockedModel) Index(deviceID protocol.DeviceID, folder string, files []protocol.FileInfo) {}
+func (m *mockedModel) IndexUpdate(deviceID protocol.DeviceID, folder string, files []protocol.FileInfo) {
+}
+
+func (m *mockedModel) Request(deviceID protocol.DeviceID, folder, name string, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (protocol.RequestResponse, error) {
+	return nil, nil
+}
+
+func (m *mockedModel) ClusterConfig(deviceID protocol.DeviceID, config protocol.ClusterConfig) {}
+
+func (m *mockedModel) Closed(conn protocol.Connection, err error) {}
+
+func (m *mockedModel) DownloadProgress(deviceID protocol.DeviceID, folder string, updates []protocol.FileDownloadProgressUpdate) {
+}
+
+func (m *mockedModel) AddConnection(conn connections.Connection, hello protocol.HelloResult) {}
+
+func (m *mockedModel) OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult) error {
+	return nil
+}
+
+func (m *mockedModel) GetHello(protocol.DeviceID) protocol.HelloIntf {
+	return nil
+}
+
+func (m *mockedModel) AddFolder(cfg config.FolderConfiguration) {}
+
+func (m *mockedModel) RestartFolder(from, to config.FolderConfiguration) {}
+
+func (m *mockedModel) StartFolder(folder string) {}
+
+func (m *mockedModel) StartDeadlockDetector(timeout time.Duration) {}

--- a/cmd/syncthing/summaryservice.go
+++ b/cmd/syncthing/summaryservice.go
@@ -9,7 +9,9 @@ package main
 import (
 	"time"
 
+	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/thejerf/suture"
@@ -20,8 +22,8 @@ import (
 type folderSummaryService struct {
 	*suture.Supervisor
 
-	cfg       configIntf
-	model     modelIntf
+	cfg       config.Wrapper
+	model     model.Model
 	stop      chan struct{}
 	immediate chan string
 
@@ -34,7 +36,7 @@ type folderSummaryService struct {
 	lastEventReqMut sync.Mutex
 }
 
-func newFolderSummaryService(cfg configIntf, m modelIntf) *folderSummaryService {
+func newFolderSummaryService(cfg config.Wrapper, m model.Model) *folderSummaryService {
 	service := &folderSummaryService{
 		Supervisor: suture.New("folderSummaryService", suture.Spec{
 			PassThroughPanics: true,

--- a/cmd/syncthing/usage_report.go
+++ b/cmd/syncthing/usage_report.go
@@ -37,7 +37,7 @@ const usageReportVersion = 3
 
 // reportData returns the data to be sent in a usage report. It's used in
 // various places, so not part of the usageReportingManager object.
-func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf, version int, preview bool) map[string]interface{} {
+func reportData(cfg config.Wrapper, m model.Model, connectionsService connections.Service, version int, preview bool) map[string]interface{} {
 	opts := cfg.Options()
 	res := make(map[string]interface{})
 	res["urVersion"] = version
@@ -323,16 +323,16 @@ func reportData(cfg configIntf, m modelIntf, connectionsService connectionsIntf,
 }
 
 type usageReportingService struct {
-	cfg                *config.Wrapper
-	model              *model.Model
-	connectionsService *connections.Service
+	cfg                config.Wrapper
+	model              model.Model
+	connectionsService connections.Service
 	forceRun           chan struct{}
 	stop               chan struct{}
 	stopped            chan struct{}
 	stopMut            sync.RWMutex
 }
 
-func newUsageReportingService(cfg *config.Wrapper, model *model.Model, connectionsService *connections.Service) *usageReportingService {
+func newUsageReportingService(cfg config.Wrapper, model model.Model, connectionsService connections.Service) *usageReportingService {
 	svc := &usageReportingService{
 		cfg:                cfg,
 		model:              model,

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -93,7 +93,7 @@ func TestDeviceConfig(t *testing.T) {
 			t.Fatal("Unexpected file")
 		}
 
-		cfg := wr.cfg
+		cfg := wr.(*wrapper).cfg
 
 		expectedFolders := []FolderConfiguration{
 			{
@@ -515,7 +515,7 @@ func TestNewSaveLoad(t *testing.T) {
 	cfg := Wrap(path, intCfg)
 
 	// To make the equality pass later
-	cfg.cfg.XMLName.Local = "configuration"
+	cfg.(*wrapper).cfg.XMLName.Local = "configuration"
 
 	if exists(path) {
 		t.Error(path, "exists")
@@ -827,7 +827,7 @@ func TestIgnoredFolders(t *testing.T) {
 
 	// 2 for folder2, 1 for folder1, as non-existing device and device the folder is shared with is removed.
 	expectedIgnoredFolders := 3
-	for _, dev := range wrapper.cfg.Devices {
+	for _, dev := range wrapper.Devices() {
 		expectedIgnoredFolders -= len(dev.IgnoredFolders)
 	}
 	if expectedIgnoredFolders != 0 {

--- a/lib/connections/lan_test.go
+++ b/lib/connections/lan_test.go
@@ -36,7 +36,7 @@ func TestIsLANHost(t *testing.T) {
 			AlwaysLocalNets: []string{"10.20.30.0/24"},
 		},
 	})
-	s := &Service{cfg: cfg}
+	s := &service{cfg: cfg}
 
 	for _, tc := range cases {
 		res := s.isLANHost(tc.addr)

--- a/lib/connections/limiter.go
+++ b/lib/connections/limiter.go
@@ -36,7 +36,7 @@ type waiter interface {
 
 const limiterBurstSize = 4 * 128 << 10
 
-func newLimiter(cfg *config.Wrapper) *limiter {
+func newLimiter(cfg config.Wrapper) *limiter {
 	l := &limiter{
 		write:               rate.NewLimiter(rate.Inf, limiterBurstSize),
 		read:                rate.NewLimiter(rate.Inf, limiterBurstSize),

--- a/lib/connections/limiter_test.go
+++ b/lib/connections/limiter_test.go
@@ -24,7 +24,7 @@ func init() {
 	device4, _ = protocol.DeviceIDFromString("P56IOI7-MZJNU2Y-IQGDREY-DM2MGTI-MGL3BXN-PQ6W5BM-TBBZ4TJ-XZWICQ2")
 }
 
-func initConfig() *config.Wrapper {
+func initConfig() config.Wrapper {
 	cfg := config.Wrap("/dev/null", config.New(device1))
 	dev1Conf = config.NewDeviceConfiguration(device1, "device1")
 	dev2Conf = config.NewDeviceConfiguration(device2, "device2")

--- a/lib/connections/relay_dial.go
+++ b/lib/connections/relay_dial.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 type relayDialer struct {
-	cfg    *config.Wrapper
+	cfg    config.Wrapper
 	tlsCfg *tls.Config
 }
 
@@ -70,7 +70,7 @@ func (d *relayDialer) RedialFrequency() time.Duration {
 
 type relayDialerFactory struct{}
 
-func (relayDialerFactory) New(cfg *config.Wrapper, tlsCfg *tls.Config) genericDialer {
+func (relayDialerFactory) New(cfg config.Wrapper, tlsCfg *tls.Config) genericDialer {
 	return &relayDialer{
 		cfg:    cfg,
 		tlsCfg: tlsCfg,

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -29,7 +29,7 @@ type relayListener struct {
 	onAddressesChangedNotifier
 
 	uri     *url.URL
-	cfg     *config.Wrapper
+	cfg     config.Wrapper
 	tlsCfg  *tls.Config
 	conns   chan internalConn
 	factory listenerFactory
@@ -180,7 +180,7 @@ func (t *relayListener) NATType() string {
 
 type relayListenerFactory struct{}
 
-func (f *relayListenerFactory) New(uri *url.URL, cfg *config.Wrapper, tlsCfg *tls.Config, conns chan internalConn, natService *nat.Service) genericListener {
+func (f *relayListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls.Config, conns chan internalConn, natService *nat.Service) genericListener {
 	return &relayListener{
 		uri:     uri,
 		cfg:     cfg,

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -122,7 +122,7 @@ func (c internalConn) String() string {
 }
 
 type dialerFactory interface {
-	New(*config.Wrapper, *tls.Config) genericDialer
+	New(config.Wrapper, *tls.Config) genericDialer
 	Priority() int
 	AlwaysWAN() bool
 	Valid(config.Configuration) error
@@ -135,7 +135,7 @@ type genericDialer interface {
 }
 
 type listenerFactory interface {
-	New(*url.URL, *config.Wrapper, *tls.Config, chan internalConn, *nat.Service) genericListener
+	New(*url.URL, config.Wrapper, *tls.Config, chan internalConn, *nat.Service) genericListener
 	Valid(config.Configuration) error
 }
 

--- a/lib/connections/tcp_dial.go
+++ b/lib/connections/tcp_dial.go
@@ -24,7 +24,7 @@ func init() {
 }
 
 type tcpDialer struct {
-	cfg    *config.Wrapper
+	cfg    config.Wrapper
 	tlsCfg *tls.Config
 }
 
@@ -62,7 +62,7 @@ func (d *tcpDialer) RedialFrequency() time.Duration {
 
 type tcpDialerFactory struct{}
 
-func (tcpDialerFactory) New(cfg *config.Wrapper, tlsCfg *tls.Config) genericDialer {
+func (tcpDialerFactory) New(cfg config.Wrapper, tlsCfg *tls.Config) genericDialer {
 	return &tcpDialer{
 		cfg:    cfg,
 		tlsCfg: tlsCfg,

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -29,7 +29,7 @@ type tcpListener struct {
 	onAddressesChangedNotifier
 
 	uri     *url.URL
-	cfg     *config.Wrapper
+	cfg     config.Wrapper
 	tlsCfg  *tls.Config
 	stop    chan struct{}
 	conns   chan internalConn
@@ -195,7 +195,7 @@ func (t *tcpListener) NATType() string {
 
 type tcpListenerFactory struct{}
 
-func (f *tcpListenerFactory) New(uri *url.URL, cfg *config.Wrapper, tlsCfg *tls.Config, conns chan internalConn, natService *nat.Service) genericListener {
+func (f *tcpListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls.Config, conns chan internalConn, natService *nat.Service) genericListener {
 	return &tcpListener{
 		uri:        fixupPort(uri, config.DefaultTCPPort),
 		cfg:        cfg,

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -49,7 +49,6 @@ func init() {
 		panic(err)
 	}
 }
-
 func SetBaseDir(baseDirName BaseDirEnum, path string) error {
 	_, ok := baseDirs[baseDirName]
 	if !ok {

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -49,6 +49,7 @@ func init() {
 		panic(err)
 	}
 }
+
 func SetBaseDir(baseDirName BaseDirEnum, path string) error {
 	_, ok := baseDirs[baseDirName]
 	if !ok {

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -39,7 +39,7 @@ type folder struct {
 	config.FolderConfiguration
 	localFlags uint32
 
-	model   *Model
+	model   *model
 	shortID protocol.ShortID
 	ctx     context.Context
 	cancel  context.CancelFunc
@@ -73,7 +73,7 @@ type puller interface {
 	pull() bool // true when successfull and should not be retried
 }
 
-func newFolder(model *Model, cfg config.FolderConfiguration) folder {
+func newFolder(model *model, cfg config.FolderConfiguration) folder {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	return folder{

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -56,7 +56,7 @@ type receiveOnlyFolder struct {
 	*sendReceiveFolder
 }
 
-func newReceiveOnlyFolder(model *Model, cfg config.FolderConfiguration, ver versioner.Versioner, fs fs.Filesystem) service {
+func newReceiveOnlyFolder(model *model, cfg config.FolderConfiguration, ver versioner.Versioner, fs fs.Filesystem) service {
 	sr := newSendReceiveFolder(model, cfg, ver, fs).(*sendReceiveFolder)
 	sr.localFlags = protocol.FlagLocalReceiveOnly // gets propagated to the scanner, and set on locally changed files
 	return &receiveOnlyFolder{sr}

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -336,7 +336,7 @@ func setupKnownFiles(t *testing.T, data []byte) []protocol.FileInfo {
 	return knownFiles
 }
 
-func setupROFolder() *Model {
+func setupROFolder() *model {
 	fcfg := config.NewFolderConfiguration(myID, "ro", "receive only test", fs.FilesystemTypeBasic, "_recvonly")
 	fcfg.Type = config.FolderTypeReceiveOnly
 	fcfg.Devices = []config.FolderDeviceConfiguration{{DeviceID: device1}}
@@ -349,7 +349,7 @@ func setupROFolder() *Model {
 	wrp := createTmpWrapper(cfg)
 
 	db := db.OpenMemory()
-	m := NewModel(wrp, myID, "syncthing", "dev", db, nil)
+	m := newModel(wrp, myID, "syncthing", "dev", db, nil)
 
 	m.ServeBackground()
 	m.AddFolder(fcfg)

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -22,7 +22,7 @@ type sendOnlyFolder struct {
 	folder
 }
 
-func newSendOnlyFolder(model *Model, cfg config.FolderConfiguration, _ versioner.Versioner, _ fs.Filesystem) service {
+func newSendOnlyFolder(model *model, cfg config.FolderConfiguration, _ versioner.Versioner, _ fs.Filesystem) service {
 	f := &sendOnlyFolder{
 		folder: newFolder(model, cfg),
 	}

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -104,7 +104,7 @@ type sendReceiveFolder struct {
 	pullErrorsMut sync.Mutex
 }
 
-func newSendReceiveFolder(model *Model, cfg config.FolderConfiguration, ver versioner.Versioner, fs fs.Filesystem) service {
+func newSendReceiveFolder(model *model, cfg config.FolderConfiguration, ver versioner.Versioner, fs fs.Filesystem) service {
 	f := &sendReceiveFolder{
 		folder:        newFolder(model, cfg),
 		fs:            fs,

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -75,9 +75,9 @@ func setUpFile(filename string, blockNumbers []int) protocol.FileInfo {
 	}
 }
 
-func setupSendReceiveFolder(files ...protocol.FileInfo) (*Model, *sendReceiveFolder, string) {
+func setupSendReceiveFolder(files ...protocol.FileInfo) (*model, *sendReceiveFolder, string) {
 	w := createTmpWrapper(defaultCfg)
-	model := NewModel(w, myID, "syncthing", "dev", db.OpenMemory(), nil)
+	model := newModel(w, myID, "syncthing", "dev", db.OpenMemory(), nil)
 	fcfg, tmpDir := testFolderConfigTmp()
 	model.AddFolder(fcfg)
 

--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -31,7 +31,7 @@ type ProgressEmitter struct {
 
 // NewProgressEmitter creates a new progress emitter which emits
 // DownloadProgress events every interval.
-func NewProgressEmitter(cfg *config.Wrapper) *ProgressEmitter {
+func NewProgressEmitter(cfg config.Wrapper) *ProgressEmitter {
 	t := &ProgressEmitter{
 		stop:               make(chan struct{}),
 		registry:           make(map[string]*sharedPullerState),

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -684,7 +684,7 @@ func TestRequestSymlinkWindows(t *testing.T) {
 	}
 }
 
-func tmpDefaultWrapper() (*config.Wrapper, string) {
+func tmpDefaultWrapper() (config.Wrapper, string) {
 	w := createTmpWrapper(defaultCfgWrapper.RawCopy())
 	fcfg, tmpDir := testFolderConfigTmp()
 	w.SetFolder(fcfg)
@@ -703,13 +703,13 @@ func testFolderConfig(path string) config.FolderConfiguration {
 	return cfg
 }
 
-func setupModelWithConnection() (*Model, *fakeConnection, string, *config.Wrapper) {
+func setupModelWithConnection() (*model, *fakeConnection, string, config.Wrapper) {
 	w, tmpDir := tmpDefaultWrapper()
 	m, fc := setupModelWithConnectionFromWrapper(w)
 	return m, fc, tmpDir, w
 }
 
-func setupModelWithConnectionFromWrapper(w *config.Wrapper) (*Model, *fakeConnection) {
+func setupModelWithConnectionFromWrapper(w config.Wrapper) (*model, *fakeConnection) {
 	m := setupModel(w)
 
 	fc := addFakeConn(m, device1)

--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -23,7 +23,7 @@ import (
 // setup/renewal of a port mapping.
 type Service struct {
 	id   protocol.DeviceID
-	cfg  *config.Wrapper
+	cfg  config.Wrapper
 	stop chan struct{}
 
 	mappings []*Mapping
@@ -31,7 +31,7 @@ type Service struct {
 	mut      sync.RWMutex
 }
 
-func NewService(id protocol.DeviceID, cfg *config.Wrapper) *Service {
+func NewService(id protocol.DeviceID, cfg config.Wrapper) *Service {
 	return &Service{
 		id:  id,
 		cfg: cfg,

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -125,14 +125,14 @@ func newAggregator(folderCfg config.FolderConfiguration, ctx context.Context) *a
 	return a
 }
 
-func Aggregate(in <-chan fs.Event, out chan<- []string, folderCfg config.FolderConfiguration, cfg *config.Wrapper, ctx context.Context) {
+func Aggregate(in <-chan fs.Event, out chan<- []string, folderCfg config.FolderConfiguration, cfg config.Wrapper, ctx context.Context) {
 	a := newAggregator(folderCfg, ctx)
 
 	// Necessary for unit tests where the backend is mocked
 	go a.mainLoop(in, out, cfg)
 }
 
-func (a *aggregator) mainLoop(in <-chan fs.Event, out chan<- []string, cfg *config.Wrapper) {
+func (a *aggregator) mainLoop(in <-chan fs.Event, out chan<- []string, cfg config.Wrapper) {
 	a.notifyTimer = time.NewTimer(a.notifyDelay)
 	defer a.notifyTimer.Stop()
 


### PR DESCRIPTION
As per https://github.com/syncthing/syncthing/pull/5529#discussion_r257988426 here comes the PR from hell: Remove the `...Intf` interfaces in gui.go in favor of making `config.Wrapper`, `model.Model` and `connections.Service` interfaces.

I tried to order the inteface methods thematically, please tell me if it's not helpful.