### PR TITLE
lib/model: Introduce must test utility

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -35,15 +35,9 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 	testOs.MkdirAll("_recvonly/.stfolder", 0755)
 	testOs.MkdirAll("_recvonly/ignDir", 0755)
 	testOs.MkdirAll("_recvonly/unknownDir", 0755)
-	if err := ioutil.WriteFile("_recvonly/ignDir/ignFile", []byte("hello\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := ioutil.WriteFile("_recvonly/unknownDir/unknownFile", []byte("hello\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := ioutil.WriteFile("_recvonly/.stignore", []byte("ignDir\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("_recvonly/ignDir/ignFile", []byte("hello\n"), 0644) })
+	must(t, func() error { return ioutil.WriteFile("_recvonly/unknownDir/unknownFile", []byte("hello\n"), 0644) })
+	must(t, func() error { return ioutil.WriteFile("_recvonly/.stignore", []byte("ignDir\n"), 0644) })
 
 	knownFiles := setupKnownFiles(t, []byte("hello\n"))
 
@@ -166,15 +160,11 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	// Update the file.
 
 	newData := []byte("totally different data\n")
-	if err := ioutil.WriteFile("_recvonly/knownDir/knownFile", newData, 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", newData, 0644) })
 
 	// Rescan.
 
-	if err := m.ScanFolder("ro"); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return m.ScanFolder("ro") })
 
 	// We now have a newer file than the rest of the cluster. Global state should reflect this.
 
@@ -268,13 +258,9 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	// Create a file and modify another
 
 	file := "_recvonly/foo"
-	if err := ioutil.WriteFile(file, []byte("hello\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile(file, []byte("hello\n"), 0644) })
 
-	if err := ioutil.WriteFile("_recvonly/knownDir/knownFile", []byte("bye\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", []byte("bye\n"), 0644) })
 
 	m.ScanFolder("ro")
 
@@ -286,9 +272,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	// Remove the file again and undo the modification
 
 	testOs.Remove(file)
-	if err := ioutil.WriteFile("_recvonly/knownDir/knownFile", oldData, 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", oldData, 0644) })
 	folderFs.Chtimes("knownDir/knownFile", knownFiles[1].ModTime(), knownFiles[1].ModTime())
 
 	m.ScanFolder("ro")
@@ -303,9 +287,7 @@ func setupKnownFiles(t *testing.T, data []byte) []protocol.FileInfo {
 	testOs := &fatalOs{t}
 
 	testOs.MkdirAll("_recvonly/knownDir", 0755)
-	if err := ioutil.WriteFile("_recvonly/knownDir/knownFile", data, 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", data, 0644) })
 
 	t0 := time.Now().Add(-1 * time.Minute)
 	testOs.Chtimes("_recvonly/knownDir/knownFile", t0, t0)

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -35,9 +35,9 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 	testOs.MkdirAll("_recvonly/.stfolder", 0755)
 	testOs.MkdirAll("_recvonly/ignDir", 0755)
 	testOs.MkdirAll("_recvonly/unknownDir", 0755)
-	must(t, func() error { return ioutil.WriteFile("_recvonly/ignDir/ignFile", []byte("hello\n"), 0644) })
-	must(t, func() error { return ioutil.WriteFile("_recvonly/unknownDir/unknownFile", []byte("hello\n"), 0644) })
-	must(t, func() error { return ioutil.WriteFile("_recvonly/.stignore", []byte("ignDir\n"), 0644) })
+	must(t, ioutil.WriteFile("_recvonly/ignDir/ignFile", []byte("hello\n"), 0644))
+	must(t, ioutil.WriteFile("_recvonly/unknownDir/unknownFile", []byte("hello\n"), 0644))
+	must(t, ioutil.WriteFile("_recvonly/.stignore", []byte("ignDir\n"), 0644))
 
 	knownFiles := setupKnownFiles(t, []byte("hello\n"))
 
@@ -160,11 +160,11 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	// Update the file.
 
 	newData := []byte("totally different data\n")
-	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", newData, 0644) })
+	must(t, ioutil.WriteFile("_recvonly/knownDir/knownFile", newData, 0644))
 
 	// Rescan.
 
-	must(t, func() error { return m.ScanFolder("ro") })
+	must(t, m.ScanFolder("ro"))
 
 	// We now have a newer file than the rest of the cluster. Global state should reflect this.
 
@@ -258,9 +258,9 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	// Create a file and modify another
 
 	file := "_recvonly/foo"
-	must(t, func() error { return ioutil.WriteFile(file, []byte("hello\n"), 0644) })
+	must(t, ioutil.WriteFile(file, []byte("hello\n"), 0644))
 
-	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", []byte("bye\n"), 0644) })
+	must(t, ioutil.WriteFile("_recvonly/knownDir/knownFile", []byte("bye\n"), 0644))
 
 	m.ScanFolder("ro")
 
@@ -272,7 +272,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	// Remove the file again and undo the modification
 
 	testOs.Remove(file)
-	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", oldData, 0644) })
+	must(t, ioutil.WriteFile("_recvonly/knownDir/knownFile", oldData, 0644))
 	folderFs.Chtimes("knownDir/knownFile", knownFiles[1].ModTime(), knownFiles[1].ModTime())
 
 	m.ScanFolder("ro")
@@ -287,7 +287,7 @@ func setupKnownFiles(t *testing.T, data []byte) []protocol.FileInfo {
 	testOs := &fatalOs{t}
 
 	testOs.MkdirAll("_recvonly/knownDir", 0755)
-	must(t, func() error { return ioutil.WriteFile("_recvonly/knownDir/knownFile", data, 0644) })
+	must(t, ioutil.WriteFile("_recvonly/knownDir/knownFile", data, 0644))
 
 	t0 := time.Now().Add(-1 * time.Minute)
 	testOs.Chtimes("_recvonly/knownDir/knownFile", t0, t0)

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -652,23 +652,15 @@ func TestIssue3164(t *testing.T) {
 
 	ignDir := filepath.Join("issue3164", "oktodelete")
 	subDir := filepath.Join(ignDir, "foobar")
-	if err := ffs.MkdirAll(subDir, 0777); err != nil {
-		t.Fatal(err)
-	}
-	if err := ioutil.WriteFile(filepath.Join(tmpDir, subDir, "file"), []byte("Hello"), 0644); err != nil {
-		t.Fatal(err)
-	}
-	if err := ioutil.WriteFile(filepath.Join(tmpDir, ignDir, "file"), []byte("Hello"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ffs.MkdirAll(subDir, 0777) })
+	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, subDir, "file"), []byte("Hello"), 0644) })
+	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, ignDir, "file"), []byte("Hello"), 0644) })
 	file := protocol.FileInfo{
 		Name: "issue3164",
 	}
 
 	matcher := ignore.New(ffs)
-	if err := matcher.Parse(bytes.NewBufferString("(?d)oktodelete"), ""); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return matcher.Parse(bytes.NewBufferString("(?d)oktodelete"), "") })
 
 	dbUpdateChan := make(chan dbUpdateJob, 1)
 

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -79,18 +79,12 @@ func createFile(t *testing.T, name string, fs fs.Filesystem) protocol.FileInfo {
 	t.Helper()
 
 	f, err := fs.Create(name)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	f.Close()
 	fi, err := fs.Stat(name)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	file, err := scanner.CreateFileInfo(fi, name, fs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	return file
 }
 
@@ -323,9 +317,7 @@ func TestWeakHash(t *testing.T) {
 	}
 
 	f, err := ffs.Create("weakhash")
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	defer f.Close()
 	_, err = io.CopyN(f, rand.Reader, size)
 	if err != nil {
@@ -652,15 +644,15 @@ func TestIssue3164(t *testing.T) {
 
 	ignDir := filepath.Join("issue3164", "oktodelete")
 	subDir := filepath.Join(ignDir, "foobar")
-	must(t, func() error { return ffs.MkdirAll(subDir, 0777) })
-	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, subDir, "file"), []byte("Hello"), 0644) })
-	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, ignDir, "file"), []byte("Hello"), 0644) })
+	must(t, ffs.MkdirAll(subDir, 0777))
+	must(t, ioutil.WriteFile(filepath.Join(tmpDir, subDir, "file"), []byte("Hello"), 0644))
+	must(t, ioutil.WriteFile(filepath.Join(tmpDir, ignDir, "file"), []byte("Hello"), 0644))
 	file := protocol.FileInfo{
 		Name: "issue3164",
 	}
 
 	matcher := ignore.New(ffs)
