### PR TITLE
lib/connections, lib/model: Check addr before hello exchange

### DIFF
--- a/lib/connections/connections_test.go
+++ b/lib/connections/connections_test.go
@@ -104,7 +104,7 @@ func TestAllowedNetworks(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		res := IsAllowedNetwork(tc.host, tc.allowed)
+		res := isAllowedNetwork(tc.host, tc.allowed)
 		if res != tc.ok {
 			t.Errorf("allowedNetwork(%q, %q) == %v, want %v", tc.host, tc.allowed, res, tc.ok)
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -170,13 +170,12 @@ var (
 )
 
 var (
-	errDeviceUnknown     = errors.New("unknown device")
-	errDevicePaused      = errors.New("device is paused")
-	errDeviceIgnored     = errors.New("device is ignored")
-	ErrFolderPaused      = errors.New("folder is paused")
-	errFolderNotRunning  = errors.New("folder is not running")
-	errFolderMissing     = errors.New("no such folder")
-	errNetworkNotAllowed = errors.New("network not allowed")
+	errDeviceUnknown    = errors.New("unknown device")
+	errDevicePaused     = errors.New("device is paused")
+	errDeviceIgnored    = errors.New("device is ignored")
+	ErrFolderPaused     = errors.New("folder is paused")
+	errFolderNotRunning = errors.New("folder is not running")
+	errFolderMissing    = errors.New("no such folder")
 	// errors about why a connection is closed
 	errIgnoredFolderRemoved = errors.New("folder no longer ignored")
 	errReplacingConnection  = errors.New("replacing connection")
@@ -1732,12 +1731,6 @@ func (m *model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protoco
 
 	if cfg.Paused {
 		return errDevicePaused
-	}
-
-	if len(cfg.AllowedNetworks) > 0 {
-		if !connections.IsAllowedNetwork(addr.String(), cfg.AllowedNetworks) {
-			return errNetworkNotAllowed
-		}
 	}
 
 	return nil


### PR DESCRIPTION
There's no point and arguably even bad to exchange hello messages and do all kinds of stuff when the connection comes from a blacklisted address -> check that first.