### PR TITLE
test: Report time per MiB on transfer benchs

### DIFF
--- a/test/transfer-bench_test.go
+++ b/test/transfer-bench_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestBenchmarkTransferManyFiles(t *testing.T) {
-	benchmarkTransfer(t, 50000, 15)
+	benchmarkTransfer(t, 10000, 15)
 }
 
 func TestBenchmarkTransferLargeFile1G(t *testing.T) {
@@ -154,9 +154,9 @@ loop:
 		t.Fatal(err)
 	}
 
-	log.Println("Result: Wall time:", t1.Sub(t0))
-	log.Printf("Result: %.1f MiB/s synced", float64(total)/1024/1024/t1.Sub(t0).Seconds())
+	log.Printf("Result: Wall time: %v / MiB", t1.Sub(t0)/time.Duration(total/1024/1024))
+	log.Printf("Result: %.3g KiB/s synced", float64(total)/1024/t1.Sub(t0).Seconds())
 
-	printUsage("Receiver", recvProc)
-	printUsage("Sender", sendProc)
+	printUsage("Receiver", recvProc, total)
+	printUsage("Sender", sendProc, total)
 }

--- a/test/usage_unix.go
+++ b/test/usage_unix.go
@@ -16,10 +16,11 @@ import (
 	"time"
 )
 
-func printUsage(name string, proc *os.ProcessState) {
+func printUsage(name string, proc *os.ProcessState, total int64) {
 	if rusage, ok := proc.SysUsage().(*syscall.Rusage); ok {
-		log.Printf("%s: Utime: %s", name, time.Duration(rusage.Utime.Nano()))
-		log.Printf("%s: Stime: %s", name, time.Duration(rusage.Stime.Nano()))
+		mib := total / 1024 / 1024
+		log.Printf("%s: Utime: %s / MiB", name, time.Duration(rusage.Utime.Nano()/mib))
+		log.Printf("%s: Stime: %s / MiB", name, time.Duration(rusage.Stime.Nano()/mib))
 		if runtime.GOOS == "darwin" {
 			// Darwin reports in bytes, Linux seems to report in KiB even
 			// though the manpage says otherwise.

--- a/test/usage_windows.go
+++ b/test/usage_windows.go
@@ -20,9 +20,10 @@ func ftToDuration(ft *syscall.Filetime) time.Duration {
 	return time.Duration(n*100) * time.Nanosecond
 }
 
-func printUsage(name string, proc *os.ProcessState) {
+func printUsage(name string, proc *os.ProcessState, total int64) {
 	if rusage, ok := proc.SysUsage().(*syscall.Rusage); ok {
-		log.Printf("%s: Utime: %s", name, ftToDuration(&rusage.UserTime))
-		log.Printf("%s: Stime: %s", name, ftToDuration(&rusage.KernelTime))
+		mib := total / 1024 / 1024
+		log.Printf("%s: Utime: %s / MiB", name, time.Duration(&rusage.UserTime/mib))
+		log.Printf("%s: Stime: %s / MiB", name, time.Duration(&rusage.KernelTime/mib))
 	}
 }


### PR DESCRIPTION
This is just a bit of polish for the integration transfer benchmarks:  
50000 files took more than 10min on my machine, and 10min is the internal timeout of the supervisor stuff (lib/rc).  
Also transfer rates are so low, that `%.1f`with MiB wasn't particularly useful. And I now print time per MiB instead of total time, to get rid of variation due to slightly varying total MiBs transferred.