### PR TITLE
lib/model: NewFileSet outside fmut

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -370,7 +370,10 @@ func (m *model) AddFolder(cfg config.FolderConfiguration) {
 		panic("cannot add empty folder path")
 	}
 
+	// Creating the fileset can take a long time (metadata calculation) so
+	// we do it outside of the lock.
 	fset := db.NewFileSet(cfg.ID, cfg.Filesystem(), m.db)
+
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
 	m.addFolderLocked(cfg, fset)
@@ -460,6 +463,8 @@ func (m *model) RestartFolder(from, to config.FolderConfiguration) {
 
 	var fset *db.FileSet
 	if !to.Paused {
+		// Creating the fileset can take a long time (metadata calculation)
+		// so we do it outside of the lock.
 		fset = db.NewFileSet(to.ID, to.Filesystem(), m.db)
 	}
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -370,17 +370,17 @@ func (m *model) AddFolder(cfg config.FolderConfiguration) {
 		panic("cannot add empty folder path")
 	}
 
+	fset := db.NewFileSet(cfg.ID, cfg.Filesystem(), m.db)
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
-	m.addFolderLocked(cfg)
+	m.addFolderLocked(cfg, fset)
 }
 
-func (m *model) addFolderLocked(cfg config.FolderConfiguration) {
+func (m *model) addFolderLocked(cfg config.FolderConfiguration, fset *db.FileSet) {
 	m.folderCfgs[cfg.ID] = cfg
-	folderFs := cfg.Filesystem()
-	m.folderFiles[cfg.ID] = db.NewFileSet(cfg.ID, folderFs, m.db)
+	m.folderFiles[cfg.ID] = fset
 
-	ignores := ignore.New(folderFs, ignore.WithCache(m.cacheIgnoredFiles))
+	ignores := ignore.New(cfg.Filesystem(), ignore.WithCache(m.cacheIgnoredFiles))
 	if err := ignores.Load(".stignore"); err != nil && !fs.IsNotExist(err) {
 		l.Warnln("Loading ignores:", err)
 	}
@@ -458,12 +458,17 @@ func (m *model) RestartFolder(from, to config.FolderConfiguration) {
 		errMsg = "restarting"
 	}
 
+	var fset *db.FileSet
+	if !to.Paused {
+		fset = db.NewFileSet(to.ID, to.Filesystem(), m.db)
+	}
+
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
 
 	m.tearDownFolderLocked(from, fmt.Errorf("%v folder %v", errMsg, to.Description()))
 	if !to.Paused {
-		m.addFolderLocked(to)
+		m.addFolderLocked(to, fset)
 		m.startFolderLocked(to)
 	}
 	l.Infof("%v folder %v (%v)", infoMsg, to.Description(), to.Type)


### PR DESCRIPTION
This change is motivated by a particular fmut lock panic, e.g. https://sentry.syncthing.net/syncthing/syncthing/issues/29/events/3325/:

```
[many more levels in goleveldb]
github.com/syndtr/goleveldb/leveldb.(*Snapshot).Get(0xc000d592f0, 0xc000c5b450, 0x5e, 0xca, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	C:/BuildAgent/work/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190318030020-c3a204f8e965/leveldb/db_snapshot.go:113 +0x162
github.com/syncthing/syncthing/lib/db.(*instance).checkGlobals(0xc000cd7c80, 0xc0001e3120, 0x10, 0x10, 0xc0006166c0)
	C:/BuildAgent/work/174e136266f8a219/lib/db/instance.go:467 +0x629
github.com/syncthing/syncthing/lib/db.(*FileSet).recalcCounts(0xc000616480)
	C:/BuildAgent/work/174e136266f8a219/lib/db/set.go:94 +0x10e
github.com/syncthing/syncthing/lib/db.NewFileSet(0xc000072cc0, 0x10, 0x1055100, 0xc00005ded0, 0xc000276960, 0xc00009c120)
	C:/BuildAgent/work/174e136266f8a219/lib/db/set.go:85 +0x4ab
github.com/syncthing/syncthing/lib/model.(*model).addFolderLocked(0xc0001582c0, 0xc000072cc0, 0x10, 0xc0000704c0, 0x17, 0x0, 0xc00009c120, 0x26, 0x0, 0xc000212c40, ...)
	C:/BuildAgent/work/174e136266f8a219/lib/model/model.go:381 +0x132
github.com/syncthing/syncthing/lib/model.(*model).AddFolder(0xc0001582c0, 0xc000072cc0, 0x10, 0xc0000704c0, 0x17, 0x0, 0xc00009c120, 0x26, 0x0, 0xc000212c40, ...)
	C:/BuildAgent/work/174e136266f8a219/lib/model/model.go:375 +0xeb
main.syncthingMain(0xc00009c036, 0x25, 0x0, 0x0, 0x0, 0x10001, 0xc00008bc40, 0x33, 0x0, 0x0, ...)
	C:/BuildAgent/work/174e136266f8a219/cmd/syncthing/main.go:778 +0x15ad
main.main()
	C:/BuildAgent/work/174e136266f8a219/cmd/syncthing/main.go:430 +0x412
```

What happens is that the metadata recalculation is due, and that takes long enough for the deadlock detector to trigger. While that won't happen in release builds, most model operations (so most operations in general) will be blocked on fmut, which is bad.

Therefore I now generate the file set before acquiring fmut.