### PR TITLE
build: Include cross-package test coverage

### DIFF
--- a/build.go
+++ b/build.go
@@ -348,7 +348,7 @@ func test(pkgs ...string) {
 	}
 
 	if coverage {
-		args = append(args, "-covermode", "atomic", "-coverprofile", "coverage.txt")
+		args = append(args, "-covermode", "atomic", "-coverprofile", "coverage.txt", "-coverpkg", strings.Join(pkgs, ","))
 	}
 
 	runPrint(goCmd, append(args, pkgs...)...)


### PR DESCRIPTION
Our currently calculated coverage is quite a bit lower than it actually is, as go by default only considers coverage of the currently tested package even if many packages are given (as in our case with `lib/...`). On my system this change doesn't work, I reported it upstream at https://github.com/golang/go/issues/30374#issuecomment-493425265. If this passes it proofes something is broken on my side and we can use it, otherwise it works as another data point for the upstream issue.