-	must(t, func() error { return matcher.Parse(bytes.NewBufferString("(?d)oktodelete"), "") })
+	must(t, matcher.Parse(bytes.NewBufferString("(?d)oktodelete"), ""))
 
 	dbUpdateChan := make(chan dbUpdateJob, 1)
 
@@ -749,13 +741,9 @@ func TestDeleteIgnorePerms(t *testing.T) {
 	defer file.Close()
 
 	stat, err := file.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	fi, err := scanner.CreateFileInfo(stat, name, ffs)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	ffs.Chmod(name, 0600)
 	scanChan := make(chan string)
 	finished := make(chan struct{})
@@ -768,9 +756,7 @@ func TestDeleteIgnorePerms(t *testing.T) {
 		<-finished
 	case <-finished:
 	}
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 }
 
 func TestCopyOwner(t *testing.T) {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2343,13 +2343,9 @@ func TestIssue3028(t *testing.T) {
 
 	// Create two files that we'll delete, one with a name that is a prefix of the other.
 
-	if err := ioutil.WriteFile("testdata/testrm", []byte("Hello"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("testdata/testrm", []byte("Hello"), 0644) })
 	defer testOs.Remove("testdata/testrm")
-	if err := ioutil.WriteFile("testdata/testrm2", []byte("Hello"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("testdata/testrm2", []byte("Hello"), 0644) })
 	defer testOs.Remove("testdata/testrm2")
 
 	// Create a model and default folder
@@ -2831,10 +2827,7 @@ func TestIssue2571(t *testing.T) {
 	}()
 
 	for _, dir := range []string{"toLink", "linkTarget"} {
-		err := testFs.MkdirAll(dir, 0775)
-		if err != nil {
-			t.Fatal(err)
-		}
+		must(t, func() error { return testFs.MkdirAll(dir, 0775) })
 		fd, err := testFs.Create(filepath.Join(dir, "a"))
 		if err != nil {
 			t.Fatal(err)
@@ -2844,13 +2837,11 @@ func TestIssue2571(t *testing.T) {
 
 	m := setupModel(w)
 
-	if err := testFs.RemoveAll("toLink"); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return testFs.RemoveAll("toLink") })
 
-	if err := osutil.DebugSymlinkForTestsOnly(filepath.Join(testFs.URI(), "linkTarget"), filepath.Join(testFs.URI(), "toLink")); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error {
+		return osutil.DebugSymlinkForTestsOnly(filepath.Join(testFs.URI(), "linkTarget"), filepath.Join(testFs.URI(), "toLink"))
+	})
 
 	m.ScanFolder("default")
 
@@ -2879,10 +2870,7 @@ func TestIssue4573(t *testing.T) {
 		os.Remove(w.ConfigPath())
 	}()
 
-	err := testFs.MkdirAll("inaccessible", 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return testFs.MkdirAll("inaccessible", 0755) })
 	defer testFs.Chmod("inaccessible", 0777)
 
 	file := filepath.Join("inaccessible", "a")
@@ -2894,10 +2882,7 @@ func TestIssue4573(t *testing.T) {
 
 	m := setupModel(w)
 
-	err = testFs.Chmod("inaccessible", 0000)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return testFs.Chmod("inaccessible", 0000) })
 
 	m.ScanFolder("default")
 
