### PR TITLE
lib/fs: Consider win83 for root path as well when watching (ref #5706)

### DIFF
--- a/lib/fs/basicfs_unix.go
+++ b/lib/fs/basicfs_unix.go
@@ -76,3 +76,19 @@ func rel(path, prefix string) string {
 }
 
 var evalSymlinks = filepath.EvalSymlinks
+
+// watchPaths adjust the folder root for use with the notify backend and the
+// corresponding absolute path to be passed to notify to watch name.
+func (f *BasicFilesystem) watchPaths(name string) (string, string, error) {
+	root, err := evalSymlinks(f.root)
+	if err != nil {
+		return "", "", err
+	}
+
+	absName, err := rooted(name, root)
+	if err != nil {
+		return "", "", err
+	}
+
+	return filepath.Join(absName, "..."), root, nil
+}

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -11,8 +11,6 @@ package fs
 import (
 	"context"
 	"errors"
-	"path/filepath"
-	"runtime"
 
 	"github.com/syncthing/notify"
 )
@@ -55,28 +53,6 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 	go f.watchLoop(name, root, backendChan, outChan, ignore, ctx)
 
 	return outChan, nil
-}
-
-// watchPaths adjust the folder root for use with the notify backend and the
-// corresponding absolute path to be passed to notify to watch name.
-func (f *BasicFilesystem) watchPaths(name string) (string, string, error) {
-	root, err := evalSymlinks(f.root)
-	if err != nil {
-		return "", "", err
-	}
-
-	// Remove `\\?\` prefix if the path is just a drive letter as a dirty
-	// fix for https://github.com/syncthing/syncthing/issues/5578
-	if runtime.GOOS == "windows" && filepath.Clean(name) == "." && len(root) <= 7 && len(root) > 4 && root[:4] == `\\?\` {
-		root = root[4:]
-	}
-
-	absName, err := rooted(name, root)
-	if err != nil {
-		return "", "", err
-	}
-
-	return filepath.Join(absName, "..."), root, nil
 }
 
 func (f *BasicFilesystem) watchLoop(name, evalRoot string, backendChan chan notify.EventInfo, outChan chan<- Event, ignore Matcher, ctx context.Context) {

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -45,7 +45,7 @@ func TestWindowsPaths(t *testing.T) {
 func TestResolveWindows83(t *testing.T) {
 	fs, dir := setup(t)
 	if isMaybeWin83(dir) {
-		dir = resolveWin83(dir)
+		dir = fs.resolveWin83(dir)
 		fs = newBasicFilesystem(dir)
 	}
 	defer os.RemoveAll(dir)
@@ -76,7 +76,7 @@ func TestResolveWindows83(t *testing.T) {
 func TestIsWindows83(t *testing.T) {
 	fs, dir := setup(t)
 	if isMaybeWin83(dir) {
-		dir = resolveWin83(dir)
+		dir = fs.resolveWin83(dir)
 		fs = newBasicFilesystem(dir)
 	}
 	defer os.RemoveAll(dir)

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -44,6 +44,10 @@ func TestWindowsPaths(t *testing.T) {
 
 func TestResolveWindows83(t *testing.T) {
 	fs, dir := setup(t)
+	if isMaybeWin83(dir) {
+		dir = resolveWin83(dir)
+		fs = newBasicFilesystem(dir)
+	}
 	defer os.RemoveAll(dir)
 
 	shortAbs, _ := fs.rooted("LFDATA~1")
@@ -71,6 +75,10 @@ func TestResolveWindows83(t *testing.T) {
 
 func TestIsWindows83(t *testing.T) {
 	fs, dir := setup(t)
+	if isMaybeWin83(dir) {
+		dir = resolveWin83(dir)
+		fs = newBasicFilesystem(dir)
+	}
 	defer os.RemoveAll(dir)
 
 	tempTop, _ := fs.rooted(TempName("baz"))


### PR DESCRIPTION
When checking paths from watches we resolve win83 stuff on the full path including root, but we never checked root itself. Funnily we haven't been bitten by it in production, potentially because of a side-effect of `filepath.EvalSymlinks`. Now we go the save way and treat both the root and paths from watches the same way. Hopefully fixes part of #5706 