### PR TITLE
lib/protocol: Don't call receiver after calling Closed (fixes #4170)

### DIFF
--- a/lib/protocol/common_test.go
+++ b/lib/protocol/common_test.go
@@ -13,6 +13,7 @@ type TestModel struct {
 	hash          []byte
 	weakHash      uint32
 	fromTemporary bool
+	indexFn       func(DeviceID, string, []FileInfo)
 	closedCh      chan struct{}
 	closedErr     error
 }
@@ -24,6 +25,9 @@ func newTestModel() *TestModel {
 }
 
 func (t *TestModel) Index(deviceID DeviceID, folder string, files []FileInfo) {
+	if t.indexFn != nil {
+		t.indexFn(deviceID, folder, files)
+	}
 }
 
 func (t *TestModel) IndexUpdate(deviceID DeviceID, folder string, files []FileInfo) {

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -125,6 +125,53 @@ func TestCloseOnBlockingSend(t *testing.T) {
 	}
 }
 
+func TestCloseRace(t *testing.T) {
+	indexReceived := make(chan struct{})
+	unblockIndex := make(chan struct{})
+	m0 := newTestModel()
+	m0.indexFn = func(_ DeviceID, _ string, _ []FileInfo) {
+		close(indexReceived)
+		<-unblockIndex
+	}
+	m1 := newTestModel()
+
+	ar, aw := io.Pipe()
+	br, bw := io.Pipe()
+
+	c0 := NewConnection(c0ID, ar, bw, m0, "c0", CompressNever).(wireFormatConnection).Connection.(*rawConnection)
+	c0.Start()
+	c1 := NewConnection(c1ID, br, aw, m1, "c1", CompressNever)
+	c1.Start()
+	c0.ClusterConfig(ClusterConfig{})
+	c1.ClusterConfig(ClusterConfig{})
+
+	c1.Index("default", nil)
+	select {
+	case <-indexReceived:
+	case <-time.After(time.Second):
+		t.Fatal("timed out before receiving index")
+	}
+
+	go c0.internalClose(errManual)
+	select {
+	case <-c0.closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out before c0.closed was closed")
+	}
+
+	select {
+	case <-m0.closedCh:
+		t.Errorf("receiver.Closed called before receiver.Index")
+	default:
+	}
+
+	close(unblockIndex)
+
+	if err := m0.closedError(); err != errManual {
+		t.Fatal("Connection should be closed")
+	}
+}
+
 func TestMarshalIndexMessage(t *testing.T) {
 	if testing.Short() {
 		quickCfg.MaxCount = 10


### PR DESCRIPTION
We have to make sure, that the receiver/model isn't called after its `Closed` method is called. Due to the blocking nature of the underlying reader, we can't wait for reading to finish. Therefore reading is done in a separate routine and we wait for the routine handling the read message to terminate.