### PR TITLE
lib/relay: Initialise stop channel (fixes #5801)

### DIFF
--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -43,7 +43,8 @@ func newDynamicClient(uri *url.URL, certs []tls.Certificate, invitations chan pr
 		closeInvitationsOnFinish: closeInvitationsOnFinish,
 		timeout:                  timeout,
 
-		mut: sync.NewRWMutex(),
+		mut:  sync.NewRWMutex(),
+		stop: make(chan struct{}),
 	}
 }
 


### PR DESCRIPTION
The stop channel is defined within `Serve`, so if `Stop` is called before that it closes a nil channel -> define at creation time. I left the (re-)definition in `Serve`, as despite the naming this isn't a suture service, but something custom, that may be restarted. I looked into cleaning this up, but it would be a major change so I abandoned that.

Testing: None.