### PR TITLE
all: Remove "large blocks" config

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -78,7 +78,6 @@ angular.module('syncthing.core')
             externalCommand: "",
             autoNormalize: true,
             path: "",
-            useLargeBlocks: true,
         };
 
         $scope.localStateTotal = {

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -155,8 +155,6 @@
                 <div class="col-md-6">
                   <input type="checkbox" ng-model="currentFolder.fsWatcherEnabled" ng-change="fsWatcherToggled()" tooltip data-original-title="{{'Use notifications from the filesystem to detect changed items.' | translate }}">&nbsp;<span translate>Watch for Changes</span>
                   <p translate class="help-block">Watching for changes discovers most changes without periodic scanning.</p>
-                  <input type="checkbox" ng-model="currentFolder.useLargeBlocks"> <span translate>Variable Size Blocks</span>
-                  <p translate class="help-block">Variable size blocks (also "large blocks") are more efficient for large files.</p>
                 </div>
                 <div class="col-md-6">
                   <label for="rescanIntervalS" translate>Full Rescan Interval (s)</label>

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -52,7 +52,6 @@ type FolderConfiguration struct {
 	Paused                  bool                        `xml:"paused" json:"paused"`
 	WeakHashThresholdPct    int                         `xml:"weakHashThresholdPct" json:"weakHashThresholdPct"` // Use weak hash if more than X percent of the file has changed. Set to -1 to always use weak hash.
 	MarkerName              string                      `xml:"markerName" json:"markerName"`
-	UseLargeBlocks          bool                        `xml:"useLargeBlocks" json:"useLargeBlocks" default:"true"`
 	CopyOwnershipFromParent bool                        `xml:"copyOwnershipFromParent" json:"copyOwnershipFromParent"`
 
 	cachedFilesystem fs.Filesystem

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -349,7 +349,6 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 		Hashers:               f.model.numHashers(f.ID),
 		ShortID:               f.shortID,
 		ProgressTickIntervalS: f.ScanProgressIntervalS,
-		UseLargeBlocks:        f.UseLargeBlocks,
 		LocalFlags:            f.localFlags,
 	})
 

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -52,8 +52,6 @@ type Config struct {
 	// Optional progress tick interval which defines how often FolderScanProgress
 	// events are emitted. Negative number means disabled.
 	ProgressTickIntervalS int
-	// Whether to use large blocks for large files or the old standard of 128KiB for everything.
-	UseLargeBlocks bool
 	// Local flags to set on scanned files
 	LocalFlags uint32
 }
@@ -326,23 +324,19 @@ func (w *walker) handleItem(ctx context.Context, path string, toHashChan chan<- 
 func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileInfo, toHashChan chan<- protocol.FileInfo) error {
 	curFile, hasCurFile := w.CurrentFiler.CurrentFile(relPath)
 
-	blockSize := protocol.MinBlockSize
+	blockSize := protocol.BlockSize(info.Size())
 
-	if w.UseLargeBlocks {
-		blockSize = protocol.BlockSize(info.Size())
-
-		if hasCurFile {
-			// Check if we should retain current block size.
-			curBlockSize := curFile.BlockSize()
-			if blockSize > curBlockSize && blockSize/curBlockSize <= 2 {
-				// New block size is larger, but not more than twice larger.
-				// Retain.
-				blockSize = curBlockSize
-			} else if curBlockSize > blockSize && curBlockSize/blockSize <= 2 {
-				// Old block size is larger, but not more than twice larger.
-				// Retain.
-				blockSize = curBlockSize
-			}
+	if hasCurFile {
+		// Check if we should retain current block size.
+		curBlockSize := curFile.BlockSize()
+		if blockSize > curBlockSize && blockSize/curBlockSize <= 2 {
+			// New block size is larger, but not more than twice larger.
+			// Retain.
+			blockSize = curBlockSize
+		} else if curBlockSize > blockSize && curBlockSize/blockSize <= 2 {
+			// Old block size is larger, but not more than twice larger.
+			// Retain.
+			blockSize = curBlockSize
 		}
 	}
 

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -467,14 +467,13 @@ func TestWalkReceiveOnly(t *testing.T) {
 
 func walkDir(fs fs.Filesystem, dir string, cfiler CurrentFiler, matcher *ignore.Matcher, localFlags uint32) []protocol.FileInfo {
 	fchan := Walk(context.TODO(), Config{
-		Filesystem:     fs,
-		Subs:           []string{dir},
-		AutoNormalize:  true,
-		Hashers:        2,
-		UseLargeBlocks: true,
-		CurrentFiler:   cfiler,
-		Matcher:        matcher,
-		LocalFlags:     localFlags,
+		Filesystem:    fs,
+		Subs:          []string{dir},
+		AutoNormalize: true,
+		Hashers:       2,
+		CurrentFiler:  cfiler,
+		Matcher:       matcher,
+		LocalFlags:    localFlags,
 	})
 
 	var tmp []protocol.FileInfo


### PR DESCRIPTION
We now always use large / variable blocks.

This also needs a doc update, specific mention in the release notes and, potentially, a notice dialog on first startup? I personally think we *don't* need to do an alert for it, as it's not that big of a deal and it's not particularly actionable by the user anyway.