### PR TITLE
gui: Fix typo in log viewer modal

### DIFF
--- a/gui/default/syncthing/core/logViewerModalView.html
+++ b/gui/default/syncthing/core/logViewerModalView.html
@@ -9,7 +9,7 @@
       <div id="log-viewer-log" class="tab-pane in active">
         <label translate ng-if="logging.logEntries.length == 0">Loading...</label>
         <textarea id="logViewerText" class="form-control" rows="20" ng-if="logging.logEntries.length != 0" readonly style="font-family: Consolas; font-size: 11px; overflow: auto;">{{ logging.content() }}</textarea>
-        <p translate class="help-block" ng-style="{'visibility': logging.paused ? 'visible' : 'hidden'}">Log tailing paused. Scroll to bottom continue.</p>
+        <p translate class="help-block" ng-style="{'visibility': logging.paused ? 'visible' : 'hidden'}">Log tailing paused. Scroll to the bottom to continue.</p>
       </div>
 
       <div id="log-viewer-facilities" class="tab-pane">


### PR DESCRIPTION
### Purpose

Replaces `Log tailing paused. Scroll to bottom continue.` with `Log tailing paused. Scroll to the bottom to continue.` in the web GUI's log viewer modal.

### Authorship
`Nitroretro <nitroretro@protonmail.com>`