### PR TITLE
build: Add go major version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,3 +48,5 @@ require (
 	gopkg.in/ldap.v2 v2.5.1
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+go 1.12


### PR DESCRIPTION
I locally updated to the go1.13 beta and now the go toolchain always adds this annoying `go 1.13` line to the end of go.mod. I am bound to accidentally include that at some point through `git commit -a`. This behaviour disappears if I manually add `go 1.12` to go.mod. I have no clue what this does, I found no documentation on it at all and the only reference I found was in a tutorial, writing (emphasis mine):

> It created a go.mod file which contains the module import path and **version of the Go this module was created on**.
https://medium.com/rungo/anatomy-of-modules-in-go-c8274d215c16

So I assume this won't do any harm and it will prevent me from adding some kind of a reference to a beta go version into Syncthing.

If anyone knows what this line is about or how its appearance can be prevented alltogether, please let me know.