### PR TITLE
cmd/stcrashreceiver: Store and serve compressed reports

### DIFF
--- a/cmd/stcrashreceiver/stcrashreceiver.go
+++ b/cmd/stcrashreceiver/stcrashreceiver.go
@@ -54,12 +54,12 @@ func (r *crashReceiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// The final path component should be a SHA256 hash in hex, so 64 hex
 	// characters. We don't care about case on the request but use lower
 	// case internally.
-	base := strings.ToLower(path.Base(req.URL.Path))
-	if len(base) != 64 {
+	reportID := strings.ToLower(path.Base(req.URL.Path))
+	if len(reportID) != 64 {
 		http.Error(w, "Bad request", http.StatusBadRequest)
 		return
 	}
-	for _, c := range base {
+	for _, c := range reportID {
 		if c >= 'a' && c <= 'f' {
 			continue
 		}
@@ -70,70 +70,58 @@ func (r *crashReceiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	// The location of the report on disk, compressed
+	fullPath := filepath.Join(r.dir, r.dirFor(reportID), reportID) + ".gz"
+
 	switch req.Method {
 	case http.MethodGet:
-		r.serveGet(base, w, req)
+		r.serveGet(fullPath, w, req)
 	case http.MethodHead:
-		r.serveHead(base, w, req)
+		r.serveHead(fullPath, w, req)
 	case http.MethodPut:
-		r.servePut(base, w, req)
+		r.servePut(reportID, fullPath, w, req)
 	default:
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 	}
 }
 
 // serveGet responds to GET requests by serving the uncompressed report.
-func (r *crashReceiver) serveGet(base string, w http.ResponseWriter, req *http.Request) {
-	path := filepath.Join(r.dirFor(base), base)
-	fullPath := filepath.Join(r.dir, path)
-	if fd, err := os.Open(fullPath + ".gz"); err == nil {
-		// There is a compressed report
-		defer fd.Close()
-		gr, err := gzip.NewReader(fd)
-		if err != nil {
-			http.Error(w, "Internal server error", http.StatusInternalServerError)
-			return
-		}
-		_, _ = io.Copy(w, gr) // best effort
+func (r *crashReceiver) serveGet(fullPath string, w http.ResponseWriter, req *http.Request) {
+	fd, err := os.Open(fullPath)
+	if err != nil {
+		http.Error(w, "Not found", http.StatusNotFound)
 		return
 	}
-	if _, err := os.Lstat(fullPath); err == nil {
-		http.ServeFile(w, req, fullPath)
+
+	defer fd.Close()
+	gr, err := gzip.NewReader(fd)
+	if err != nil {
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
-	http.Error(w, "Not found", http.StatusNotFound)
+	_, _ = io.Copy(w, gr) // best effort
 }
 
 // serveHead responds to HEAD requests by checking if the named report
 // already exists in the system.
-func (r *crashReceiver) serveHead(base string, w http.ResponseWriter, _ *http.Request) {
-	path := filepath.Join(r.dirFor(base), base)
-	fullPath := filepath.Join(r.dir, path)
-	if _, err := os.Lstat(fullPath + ".gz"); err == nil {
-		// There is a compressed report
-		return
-	}
+func (r *crashReceiver) serveHead(fullPath string, w http.ResponseWriter, _ *http.Request) {
 	if _, err := os.Lstat(fullPath); err == nil {
-		// There is an uncompressed report
 		return
 	}
 	http.Error(w, "Not found", http.StatusNotFound)
 }
 
 // servePut accepts and stores the given report.
-func (r *crashReceiver) servePut(base string, w http.ResponseWriter, req *http.Request) {
-	path := filepath.Join(r.dirFor(base), base)
-	fullPath := filepath.Join(r.dir, path)
-
+func (r *crashReceiver) servePut(reportID, fullPath string, w http.ResponseWriter, req *http.Request) {
 	// Ensure the destination directory exists
 	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
-		log.Printf("Creating directory for report %s: %v", base, err)
+		log.Println("Creating directory:", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
 
 	// Read at most maxRequestSize of report data.
-	log.Println("Receiving report", base)
+	log.Println("Receiving report", reportID)
 	lr := io.LimitReader(req.Body, maxRequestSize)
 	bs, err := ioutil.ReadAll(lr)
 	if err != nil {
@@ -145,13 +133,13 @@ func (r *crashReceiver) servePut(base string, w http.ResponseWriter, req *http.R
 	// Compress the report for storage
 	buf := new(bytes.Buffer)
 	gw := gzip.NewWriter(buf)
-	gw.Write(bs)
+	_, _ = gw.Write(bs) // can't fail
 	gw.Close()
 
 	// Create an output file with the compressed report
-	err = ioutil.WriteFile(fullPath+".gz", buf.Bytes(), 0644)
+	err = ioutil.WriteFile(fullPath, buf.Bytes(), 0644)
 	if err != nil {
-		log.Printf("Creating file for report %s: %v", base, err)
+		log.Println("Saving report:", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -160,7 +148,7 @@ func (r *crashReceiver) servePut(base string, w http.ResponseWriter, req *http.R
 	if r.dsn != "" {
 		go func() {
 			// There's no need for the client to have to wait for this part.
-			if err := sendReport(r.dsn, base, bs); err != nil {
+			if err := sendReport(r.dsn, reportID, bs); err != nil {
 				log.Println("Failed to send report:", err)
 			}
 		}()

--- a/cmd/stcrashreceiver/stcrashreceiver.go
+++ b/cmd/stcrashreceiver/stcrashreceiver.go
@@ -86,7 +86,7 @@ func (r *crashReceiver) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 // serveGet responds to GET requests by serving the uncompressed report.
-func (r *crashReceiver) serveGet(fullPath string, w http.ResponseWriter, req *http.Request) {
+func (r *crashReceiver) serveGet(fullPath string, w http.ResponseWriter, _ *http.Request) {
 	fd, err := os.Open(fullPath)
 	if err != nil {
 		http.Error(w, "Not found", http.StatusNotFound)

--- a/cmd/stcrashreceiver/stcrashreceiver.go
+++ b/cmd/stcrashreceiver/stcrashreceiver.go
@@ -105,10 +105,9 @@ func (r *crashReceiver) serveGet(fullPath string, w http.ResponseWriter, _ *http
 // serveHead responds to HEAD requests by checking if the named report
 // already exists in the system.
 func (r *crashReceiver) serveHead(fullPath string, w http.ResponseWriter, _ *http.Request) {
-	if _, err := os.Lstat(fullPath); err == nil {
-		return
+	if _, err := os.Lstat(fullPath); err != nil {
+		http.Error(w, "Not found", http.StatusNotFound)
 	}
-	http.Error(w, "Not found", http.StatusNotFound)
 }
 
 // servePut accepts and stores the given report.


### PR DESCRIPTION
This changes the on disk format for new raw reports to be gzip
compressed. Also adds the ability to serve these reports in plain text,
to insulate web browsers from the change (previously we just served the
raw reports from disk using Caddy).
