### PR TITLE
Remove superfluous check for IndexID in remote ClusterConfig.

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1118,7 +1118,7 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 					l.Infof("Device %v folder %s has mismatching index ID for us (%v != %v)", deviceID, folder.Description(), dev.IndexID, myIndexID)
 					startSequence = 0
 				}
-			} else if dev.ID == deviceID && dev.IndexID != 0 {
+			} else if dev.ID == deviceID {
 				// This is the other side's description of themselves. We
 				// check to see that it matches the IndexID we have on file,
 				// otherwise we drop our old index data and expect to get a


### PR DESCRIPTION
### Purpose

Fix an obvious logic error in the model when handling `ClusterConfig` messages.  Checking for `IndexID == 0` inside a block where `IndexID != 0` was a precondition.  This should now correctly clear local index data when the remote side announces an IndexID of zero.

### Testing

Builds okay with this change, and the test suite fails locally for reasons I think are unrelated to this change (same FAILs on master).  I don't know enough about the protocol internals to imagine a real-world test scenario.  The logic error seems clear enough though, causing the intended handling code not to be called.
