### PR TITLE
lib/model: Remove incorrect/useless panics

### DIFF
--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -68,7 +68,7 @@ func (f *sendOnlyFolder) pull() bool {
 		curFile, ok := f.fset.Get(protocol.LocalDeviceID, intf.FileName())
 		if !ok {
 			if intf.IsDeleted() {
-				panic("Should never get a deleted file as needed when we don't have it")
+				l.Debugln("Should never get a deleted file as needed when we don't have it")
 			}
 			return true
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -248,10 +248,8 @@ func (m *model) StartFolder(folder string) {
 
 // Need to hold lock on m.fmut when calling this.
 func (m *model) startFolderLocked(cfg config.FolderConfiguration) {
-	if err := m.checkFolderRunningLocked(cfg.ID); err == errFolderMissing {
-		l.Warnln("Cannot start nonexistent folder", cfg.Description())
-		panic("cannot start nonexistent folder")
-	} else if err == nil {
+	_, ok := m.folderRunners[cfg.ID]
+	if ok {
 		l.Warnln("Cannot start already running folder", cfg.Description())
 		panic("cannot start already running folder")
 	}


### PR DESCRIPTION
This PR removes the following two panics:
https://sentry.syncthing.net/share/issue/36dca98f1c154311b1e868aaa07e4ccc/  
https://sentry.syncthing.net/share/issue/0203181ba1674e1ba4f1d54929eee492/  

The one in folder_sendonly is simply useless, as it doesn't represent an unrecoverable/dangerous state nor does it provide useful info to find out why it happens. Without throwing a panic that item might be incorrectly shown as out-of-sync in the UI, but that's better than a panic, as the user could report that to us and we might be able to find out why it happens.

In model we previously did check the wrapper when starting a folder. That's incorrect, as starting a model is triggered by the wrapper, but at the point that we actually do it the wrapper might already be updated again. Simply ignoring the wrapper and going ahead means we proceed starting the folder and shortly after will stop it regularly again, which is totally fine.