### PR TITLE
 lib/protocol: Fix deadlock on sending close message 

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -891,9 +891,12 @@ func (c *rawConnection) internalClose(err error, send bool) {
 			case c.outbox <- asyncMessage{&Close{err.Error()}, done}:
 				select {
 				case <-done:
+					l.Debugln("sent close due to", err)
 				case <-timeout:
+					l.Debugln("timed out sending close due to", err)
 				}
 			case <-timeout:
+				l.Debugln("timed out sending close due to", err)
 			}
 		}
 

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -57,7 +57,7 @@ func TestClose(t *testing.T) {
 	c0.ClusterConfig(ClusterConfig{})
 	c1.ClusterConfig(ClusterConfig{})
 
-	c0.internalClose(errors.New("manual close"))
+	c0.internalClose(errors.New("manual close"), false)
 
 	<-c0.closed
 	if err := m0.closedError(); err == nil || !strings.Contains(err.Error(), "manual close") {


### PR DESCRIPTION
Please bear with me, unfortunately it's necessary, due to the deadlock reproduced in this PR: Writing is also a blocking call, so by waiting on `writerLoop`, we can get into a deadlock. To summarize what I want to achieve (not only in this PR, in all those related PRs):

1. After calling `receiver.Closed`, more calls to `receiver` must not happen:  
Reason for the whole wait/channel business on close.
2. Send close messages to remotes to propagate close reasons and speed closing up.
3. Do not try to send a close message after an error occurred while sending (not much chance for it to succeed).
4. Do not block on sending the final close message (current timeout is 1s, maybe a bit short?).

This passes both unit and integration tests.