### PR TITLE
lib/relay: Call the proper Error method (ref #5806)

### DIFF
--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -108,7 +108,7 @@ func (c *dynamicClient) Error() error {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
 	if c.client == nil {
-		return c.Error()
+		return c.commonClient.Error()
 	}
 	return c.client.Error()
 }


### PR DESCRIPTION
The problem was hidden in plain sight. Luckily spinning up a test instance for entirely different reasons triggered a relay error and thus an unexpected crash:


```
runtime: goroutine stack exceeds 1000000000-byte limit
fatal error: stack overflow

runtime stack:
runtime.throw(0xd8d6cc, 0xe)
	/media/ext4_data/Linux/source/go/src/runtime/panic.go:758 +0x72
runtime.newstack()
	/media/ext4_data/Linux/source/go/src/runtime/stack.go:1046 +0x6e9
runtime.morestack()
	/media/ext4_data/Linux/source/go/src/runtime/asm_amd64.s:449 +0x8f

goroutine 209 [running]:
sync.(*RWMutex).RLock(0xc00003a680)
	/media/ext4_data/Linux/source/go/src/sync/rwmutex.go:43 +0x5e fp=0xc0229b8340 sp=0xc0229b8338 pc=0x46ffae
github.com/syncthing/syncthing/lib/relay/client.(*dynamicClient).Error(0xc000442000, 0x0, 0x0)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/relay/client/dynamic.go:108 +0x40 fp=0xc0229b83a0 sp=0xc0229b8340 pc=0xa11440
github.com/syncthing/syncthing/lib/relay/client.(*dynamicClient).Error(0xc000442000, 0x0, 0x0)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/relay/client/dynamic.go:111 +0xc0 fp=0xc0229b8400 sp=0xc0229b83a0 pc=0xa114c0
github.com/syncthing/syncthing/lib/relay/client.(*dynamicClient).Error(0xc000442000, 0x0, 0x0)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/relay/client/dynamic.go:111 +0xc0 fp=0xc0229b8460 sp=0xc0229b8400 pc=0xa114c0
github.com/syncthing/syncthing/lib/relay/client.(*dynamicClient).Error(0xc000442000, 0x0, 0x0)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/relay/client/dynamic.go:111 +0xc0 fp=0xc0229b84c0 sp=0xc0229b8460 pc=0xa114c0
github.com/syncthing/syncthing/lib/relay/client.(*dynamicClient).Error(0xc000442000, 0x0, 0x0)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/relay/client/dynamic.go:111 +0xc0 fp=0xc0229b8520 sp=0xc0229b84c0 pc=0xa114c0
github.com/syncthing/syncthing/lib/relay/client.(*dynamicClient).Error(0xc000442000, 0x0, 0x0)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/relay/client/dynamic.go:111 +0xc0 fp=0xc0229b8580 sp=0xc0229b8520 pc=0xa114c0
github.com/syncthing/syncthing/lib/relay/client.(*dynamicClient).Error(0xc000442000, 0x0, 0x0)
	/media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/relay/client/dynamic.go:111 +0xc0 fp=0xc0229b85e0 sp=0xc0229b8580 pc=0xa114c0
[...]
...additional frames elided...
created by net/http.(*Server).Serve
	/media/ext4_data/Linux/source/go/src/net/http/server.go:2927 +0x38e

```
