### PR TITLE
Remove Systemd hardening options unsupported in user mode

### DIFF
--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -9,8 +9,6 @@ SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 
 # Hardening
-ProtectSystem=full
-PrivateTmp=true
 SystemCallArchitectures=native
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true


### PR DESCRIPTION
Systemd service hardening options related to mount namespaces are unsupported for Systemd user instances.

The Systemd documentation has been updated to reflect this: 
> This option is only available for system services and is not supported for services running in per-user instances of the service manager.

https://www.freedesktop.org/software/systemd/man/systemd.exec.html

Note that this has no impact and the options are simply ignored, so remove them for clarity.