### PR TITLE
lib/versioner: Fix staggered version cleanup and all versioner restoration (fixes #5807)

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2852,9 +2852,7 @@ func TestVersionRestore(t *testing.T) {
 	defer cleanupModel(m)
 	m.ScanFolder("default")
 
-	sentinel, err := time.ParseInLocation(versioner.TimeFormat, "20200101-010101", time.Local)
-	must(t, err)
-	sentinelTag := sentinel.Format(versioner.TimeFormat)
+	sentinel, err := time.ParseInLocation(versioner.TimeFormat, "20180101-010101", time.Local)
 
 	for _, file := range []string{
 		// Versions directory
@@ -2866,7 +2864,6 @@ func TestVersionRestore(t *testing.T) {
 		".stversions/dir/file~20171210-040406.txt",
 		".stversions/very/very/deep/one~20171210-040406.txt", // lives deep down, no directory exists.
 		".stversions/dir/existing~20171210-040406.txt",       // exists, should expect to be archived.
-		".stversions/dir/file.txt~20171210-040405",           // old tag format, supported
 		".stversions/dir/cat",                                // untagged which was used by trashcan, supported
 
 		// "file.txt" will be restored
@@ -2897,7 +2894,7 @@ func TestVersionRestore(t *testing.T) {
 		"file.txt":               1,
 		"existing":               1,
 		"something":              1,
-		"dir/file.txt":           4,
+		"dir/file.txt":           3,
 		"dir/existing.txt":       1,
 		"very/very/deep/one.txt": 1,
 		"dir/cat":                1,
@@ -2942,6 +2939,8 @@ func TestVersionRestore(t *testing.T) {
 		"very/very/deep/one.txt": makeTime("20171210-040406"),
 	}
 
+	beforeRestore := time.Now().Truncate(time.Second)
+
 	ferr, err := m.RestoreFolderVersions("default", restore)
 	must(t, err)
 
@@ -2977,51 +2976,48 @@ func TestVersionRestore(t *testing.T) {
 		}
 	}
 
-	// Simple versioner uses modtime for timestamp generation, so we can check
-	// if existing stuff was correctly archived as we restored.
+	// Simple versioner uses now for timestamp generation, so we can check
+	// if existing stuff was correctly archived as we restored (oppose to deleteD), and version time as after beforeRestore
 	expectArchived := map[string]struct{}{
 		"existing":         {},
 		"dir/file.txt":     {},
 		"dir/existing.txt": {},
 	}
 
-	// Even if they are at the archived path, content should have the non
-	// archived name.
-	for file := range expectArchived {
+	allFileVersions, err := m.GetFolderVersions("default")
+	must(t, err)
+	for file, versions := range allFileVersions {
+		key := file
 		if runtime.GOOS == "windows" {
 			file = filepath.FromSlash(file)
 		}
-		taggedName := versioner.TagFilename(file, sentinelTag)
-		taggedArchivedName := filepath.Join(".stversions", taggedName)
+		for _, version := range versions {
+			if version.VersionTime.Equal(beforeRestore) || version.VersionTime.After(beforeRestore) {
+				fd, err := filesystem.Open(".stversions/" + versioner.TagFilename(file, version.VersionTime.Format(versioner.TimeFormat)))
+				must(t, err)
+				defer fd.Close()
 
-		fd, err := filesystem.Open(taggedArchivedName)
-		must(t, err)
-		defer fd.Close()
-
-		content, err := ioutil.ReadAll(fd)
-		if err != nil {
-			t.Error(err)
-		}
-		if !bytes.Equal(content, []byte(file)) {
-			t.Errorf("%s: %s != %s", file, string(content), file)
+				content, err := ioutil.ReadAll(fd)
+				if err != nil {
+					t.Error(err)
+				}
+				// Even if they are at the archived path, content should have the non
+				// archived name.
+				if !bytes.Equal(content, []byte(file)) {
+					t.Errorf("%s (%s): %s != %s", file, fd.Name(), string(content), file)
+				}
+				_, ok := expectArchived[key]
+				if !ok {
+					t.Error("unexpected archived file with future timestamp", file, version.VersionTime)
+				}
+				delete(expectArchived, key)
+			}
 		}
 	}
 
-	// Check for other unexpected things that are tagged.
-	filesystem.Walk(".", func(path string, f fs.FileInfo, err error) error {
-		if !f.IsRegular() {
-			return nil
-		}
-		if strings.Contains(path, sentinelTag) {
-			path = osutil.NormalizedFilename(path)
-			name, _ := versioner.UntagFilename(path)
-			name = strings.TrimPrefix(name, ".stversions/")
-			if _, ok := expectArchived[name]; !ok {
-				t.Errorf("unexpected file with sentinel tag: %s", name)
-			}
-		}
-		return nil
-	})
+	if len(expectArchived) != 0 {
+		t.Fatal("missed some archived files", expectArchived)
+	}
 }
 
 func TestPausedFolders(t *testing.T) {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2853,6 +2853,9 @@ func TestVersionRestore(t *testing.T) {
 	m.ScanFolder("default")
 
 	sentinel, err := time.ParseInLocation(versioner.TimeFormat, "20180101-010101", time.Local)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, file := range []string{
 		// Versions directory

--- a/lib/versioner/simple.go
+++ b/lib/versioner/simple.go
@@ -48,8 +48,7 @@ func (v Simple) Archive(filePath string) error {
 		return err
 	}
 
-	// Amend with mtime, sort on mtime, delete the oldest first. Mtime,
-	// nowadays at least, is the time when the archiving happened.
+	// Versions are sorted by timestamp in the file name, oldest first.
 	versions := findAllVersions(v.versionsFs, filePath)
 	if len(versions) > v.keep {
 		for _, toRemove := range versions[:len(versions)-v.keep] {

--- a/lib/versioner/simple.go
+++ b/lib/versioner/simple.go
@@ -50,11 +50,11 @@ func (v Simple) Archive(filePath string) error {
 
 	// Amend with mtime, sort on mtime, delete the oldest first. Mtime,
 	// nowadays at least, is the time when the archiving happened.
-	versionsWithMtimes := findAllVersions(v.versionsFs, filePath)
-	if len(versionsWithMtimes) > v.keep {
-		for _, toRemove := range versionsWithMtimes[:len(versionsWithMtimes)-v.keep] {
+	versions := findAllVersions(v.versionsFs, filePath)
+	if len(versions) > v.keep {
+		for _, toRemove := range versions[:len(versions)-v.keep] {
 			l.Debugln("cleaning out", toRemove)
-			err = v.versionsFs.Remove(toRemove.name)
+			err = v.versionsFs.Remove(toRemove)
 			if err != nil {
 				l.Warnln("removing old version:", err)
 			}

--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -125,7 +125,7 @@ func (v *Staggered) clean() {
 		}
 
 		versionsPerFile[name] = append(versionsPerFile[name], versionWithMtime{
-			name:  name,
+			name:  path,
 			mtime: f.ModTime(),
 		})
 

--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -101,7 +101,7 @@ func (v *Staggered) clean() {
 		return
 	}
 
-	versionsPerFile := make(map[string][]versionWithMtime)
+	versionsPerFile := make(map[string][]string)
 	dirTracker := make(emptyDirTracker)
 
 	walkFn := func(path string, f fs.FileInfo, err error) error {
@@ -122,10 +122,7 @@ func (v *Staggered) clean() {
 			return nil
 		}
 
-		versionsPerFile[name] = append(versionsPerFile[name], versionWithMtime{
-			name:  path,
-			mtime: f.ModTime().Truncate(time.Second),
-		})
+		versionsPerFile[name] = append(versionsPerFile[name], path)
 
 		return nil
 	}
@@ -144,7 +141,7 @@ func (v *Staggered) clean() {
 	l.Debugln("Cleaner: Finished cleaning", v.versionsFs)
 }
 
-func (v *Staggered) expire(versions []versionWithMtime) {
+func (v *Staggered) expire(versions []string) {
 	l.Debugln("Versioner: Expiring versions", versions)
 	for _, file := range v.toRemove(versions, time.Now()) {
 		if fi, err := v.versionsFs.Lstat(file); err != nil {
@@ -161,24 +158,26 @@ func (v *Staggered) expire(versions []versionWithMtime) {
 	}
 }
 
-func (v *Staggered) toRemove(versions []versionWithMtime, now time.Time) []string {
+func (v *Staggered) toRemove(versions []string, now time.Time) []string {
 	var prevAge int64
 	firstFile := true
 	var remove []string
 
-	// The list of versions may or may not be properly sorted. Let's take
-	// off and nuke from orbit, it's the only way to be sure.
-	sort.Slice(versions, func(i, j int) bool {
-		return versions[i].mtime.Before(versions[j].mtime)
-	})
+	// The list of versions may or may not be properly sorted.
+	sort.Strings(versions)
 
 	for _, version := range versions {
-		age := int64(now.Sub(version.mtime).Seconds())
+		versionTime, err := time.ParseInLocation(TimeFormat, ExtractTag(version), time.Local)
+		if err != nil {
+			l.Debugf("Versioner: file name %q is invalid: %v", version, err)
+			continue
+		}
+		age := int64(now.Sub(versionTime).Seconds())
 
 		// If the file is older than the max age of the last interval, remove it
 		if lastIntv := v.interval[len(v.interval)-1]; lastIntv.end > 0 && age > lastIntv.end {
-			l.Debugln("Versioner: File over maximum age -> delete ", version.name)
-			remove = append(remove, version.name)
+			l.Debugln("Versioner: File over maximum age -> delete ", version)
+			remove = append(remove, version)
 			continue
 		}
 
@@ -198,8 +197,8 @@ func (v *Staggered) toRemove(versions []versionWithMtime, now time.Time) []strin
 		}
 
 		if prevAge-age < usedInterval.step {
-			l.Debugln("too many files in step -> delete", version.name)
-			remove = append(remove, version.name)
+			l.Debugln("too many files in step -> delete", version)
+			remove = append(remove, version)
 			continue
 		}
 

--- a/lib/versioner/staggered_test.go
+++ b/lib/versioner/staggered_test.go
@@ -26,25 +26,25 @@ func TestStaggeredVersioningVersionCount(t *testing.T) {
 	*/
 
 	now := parseTime("20160415-140000")
-	versionsWithMtime := []versionWithMtime{
+	versionsWithMtime := []string{
 		// 14:00:00 is "now"
-		{"test~20160415-140000", parseTime("20160415-140000")}, // 0 seconds ago
-		{"test~20160415-135959", parseTime("20160415-135959")}, // 1 second ago
-		{"test~20160415-135958", parseTime("20160415-135958")}, // 2 seconds ago
-		{"test~20160415-135900", parseTime("20160415-135900")}, // 1 minute ago
-		{"test~20160415-135859", parseTime("20160415-135859")}, // 1 minute 1 second ago
-		{"test~20160415-135830", parseTime("20160415-135830")}, // 1 minute 30 seconds ago
-		{"test~20160415-135829", parseTime("20160415-135829")}, // 1 minute 31 seconds ago
-		{"test~20160415-135700", parseTime("20160415-135700")}, // 3 minutes ago
-		{"test~20160415-135630", parseTime("20160415-135630")}, // 3 minutes 30 seconds ago
-		{"test~20160415-133000", parseTime("20160415-133000")}, // 30 minutes ago
-		{"test~20160415-132900", parseTime("20160415-132900")}, // 31 minutes ago
-		{"test~20160415-132500", parseTime("20160415-132500")}, // 35 minutes ago
-		{"test~20160415-132000", parseTime("20160415-132000")}, // 40 minutes ago
-		{"test~20160415-130000", parseTime("20160415-130000")}, // 60 minutes ago
-		{"test~20160415-124000", parseTime("20160415-124000")}, // 80 minutes ago
-		{"test~20160415-122000", parseTime("20160415-122000")}, // 100 minutes ago
-		{"test~20160415-110000", parseTime("20160415-110000")}, // 120 minutes ago
+		"test~20160415-140000", // 0 seconds ago
+		"test~20160415-135959", // 1 second ago
+		"test~20160415-135958", // 2 seconds ago
+		"test~20160415-135900", // 1 minute ago
+		"test~20160415-135859", // 1 minute 1 second ago
+		"test~20160415-135830", // 1 minute 30 seconds ago
+		"test~20160415-135829", // 1 minute 31 seconds ago
+		"test~20160415-135700", // 3 minutes ago
+		"test~20160415-135630", // 3 minutes 30 seconds ago
+		"test~20160415-133000", // 30 minutes ago
+		"test~20160415-132900", // 31 minutes ago
+		"test~20160415-132500", // 35 minutes ago
+		"test~20160415-132000", // 40 minutes ago
+		"test~20160415-130000", // 60 minutes ago
+		"test~20160415-124000", // 80 minutes ago
+		"test~20160415-122000", // 100 minutes ago
+		"test~20160415-110000", // 120 minutes ago
 	}
 
 	delete := []string{

--- a/lib/versioner/trashcan.go
+++ b/lib/versioner/trashcan.go
@@ -133,9 +133,15 @@ func (t *Trashcan) Restore(filepath string, versionTime time.Time) error {
 
 	taggedName := ""
 	tagger := func(name, tag string) string {
-		// We can't use TagFilename here, as restoreFii would discover that as a valid version and restore that instead.
+		// We also abuse the fact that tagger gets called twice, once for tagging the restoration version, which
+		// should just return the plain name, and second time by archive which archives existing file in the folder.
+		// We can't use TagFilename here, as restoreFile would discover that as a valid version and restore that instead.
+		if taggedName != "" {
+			return taggedName
+		}
+
 		taggedName = fs.TempName(name)
-		return taggedName
+		return name
 	}
 
 	err := restoreFile(t.versionsFs, t.folderFs, filepath, versionTime, tagger)

--- a/lib/versioner/trashcan_test.go
+++ b/lib/versioner/trashcan_test.go
@@ -108,9 +108,21 @@ func TestTrashcanArchiveRestoreSwitcharoo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	versionInfo, err := versionsFs.Stat("file")
+	// Check versions
+	versions, err := versioner.GetVersions()
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	fileVersions := versions["file"]
+	if len(fileVersions) != 1 {
+		t.Fatalf("unexpected number of versions: %d != 1", len(fileVersions))
+	}
+
+	fileVersion := fileVersions[0]
+
+	if !fileVersion.ModTime.Equal(fileVersion.VersionTime) {
+		t.Error("time mismatch")
 	}
 
 	if content := readFile(t, versionsFs, "file"); content != "A" {
@@ -119,7 +131,16 @@ func TestTrashcanArchiveRestoreSwitcharoo(t *testing.T) {
 
 	writeFile(t, folderFs, "file", "B")
 
-	if err := versioner.Restore("file", versionInfo.ModTime().Truncate(time.Second)); err != nil {
+	versionInfo, err := versionsFs.Stat("file")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !versionInfo.ModTime().Truncate(time.Second).Equal(fileVersion.ModTime) {
+		t.Error("time mismatch")
+	}
+
+	if err := versioner.Restore("file", fileVersion.VersionTime); err != nil {
 		t.Fatal(err)
 	}
 

--- a/lib/versioner/util.go
+++ b/lib/versioner/util.go
@@ -109,15 +109,11 @@ func retrieveVersions(fileSystem fs.Filesystem) (map[string][]FileVersion, error
 			return nil
 		}
 
-		if err == nil {
-			files[name] = append(files[name], FileVersion{
-				// This looks backwards, but mtime of the file is when we archived it, making that the version time
-				// The mod time of the file before archiving is embedded in the file name.
-				VersionTime: versionTime,
-				ModTime:     modTime,
-				Size:        f.Size(),
-			})
-		}
+		files[name] = append(files[name], FileVersion{
+			VersionTime: versionTime,
+			ModTime:     modTime,
+			Size:        f.Size(),
+		})
 
 		return nil
 	})


### PR DESCRIPTION
Idk, wrote the code, tests pass, did not test.

The problem is that version restoration now happens based on mtime of the file not the name, so restoring requires looking up all versions.