### PR TITLE
cmd: Add check for newer config file and an option to override it (fixes #4921)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -990,7 +990,7 @@ func loadConfigAtStartup(forceNewConfig bool) (config.Wrapper, error) {
 
 	if cfg.RawCopy().OriginalVersion != config.CurrentVersion {
 		if cfg.RawCopy().OriginalVersion > config.CurrentVersion && !forceNewConfig {
-			return nil, errors.New("Existing config version is newer than expected. Use -force-new-config to override.")
+			return nil, errors.New("Config file version (" + strconv.Itoa(cfg.RawCopy().OriginalVersion) + ") is newer than supported version (" + strconv.Itoa(config.CurrentVersion) + "). If this is expected, use -force-new-config to override.")
 		}
 		err = archiveAndSaveConfig(cfg)
 		if err != nil {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -163,35 +163,35 @@ var (
 )
 
 type RuntimeOptions struct {
-	confDir        string
-	resetDatabase  bool
-	resetDeltaIdxs bool
-	showVersion    bool
-	showPaths      bool
-	showDeviceId   bool
-	doUpgrade      bool
-	doUpgradeCheck bool
-	upgradeTo      string
-	noBrowser      bool
-	browserOnly    bool
-	hideConsole    bool
-	logFile        string
-	auditEnabled   bool
-	auditFile      string
-	verbose        bool
-	paused         bool
-	unpaused       bool
-	guiAddress     string
-	guiAPIKey      string
-	generateDir    string
-	noRestart      bool
-	profiler       string
-	assetDir       string
-	cpuProfile     bool
-	stRestarting   bool
-	logFlags       int
-	showHelp       bool
-	allowNewConfig bool
+	confDir          string
+	resetDatabase    bool
+	resetDeltaIdxs   bool
+	showVersion      bool
+	showPaths        bool
+	showDeviceId     bool
+	doUpgrade        bool
+	doUpgradeCheck   bool
+	upgradeTo        string
+	noBrowser        bool
+	browserOnly      bool
+	hideConsole      bool
+	logFile          string
+	auditEnabled     bool
+	auditFile        string
+	verbose          bool
+	paused           bool
+	unpaused         bool
+	guiAddress       string
+	guiAPIKey        string
+	generateDir      string
+	noRestart        bool
+	profiler         string
+	assetDir         string
+	cpuProfile       bool
+	stRestarting     bool
+	logFlags         int
+	showHelp         bool
+	allowNewerConfig bool
 }
 
 func defaultRuntimeOptions() RuntimeOptions {
@@ -245,7 +245,7 @@ func parseCommandLineOptions() RuntimeOptions {
 	flag.BoolVar(&options.unpaused, "unpaused", false, "Start with all devices and folders unpaused")
 	flag.StringVar(&options.logFile, "logfile", options.logFile, "Log file name (still always logs to stdout). Cannot be used together with -no-restart/STNORESTART environment variable.")
 	flag.StringVar(&options.auditFile, "auditfile", options.auditFile, "Specify audit file (use \"-\" for stdout, \"--\" for stderr)")
-	flag.BoolVar(&options.allowNewConfig, "allow-new-config", false, "Allow loading newer version of config file")
+	flag.BoolVar(&options.allowNewerConfig, "allow-newer-config", false, "Allow loading newer than current config version")
 	if runtime.GOOS == "windows" {
 		// Allow user to hide the console window
 		flag.BoolVar(&options.hideConsole, "no-console", false, "Hide console window")
@@ -669,7 +669,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		"myID": myID.String(),
 	})
 
-	cfg, err := loadConfigAtStartup(runtimeOptions.allowNewConfig)
+	cfg, err := loadConfigAtStartup(runtimeOptions.allowNewerConfig)
 	if err != nil {
 		l.Warnln("Failed to initialize config:", err)
 		os.Exit(exitError)
@@ -969,7 +969,7 @@ func loadOrDefaultConfig() (config.Wrapper, error) {
 	return cfg, err
 }
 
-func loadConfigAtStartup(allowNewConfig bool) (config.Wrapper, error) {
+func loadConfigAtStartup(allowNewerConfig bool) (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, err := config.Load(cfgFile, myID)
 	if os.IsNotExist(err) {
@@ -989,8 +989,8 @@ func loadConfigAtStartup(allowNewConfig bool) (config.Wrapper, error) {
 	}
 
 	if cfg.RawCopy().OriginalVersion != config.CurrentVersion {
-		if cfg.RawCopy().OriginalVersion > config.CurrentVersion && !allowNewConfig {
-			return nil, fmt.Errorf("Config file version (%d) is newer than supported version (%d). If this is expected, use -allow-new-config to override.", cfg.RawCopy().OriginalVersion, config.CurrentVersion)
+		if cfg.RawCopy().OriginalVersion > config.CurrentVersion && !allowNewerConfig {
+			return nil, fmt.Errorf("Config file version (%d) is newer than supported version (%d). If this is expected, use -allow-newer-config to override.", cfg.RawCopy().OriginalVersion, config.CurrentVersion)
 		}
 		err = archiveAndSaveConfig(cfg)
 		if err != nil {


### PR DESCRIPTION
### Testing

Compiled and tested manually on linux-amd64, works as expected.