### PR TITLE
lib/connections: Do not leak FDs, fix address copy (fixes #5767)

### DIFF
--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -166,7 +166,7 @@ func (t *quicListener) Serve() {
 			continue
 		}
 
-		t.conns <- internalConn{&quicTlsConn{session, stream}, connTypeQUICServer, quicPriority}
+		t.conns <- internalConn{&quicTlsConn{session, stream, nil}, connTypeQUICServer, quicPriority}
 	}
 }
 

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -59,7 +59,8 @@ func (t *quicListener) OnNATTypeChanged(natType stun.NATType) {
 func (t *quicListener) OnExternalAddressChanged(address *stun.Host, via string) {
 	var uri *url.URL
 	if address != nil {
-		uri = &(*t.uri)
+		uri = &url.URL{}
+		*uri = *t.uri
 		uri.Host = address.TransportAddr()
 	}
 

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -59,8 +59,8 @@ func (t *quicListener) OnNATTypeChanged(natType stun.NATType) {
 func (t *quicListener) OnExternalAddressChanged(address *stun.Host, via string) {
 	var uri *url.URL
 	if address != nil {
-		uri = &url.URL{}
-		*uri = *t.uri
+		copy := *t.uri
+		uri = &copy		
 		uri.Host = address.TransportAddr()
 	}
 

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -60,7 +60,7 @@ func (t *quicListener) OnExternalAddressChanged(address *stun.Host, via string) 
 	var uri *url.URL
 	if address != nil {
 		copy := *t.uri
-		uri = &copy		
+		uri = &copy
 		uri.Host = address.TransportAddr()
 	}
 


### PR DESCRIPTION
It's unexpected that `&(*foo)` does not work :/