### PR TITLE
lib/model: Prevent nil deref if folder stopped (fixes #5780)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -59,8 +59,6 @@ type service interface {
 	GetStatistics() stats.FolderStatistics
 
 	getState() (folderState, time.Time, error)
-	setState(state folderState)
-	setError(err error)
 }
 
 type Availability struct {
@@ -2072,15 +2070,6 @@ func (m *model) ScanFolders() map[string]error {
 				errorsMut.Lock()
 				errors[folder] = err
 				errorsMut.Unlock()
-
-				// Potentially sets the error twice, once in the scanner just
-				// by doing a check, and once here, if the error returned is
-				// the same one as returned by CheckHealth, though
-				// duplicate set is handled by setError.
-				m.fmut.RLock()
-				srv := m.folderRunners[folder]
-				m.fmut.RUnlock()
-				srv.setError(err)
 			}
 			wg.Done()
 		}()


### PR DESCRIPTION
And crash reporting is coming in :D 

https://crash.syncthing.net/report/e8/a1/e8a10dcdd334c71b6f020da6a832266ae3c73d6ea9acc106137790bdb17587e5

```
10:01:35 INFO: syncthing v1.1.4 "Erbium Earthworm" (go1.12.5 linux-amd64) teamcity@build.syncthing.net 2019-05-12 19:17:55 UTC
Panic at 2019-06-05T10:33:43+02:00
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x90 pc=0xa65a3d]

goroutine 5911 [running]:
github.com/syncthing/syncthing/lib/model.(*model).ScanFolders.func1(0xc0001ca2c0, 0xc000358730, 0xb, 0xf18b20, 0xc000d15860, 0xc000c015f0, 0xf1eba0, 0xc000d15870)
	/opt/tcagent/syncthing-1-work/174e136266f8a219/lib/model/model.go:2020 +0x1ad
created by github.com/syncthing/syncthing/lib/model.(*model).ScanFolders
	/opt/tcagent/syncthing-1-work/174e136266f8a219/lib/model/model.go:2006 +0x361
```

As the comment already says: The code producing the panic is redundant -> removed. And for good measure remove the `setState`/`setError` methods on the `service` interface. Nobody but the folders themselves have any reason to use those.