### PR TITLE
lib/fs: When watching remove \\?\ for drive letters (fixes #5578)

### DIFF
--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"runtime"
 
 	"github.com/syncthing/notify"
 )
@@ -34,7 +35,7 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 
 	// Remove `\\?\` prefix if the path is just a drive letter as a dirty
 	// fix for https://github.com/syncthing/syncthing/issues/5578
-	if runtime.GOOS == "windows" && len(absName) <= 7 && absName[:4] == `\\?\` {
+	if runtime.GOOS == "windows" && len(absName) <= 7 && len(absName) > 4 && absName[:4] == `\\?\` {
 		absName = absName[4:]
 	}
 

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -32,6 +32,12 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 		return nil, err
 	}
 
+	// Remove `\\?\` prefix if the path is just a drive letter as a dirty
+	// fix for https://github.com/syncthing/syncthing/issues/5578
+	if runtime.GOOS == "windows" && len(absName) <= 7 && absName[:4] == `\\?\` {
+		absName = absName[4:]
+	}
+
 	outChan := make(chan Event)
 	backendChan := make(chan notify.EventInfo, backendBuffer)
 


### PR DESCRIPTION
Should fix #5578 according to this https://forum.syncthing.net/t/filesystem-watcher-errors-getfileinformationbyhandle-w-incorrect-function/12974/12  
However it's obviously super ugly and finding the real change between Go 1.11 (worked) 1.12 (fails) or revisiting the use of `\\?\` in general as proposed by calmh would be preferable:

> Do we need `\\?\` anywhere at all any more? Go 1.8 (!) added a change 10 that should use long filenames “when possible” which I think should cover all the regular OS stuff. Maybe the filewatcher library does need it if it does direct syscalls, but then it could fixup the path to whatever is the right format, and maybe only do so if it’s longer 260 chars etc?

However the former needs debugging and I don't want to do the latter without more thought/testing put into it, that's why I propose to merge this hotfix for 1.1.2 if neither of the two happen in time.