### PR TITLE
lib/model: Send item finished event after deregistering (fixes #5362)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1568,6 +1568,10 @@ func (f *sendReceiveFolder) finisherRoutine(in <-chan *sharedPullerState, dbUpda
 				blockStatsMut.Unlock()
 			}
 
+			if f.model.progressEmitter != nil {
+				f.model.progressEmitter.Deregister(state)
+			}
+
 			events.Default.Log(events.ItemFinished, map[string]interface{}{
 				"folder": f.folderID,
 				"item":   state.file.Name,
@@ -1575,10 +1579,6 @@ func (f *sendReceiveFolder) finisherRoutine(in <-chan *sharedPullerState, dbUpda
 				"type":   "file",
 				"action": "update",
 			})
-
-			if f.model.progressEmitter != nil {
-				f.model.progressEmitter.Deregister(state)
-			}
 		}
 	}
 }


### PR DESCRIPTION
The `DeregisterOnFailIn...` tests are still flaky:  
https://build.syncthing.net/project.html?projectId=Syncthing&buildTypeId=&tab=testDetails&testNameId=-1067371058420929398&order=TEST_STATUS_DESC&branch_Syncthing=__all_branches__&itemsCount=50  
https://build.syncthing.net/project.html?projectId=Syncthing&buildTypeId=&tab=testDetails&testNameId=-6699784144011712658&order=TEST_STATUS_DESC&branch_Syncthing=__all_branches__&itemsCount=50  

They always fail with everything deregistered except the progress emitter:
```
    folder_sendrecv_test.go:609: event took 5.020876ms
    folder_sendrecv_test.go:619: Still registered 1 0 0
```

In the test we wait for the item finished event before checking and in the finisher, we emit that event before deregistering from the progress emitter. Apparently emitting/receiving the event is asynchronous and much slower than deregistering, so test still passed mostly, but not always. Hopefully this is really it, I would not miss those red crosses.