@@ -2931,8 +2916,7 @@ func TestInternalScan(t *testing.T) {
 	for _, dir := range baseDirs {
 		sub := filepath.Join(dir, "subDir")
 		for _, dir := range []string{dir, sub} {
-			err := testFs.MkdirAll(dir, 0775)
-			if err != nil {
+			if err := testFs.MkdirAll(dir, 0775); err != nil {
 				t.Fatalf("%v: %v", dir, err)
 			}
 		}
@@ -2955,9 +2939,7 @@ func TestInternalScan(t *testing.T) {
 	m := setupModel(w)
 
 	for _, dir := range baseDirs {
-		if err := testFs.RemoveAll(dir); err != nil {
-			t.Fatal(err)
-		}
+		must(t, func() error { return testFs.RemoveAll(dir) })
 	}
 
 	fd, err := testFs.Create("dirToFile")
@@ -3099,16 +3081,9 @@ func TestIssue4475(t *testing.T) {
 	// This should result in the directory being recreated and added to the
 	// db locally.
 
-	err := testFs.MkdirAll("delDir", 0755)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return testFs.MkdirAll("delDir", 0755) })
 
 	m.ScanFolder("default")
-
-	if err = testFs.RemoveAll("delDir"); err != nil {
-		t.Fatal(err)
-	}
 
 	m.ScanFolder("default")
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2343,9 +2343,9 @@ func TestIssue3028(t *testing.T) {
 
 	// Create two files that we'll delete, one with a name that is a prefix of the other.
 
-	must(t, func() error { return ioutil.WriteFile("testdata/testrm", []byte("Hello"), 0644) })
+	must(t, ioutil.WriteFile("testdata/testrm", []byte("Hello"), 0644))
 	defer testOs.Remove("testdata/testrm")
-	must(t, func() error { return ioutil.WriteFile("testdata/testrm2", []byte("Hello"), 0644) })
+	must(t, ioutil.WriteFile("testdata/testrm2", []byte("Hello"), 0644))
 	defer testOs.Remove("testdata/testrm2")
 
 	// Create a model and default folder
@@ -2827,21 +2827,17 @@ func TestIssue2571(t *testing.T) {
 	}()
 
 	for _, dir := range []string{"toLink", "linkTarget"} {
-		must(t, func() error { return testFs.MkdirAll(dir, 0775) })
+		must(t, testFs.MkdirAll(dir, 0775))
 		fd, err := testFs.Create(filepath.Join(dir, "a"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		must(t, err)
 		fd.Close()
 	}
 
 	m := setupModel(w)
 
-	must(t, func() error { return testFs.RemoveAll("toLink") })
+	must(t, testFs.RemoveAll("toLink"))
 
-	must(t, func() error {
-		return osutil.DebugSymlinkForTestsOnly(filepath.Join(testFs.URI(), "linkTarget"), filepath.Join(testFs.URI(), "toLink"))
-	})
+	must(t, osutil.DebugSymlinkForTestsOnly(filepath.Join(testFs.URI(), "linkTarget"), filepath.Join(testFs.URI(), "toLink")))
 
 	m.ScanFolder("default")
 
@@ -2870,19 +2866,17 @@ func TestIssue4573(t *testing.T) {
 		os.Remove(w.ConfigPath())
 	}()
 
-	must(t, func() error { return testFs.MkdirAll("inaccessible", 0755) })
+	must(t, testFs.MkdirAll("inaccessible", 0755))
 	defer testFs.Chmod("inaccessible", 0777)
 
 	file := filepath.Join("inaccessible", "a")
 	fd, err := testFs.Create(file)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	fd.Close()
 
 	m := setupModel(w)
 
-	must(t, func() error { return testFs.Chmod("inaccessible", 0000) })
+	must(t, testFs.Chmod("inaccessible", 0000))
 
 	m.ScanFolder("default")
 
@@ -2926,9 +2920,7 @@ func TestInternalScan(t *testing.T) {
 		for _, dir := range []string{dir, sub} {
 			file := filepath.Join(dir, "a")
 			fd, err := testFs.Create(file)
-			if err != nil {
-				t.Fatal(err)
-			}
+			must(t, err)
 			fd.Close()
 			testCases[file] = func(f protocol.FileInfo) bool {
 				return !f.Deleted
@@ -2939,13 +2931,11 @@ func TestInternalScan(t *testing.T) {
 	m := setupModel(w)
 
 	for _, dir := range baseDirs {
-		must(t, func() error { return testFs.RemoveAll(dir) })
+		must(t, testFs.RemoveAll(dir))
 	}
 
 	fd, err := testFs.Create("dirToFile")
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	fd.Close()
 
 	m.ScanFolder("default")
@@ -3011,10 +3001,7 @@ func TestRemoveDirWithContent(t *testing.T) {
 	defaultFs.MkdirAll("dirwith", 0755)
 	content := filepath.Join("dirwith", "content")
 	fd, err := defaultFs.Create(content)
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
+	must(t, err)
 	fd.Close()
 
 	m := setupModel(defaultCfgWrapper)
@@ -3081,7 +3068,7 @@ func TestIssue4475(t *testing.T) {
 	// This should result in the directory being recreated and added to the
 	// db locally.
 
-	must(t, func() error { return testFs.MkdirAll("delDir", 0755) })
+	must(t, testFs.MkdirAll("delDir", 0755))
 
 	m.ScanFolder("default")
 
@@ -3133,9 +3120,7 @@ func TestVersionRestore(t *testing.T) {
 	// We verify that the content matches at the expected filenames
 	// after the restore operation.
 	dir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	defer os.RemoveAll(dir)
 
 	fcfg := config.NewFolderConfiguration(myID, "default", "default", fs.FilesystemTypeBasic, dir)
@@ -3153,9 +3138,7 @@ func TestVersionRestore(t *testing.T) {
 	m.ScanFolder("default")
 
 	sentinel, err := time.ParseInLocation(versioner.TimeFormat, "20200101-010101", locationLocal)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	sentinelTag := sentinel.Format(versioner.TimeFormat)
 
 	for _, file := range []string{
@@ -3181,9 +3164,7 @@ func TestVersionRestore(t *testing.T) {
 			file = filepath.FromSlash(file)
 		}
 		dir := filepath.Dir(file)
-		if err := filesystem.MkdirAll(dir, 0755); err != nil {
-			t.Fatal(err)
-		}
+		must(t, filesystem.MkdirAll(dir, 0755))
 		if fd, err := filesystem.Create(file); err != nil {
 			t.Fatal(err)
 		} else if _, err := fd.Write([]byte(file)); err != nil {
@@ -3196,9 +3177,7 @@ func TestVersionRestore(t *testing.T) {
 	}
 
 	versions, err := m.GetFolderVersions("default")
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	expectedVersions := map[string]int{
 		"file.txt":               1,
 		"existing":               1,
@@ -3248,9 +3227,7 @@ func TestVersionRestore(t *testing.T) {
 	}
 
 	ferr, err := m.RestoreFolderVersions("default", restore)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 
 	if err, ok := ferr["something"]; len(ferr) > 1 || !ok || err != "cannot replace a non-file" {
 		t.Fatalf("incorrect error or count: %d %s", len(ferr), ferr)
@@ -3302,9 +3279,7 @@ func TestVersionRestore(t *testing.T) {
 		taggedArchivedName := filepath.Join(".stversions", taggedName)
 
 		fd, err := filesystem.Open(taggedArchivedName)
-		if err != nil {
-			t.Fatal(err)
-		}
+		must(t, err)
 		defer fd.Close()
 
 		content, err := ioutil.ReadAll(fd)
@@ -3348,9 +3323,7 @@ func TestPausedFolders(t *testing.T) {
 	pausedConfig := wrapper.RawCopy()
 	pausedConfig.Folders[0].Paused = true
 	w, err := m.cfg.Replace(pausedConfig)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	w.Wait()
 
 	if err := m.ScanFolder("default"); err != ErrFolderPaused {
@@ -3387,9 +3360,7 @@ func TestIssue4094(t *testing.T) {
 	}
 	cfg.Folders = []config.FolderConfiguration{fcfg}
 	p, err := wrapper.Replace(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	p.Wait()
 
 	if err := m.SetIgnores(fcfg.ID, []string{"foo"}); err != nil {
@@ -3426,9 +3397,7 @@ func TestIssue4903(t *testing.T) {
 	}
 	cfg.Folders = []config.FolderConfiguration{fcfg}
 	p, err := wrapper.Replace(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
+	must(t, err)
 	p.Wait()
 
 	if err := fcfg.CheckPath(); err != config.ErrPathMissing {

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -482,9 +482,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 
 	payload := []byte("hello")
 
-	if err := ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777) })
 
 	received := make(chan protocol.FileInfo)
 	fc.mut.Lock()
@@ -521,9 +519,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 	payload = []byte("bye")
 	buf = make([]byte, len(payload))
 
-	if err := ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777) })
 
 	_, err = m.Request(device1, "default", "foo", int32(len(payload)), 0, f.Blocks[0].Hash, f.Blocks[0].WeakHash, false)
 	if err == nil {
@@ -573,9 +569,7 @@ func TestParentDeletion(t *testing.T) {
 	}
 
 	// Delete parent dir
-	if err := testFs.RemoveAll(parent); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return testFs.RemoveAll(parent) })
 
 	// Scan only the child dir (not the parent)
 	if err := m.ScanFolderSubdirs("default", []string{child}); err != nil {
@@ -783,9 +777,7 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 	}
 
 	for _, n := range [2]string{a, b} {
-		if err := equalContents(filepath.Join(tmpDir, n), data[n]); err != nil {
-			t.Fatal(err)
-		}
+		must(t, func() error { return equalContents(filepath.Join(tmpDir, n), data[n]) })
 	}
 
 	var gotA, gotB, gotConfl bool
@@ -912,9 +904,7 @@ func TestRequestRemoteRenameConflict(t *testing.T) {
 	}
 
 	for _, n := range [2]string{a, b} {
-		if err := equalContents(filepath.Join(tmpDir, n), data[n]); err != nil {
-			t.Fatal(err)
-		}
+		must(t, func() error { return equalContents(filepath.Join(tmpDir, n), data[n]) })
 	}
 
 	fd, err := tfs.OpenFile(b, fs.OptReadWrite, 0644)

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -482,7 +482,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 
 	payload := []byte("hello")
 
-	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777) })
+	must(t, ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777))
 
 	received := make(chan protocol.FileInfo)
 	fc.mut.Lock()
@@ -519,7 +519,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 	payload = []byte("bye")
 	buf = make([]byte, len(payload))
 
-	must(t, func() error { return ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777) })
+	must(t, ioutil.WriteFile(filepath.Join(tmpDir, "foo"), payload, 0777))
 
 	_, err = m.Request(device1, "default", "foo", int32(len(payload)), 0, f.Blocks[0].Hash, f.Blocks[0].WeakHash, false)
 	if err == nil {
@@ -569,7 +569,7 @@ func TestParentDeletion(t *testing.T) {
 	}
 
 	// Delete parent dir
-	must(t, func() error { return testFs.RemoveAll(parent) })
+	must(t, testFs.RemoveAll(parent))
 
 	// Scan only the child dir (not the parent)
 	if err := m.ScanFolderSubdirs("default", []string{child}); err != nil {
@@ -777,7 +777,7 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 	}
 
 	for _, n := range [2]string{a, b} {
-		must(t, func() error { return equalContents(filepath.Join(tmpDir, n), data[n]) })
+		must(t, equalContents(filepath.Join(tmpDir, n), data[n]))
 	}
 
 	var gotA, gotB, gotConfl bool
@@ -904,7 +904,7 @@ func TestRequestRemoteRenameConflict(t *testing.T) {
 	}
 
 	for _, n := range [2]string{a, b} {
-		must(t, func() error { return equalContents(filepath.Join(tmpDir, n), data[n]) })
+		must(t, equalContents(filepath.Join(tmpDir, n), data[n]))
 	}
 
 	fd, err := tfs.OpenFile(b, fs.OptReadWrite, 0644)

--- a/lib/model/testos_test.go
+++ b/lib/model/testos_test.go
@@ -21,7 +21,7 @@ type fatalOs struct {
 	fatal
 }
 
-func (f *fatalOs) must(fn func() error) {
+func must(f fatal, fn func() error) {
 	f.Helper()
 	if err := fn(); err != nil {
 		f.Fatal(err)
@@ -30,12 +30,12 @@ func (f *fatalOs) must(fn func() error) {
 
 func (f *fatalOs) Chmod(name string, mode os.FileMode) {
 	f.Helper()
-	f.must(func() error { return os.Chmod(name, mode) })
+	must(f, func() error { return os.Chmod(name, mode) })
 }
 
 func (f *fatalOs) Chtimes(name string, atime time.Time, mtime time.Time) {
 	f.Helper()
-	f.must(func() error { return os.Chtimes(name, atime, mtime) })
+	must(f, func() error { return os.Chtimes(name, atime, mtime) })
 }
 
 func (f *fatalOs) Create(name string) *os.File {
@@ -49,12 +49,12 @@ func (f *fatalOs) Create(name string) *os.File {
 
 func (f *fatalOs) Mkdir(name string, perm os.FileMode) {
 	f.Helper()
-	f.must(func() error { return os.Mkdir(name, perm) })
+	must(f, func() error { return os.Mkdir(name, perm) })
 }
 
 func (f *fatalOs) MkdirAll(name string, perm os.FileMode) {
 	f.Helper()
-	f.must(func() error { return os.MkdirAll(name, perm) })
+	must(f, func() error { return os.MkdirAll(name, perm) })
 }
 
 func (f *fatalOs) Remove(name string) {
@@ -73,7 +73,7 @@ func (f *fatalOs) RemoveAll(name string) {
 
 func (f *fatalOs) Rename(oldname, newname string) {
 	f.Helper()
-	f.must(func() error { return os.Rename(oldname, newname) })
+	must(f, func() error { return os.Rename(oldname, newname) })
 }
 
 func (f *fatalOs) Stat(name string) os.FileInfo {

--- a/lib/model/testos_test.go
+++ b/lib/model/testos_test.go
@@ -21,40 +21,38 @@ type fatalOs struct {
 	fatal
 }
 
-func must(f fatal, fn func() error) {
+func must(f fatal, err error) {
 	f.Helper()
-	if err := fn(); err != nil {
+	if err != nil {
 		f.Fatal(err)
 	}
 }
 
 func (f *fatalOs) Chmod(name string, mode os.FileMode) {
 	f.Helper()
-	must(f, func() error { return os.Chmod(name, mode) })
+	must(f, os.Chmod(name, mode))
 }
 
 func (f *fatalOs) Chtimes(name string, atime time.Time, mtime time.Time) {
 	f.Helper()
-	must(f, func() error { return os.Chtimes(name, atime, mtime) })
+	must(f, os.Chtimes(name, atime, mtime))
 }
 
 func (f *fatalOs) Create(name string) *os.File {
 	f.Helper()
 	file, err := os.Create(name)
-	if err != nil {
-		f.Fatal(err)
-	}
+	must(f, err)
 	return file
 }
 
 func (f *fatalOs) Mkdir(name string, perm os.FileMode) {
 	f.Helper()
-	must(f, func() error { return os.Mkdir(name, perm) })
+	must(f, os.Mkdir(name, perm))
 }
 
 func (f *fatalOs) MkdirAll(name string, perm os.FileMode) {
 	f.Helper()
-	must(f, func() error { return os.MkdirAll(name, perm) })
+	must(f, os.MkdirAll(name, perm))
 }
 
 func (f *fatalOs) Remove(name string) {
@@ -73,14 +71,12 @@ func (f *fatalOs) RemoveAll(name string) {
 
 func (f *fatalOs) Rename(oldname, newname string) {
 	f.Helper()
-	must(f, func() error { return os.Rename(oldname, newname) })
+	must(f, os.Rename(oldname, newname))
 }
 
 func (f *fatalOs) Stat(name string) os.FileInfo {
 	f.Helper()
 	info, err := os.Stat(name)
-	if err != nil {
-		f.Fatal(err)
-	}
+	must(f, err)
 	return info
 }


### PR DESCRIPTION
As there's already `fatalOs.must`, why not change that to `must(fatal, func() error)` to save a few constructs like

```
if err := fn(...); err != nil {
        t.Fatal(err)
}
```

However now a few days after that thought I am no longer convinced that this is really any better:

```diff
-	if err := ioutil.WriteFile("testdata/testrm2", []byte("Hello"), 0644); err != nil {
-		t.Fatal(err)
-	}
+	must(t, func() error { return ioutil.WriteFile("testdata/testrm2", []byte("Hello"), 0644) })
```

Since variadic return values don't exist, it's anyway just a partial patch.

Before sending the change to oblivion I'd like to hear another opinion.