### PR TITLE
lib/model: Missing queue.Done and reset between pulls (fixes #5332)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -291,6 +291,8 @@ func (f *sendReceiveFolder) pullerIteration(scanChan chan<- string) int {
 }
 
 func (f *sendReceiveFolder) processNeeded(dbUpdateChan chan<- dbUpdateJob, copyChan chan<- copyBlocksState, scanChan chan<- string) (int, map[string]protocol.FileInfo, []protocol.FileInfo, error) {
+	defer f.queue.Reset()
+
 	changed := 0
 	var processDirectly []protocol.FileInfo
 	var dirDeletions []protocol.FileInfo
@@ -478,6 +480,7 @@ nextFile:
 				// Remove the pending deletion (as we performed it by renaming)
 				delete(fileDeletions, candidate.Name)
 
+				changed++
 				f.queue.Done(fileName)
 				continue nextFile
 			}
@@ -493,6 +496,7 @@ nextFile:
 			}
 		}
 		f.newPullError(fileName, errNotAvailable)
+		f.queue.Done(fileName)
 	}
 
 	return changed, fileDeletions, dirDeletions, nil

--- a/lib/model/queue.go
+++ b/lib/model/queue.go
@@ -110,6 +110,13 @@ func (q *jobQueue) Shuffle() {
 	}
 }
 
+func (q *jobQueue) Reset() {
+	q.mut.Lock()
+	defer q.mut.Unlock()
+	q.progress = nil
+	q.queued = nil
+}
+
 func (q *jobQueue) lenQueued() int {
 	q.mut.Lock()
 	defer q.mut.Unlock()


### PR DESCRIPTION
I am not actually certain it fixes #5332 for lack of reproducer, but it's likely the cause: When a file cannot be pulled, it isn't removed from the queue and readded on the next try. And the queue is never reset, so that stays there "forever" (as long as the folder is constantly running). I fixed that instance and added `jobQueue.Reset` that removes everything from queue that's invoked when the iteration is finished - in case the folder is stopped (or I missed something else). And I noticed a missing `changed++` on rename, which is largely cosmetic (as in can't think of an adverse effect right now).