### PR TITLE
lib/model: Close connections when model is stopped

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -180,6 +180,7 @@ var (
 	// errors about why a connection is closed
 	errIgnoredFolderRemoved = errors.New("folder no longer ignored")
 	errReplacingConnection  = errors.New("replacing connection")
+	errStopped              = errors.New("Syncthing is being stopped")
 )
 
 // NewModel creates and starts a new model. The model starts in read-only mode,
@@ -223,6 +224,25 @@ func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersio
 	cfg.Subscribe(m)
 
 	return m
+}
+
+func (m *model) Stop() {
+	m.Supervisor.Stop()
+	devs := m.cfg.Devices()
+	ids := make([]protocol.DeviceID, 0, len(devs))
+	for id := range devs {
+		ids = append(ids, id)
+	}
+	m.pmut.RLock()
+	closed := make([]chan struct{}, 0, len(m.closed))
+	for _, c := range m.closed {
+		closed = append(closed, c)
+	}
+	m.pmut.RUnlock()
+	m.closeConns(ids, errStopped)
+	for _, c := range closed {
+		<-c
+	}
 }
 
 // StartDeadlockDetector starts a deadlock detector on the models locks which

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -868,6 +868,7 @@ func TestIssue5063(t *testing.T) {
 		conn.mut.Lock()
 		conn.closeFn = func(_ error) {}
 		conn.mut.Unlock()
+		defer m.Closed(c, errStopped) // to unblock m.Stop()
 	}
 	m.pmut.Unlock()
 
@@ -3267,12 +3268,7 @@ func TestSanitizePath(t *testing.T) {
 func TestConnCloseOnRestart(t *testing.T) {
 	w, fcfg := tmpDefaultWrapper()
 	m := setupModel(w)
-	defer func() {
-		m.Stop()
-		m.db.Close()
-		os.RemoveAll(fcfg.Filesystem().URI())
-		os.Remove(w.ConfigPath())
-	}()
+	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem().URI())
 
 	br := &testutils.BlockingRW{}
 	nw := &testutils.NoopRW{}
@@ -3291,6 +3287,7 @@ func TestConnCloseOnRestart(t *testing.T) {
 		t.Fatal("Timed out before folder restart returned")
 	}
 	m.pmut.RLock()
+	defer m.pmut.RUnlock()
 	if len(m.conn) != 0 {
 		t.Errorf("Conn wasn't removed on restart (len(m.conn) == %v)", len(m.conn))
 	}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -862,16 +862,6 @@ func TestIssue5063(t *testing.T) {
 	m := newState(defaultAutoAcceptCfg)
 	defer cleanupModel(m)
 
-	m.pmut.Lock()
-	for _, c := range m.conn {
-		conn := c.(*fakeConnection)
-		conn.mut.Lock()
-		conn.closeFn = func(_ error) {}
-		conn.mut.Unlock()
-		defer m.Closed(c, errStopped) // to unblock m.Stop()
-	}
-	m.pmut.Unlock()
-
 	wg := sync.WaitGroup{}
 
 	addAndVerify := func(id string) {


### PR DESCRIPTION
The idea is that we notify connected remotes that were stopping instead of just dropping the connection.