### PR TITLE
gui: Use of AngularJS markup in URL-valued attribute

### DIFF
--- a/gui/default/syncthing/core/majorUpgradeModalView.html
+++ b/gui/default/syncthing/core/majorUpgradeModalView.html
@@ -6,7 +6,7 @@
       <span translate>Please consult the release notes before performing a major upgrade.</span>
     </p>
     <p>
-      <a href="https://github.com/syncthing/syncthing/releases/tag/{{upgradeInfo.latest}}" target="_blank" translate>Release Notes</a>
+      <a ng-href="https://github.com/syncthing/syncthing/releases/tag/{{upgradeInfo.latest}}" target="_blank" translate>Release Notes</a>
     </p>
   </div>
   <div class="modal-footer">


### PR DESCRIPTION
Using AngularJS markup (that is, AngularJS expressions enclosed in double curly braces) in HTML attributes that reference URLs is not recommended: the browser may attempt to fetch the URL before the AngularJS compiler evaluates the markup, resulting in a request for an invalid URL.