### PR TITLE
lib/model: Debug and test fixes

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1940,15 +1940,6 @@ func sendIndexTo(prevSequence int64, conn protocol.Connection, folder string, fs
 			}
 		}
 
-		if shouldDebug() {
-			if fi.SequenceNo() < prevSequence+1 {
-				panic(fmt.Sprintln("sequence lower than requested, got:", fi.SequenceNo(), ", asked to start at:", prevSequence+1))
-			}
-			if f.Sequence > 0 && fi.SequenceNo() <= f.Sequence {
-				panic(fmt.Sprintln("non-increasing sequence, current:", fi.SequenceNo(), "<= previous:", f.Sequence))
-			}
-		}
-
 		f = fi.(protocol.FileInfo)
 
 		// Mark the file as invalid if any of the local bad stuff flags are set.

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -370,14 +370,12 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 
 	fc.sendIndexUpdate()
 
-	timeout := time.NewTimer(5 * time.Second)
 	select {
 	case ev := <-sub.C():
 		t.Fatalf("Errors while pulling: %v", ev)
-	case <-timeout.C:
+	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out before index was received")
 	case <-done:
-		return
 	}
 
 	fc.mut.Lock()
@@ -421,12 +419,10 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 		panic(err)
 	}
 
-	timeout = time.NewTimer(5 * time.Second)
 	select {
-	case <-timeout.C:
+	case <-time.After(5 * time.Second):
 		t.Fatalf("timed out before index was received")
 	case <-done:
-		return
 	}
 }
 


### PR DESCRIPTION
The deleted `shouldDebug` block is duplicated on the lines just above it.

The first removed return exits the test preemptively. Removing the second doesn't change anything, but it's still superfluous.