### PR TITLE
lib/api, lib/connections, gui: Show connection error for disconnected devices (fixes #3345)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -717,11 +717,11 @@
                       <td ng-if="!connections[deviceCfg.deviceID].connected" class="text-right">
                         <span ng-repeat="addr in deviceCfg.addresses">
                             <span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br>
-                            <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].when | date:'yyyy-MM-dd HH:mm:ss'}}" class="text-danger">{{system.lastDialStatus[addr].error}}<br></small>
+                            <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
                         </span>
                         <span ng-repeat="addr in discoveryCache[deviceCfg.deviceID].addresses">
                           <span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br>
-                          <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].when | date:'yyyy-MM-dd HH:mm:ss'}}" class="text-danger">{{system.lastDialStatus[addr].error}}<br></small>
+                          <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
                         </span>
                       </td>
                     </tr>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -715,8 +715,14 @@
                         </span>
                       </td>
                       <td ng-if="!connections[deviceCfg.deviceID].connected" class="text-right">
-                        <span ng-repeat="addr in deviceCfg.addresses"><span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br></span>
-                        <span ng-repeat="addr in discoveryCache[deviceCfg.deviceID].addresses"><span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br></span>
+                        <span ng-repeat="addr in deviceCfg.addresses">
+                            <span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br>
+                            <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].when | date:'yyyy-MM-dd HH:mm:ss'}}" class="text-danger">{{system.lastDialStatus[addr].error}}<br></small>
+                        </span>
+                        <span ng-repeat="addr in discoveryCache[deviceCfg.deviceID].addresses">
+                          <span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br>
+                          <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].when | date:'yyyy-MM-dd HH:mm:ss'}}" class="text-danger">{{system.lastDialStatus[addr].error}}<br></small>
+                        </span>
                       </td>
                     </tr>
                     <tr ng-if="connections[deviceCfg.deviceID].connected && connections[deviceCfg.deviceID].type.indexOf('Relay') > -1" tooltip data-original-title="Connections via relays might be rate limited by the relay">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2412,8 +2412,8 @@ angular.module('syncthing.core')
             if (!status || !status.error) {
                 return null;
             }
-            var date = $filter('date')(status.when, "HH:mm:ss")
+            var time = $filter('date')(status.when, "HH:mm:ss")
             var err = status.error.replace(/.+: /, '');
-            return date + ": " + err;
+            return err + " (" + time + ")";
         }
     });

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2406,4 +2406,14 @@ angular.module('syncthing.core')
                 $scope.saveConfig();
             }
         };
+
+        $scope.abbreviatedError = function (addr) {
+            var status = $scope.system.lastDialStatus[addr];
+            if (!status || !status.error) {
+                return null;
+            }
+            var date = $filter('date')(status.when, "HH:mm:ss")
+            var err = status.error.replace(/.+: /, '');
+            return date + ": " + err;
+        }
     });

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -898,7 +898,8 @@ func (s *service) getSystemStatus(w http.ResponseWriter, r *http.Request) {
 		res["discoveryErrors"] = discoErrors
 	}
 
-	res["connectionServiceStatus"] = s.connectionsService.Status()
+	res["connectionServiceStatus"] = s.connectionsService.ListenerStatus()
+	res["lastDialStatus"] = s.connectionsService.ConnectionStatus()
 	// cpuUsage.Rate() is in milliseconds per second, so dividing by ten
 	// gives us percent
 	res["cpuPercent"] = s.cpu.Rate() / 10 / float64(runtime.NumCPU())

--- a/lib/api/mocked_connections_test.go
+++ b/lib/api/mocked_connections_test.go
@@ -6,9 +6,17 @@
 
 package api
 
+import (
+	"github.com/syncthing/syncthing/lib/connections"
+)
+
 type mockedConnections struct{}
 
