### PR TITLE
lib/relay: Prevent spurious relay error message (fixes #5861)

### DIFF
--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -169,8 +169,7 @@ func relayAddressesOrder(input []string) []string {
 
 	sort.Ints(ids)
 
-	addresses := make([]string, len(input))
-
+	addresses := make([]string, 0, len(input))
 	for _, id := range ids {
 		addresses = append(addresses, buckets[id]...)
 	}

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -145,7 +145,7 @@ func (c *staticClient) URI() *url.URL {
 
 func (c *staticClient) connect() error {
 	if c.uri.Scheme != "relay" {
-		return fmt.Errorf("Unsupported relay schema: %v", c.uri.Scheme)
+		return fmt.Errorf("unsupported relay scheme: %v", c.uri.Scheme)
 	}
 
 	t0 := time.Now()
@@ -196,7 +196,7 @@ func (c *staticClient) join() error {
 	switch msg := message.(type) {
 	case protocol.Response:
 		if msg.Code != 0 {
-			return fmt.Errorf("Incorrect response code %d: %s", msg.Code, msg.Message)
+			return fmt.Errorf("incorrect response code %d: %s", msg.Code, msg.Message)
 		}
 
 	case protocol.RelayFull:


### PR DESCRIPTION
We were always adding a bunch of empty relays, I guess we just didn't
use to print errors about them.
