### PR TITLE
gui: Add new folder state "Failed Items" (fixes #5456)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -328,6 +328,7 @@
                     <span ng-show="syncRemaining(folder.id)">({{syncPercentage(folder.id) | percent}}, {{syncRemaining(folder.id) | binary}}B)</span>
                   </span>
                   <span ng-switch-when="outofsync"><span class="hidden-xs" translate>Out of Sync</span><span class="visible-xs" aria-label="{{'Out of Sync' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
+                  <span ng-switch-when="faileditems"><span class="hidden-xs" translate>Failed Items</span><span class="visible-xs" aria-label="{{'Failed Items' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
                 </div>
                 <div class="panel-title-text">
                   <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -751,6 +751,9 @@ angular.module('syncthing.core')
             if (state === 'idle' && $scope.model[folderCfg.id].needTotalItems > 0) {
                 return 'outofsync';
             }
+            if ($scope.hasFailedFiles(folderCfg.id)) {
+                return 'faileditems';
+            }
             if (state === 'scanning') {
                 return state;
             }
@@ -777,7 +780,7 @@ angular.module('syncthing.core')
             if (status === 'unknown') {
                 return 'info';
             }
-            if (status === 'stopped' || status === 'outofsync' || status === 'error') {
+            if (status === 'stopped' || status === 'outofsync' || status === 'error' || status === 'faileditems') {
                 return 'danger';
             }
             if (status === 'unshared' || status === 'scan-waiting') {


### PR DESCRIPTION
### Purpose

Previously whenever there were any failures, those were failures during pulling and thus the folder was also out of sync as in there are needed files. Now that failures can occur when scanning, this is not the case and there can be failed items with no indication whatsover in the folder status. As folders aren't really out-of-sync due to scanning errors, I added the new state "Failed Items". It only takes effect if the folder is not out of sync.

### Testing

Manual testing.

### Screenshots

![Screenshot_2019-03-22_17-29-22](https://user-images.githubusercontent.com/15955093/54838369-baa42300-4cc8-11e9-94cd-0038cee789ee.png)
