### PR TITLE
lib/model: Release pmut before logging event in Closed

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1406,9 +1406,9 @@ func (m *model) Closed(conn protocol.Connection, err error) {
 	device := conn.ID()
 
 	m.pmut.Lock()
-	defer m.pmut.Unlock()
 	conn, ok := m.conn[device]
 	if !ok {
+		m.pmut.Unlock()
 		return
 	}
 	m.progressEmitter.temporaryIndexUnsubscribe(conn)
@@ -1419,6 +1419,7 @@ func (m *model) Closed(conn protocol.Connection, err error) {
 	delete(m.remotePausedFolders, device)
 	closed := m.closed[device]
 	delete(m.closed, device)
+	m.pmut.Unlock()
 
 	l.Infof("Connection to %s at %s closed: %v", device, conn.Name(), err)
 	events.Default.Log(events.DeviceDisconnected, map[string]string{


### PR DESCRIPTION
This is due to https://sentry.syncthing.net/syncthing/syncthing/issues/26, where the routine holding pmut is executing this:

```
	events.Default.Log(events.DeviceDisconnected, map[string]string{
		"id":    device.String(),
		"error": err.Error(),
	})
```

While there's no (good) reason for this to block, there's also no reason to keep holding pmut for that.

I think this is tiny enough to be issueless :)