### PR TITLE
cmd, lib/db: Actually close goleveldb (fixes #5505)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -928,6 +928,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	code := exit.waitForExit()
 
 	mainService.Stop()
+	ldb.Close()
 
 	l.Infoln("Exiting")
 

--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -506,6 +506,9 @@ func (db *instance) getIndexID(device, folder []byte) protocol.IndexID {
 func (db *instance) setIndexID(device, folder []byte, id protocol.IndexID) {
 	bs, _ := id.Marshal() // marshalling can't fail
 	if err := db.Put(db.keyer.GenerateIndexIDKey(nil, device, folder), bs, nil); err != nil {
+		if err == leveldb.ErrClosed {
+			return
+		}
 		panic("storing index ID: " + err.Error())
 	}
 }

--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -505,10 +505,7 @@ func (db *instance) getIndexID(device, folder []byte) protocol.IndexID {
 
 func (db *instance) setIndexID(device, folder []byte, id protocol.IndexID) {
 	bs, _ := id.Marshal() // marshalling can't fail
-	if err := db.Put(db.keyer.GenerateIndexIDKey(nil, device, folder), bs, nil); err != nil {
-		if err == leveldb.ErrClosed {
-			return
-		}
+	if err := db.Put(db.keyer.GenerateIndexIDKey(nil, device, folder), bs, nil); err != nil && err != leveldb.ErrClosed {
 		panic("storing index ID: " + err.Error())
 	}
 }

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -186,7 +186,7 @@ func (b *batch) checkFlush() {
 }
 
 func (b *batch) flush() {
-	if err := b.db.Write(b.Batch, nil); err != nil {
+	if err := b.db.Write(b.Batch, nil); err != nil && err != leveldb.ErrClosed {
 		panic(err)
 	}
 }

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -125,7 +125,10 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 		if new, ok := t.getFileByKey(keyBuf); ok {
 			global = new
 		} else {
-			panic("This file must exist in the db")
+			// This file must exist in the db, so this must be caused
+			// by the db being closed - bail out.
+			l.Debugln("File should exist:", name)
+			return keyBuf, false
 		}
 	}
 
@@ -242,7 +245,10 @@ func (t readWriteTransaction) removeFromGlobal(gk, keyBuf, folder, device []byte
 		keyBuf = t.keyer.GenerateDeviceFileKey(keyBuf, folder, fl.Versions[0].Device, file)
 		global, ok := t.getFileByKey(keyBuf)
 		if !ok {
-			panic("This file must exist in the db")
+			// This file must exist in the db, so this must be caused
+			// by the db being closed - bail out.
+			l.Debugln("File should exist:", file)
+			return keyBuf
 		}
 		keyBuf = t.updateLocalNeed(keyBuf, folder, file, fl, global)
 		meta.addFile(protocol.GlobalDeviceID, global)

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -14,17 +14,13 @@ import (
 
 // A readOnlyTransaction represents a database snapshot.
 type readOnlyTransaction struct {
-	*leveldb.Snapshot
+	snapshot
 	keyer keyer
 }
 
 func (db *instance) newReadOnlyTransaction() readOnlyTransaction {
-	snap, err := db.GetSnapshot()
-	if err != nil {
-		panic(err)
-	}
 	return readOnlyTransaction{
-		Snapshot: snap,
+		snapshot: db.GetSnapshot(),
 		keyer:    db.keyer,
 	}
 }

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -32,6 +32,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 	ffs := f.Filesystem()
 	defer os.Remove(m.cfg.ConfigPath())
 	defer os.Remove(ffs.URI())
+	defer m.db.Close()
 	defer m.Stop()
 
 	// Create some test data
@@ -115,6 +116,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	ffs := f.Filesystem()
 	defer os.Remove(m.cfg.ConfigPath())
 	defer os.Remove(ffs.URI())
+	defer m.db.Close()
 	defer m.Stop()
 
 	// Create some test data
@@ -208,6 +210,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	ffs := f.Filesystem()
 	defer os.Remove(m.cfg.ConfigPath())
 	defer os.Remove(ffs.URI())
+	defer m.db.Close()
 	defer m.Stop()
 
 	// Create some test data

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -32,6 +32,7 @@ func TestRequestSimple(t *testing.T) {
 	tfs := fcfg.Filesystem()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(tfs.URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -78,6 +79,7 @@ func TestSymlinkTraversalRead(t *testing.T) {
 	m, fc, fcfg, w := setupModelWithConnection()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(fcfg.Filesystem().URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -125,6 +127,7 @@ func TestSymlinkTraversalWrite(t *testing.T) {
 	m, fc, fcfg, w := setupModelWithConnection()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(fcfg.Filesystem().URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -188,6 +191,7 @@ func TestRequestCreateTmpSymlink(t *testing.T) {
 	m, fc, fcfg, w := setupModelWithConnection()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(fcfg.Filesystem().URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -238,8 +242,8 @@ func TestRequestVersioningSymlinkAttack(t *testing.T) {
 
 	fcfg.Versioning = config.VersioningConfiguration{Type: "trashcan"}
 	w.SetFolder(fcfg)
-
 	m, fc := setupModelWithConnectionFromWrapper(w)
+	defer m.db.Close()
 	defer m.Stop()
 
 	// Create a temporary directory that we will use as target to see if
@@ -312,6 +316,7 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 	m, fc := setupModelWithConnectionFromWrapper(w)
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(fss.URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -430,6 +435,7 @@ func TestIssue4841(t *testing.T) {
 	m, fc, fcfg, w := setupModelWithConnection()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(fcfg.Filesystem().URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -473,6 +479,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 	tmpDir := fcfg.Filesystem().URI()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(tmpDir)
 		os.Remove(w.ConfigPath())
 	}()
@@ -538,6 +545,7 @@ func TestParentDeletion(t *testing.T) {
 	testFs := fcfg.Filesystem()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(testFs.URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -620,6 +628,7 @@ func TestRequestSymlinkWindows(t *testing.T) {
 	m, fc, fcfg, w := setupModelWithConnection()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(fcfg.Filesystem().URI())
 		os.Remove(w.ConfigPath())
 	}()
@@ -737,6 +746,7 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 	tmpDir := tfs.URI()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(tmpDir)
 		os.Remove(w.ConfigPath())
 	}()
@@ -869,6 +879,7 @@ func TestRequestRemoteRenameConflict(t *testing.T) {
 	tmpDir := tfs.URI()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(tmpDir)
 		os.Remove(w.ConfigPath())
 	}()
@@ -963,6 +974,7 @@ func TestRequestDeleteChanged(t *testing.T) {
 	tfs := fcfg.Filesystem()
 	defer func() {
 		m.Stop()
+		m.db.Close()
 		os.RemoveAll(tfs.URI())
 		os.Remove(w.ConfigPath())
 	}()


### PR DESCRIPTION
We currently don't close the database, just call `os.Exit`. At the same time we do not keep track of whatever is currently accessing the database (model, api, ...), which is fine in many cases, but not for a few random `panic`s we have in our code and `goleveldb.DB.NewIterator` (https://github.com/syndtr/goleveldb/issues/235, other functions just report `goleveldb.ErrClosed`). Therefore I had to add some bubblewrap to prevent panics after close.

This does not ensure that we are in a consistent state on close, but it at least explicitly closes the database instead of crashing it. Doing that would probably require actually keeping track of everything the model does and adding `model.Close` that ensures everything is terminated before it returns - I'd say that would be quite a lot of work.