-func (m *mockedConnections) Status() map[string]interface{} {
+func (m *mockedConnections) ListenerStatus() map[string]connections.ListenerStatusEntry {
+	return nil
+}
+
+func (m *mockedConnections) ConnectionStatus() map[string]connections.ConnectionStatusEntry {
 	return nil
 }
 

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -90,8 +90,20 @@ var tlsVersionNames = map[uint16]string{
 // dialers. Successful connections are handed to the model.
 type Service interface {
 	suture.Service
-	Status() map[string]interface{}
+	ListenerStatus() map[string]ListenerStatusEntry
+	ConnectionStatus() map[string]ConnectionStatusEntry
 	NATType() string
+}
+
+type ListenerStatusEntry struct {
+	Error        string   `json:"error,omitempty"`
+	LANAddresses []string `json:"lanAddresses"`
+	WANAddresses []string `json:"wanAddresses"`
+}
+
+type ConnectionStatusEntry struct {
+	When  time.Time `json:"when"`
+	Error string    `json:"error,omitempty"`
 }
 
 type service struct {
@@ -112,6 +124,9 @@ type service struct {
 	listeners          map[string]genericListener
 	listenerTokens     map[string]suture.ServiceToken
 	listenerSupervisor *suture.Supervisor
+
+	connectionStatusMut sync.RWMutex
+	connectionStatus    map[string]ConnectionStatusEntry // address -> latest error/status
 }
 
 func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *tls.Config, discoverer discover.Finder,
@@ -151,6 +166,9 @@ func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *t
 			FailureBackoff:    600 * time.Second,
 			PassThroughPanics: true,
 		}),
+
+		connectionStatusMut: sync.NewRWMutex(),
+		connectionStatus:    make(map[string]ConnectionStatusEntry),
 	}
 	cfg.Subscribe(service)
 
