### PR TITLE
build: Disable codecov comments/statuses

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,10 @@
+comment: off
+
 coverage:
   range: "40...100"
+  status:
+    project: off
+    patch: off
 
 ignore:
   - "**.pb.go"


### PR DESCRIPTION
> I just revoked its permissions for syncthing/syncthing as the comments were … less than illuminating. (No comment on the rest.)  
https://forum.syncthing.net/t/code-coverage-integration/11848/7

So we can add the permissions again but still aren't troubled by less than enlightening comments/statuses.