### PR TITLE
cmd/syncthing, lib/db: Exit/close db faster (fixes #5781)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -928,7 +928,17 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	code := exit.waitForExit()
 
 	mainService.Stop()
-	ldb.Close()
+
+	done := make(chan struct{})
+	go func() {
+		ldb.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		l.Warnln("Database failed to stop within 10s")
+	}
 
 	l.Infoln("Exiting")
 

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -119,6 +119,11 @@ func (db *Lowlevel) Write(batch *leveldb.Batch, wo *opt.WriteOptions) error {
 }
 
 func (db *Lowlevel) Delete(key []byte, wo *opt.WriteOptions) error {
+	db.closeMut.RLock()
+	defer db.closeMut.RUnlock()
+	if db.closed {
+		return leveldb.ErrClosed
+	}
 	atomic.AddInt64(&db.committed, 1)
 	return db.DB.Delete(key, wo)
 }


### PR DESCRIPTION
This adds a 10s timeout on closing the db and additionally cancels active
db iterators and waits for them to terminate before closing the db.

@calmh I hope the amount of introduced complications passes below the bar - I am actually quite happy with it, but I suspect mine is also a bit high :)