### PR TITLE
Add -umask option to set umask (for non-Windows platforms)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -180,7 +180,7 @@ type RuntimeOptions struct {
 	logFlags         int
 	showHelp         bool
 	allowNewerConfig bool
-	umask		 string
+	umask            string
 }
 
 func defaultRuntimeOptions() RuntimeOptions {
@@ -194,7 +194,7 @@ func defaultRuntimeOptions() RuntimeOptions {
 		cpuProfile:   os.Getenv("STCPUPROFILE") != "",
 		stRestarting: os.Getenv("STRESTART") != "",
 		logFlags:     log.Ltime,
-		umask:	      "",
+		umask:        "",
 	}
 
 	if os.Getenv("STTRACE") != "" {
@@ -271,8 +271,8 @@ func main() {
 			}
 
 			if mask < 0 || mask > 0777 {
-                                l.Warnln("Umask invalid, must between 0000 and 0777")
-                                os.Exit(exitError)
+				l.Warnln("Umask invalid, must between 0000 and 0777")
+				os.Exit(exitError)
 			}
 			syscall.Umask(int(mask))
 		}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -274,7 +274,7 @@ func main() {
 				l.Warnln("Umask invalid, must between 0000 and 0777")
 				os.Exit(exitError)
 			}
-			syscall.Umask(int(mask))
+			umask(int(mask))
 		}
 	}
 

--- a/cmd/syncthing/umask_unix.go
+++ b/cmd/syncthing/umask_unix.go
@@ -1,0 +1,17 @@
+// Copyright (C) 2019 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// +build !windows
+
+package main
+
+import (
+	"syscall"
+)
+
+func umask(mask int) int {
+	return syscall.Umask(mask)
+}

--- a/cmd/syncthing/umask_windows.go
+++ b/cmd/syncthing/umask_windows.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2019 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// +build windows
+
+package main
+
+func umask(mask int) int {
+	panic("umask called for Windows")
+}


### PR DESCRIPTION
### Purpose

Allow setting of umask directly which simplifies startup scripts.

### Testing

Light testing on a FreeBSD server, verified new files are created with the expected permissions.

### Documentation

https://github.com/syncthing/docs/pull/460

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.
