### PR TITLE
gui: Check data before calling .reverse()

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -726,6 +726,11 @@ angular.module('syncthing.core')
 
         var refreshGlobalChanges = debounce(function () {
             $http.get(urlbase + "/events/disk?limit=25").success(function (data) {
+                if (!data) {
+                    // For reasons unknown this is called with data being the empty
+                    // string on shutdown, causing an error on .reverse().
+                    return;
+                }
                 data = data.reverse();
                 $scope.globalChangeEvents = data;
                 console.log("refreshGlobalChanges", data);


### PR DESCRIPTION
Yet another check that shouldn't be necessary, but apparently is:  
When shutting down Syncthing from the web UI, I get a JS error:

```
Error: data.reverse is not a function
refreshGlobalChanges</<@http://localhost:8385/syncthing/core/syncthingController.js:729:24
$http/promise.success/<@http://localhost:8385/vendor/angular/angular.js:9452:11
processQueue@http://localhost:8385/vendor/angular/angular.js:13337:27
scheduleProcessQueue/<@http://localhost:8385/vendor/angular/angular.js:13353:27
$eval@http://localhost:8385/vendor/angular/angular.js:14589:16
$digest@http://localhost:8385/vendor/angular/angular.js:14405:15
$apply@http://localhost:8385/vendor/angular/angular.js:14694:13
scheduleApplyAsync/applyAsyncId<@http://localhost:8385/vendor/angular/angular.js:14984:11
completeOutstandingRequest@http://localhost:8385/vendor/angular/angular.js:4959:7
Browser/self.defer/timeoutId<@http://localhost:8385/vendor/angular/angular.js:5347:7
```

Turns out `data == ''` and there's nothing wrong with the events endpoint, it sends a single event. So somewhere in JS/angular/...-land that gets scrapped, but still the success function is called. Again, the proper thing to do would probably be a deep-dive or update of the framework, but I have no intention of doing either of those things.

Testing: Error on shutdown is gone.