### PR TITLE
Minify JavaScript and CSS files prior to building Syncthing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.12 AS builder
 WORKDIR /src
 COPY . .
 
-RUN apk update && apk add nodejs nodejs-npm
+RUN apk update && apk add findutils nodejs nodejs-npm
 RUN npm install -g --unsafe-perm csso-cli uglify-js
 RUN find / -type f -name '*.js' | while read -r line; do uglifyjs "$line" -c -o "$line"; done
 RUN find / -type f -name '*.css' | while read -r line; do csso "$line" -o "$line"; done

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM golang:1.12 AS builder
 WORKDIR /src
 COPY . .
 
+RUN apk update && apk add nodejs nodejs-npm
+RUN npm install -g --unsafe-perm csso-cli uglify-js
+RUN find / -type f -name '*.js' | while read -r line; do uglifyjs "$line" -c -o "$line"; done
+RUN find / -type f -name '*.css' | while read -r line; do csso "$line" -o "$line"; done
+
 ENV CGO_ENABLED=0
 ENV BUILD_HOST=syncthing.net
 ENV BUILD_USER=docker


### PR DESCRIPTION
### Purpose

Fixes #5432.

### Testing

I've been running a minified build of Syncthing for the past six months without noticing any issues.