### PR TITLE
lib/versioner: Replace all placeholders in external command (fixes #5849)

### DIFF
--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -75,7 +74,6 @@ func (v External) Archive(filePath string) error {
 		"%FOLDER_FILESYSTEM%": v.filesystem.Type().String(),
 		"%FOLDER_PATH%":       v.filesystem.URI(),
 		"%FILE_PATH%":         filePath,
-		"%FILE_PATH_FULL%":    filepath.Join(v.filesystem.URI(), filePath),
 	}
 
 	for i, word := range words {

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -78,7 +78,7 @@ func (v External) Archive(filePath string) error {
 
 	for i, word := range words {
 		for key, val := range context {
-			word = strings.ReplaceAll(word, key, val)
+			word = strings.Replace(word, key, val, -1)
 		}
 
 		words[i] = word

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -77,9 +77,11 @@ func (v External) Archive(filePath string) error {
 	}
 
 	for i, word := range words {
-		if replacement, ok := context[word]; ok {
-			words[i] = replacement
+		for key, val := range context {
+			word = strings.ReplaceAll(word, key, val)
 		}
+
+		words[i] = word
 	}
 
 	cmd := exec.Command(words[0], words[1:]...)

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
@@ -74,6 +75,7 @@ func (v External) Archive(filePath string) error {
 		"%FOLDER_FILESYSTEM%": v.filesystem.Type().String(),
 		"%FOLDER_PATH%":       v.filesystem.URI(),
 		"%FILE_PATH%":         filePath,
+		"%FILE_PATH_FULL%":    filepath.Join(v.filesystem.URI(), filePath),
 	}
 
 	for i, word := range words {


### PR DESCRIPTION
### Old title: lib/versioner: Add placeholder to provide the absolute file path to external commands

This commit adds support for a new placeholder, %FILE_PATH_FULL%, to the
command of the external versioner. The placeholder will be replaced by
the absolute path of the file that should be deleted.

### Purpose

I want syncthing to move deleted file versions to the [FreeDesktop.org Trash](https://specifications.freedesktop.org/trash-spec/trashspec-1.0.html). There is already a set of scripts, [trash-cli](https://github.com/andreafrancia/trash-cli), that can be used to interact with the trash on command line, but it requires the absolute path of the file that should be moved to trash. If the existing placeholders were used, a wrapper script would be required, because constructs like `"%FOLDER_PATH%/%FILE_PATH%"` are not supported. By using the new placeholder, no wrapper script is necessary:
`/usr/bin/trash-put -- %FILE_PATH_FULL%`

### Testing

The command `/usr/bin/trash-put -- %FILE_PATH_FULL%` was configured as external versioner command for a folder and several files were deleted from this folder on a linked device.

### Documentation

The documentation will be added as soon as the name of the placeholder is confirmed.