### PR TITLE
lib/fs: Fix kqueue event list (fixes #5308)

### DIFF
--- a/lib/fs/basicfs_watch_eventtypes_kqueue.go
+++ b/lib/fs/basicfs_watch_eventtypes_kqueue.go
@@ -11,7 +11,9 @@ package fs
 import "github.com/syncthing/notify"
 
 const (
-	subEventMask  = notify.NoteDelete | notify.NoteWrite | notify.NoteRename
-	permEventMask = notify.NoteAttrib
+	// Platform independent notify.Create is required, as kqueue does not have
+	// any event signalling file creation, but notify does generate those internally.
+	subEventMask  = notify.NoteDelete | notify.NoteWrite | notify.NoteRename | notify.Create
+	permEventMask = notify.NoteAttrib | notify.NoteExtend
 	rmEventMask   = notify.NoteDelete | notify.NoteRename
 )


### PR DESCRIPTION
### Purpose

> The problem might related to this comment (https://github.com/rjeczalik/notify/blob/master/watcher_kqueue.go#L157):
> ```
> 		// Create event is not supported by kqueue. Instead NoteWrite event will
> 		// be registered for a directory. If this event will be reported on dir
> 		// which is to be monitored for Create, dir will be rescanned
> 		// and Create events will be generated and returned for new files.
> 		// In case of files, if not requested NoteRename event is reported,
> 		// it will be ignored.
> ```
> 
> We use platform specific events, not the cross-platform `notify.Create` which is created "synthetically" according to this comment. I'll investigate whether it's fine to mix both.

Looking at the event description in the notify library I think we also need to subscribe to `notify.NoteExtend` for attribute (permission) changes.

### Testing

None. @cowai, @jsm222 please give this a try and report whether it fixes your problem. Binaries are available from CI (need to create a guest account):  
https://build.syncthing.net/viewLog.html?buildId=43346&buildTypeId=Syncthing_BuildLinuxCross&tab=artifacts  
Or directly for freebsd amd64 if you trust me:  
https://drive.google.com/open?id=1g03ZFkGZmPGD05GWYKzZvx6aEtfINnZj