### PR TITLE
lib/model, lib/testutils: Test closing a connection on folder restart

### DIFF
--- a/lib/model/fakeconns_test.go
+++ b/lib/model/fakeconns_test.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/syncthing/syncthing/lib/connections"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/scanner"
 )
@@ -23,6 +24,7 @@ type downloadProgressMessage struct {
 }
 
 type fakeConnection struct {
+	fakeUnderlyingConn
 	id                       protocol.DeviceID
 	downloadProgressMessages []downloadProgressMessage
 	closed                   bool
@@ -55,10 +57,6 @@ func (f *fakeConnection) ID() protocol.DeviceID {
 }
 
 func (f *fakeConnection) Name() string {
-	return ""
-}
-
-func (f *fakeConnection) String() string {
 	return ""
 }
 
@@ -109,26 +107,6 @@ func (f *fakeConnection) Closed() bool {
 
 func (f *fakeConnection) Statistics() protocol.Statistics {
 	return protocol.Statistics{}
-}
-
-func (f *fakeConnection) RemoteAddr() net.Addr {
-	return &fakeAddr{}
-}
-
-func (f *fakeConnection) Type() string {
-	return "fake"
-}
-
-func (f *fakeConnection) Crypto() string {
-	return "fake"
-}
-
-func (f *fakeConnection) Transport() string {
-	return "fake"
-}
-
-func (f *fakeConnection) Priority() int {
-	return 9000
 }
 
 func (f *fakeConnection) DownloadProgress(folder string, updates []protocol.FileDownloadProgressUpdate) {
@@ -233,6 +211,43 @@ func addFakeConn(m *model, dev protocol.DeviceID) *fakeConnection {
 	})
 
 	return fc
+}
+
+type fakeProtoConn struct {
+	protocol.Connection
+	fakeUnderlyingConn
+}
+
+func newFakeProtoConn(protoConn protocol.Connection) connections.Connection {
+	return &fakeProtoConn{Connection: protoConn}
+}
+
+// fakeUnderlyingConn implements the methods of connections.Connection that are
+// not implemented by protocol.Connection
+type fakeUnderlyingConn struct{}
+
+func (f *fakeUnderlyingConn) RemoteAddr() net.Addr {
+	return &fakeAddr{}
+}
+
+func (f *fakeUnderlyingConn) Type() string {
+	return "fake"
+}
+
+func (f *fakeUnderlyingConn) Crypto() string {
+	return "fake"
+}
+
+func (f *fakeUnderlyingConn) Transport() string {
+	return "fake"
+}
+
+func (f *fakeUnderlyingConn) Priority() int {
+	return 9000
+}
+
+func (f *fakeUnderlyingConn) String() string {
+	return ""
 }
 
 type fakeAddr struct{}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	srand "github.com/syncthing/syncthing/lib/rand"
-	"github.com/syncthing/syncthing/lib/testutil"
+	"github.com/syncthing/syncthing/lib/testutils"
 	"github.com/syncthing/syncthing/lib/versioner"
 )
 
@@ -3426,8 +3426,8 @@ func TestConnCloseOnRestart(t *testing.T) {
 		os.Remove(w.ConfigPath())
 	}()
 
-	br := &testutil.BlockingRW{}
-	nw := &testutil.NoopRW{}
+	br := &testutils.BlockingRW{}
+	nw := &testutils.NoopRW{}
 	m.AddConnection(newFakeProtoConn(protocol.NewConnection(device1, br, nw, m, "testConn", protocol.CompressNever)), protocol.HelloResult{})
 
 	newFcfg := fcfg.Copy()

--- a/lib/testutil/testutils.go
+++ b/lib/testutil/testutils.go
@@ -1,0 +1,31 @@
+// Copyright (C) 2019 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package testutil
+
+// BlockingRW implements io.Reader and Writer but never returns when called
+type BlockingRW struct{ nilChan chan struct{} }
+
+func (rw *BlockingRW) Read(p []byte) (n int, err error) {
+	<-rw.nilChan
+	return
+}
+
+func (rw *BlockingRW) Write(p []byte) (n int, err error) {
+	<-rw.nilChan
+	return
+}
+
+// NoopRW implements io.Reader and Writer but never returns when called
+type NoopRW struct{}
+
+func (rw *NoopRW) Read(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (rw *NoopRW) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}

--- a/lib/testutils/testutils.go
+++ b/lib/testutils/testutils.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package testutil
+package testutils
 
 // BlockingRW implements io.Reader and Writer but never returns when called
 type BlockingRW struct{ nilChan chan struct{} }


### PR DESCRIPTION
The added test would have caught a deadlock that in the end resulted in the revert of all these changes (https://github.com/syncthing/syncthing/pull/5688).

lib/testutil is currently only used in model, but I wrote some more tests reproducing e.g. #4170 in lib/protocol which will also use this code. I intentionally put it into lib/testutil not lib/util, as this is code that should never be included in production code. And there's certainly more test helpers useful in many packages, e.g. lib/model/testos_test.go which could go there in the future.