### PR TITLE
lib/fs: Fallback EvalSymlinks method on windows (fixes #5609)

### DIFF
--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -152,7 +152,7 @@ func TestGetFinalPath(t *testing.T) {
 	for _, testCase := range testCases {
 		out, err := getFinalPathName(testCase.input)
 		if err != nil {
-			if testCase.ignoreMissing {
+			if testCase.ignoreMissing && os.IsNotExist(err) {
 				continue
 			}
 			t.Errorf("getFinalPathName failed at %q with error %s", testCase.input, err)

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -135,3 +135,42 @@ func TestRelUnrootedCheckedWindows(t *testing.T) {
 		}
 	}
 }
+
+func TestGetFinalPath(t *testing.T) {
+	testCases := []struct {
+		input         string
+		expectedPath  string
+		eqToEvalSyml  bool
+		ignoreMissing bool
+	}{
+		{`c:\`, `C:\`, true, false},
+		{`\\?\c:\`, `C:\`, false, false},
+		{`c:\wInDows\sYstEm32`, `C:\Windows\System32`, true, false},
+		{`c:\parent\child`, `C:\parent\child`, false, true},
+	}
+
+	for _, testCase := range testCases {
+		out, err := getFinalPathName(testCase.input)
+		if err != nil {
+			if testCase.ignoreMissing {
+				continue
+			}
+			t.Errorf("getFinalPathName failed at %q with error %s", testCase.input, err)
+		}
+		// Trim UNC prefix
+		if strings.HasPrefix(out, `\\?\UNC\`) {
+			out = `\` + out[7:]
+		} else {
+			out = strings.TrimPrefix(out, `\\?\`)
+		}
+		if out != testCase.expectedPath {
+			t.Errorf("getFinalPathName got wrong path: %q (expected %q)", out, testCase.expectedPath)
+		}
+		if testCase.eqToEvalSyml {
+			evlPath, err1 := filepath.EvalSymlinks(testCase.input)
+			if err1 != nil || out != evlPath {
+				t.Errorf("EvalSymlinks got different results %q %s", evlPath, err1)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Purpose

This PR fixes #5609 by circumventing the "access denied" error of `filepath.EvalSymlinks`. In the current implementation of `EvalSymlinks`, it makes a [`FindFirstFile` system call](https://github.com/golang/go/blob/44d3bb998ca00e49d9e0138954287af206b614bf/src/path/filepath/symlink_windows.go#L34) for every ancestor directories. Therefore it will fail if If the user lacks access permission to any of those ancestors.

This PR introduces a fallback method to get the ["normalized"](https://docs.microsoft.com/en-us/windows/desktop/api/fileapi/nf-fileapi-getfinalpathnamebyhandlew#remarks) path from a more suitable WinAPI call, `GetFinalPathNameByHandle` which tries to query the norm path from the file system directly without visiting any ancestor directory. Therefore it can circumvent the above problem.

By definition, the norm path doesn't contain any symlink or short 8.3 file names. The case of the path components should also be correct. 

### Testing

A unit test function `TestGetFinalPath` is composed to test normal windows paths as long as a path to a special folder structure with ACLs that will trigger the issue [#5609](https://github.com/syncthing/syncthing/issues/5609#issuecomment-475275310). This test finishes successfully on Windows 10 (build 1809).

## Authorship

The PR is authored by Mingxuan Lin

