### PR TITLE
lib/protocol: Send close msg on receive error

### DIFF
--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -57,7 +57,7 @@ func TestClose(t *testing.T) {
 	c0.ClusterConfig(ClusterConfig{})
 	c1.ClusterConfig(ClusterConfig{})
 
-	c0.internalClose(errors.New("manual close"))
+	c0.closeWithoutSend(errors.New("manual close"))
 
 	<-c0.closed
 	if err := m0.closedError(); err == nil || !strings.Contains(err.Error(), "manual close") {


### PR DESCRIPTION
There are three related changes:
 - Send a close message with a reason when an error occurs with incoming messages.
 - Wait for reader and writer loops to exit before signalling to the model that the connection was removed. This could in principle be the reason for the cluster-config-panic (https://github.com/syncthing/syncthing/issues/4170), if the cluster config comes in just before the connection is closed and parsing it takes longer than closing the connection.
 - Don't send close messages via the writer loop, but wait for that to stop and then send the close message directly. This has the advantage that if there are outstanding send operations, the close message doesn't have to "compete" with those to get sent.