### PR TITLE
all: add comment to ensure correct atomics alignment (closes #5813)

### DIFF
--- a/cmd/strelaysrv/status.go
+++ b/cmd/strelaysrv/status.go
@@ -86,9 +86,9 @@ func getStatus(w http.ResponseWriter, r *http.Request) {
 }
 
 type rateCalculator struct {
+	counter   *int64 // atomic, must remain 64-bit aligned
 	rates     []int64
 	prev      int64
-	counter   *int64
 	startTime time.Time
 }
 

--- a/lib/protocol/counting.go
+++ b/lib/protocol/counting.go
@@ -10,8 +10,8 @@ import (
 
 type countingReader struct {
 	io.Reader
-	tot  int64 // bytes
-	last int64 // unix nanos
+	tot  int64 // bytes (atomic, must remain 64-bit aligned)
+	last int64 // unix nanos (atomic, must remain 64-bit aligned)
 }
 
 var (
@@ -37,8 +37,8 @@ func (c *countingReader) Last() time.Time {
 
 type countingWriter struct {
 	io.Writer
-	tot  int64 // bytes
-	last int64 // unix nanos
+	tot  int64 // bytes (atomic, must remain 64-bit aligned)
+	last int64 // unix nanos (atomic, must remain 64-bit aligned)
 }
 
 func (c *countingWriter) Write(bs []byte) (int, error) {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -537,7 +537,7 @@ func (w *walker) handleError(ctx context.Context, context, path string, err erro
 // A byteCounter gets bytes added to it via Update() and then provides the
 // Total() and one minute moving average Rate() in bytes per second.
 type byteCounter struct {
-	total int64
+	total int64 // atomic, must remain 64-bit aligned
 	metrics.EWMA
 	stop chan struct{}
 }

--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -39,7 +39,7 @@ const (
 )
 
 type writeTrackingPacketConn struct {
-	lastWrite int64
+	lastWrite int64 // atomic, must remain 64-bit aligned
 	net.PacketConn
 }
 


### PR DESCRIPTION
### Purpose

There was really nothing to fix, as I checked the entire code base and **all** atomically accessed 64-bit variables (via sync/atomic) **are** actually 64-bit aligned.

This is the commit message:

Per the [`sync/atomic` bug note](https://golang.org/pkg/sync/atomic/#pkg-note-BUG):

> On ARM, x86-32, and 32-bit MIPS, it is the caller's
> responsibility to arrange for 64-bit alignment of 64-bit words
> accessed atomically. The first word in a variable or in an
> allocated struct, array, or slice can be relied upon to be
> 64-bit aligned.

All atomic accesses of 64-bit variables in syncthing code base are
currently ok (i.e they are all 64-bit aligned).

Generally, the bug is triggered because of incorrect alignement
of struct fields. Free variables (declared in a function) are
guaranteed to be 64-bit aligned by the Go compiler.

To ensure the code remains correct upon further addition/removal
of fields, which would change the currently correct alignment, I
added the following comment where required:

     // atomic, must remain 64-bit aligned


### Testing

I ran the tests on an arm v6 platform. 
No tests have been added as the only code modifications are added comments.


closes #5813