@@ -378,18 +396,23 @@ func (s *service) connect() {
 
 				uri, err := url.Parse(addr)
 				if err != nil {
+					s.setConnectionStatus(addr, err)
 					l.Infof("Parsing dialer address %s: %v", addr, err)
 					continue
 				}
 
 				if len(deviceCfg.AllowedNetworks) > 0 {
 					if !IsAllowedNetwork(uri.Host, deviceCfg.AllowedNetworks) {
+						s.setConnectionStatus(addr, errors.New("network disallowed"))
 						l.Debugln("Network for", uri, "is disallowed")
 						continue
 					}
 				}
 
 				dialerFactory, err := getDialerFactory(cfg, uri)
+				if err != nil {
+					s.setConnectionStatus(addr, err)
+				}
 				switch err {
 				case nil:
 					// all good
@@ -424,6 +447,7 @@ func (s *service) connect() {
 				}
 
 				dialTargets = append(dialTargets, dialTarget{
+					addr:     addr,
 					dialer:   dialer,
 					priority: priority,
 					deviceID: deviceID,
@@ -431,7 +455,7 @@ func (s *service) connect() {
 				})
 			}
 
-			conn, ok := dialParallel(deviceCfg.DeviceID, dialTargets)
+			conn, ok := s.dialParallel(deviceCfg.DeviceID, dialTargets)
 			if ok {
 				s.conns <- conn
 			}
@@ -633,24 +657,45 @@ func (s *service) ExternalAddresses() []string {
 	return util.UniqueStrings(addrs)
 }
 
-func (s *service) Status() map[string]interface{} {
+func (s *service) ListenerStatus() map[string]ListenerStatusEntry {
 	s.listenersMut.RLock()
-	result := make(map[string]interface{})
+	result := make(map[string]ListenerStatusEntry)
 	for addr, listener := range s.listeners {
-		status := make(map[string]interface{})
+		var status ListenerStatusEntry
 
 		err := listener.Error()
 		if err != nil {
-			status["error"] = err.Error()
+			status.Error = err.Error()
 		}
 
-		status["lanAddresses"] = urlsToStrings(listener.LANAddresses())
-		status["wanAddresses"] = urlsToStrings(listener.WANAddresses())
+		status.LANAddresses = urlsToStrings(listener.LANAddresses())
+		status.WANAddresses = urlsToStrings(listener.WANAddresses())
 
 		result[addr] = status
 	}
 	s.listenersMut.RUnlock()
 	return result
+
+}
+
+func (s *service) ConnectionStatus() map[string]ConnectionStatusEntry {
+	s.connectionStatusMut.RLock()
+	result := make(map[string]ConnectionStatusEntry)
+	for k, v := range s.connectionStatus {
+		result[k] = v
+	}
+	s.connectionStatusMut.RUnlock()
+	return result
+}
+
+func (s *service) setConnectionStatus(address string, err error) {
+	s.connectionStatusMut.Lock()
+	status := ConnectionStatusEntry{When: time.Now().UTC().Truncate(time.Second)}
+	if err != nil {
+		status.Error = err.Error()
+	}
+	s.connectionStatus[address] = status
+	s.connectionStatusMut.Unlock()
 }
 
 func (s *service) NATType() string {
@@ -769,7 +814,7 @@ func IsAllowedNetwork(host string, allowed []string) bool {
 	return false
 }
 
-func dialParallel(deviceID protocol.DeviceID, dialTargets []dialTarget) (internalConn, bool) {
+func (s *service) dialParallel(deviceID protocol.DeviceID, dialTargets []dialTarget) (internalConn, bool) {
 	// Group targets into buckets by priority
 	dialTargetBuckets := make(map[int][]dialTarget, len(dialTargets))
 	for _, tgt := range dialTargets {
@@ -793,6 +838,7 @@ func dialParallel(deviceID protocol.DeviceID, dialTargets []dialTarget) (interna
 			wg.Add(1)
 			go func(tgt dialTarget) {
 				conn, err := tgt.Dial()
+				s.setConnectionStatus(tgt.addr, err)
 				if err == nil {
 					res <- conn
 				}

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -658,13 +658,12 @@ func (s *service) ExternalAddresses() []string {
 }
 
 func (s *service) ListenerStatus() map[string]ListenerStatusEntry {
-	s.listenersMut.RLock()
 	result := make(map[string]ListenerStatusEntry)
+	s.listenersMut.RLock()
 	for addr, listener := range s.listeners {
 		var status ListenerStatusEntry
 
-		err := listener.Error()
-		if err != nil {
+		if err := listener.Error(); err != nil {
 			errStr := err.Error()
 			status.Error = &errStr
 		}
@@ -676,12 +675,11 @@ func (s *service) ListenerStatus() map[string]ListenerStatusEntry {
 	}
 	s.listenersMut.RUnlock()
 	return result
-
 }
 
 func (s *service) ConnectionStatus() map[string]ConnectionStatusEntry {
-	s.connectionStatusMut.RLock()
 	result := make(map[string]ConnectionStatusEntry)
+	s.connectionStatusMut.RLock()
 	for k, v := range s.connectionStatus {
 		result[k] = v
 	}
@@ -690,12 +688,13 @@ func (s *service) ConnectionStatus() map[string]ConnectionStatusEntry {
 }
 
 func (s *service) setConnectionStatus(address string, err error) {
-	s.connectionStatusMut.Lock()
 	status := ConnectionStatusEntry{When: time.Now().UTC().Truncate(time.Second)}
 	if err != nil {
 		errStr := err.Error()
 		status.Error = &errStr
 	}
+
+	s.connectionStatusMut.Lock()
 	s.connectionStatus[address] = status
 	s.connectionStatusMut.Unlock()
 }

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -96,16 +96,14 @@ type Service interface {
 }
 
 type ListenerStatusEntry struct {
-	Error        string   `json:"error,omitempty"`
-	OK           bool     `json:"ok,omitempty"`
+	Error        *string  `json:"error"`
 	LANAddresses []string `json:"lanAddresses"`
 	WANAddresses []string `json:"wanAddresses"`
 }
 
 type ConnectionStatusEntry struct {
 	When  time.Time `json:"when"`
-	Error string    `json:"error,omitempty"`
-	OK    bool      `json:"ok,omitempty"`
+	Error *string   `json:"error"`
 }
 
 type service struct {
@@ -667,9 +665,8 @@ func (s *service) ListenerStatus() map[string]ListenerStatusEntry {
 
 		err := listener.Error()
 		if err != nil {
-			status.Error = err.Error()
-		} else {
-			status.OK = true
+			errStr := err.Error()
+			status.Error = &errStr
 		}
 
 		status.LANAddresses = urlsToStrings(listener.LANAddresses())
@@ -696,9 +693,8 @@ func (s *service) setConnectionStatus(address string, err error) {
 	s.connectionStatusMut.Lock()
 	status := ConnectionStatusEntry{When: time.Now().UTC().Truncate(time.Second)}
 	if err != nil {
-		status.Error = err.Error()
-	} else {
-		status.OK = true
+		errStr := err.Error()
+		status.Error = &errStr
 	}
 	s.connectionStatus[address] = status
 	s.connectionStatusMut.Unlock()

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -97,6 +97,7 @@ type Service interface {
 
 type ListenerStatusEntry struct {
 	Error        string   `json:"error,omitempty"`
+	OK           bool     `json:"ok,omitempty"`
 	LANAddresses []string `json:"lanAddresses"`
 	WANAddresses []string `json:"wanAddresses"`
 }
@@ -104,6 +105,7 @@ type ListenerStatusEntry struct {
 type ConnectionStatusEntry struct {
 	When  time.Time `json:"when"`
 	Error string    `json:"error,omitempty"`
+	OK    bool      `json:"ok,omitempty"`
 }
 
 type service struct {
@@ -666,6 +668,8 @@ func (s *service) ListenerStatus() map[string]ListenerStatusEntry {
 		err := listener.Error()
 		if err != nil {
 			status.Error = err.Error()
+		} else {
+			status.OK = true
 		}
 
 		status.LANAddresses = urlsToStrings(listener.LANAddresses())
@@ -693,6 +697,8 @@ func (s *service) setConnectionStatus(address string, err error) {
 	status := ConnectionStatusEntry{When: time.Now().UTC().Truncate(time.Second)}
 	if err != nil {
 		status.Error = err.Error()
+	} else {
+		status.OK = true
 	}
 	s.connectionStatus[address] = status
 	s.connectionStatusMut.Unlock()

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -195,6 +195,7 @@ func (o *onAddressesChangedNotifier) notifyAddressesChanged(l genericListener) {
 }
 
 type dialTarget struct {
+	addr     string
 	dialer   genericDialer
 	priority int
 	uri      *url.URL


### PR DESCRIPTION
### Purpose

Aids in understanding why a device is not connecting.

This adds functionality in the connetions service to track the last error per address. That is in turn exposed in the /rest/system/status API method, as that is also where we already show the listener status from the connection service.

The GUI uses this info where it lists addresses, showing errors (if any) in red underneath each address. The time of the last connection attempt is in a tooltip, because there really isn't space to put it somewhere better. :(

I also slightly refactored the existing status method on the connection service to have a better name and return typed information, including an `ok` bool when the `error` is missing, to be clearer and friendlier.

### Testing

I've only tested this manually. Automated testing of this seems annoying. :/

### Screenshots

<img width="575" alt="Screenshot 2019-05-16 at 09 43 33" src="https://user-images.githubusercontent.com/125426/57835893-d525e480-77bf-11e9-856d-9eaccde26dad.png">

<img width="565" alt="Screenshot 2019-05-16 at 09 48 02" src="https://user-images.githubusercontent.com/125426/57835897-d8b96b80-77bf-11e9-8b31-c83c2732ed81.png">

### Documentation

The new data in system/status should be added to the example/docs.

```
jb@kvar:~ $ curl -ksH X-api-key:... https://localhost:8384/rest/system/status
{
  "alloc": 44296776,
  "connectionServiceStatus": {
    "tcp://:22000": {
      "ok": true,
      "lanAddresses": [
        "tcp://:22000"
      ],
      "wanAddresses": [
        "tcp://:22000"
      ]
    }
  },
...
  "lastDialStatus": {
    "tcp://10.20.30.40": {
      "when": "2019-05-16T07:41:23Z",
      "error": "dial tcp 10.20.30.40:22000: i/o timeout"
    },
    "tcp://172.16.33.3:22000": {
      "when": "2019-05-16T07:40:43Z",
      "ok": true
    },
    "tcp://83.233.120.221:22000": {
      "when": "2019-05-16T07:41:13Z",
      "error": "dial tcp 83.233.120.221:22000: connect: connection refused"
    }
  },
...
}
```
