### PR TITLE
lib/scanner, lib/model: File -> item when logging error

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1747,7 +1747,7 @@ func (f *sendReceiveFolder) newPullError(path string, err error) {
 		return
 	}
 
-	l.Infof("Puller (folder %s, file %q): %v", f.Description(), path, err)
+	l.Infof("Puller (folder %s, item %q): %v", f.Description(), path, err)
 
 	// Establish context to differentiate from errors while scanning.
 	// Use "syncing" as opposed to "pulling" as the latter might be used

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -530,7 +530,7 @@ func (w *walker) handleError(ctx context.Context, context, path string, err erro
 	if fs.IsNotExist(err) {
 		return
 	}
-	l.Infof("Scanner (folder %s, file %q): %s: %v", w.Folder, path, context, err)
+	l.Infof("Scanner (folder %s, item %q): %s: %v", w.Folder, path, context, err)
 	select {
 	case finishedChan <- ScanResult{
 		Err:  fmt.Errorf("%s: %s", context, err.Error()),


### PR DESCRIPTION
The file might be a directory or symlink, so call it generically "item", as already done in other places.