### PR TITLE
lib/model: Readd special handling of conn close in TestIssue5063

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -862,6 +862,16 @@ func TestIssue5063(t *testing.T) {
 	m := newState(defaultAutoAcceptCfg)
 	defer cleanupModel(m)
 
+	m.pmut.Lock()
+	for _, c := range m.conn {
+		conn := c.(*fakeConnection)
+		conn.mut.Lock()
+		conn.closeFn = func(_ error) {}
+		conn.mut.Unlock()
+		defer m.Closed(c, errStopped) // to unblock deferred m.Stop()
+	}
+	m.pmut.Unlock()
+
 	wg := sync.WaitGroup{}
 
 	addAndVerify := func(id string) {


### PR DESCRIPTION
This fixes the test flakyness "accidentally" introduces in https://github.com/syncthing/syncthing/pull/5733