### PR TITLE
lib/model, lib/protocol: Track closing connections (fixes #5828)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -411,6 +411,8 @@ func (m *model) tearDownFolderLocked(cfg config.FolderConfiguration, err error) 
 		m.RemoveAndWait(id, 0)
 	}
 
+	// Wait for connections to stop to ensure that no more calls to methods
+	// expecting this folder to exist happen (e.g. .IndexUpdate).
 	w.Wait()
 
 	m.fmut.Lock()


### PR DESCRIPTION
### Purpose

This change has a few connected elements:

1. Stopping a folder now waits on the closed connections to stop before removing the folder elements from the model (this is the actual fix of #5828).
2. The utility function closing connections now returns the closed channels of these connections, such that the caller can wait on them if required (convenience and doing both things (closing and getting closed channels) under the same lock).
3. Speed up calls to `protocol.Close` and sending close messages in the protocol:  
Close now spawns a goroutine for both sending the close message and closing, while before it spawned the goroutine just for closing after sending the message. Thus the caller can quicker go on with whatever else it needs to do and if it needs to wait, it already now has to wait for receiving the `Closed` callback.  
The second element is a mechanism to stop sending messages on close: Right now the close message competes with any other message to get sent. With the additional `sendStop` chan all messages waiting to be sent abort when a close message is to be sent.

### Testing

None specific to this issue, just spun up the test system and restarted a folder. I don't have an idea how to unit test this race consistently.