### PR TITLE
lib: Ensure timely service termination (fixes #5860)

### DIFF
--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -8,7 +8,6 @@ package beacon
 
 import (
 	"net"
-	stdsync "sync"
 
 	"github.com/thejerf/suture"
 )
@@ -18,27 +17,14 @@ type recv struct {
 	src  net.Addr
 }
 
+type readRes struct {
+	n    int
+	addr net.Addr
+}
+
 type Interface interface {
 	suture.Service
 	Send(data []byte)
 	Recv() ([]byte, net.Addr)
 	Error() error
-}
-
-type errorHolder struct {
-	err error
-	mut stdsync.Mutex // uses stdlib sync as I want this to be trivially embeddable, and there is no risk of blocking
-}
-
-func (e *errorHolder) setError(err error) {
-	e.mut.Lock()
-	e.err = err
-	e.mut.Unlock()
-}
-
-func (e *errorHolder) Error() error {
-	e.mut.Lock()
-	err := e.err
-	e.mut.Unlock()
-	return err
 }

--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -17,11 +17,6 @@ type recv struct {
 	src  net.Addr
 }
 
-type readRes struct {
-	n    int
-	addr net.Addr
-}
-
 type Interface interface {
 	suture.Service
 	Send(data []byte)

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -161,8 +161,6 @@ func (w *broadcastWriter) serve(stop chan struct{}) error {
 			w.SetError(nil)
 		}
 	}
-
-	return nil
 }
 
 func (w *broadcastWriter) String() string {
@@ -216,8 +214,6 @@ func (r *broadcastReader) serve(stop chan struct{}) error {
 			l.Debugln("dropping message")
 		}
 	}
-
-	return nil
 }
 
 func (r *broadcastReader) String() string {

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -190,7 +190,6 @@ func (r *multicastReader) serve(stop chan struct{}) error {
 		case <-stop:
 		case <-done:
 		}
-		l.Infoln("mutlicastreader close conn")
 		conn.Close()
 	}()
 

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -156,8 +156,6 @@ func (w *multicastWriter) serve(stop chan struct{}) error {
 			w.SetError(nil)
 		}
 	}
-
-	return nil
 }
 
 func (w *multicastWriter) String() string {
@@ -242,8 +240,6 @@ func (r *multicastReader) serve(stop chan struct{}) error {
 			l.Debugln("dropping message")
 		}
 	}
-
-	return nil
 }
 
 func (r *multicastReader) String() string {

--- a/lib/nat/registry.go
+++ b/lib/nat/registry.go
@@ -24,6 +24,8 @@ func discoverAll(renewal, timeout time.Duration, stop chan struct{}) map[string]
 	wg.Add(len(providers))
 
 	c := make(chan Device)
+	done := make(chan struct{})
+
 	for _, discoverFunc := range providers {
 		go func(f DiscoverFunc) {
 			defer wg.Done()
@@ -40,6 +42,7 @@ func discoverAll(renewal, timeout time.Duration, stop chan struct{}) map[string]
 	nats := make(map[string]Device)
 
 	go func() {
+		defer close(done)
 		for {
 			select {
 			case dev, ok := <-c:
@@ -55,6 +58,7 @@ func discoverAll(renewal, timeout time.Duration, stop chan struct{}) map[string]
 
 	wg.Wait()
 	close(c)
+	<-done
 
 	return nats
 }

--- a/lib/nat/registry.go
+++ b/lib/nat/registry.go
@@ -42,7 +42,10 @@ func discoverAll(renewal, timeout time.Duration, stop chan struct{}) map[string]
 	go func() {
 		for {
 			select {
-			case dev := <-c:
+			case dev, ok := <-c:
+				if !ok {
+					return
+				}
 				nats[dev.ID()] = dev
 			case <-stop:
 				return

--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -109,8 +109,8 @@ func New(cfg config.Wrapper, subscriber Subscriber, conn net.PacketConn) (*Servi
 }
 
 func (s *Service) Stop() {
-	s.Service.Stop()
 	_ = s.stunConn.Close()
+	s.Service.Stop()
 }
 
 func (s *Service) serve(stop chan struct{}) {
@@ -163,7 +163,11 @@ func (s *Service) serve(stop chan struct{}) {
 
 		// We failed to contact all provided stun servers or the nat is not punchable.
 		// Chillout for a while.
-		time.Sleep(stunRetryInterval)
+		select {
+		case <-time.After(stunRetryInterval):
+		case <-stop:
+			return
+		}
 	}
 }
 

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -187,6 +187,7 @@ func AsService(fn func(stop chan struct{})) suture.Service {
 type ServiceWithError interface {
 	suture.Service
 	Error() error
+	SetError(error)
 }
 
 // AsServiceWithError does the same as AsService, except that it keeps track
@@ -243,4 +244,10 @@ func (s *service) Error() error {
 	s.mut.Lock()
 	defer s.mut.Unlock()
 	return s.err
+}
+
+func (s *service) SetError(err error) {
+	s.mut.Lock()
+	s.err = err
+	s.mut.Unlock()
 }


### PR DESCRIPTION
Now instead of various services not terminating at all or only after like forever, everything shuts down more or less immediately. Beware this is late-night-iterating between fixing something, getting another trace, fixing the next hangup, ... - some of my approaches taken are probably on the crude/heavy-handed side, but they seem to be working, so it's at least a basis to improve on.