### PR TITLE
docker: Create entrypoint script (fixes #5631)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,11 @@ VOLUME ["/var/syncthing"]
 RUN apk add --no-cache ca-certificates su-exec
 
 COPY --from=builder /src/syncthing /bin/syncthing
+COPY --from=builder /src/script/docker-entrypoint.sh /bin/entrypoint.sh
 
 ENV PUID=1000 PGID=1000
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z localhost 8384 || exit 1
 
-ENTRYPOINT \
-  chown "${PUID}:${PGID}" /var/syncthing \
-  && su-exec "${PUID}:${PGID}" \
-     env HOME=/var/syncthing \
-     /bin/syncthing \
-       -home /var/syncthing/config \
-       -gui-address 0.0.0.0:8384
+ENTRYPOINT ["/bin/entrypoint.sh", "-home", "/var/syncthing/config", "-gui-address", "0.0.0.0:8384"]

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+chown "${PUID}:${PGID}" /var/syncthing \
+  && exec su-exec "${PUID}:${PGID}" \
+     env HOME=/var/syncthing \
+     /bin/syncthing \
+     -home /var/syncthing/config \
+     -gui-address http://0.0.0.0:8443/ \
+     "$@"

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -5,7 +5,4 @@ set -eu
 chown "${PUID}:${PGID}" /var/syncthing \
   && exec su-exec "${PUID}:${PGID}" \
      env HOME=/var/syncthing \
-     /bin/syncthing \
-     -home /var/syncthing/config \
-     -gui-address http://0.0.0.0:8443/ \
-     "$@"
+     /bin/syncthing "$@"


### PR DESCRIPTION
### Purpose

Using the [preferred "exec" form](https://docs.docker.com/engine/reference/builder/#entrypoint) of the ENTRYPOINT directive allows the user to pass additional command line arguments to the `syncthing` command when using `docker run` or `docker create`.

### Testing

I built a new image and tagged it:

```
% docker build . -t sthing
```

And then ran the image with no options to check that it behaved like before:

```
% docker run sthing
...
[Q3FAA] 21:25:45 INFO: My name is "70dd5dd00c6f"
^C[monitor] 21:25:56 INFO: Signal 2 received; exiting
[Q3FAA] 21:25:56 INFO: Shutting down
[Q3FAA] 21:25:56 INFO: Exiting
```

It was especially important that pressing "CTRL+C" in the terminal continued to deliver the interrupt signal to syncthing. (The `exec` in the entrypoint script takes care of that.)

Then, ran with `-help`, and saw the help text:

```
% docker run sthing -help
Usage:
  syncthing [options]

Options:
...
```

Finally, with a bogus option to check that exit codes were passed on:

```
% docker run sthing -bogus >/dev/null
% echo $?
2
```
