### PR TITLE
lib/syncthing: Refactor to use util.AsService

### DIFF
--- a/lib/syncthing/auditservice.go
+++ b/lib/syncthing/auditservice.go
@@ -20,16 +20,14 @@ import (
 // event per line, to the specified writer.
 type auditService struct {
 	suture.Service
-	w       io.Writer // audit destination
-	sub     *events.Subscription
-	stopped chan struct{} // signals stop complete
+	w   io.Writer // audit destination
+	sub *events.Subscription
 }
 
 func newAuditService(w io.Writer) *auditService {
 	s := &auditService{
-		w:       w,
-		sub:     events.Default.Subscribe(events.AllEvents),
-		stopped: make(chan struct{}),
+		w:   w,
+		sub: events.Default.Subscribe(events.AllEvents),
 	}
 	s.Service = util.AsService(s.serve)
 	return s
@@ -53,11 +51,4 @@ func (s *auditService) serve(stop chan struct{}) {
 func (s *auditService) Stop() {
 	s.Service.Stop()
 	events.Default.Unsubscribe(s.sub)
-	close(s.stopped)
-}
-
-// WaitForStop returns once the audit service has stopped.
-// (Needed by the tests.)
-func (s *auditService) WaitForStop() {
-	<-s.stopped
 }

--- a/lib/syncthing/auditservice_test.go
+++ b/lib/syncthing/auditservice_test.go
@@ -17,13 +17,12 @@ import (
 
 func TestAuditService(t *testing.T) {
 	buf := new(bytes.Buffer)
-	service := newAuditService(buf)
 
-	// Event sent before start, will not be logged
+	// Event sent before construction, will not be logged
 	events.Default.Log(events.ConfigSaved, "the first event")
 
+	service := newAuditService(buf)
 	go service.Serve()
-	service.WaitForStart()
 
 	// Event that should end up in the audit log
 	events.Default.Log(events.ConfigSaved, "the second event")

--- a/lib/syncthing/auditservice_test.go
+++ b/lib/syncthing/auditservice_test.go
@@ -31,7 +31,6 @@ func TestAuditService(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	service.Stop()
-	service.WaitForStop()
 
 	// This event should not be logged, since we have stopped.
 	events.Default.Log(events.ConfigSaved, "the third event")

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -126,7 +126,7 @@ func (a *App) startup() error {
 	l.SetPrefix("[start] ")
 
 	if a.opts.AuditWriter != nil {
-		a.startAuditing()
+		a.mainService.Add(newAuditService(a.opts.AuditWriter))
 	}
 
 	if a.opts.Verbose {
@@ -416,15 +416,6 @@ func (a *App) Stop(stopReason ExitStatus) ExitStatus {
 		a.exitStatus = stopReason
 	}
 	return a.exitStatus
-}
-
-func (a *App) startAuditing() {
-	auditService := newAuditService(a.opts.AuditWriter)
-	a.mainService.Add(auditService)
-
-	// We wait for the audit service to fully start before we return, to
-	// ensure we capture all events from the start.
-	auditService.WaitForStart()
 }
 
 func (a *App) setupGUI(m model.Model, defaultSub, diskSub events.BufferedSubscription, discoverer discover.CachingMux, connectionsService connections.Service, urService *ur.Service, errors, systemLog logger.Recorder) error {

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -9,45 +9,37 @@ package syncthing
 import (
 	"fmt"
 
+	"github.com/thejerf/suture"
+
 	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 // The verbose logging service subscribes to events and prints these in
 // verbose format to the console using INFO level.
 type verboseService struct {
-	stop    chan struct{} // signals time to stop
-	started chan struct{} // signals startup complete
+	suture.Service
+	sub *events.Subscription
 }
 
 func newVerboseService() *verboseService {
-	return &verboseService{
-		stop:    make(chan struct{}),
-		started: make(chan struct{}),
+	s := &verboseService{
+		sub: events.Default.Subscribe(events.AllEvents),
 	}
+	s.Service = util.AsService(s.serve)
+	return s
 }
 
-// Serve runs the verbose logging service.
-func (s *verboseService) Serve() {
-	sub := events.Default.Subscribe(events.AllEvents)
-	defer events.Default.Unsubscribe(sub)
-
-	select {
-	case <-s.started:
-		// The started channel has already been closed; do nothing.
-	default:
-		// This is the first time around. Indicate that we're ready to start
-		// processing events.
-		close(s.started)
-	}
-
+// serve runs the verbose logging service.
+func (s *verboseService) serve(stop chan struct{}) {
 	for {
 		select {
-		case ev := <-sub.C():
+		case ev := <-s.sub.C():
 			formatted := s.formatEvent(ev)
 			if formatted != "" {
 				l.Verboseln(formatted)
 			}
-		case <-s.stop:
+		case <-stop:
 			return
 		}
 	}
@@ -55,13 +47,9 @@ func (s *verboseService) Serve() {
 
 // Stop stops the verbose logging service.
 func (s *verboseService) Stop() {
-	close(s.stop)
-}
+	s.Service.Stop()
+	events.Default.Unsubscribe(s.sub)
 
-// WaitForStart returns once the verbose logging service is ready to receive
-// events, or immediately if it's already running.
-func (s *verboseService) WaitForStart() {
-	<-s.started
 }
 
 func (s *verboseService) formatEvent(ev events.Event) string {


### PR DESCRIPTION
This is a an unrelated side-effect to working on un-globalifying events. The only difference except using `util.AsService` is that I now subscribe to events in the constructor thus the whole `WaitForStart` business is not required anymore, as the service already listens for events after construction. And Unsubscribe happens in `Stop`, not deferred on `serve`, as suture might restart the service (serve being called multiple times).