### PR TITLE
lib/scanner: Use standard adler32 when we don't need rolling

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -10,9 +10,9 @@ import (
 	"bytes"
 	"context"
 	"hash"
+	"hash/adler32"
 	"io"
 
-	"github.com/chmduquesne/rollinghash/adler32"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sha256"
 )

--- a/lib/weakhash/benchmark_test.go
+++ b/lib/weakhash/benchmark_test.go
@@ -71,12 +71,12 @@ func BenchmarkBlock(b *testing.B) {
 
 	sizes := []int64{128 << 10, 16 << 20}
 
-	buf := make([]byte, 10 << 20)
+	buf := make([]byte, 10<<20)
 	rand.Read(buf)
 
 	for _, testSize := range sizes {
 		for _, test := range tests {
-			b.Run(test.name + "-" + fmt.Sprint(testSize), func(bb *testing.B) {
+			b.Run(test.name+"-"+fmt.Sprint(testSize), func(bb *testing.B) {
 				bb.Run("", func(bbb *testing.B) {
 					bbb.ResetTimer()
 					for i := 0; i < bbb.N; i++ {
@@ -95,7 +95,6 @@ func BenchmarkBlock(b *testing.B) {
 							test.hash.Reset()
 						}
 					}
-
 
 					bbb.SetBytes(int64(len(buf)))
 					bbb.ReportAllocs()
@@ -129,7 +128,7 @@ func BenchmarkRoll(b *testing.B) {
 
 	for _, testSize := range sizes {
 		for _, test := range tests {
-			b.Run(test.name + "-" + fmt.Sprint(testSize), func(bb *testing.B) {
+			b.Run(test.name+"-"+fmt.Sprint(testSize), func(bb *testing.B) {
 				bb.Run("", func(bbb *testing.B) {
 					data := make([]byte, testSize)
 

--- a/lib/weakhash/benchmark_test.go
+++ b/lib/weakhash/benchmark_test.go
@@ -7,7 +7,13 @@
 package weakhash
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"hash"
+	vadler32 "hash/adler32"
+	"io"
+	"math/rand"
 	"os"
 	"testing"
 
@@ -15,10 +21,9 @@ import (
 	"github.com/chmduquesne/rollinghash/bozo32"
 	"github.com/chmduquesne/rollinghash/buzhash32"
 	"github.com/chmduquesne/rollinghash/buzhash64"
-	"github.com/chmduquesne/rollinghash/rabinkarp64"
 )
 
-const testFile = "../model/testdata/~syncthing~file.tmp"
+const testFile = "../model/testdata/tmpfile"
 const size = 128 << 10
 
 func BenchmarkFind1MFile(b *testing.B) {
@@ -37,142 +42,115 @@ func BenchmarkFind1MFile(b *testing.B) {
 	}
 }
 
-func BenchmarkWeakHashAdler32(b *testing.B) {
-	data := make([]byte, size)
-	hf := adler32.New()
-
-	for i := 0; i < b.N; i++ {
-		hf.Write(data)
-	}
-
-	hf.Sum32()
-	b.SetBytes(size)
+type RollingHash interface {
+	hash.Hash
+	Roll(byte)
 }
 
-func BenchmarkWeakHashAdler32Roll(b *testing.B) {
-	data := make([]byte, size)
-	hf := adler32.New()
-	hf.Write(data)
+func BenchmarkBlock(b *testing.B) {
+	tests := []struct {
+		name string
+		hash hash.Hash
+	}{
+		{
+			"adler32", adler32.New(),
+		},
+		{
+			"bozo32", bozo32.New(),
+		},
+		{
+			"buzhash32", buzhash32.New(),
+		},
+		{
+			"buzhash64", buzhash64.New(),
+		},
+		{
+			"vanilla-adler32", vadler32.New(),
+		},
+	}
 
-	b.ResetTimer()
+	sizes := []int64{128 << 10, 16 << 20}
 
-	for i := 0; i < b.N; i++ {
-		for i := 0; i <= size; i++ {
-			hf.Roll('a')
+	buf := make([]byte, 10 << 20)
+	rand.Read(buf)
+
+	for _, testSize := range sizes {
+		for _, test := range tests {
+			b.Run(test.name + "-" + fmt.Sprint(testSize), func(bb *testing.B) {
+				bb.Run("", func(bbb *testing.B) {
+					bbb.ResetTimer()
+					for i := 0; i < bbb.N; i++ {
+						lr := io.LimitReader(bytes.NewReader(buf), testSize).(*io.LimitedReader)
+						for {
+							lr.N = testSize
+							n, err := io.Copy(test.hash, lr)
+							if err != nil {
+								bbb.Error(err)
+							}
+
+							if n == 0 {
+								break
+							}
+							test.hash.Sum(nil)
+							test.hash.Reset()
+						}
+					}
+
+
+					bbb.SetBytes(int64(len(buf)))
+					bbb.ReportAllocs()
+				})
+
+			})
 		}
 	}
-
-	b.SetBytes(size)
 }
 
-func BenchmarkWeakHashRabinKarp64(b *testing.B) {
-	data := make([]byte, size)
-	hf := rabinkarp64.New()
-
-	for i := 0; i < b.N; i++ {
-		hf.Write(data)
+func BenchmarkRoll(b *testing.B) {
+	tests := []struct {
+		name string
+		hash RollingHash
+	}{
+		{
+			"adler32", adler32.New(),
+		},
+		{
+			"bozo32", bozo32.New(),
+		},
+		{
+			"buzhash32", buzhash32.New(),
+		},
+		{
+			"buzhash64", buzhash64.New(),
+		},
 	}
 
-	hf.Sum64()
-	b.SetBytes(size)
-}
+	sizes := []int64{128 << 10, 16 << 20}
 
-func BenchmarkWeakHashRabinKarp64Roll(b *testing.B) {
-	data := make([]byte, size)
-	hf := rabinkarp64.New()
-	hf.Write(data)
+	for _, testSize := range sizes {
+		for _, test := range tests {
+			b.Run(test.name + "-" + fmt.Sprint(testSize), func(bb *testing.B) {
+				bb.Run("", func(bbb *testing.B) {
+					data := make([]byte, testSize)
 
-	b.ResetTimer()
+					if _, err := test.hash.Write(data); err != nil {
+						bb.Error(err)
+					}
 
-	for i := 0; i < b.N; i++ {
-		for i := 0; i <= size; i++ {
-			hf.Roll('a')
+					b.ResetTimer()
+
+					for i := 0; i < bbb.N; i++ {
+						for j := int64(0); j <= testSize; j++ {
+							test.hash.Roll('a')
+							test.hash.Size()
+						}
+					}
+
+					bbb.SetBytes(testSize)
+					bbb.ReportAllocs()
+				})
+
+			})
 		}
 	}
-
-	b.SetBytes(size)
-}
-
-func BenchmarkWeakHashBozo32(b *testing.B) {
-	data := make([]byte, size)
-	hf := bozo32.New()
-
-	for i := 0; i < b.N; i++ {
-		hf.Write(data)
-	}
-
-	hf.Sum32()
-	b.SetBytes(size)
-}
-
-func BenchmarkWeakHashBozo32Roll(b *testing.B) {
-	data := make([]byte, size)
-	hf := bozo32.New()
-	hf.Write(data)
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		for i := 0; i <= size; i++ {
-			hf.Roll('a')
-		}
-	}
-
-	b.SetBytes(size)
-}
-
-func BenchmarkWeakHashBuzhash32(b *testing.B) {
-	data := make([]byte, size)
-	hf := buzhash32.New()
-
-	for i := 0; i < b.N; i++ {
-		hf.Write(data)
-	}
-
-	hf.Sum32()
-	b.SetBytes(size)
-}
-
-func BenchmarkWeakHashBuzhash32Roll(b *testing.B) {
-	data := make([]byte, size)
-	hf := buzhash32.New()
-	hf.Write(data)
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		for i := 0; i <= size; i++ {
-			hf.Roll('a')
-		}
-	}
-
-	b.SetBytes(size)
-}
-
-func BenchmarkWeakHashBuzhash64(b *testing.B) {
-	data := make([]byte, size)
-	hf := buzhash64.New()
-
-	for i := 0; i < b.N; i++ {
-		hf.Write(data)
-	}
-
-	hf.Sum64()
-	b.SetBytes(size)
-}
-
-func BenchmarkWeakHashBuzhash64Roll(b *testing.B) {
-	data := make([]byte, size)
-	hf := buzhash64.New()
-	hf.Write(data)
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		for i := 0; i <= size; i++ {
-			hf.Roll('a')
-		}
-	}
-
-	b.SetBytes(size)
 }

--- a/lib/weakhash/benchmark_test.go
+++ b/lib/weakhash/benchmark_test.go
@@ -134,10 +134,10 @@ func BenchmarkRoll(b *testing.B) {
 					data := make([]byte, testSize)
 
 					if _, err := test.hash.Write(data); err != nil {
-						bb.Error(err)
+						bbb.Error(err)
 					}
 
-					b.ResetTimer()
+					bbb.ResetTimer()
 
 					for i := 0; i < bbb.N; i++ {
 						for j := int64(0); j <= testSize; j++ {


### PR DESCRIPTION
Seems the rolling adler32 implementation is super slow when executed on large blocks, even tho I can't explain why. Use standard adler when we don't need to roll
```
BenchmarkFind1MFile-16    	     	     	     	     100	  18739828 ns/op	  55.95 MB/s	  398924 B/op	      20 allocs/op
BenchmarkBlock/adler32-131072/#00-16     	     	     200	   9678923 ns/op	1083.36 MB/s	 2654929 B/op	     163 allocs/op
BenchmarkBlock/bozo32-131072/#00-16      	     	      20	  73577340 ns/op	 142.51 MB/s	 2654928 B/op	     163 allocs/op
BenchmarkBlock/buzhash32-131072/#00-16   	     	      20	  61456805 ns/op	 170.62 MB/s	 2654928 B/op	     163 allocs/op
BenchmarkBlock/buzhash64-131072/#00-16   	     	      20	  61651235 ns/op	 170.08 MB/s	 2654928 B/op	     163 allocs/op
BenchmarkBlock/vanilla-adler32-131072/#00-16         	     300	   4357369 ns/op	2406.44 MB/s	 2654929 B/op	     163 allocs/op
BenchmarkBlock/adler32-16777216/#00-16               	       2	 545514500 ns/op	  19.22 MB/s	   65624 B/op	       5 allocs/op
BenchmarkBlock/bozo32-16777216/#00-16                	       1	4683325500 ns/op	   2.24 MB/s	51970144 B/op	      24 allocs/op
BenchmarkBlock/buzhash32-16777216/#00-16             	       1	3880333000 ns/op	   2.70 MB/s	51970144 B/op	      24 allocs/op
BenchmarkBlock/buzhash64-16777216/#00-16             	       1	3878978300 ns/op	   2.70 MB/s	51970144 B/op	      24 allocs/op
BenchmarkBlock/vanilla-adler32-16777216/#00-16       	     300	   4011820 ns/op	2613.72 MB/s	   65624 B/op	       5 allocs/op
BenchmarkRoll/adler32-131072/#00-16                  	    2000	    949645 ns/op	 138.02 MB/s	       0 B/op	       0 allocs/op
BenchmarkRoll/bozo32-131072/#00-16                   	    2000	    796951 ns/op	 164.47 MB/s	       0 B/op	       0 allocs/op
BenchmarkRoll/buzhash32-131072/#00-16                	    2000	    860292 ns/op	 152.36 MB/s	       0 B/op	       0 allocs/op
BenchmarkRoll/buzhash64-131072/#00-16                	    2000	    882446 ns/op	 148.53 MB/s	       0 B/op	       0 allocs/op
BenchmarkRoll/adler32-16777216/#00-16                	      10	 121974010 ns/op	 137.55 MB/s	       0 B/op	       0 allocs/op
BenchmarkRoll/bozo32-16777216/#00-16                 	      10	 106611300 ns/op	 157.37 MB/s	       0 B/op	       0 allocs/op
BenchmarkRoll/buzhash32-16777216/#00-16              	      10	 116323520 ns/op	 144.23 MB/s	       0 B/op	       0 allocs/op
BenchmarkRoll/buzhash64-16777216/#00-16              	      10	 114303920 ns/op	 146.78 MB/s	       0 B/op	       0 allocs/op
```

CC @chmduquesne