### PR TITLE
lib/protocol: Return from ClusterConfig when closed

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -332,8 +332,11 @@ func (c *rawConnection) Request(folder string, name string, offset int64, size i
 // ClusterConfig sends the cluster configuration message to the peer.
 // It must be called just once (as per BEP), otherwise it will panic.
 func (c *rawConnection) ClusterConfig(config ClusterConfig) {
-	c.clusterConfigBox <- &config
-	close(c.clusterConfigBox)
+	select {
+	case c.clusterConfigBox <- &config:
+		close(c.clusterConfigBox)
+	case <-c.closed:
+	}
 }
 
 func (c *rawConnection) Closed() bool {


### PR DESCRIPTION
Flaky tests are not always just annoying, they can also detect negligent mistakes...

https://build.syncthing.net/project.html?projectId=Syncthing&testNameId=1232013402783664888&tab=testDetails