### PR TITLE
cmd: Missing explicit dependency injection

### DIFF
--- a/cmd/strelaypoolsrv/gui/index.html
+++ b/cmd/strelaypoolsrv/gui/index.html
@@ -193,9 +193,9 @@
   <script>
   angular.module('syncthing', [
   ])
-  .config(function($httpProvider) {
+  .config(['$httpProvider', function($httpProvider) {
     $httpProvider.defaults.timeout = 5000;
-  })
+  }])
   .filter('bytes', function() {
     return function(bytes, precision) {
       if (isNaN(parseFloat(bytes)) || !isFinite(bytes)) return '-';


### PR DESCRIPTION
### Purpose

> When AngularJS injects dependencies into a function that does not have an explicit dependency specification, it matches up dependencies with function parameters by name. This is dangerous, since some source code transformations such as minification may change the names of parameters. Such a renaming will break the AngularJS application.

https://lgtm.com/rules/1505800326162/

This methodology is used some lines further down, but please review as I'm unsure about possible implications.

https://github.com/syncthing/syncthing/blob/e302ccf4b4fa0c2fba77036be7f5114b5574412d/cmd/strelaypoolsrv/gui/index.html#L220