### PR TITLE
lib/protocol: Don't close asyncMessage.done on success (fixes #5674)

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -641,9 +641,9 @@ func (c *rawConnection) handleResponse(resp Response) {
 	c.awaitingMut.Unlock()
 }
 
-func (c *rawConnection) send(msg message, done chan struct{}) bool {
+func (c *rawConnection) send(msg message, done chan struct{}) (sent bool) {
 	defer func() {
-		if done != nil {
+		if !sent && done != nil {
 			close(done)
 		}
 	}()


### PR DESCRIPTION
Regression introduced in #5646 as identified by @rahrah in #5674, thus luckily not yet released.