### PR TITLE
lib/db: Use transaction when flushing batch

### DIFF
--- a/lib/db/benchmark_test.go
+++ b/lib/db/benchmark_test.go
@@ -37,7 +37,7 @@ func lazyInitBenchFileSet() {
 	oneFile = firstHalf[middle-1 : middle]
 
 	ldb := db.OpenMemory()
-	benchS = db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeFake, "."), ldb)
+	benchS = db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 	replace(benchS, remoteDevice0, files)
 	replace(benchS, protocol.LocalDeviceID, firstHalf)
 }
@@ -48,7 +48,7 @@ func BenchmarkReplaceAll(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeFake, "."), ldb)
+		m := db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 		replace(m, protocol.LocalDeviceID, files)
 	}
 
@@ -150,7 +150,7 @@ func BenchmarkNeedHalfRemote(b *testing.B) {
 
 	ldb := db.OpenMemory()
 	defer ldb.Close()
-	fset := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeFake, "."), ldb)
+	fset := db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 	replace(fset, remoteDevice0, firstHalf)
 	replace(fset, protocol.LocalDeviceID, files)
 

--- a/lib/db/benchmark_test.go
+++ b/lib/db/benchmark_test.go
@@ -37,7 +37,7 @@ func lazyInitBenchFileSet() {
 	oneFile = firstHalf[middle-1 : middle]
 
 	ldb := db.OpenMemory()
-	benchS = db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
+	benchS = db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeFake, "."), ldb)
 	replace(benchS, remoteDevice0, files)
 	replace(benchS, protocol.LocalDeviceID, firstHalf)
 }
@@ -48,7 +48,7 @@ func BenchmarkReplaceAll(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m := db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
+		m := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeFake, "."), ldb)
 		replace(m, protocol.LocalDeviceID, files)
 	}
 
@@ -150,7 +150,7 @@ func BenchmarkNeedHalfRemote(b *testing.B) {
 
 	ldb := db.OpenMemory()
 	defer ldb.Close()
-	fset := db.NewFileSet("test)", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
+	fset := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeFake, "."), ldb)
 	replace(fset, remoteDevice0, firstHalf)
 	replace(fset, protocol.LocalDeviceID, files)
 

--- a/lib/db/blockmap.go
+++ b/lib/db/blockmap.go
@@ -45,8 +45,13 @@ func (f *BlockFinder) Iterate(folders []string, hash []byte, iterFn func(string,
 	defer t.close()
 
 	var key []byte
+	var ok bool
 	for _, folder := range folders {
-		key = f.db.keyer.GenerateBlockMapKey(errorWriter{}, key, []byte(folder), hash, nil)
+		key, ok = f.db.keyer.GenerateBlockMapKeyRO(key, []byte(folder), hash, nil)
+		if !ok {
+			// No such folder
+			continue
+		}
 		iter := t.NewIterator(util.BytesPrefix(key), nil)
 
 		for iter.Next() && iter.Error() == nil {

--- a/lib/db/blockmap.go
+++ b/lib/db/blockmap.go
@@ -46,7 +46,7 @@ func (f *BlockFinder) Iterate(folders []string, hash []byte, iterFn func(string,
 
 	var key []byte
 	for _, folder := range folders {
-		key = f.db.keyer.GenerateBlockMapKey(key, []byte(folder), hash, nil)
+		key = f.db.keyer.GenerateBlockMapKey(errorWriter{}, key, []byte(folder), hash, nil)
 		iter := t.NewIterator(util.BytesPrefix(key), nil)
 
 		for iter.Next() && iter.Error() == nil {

--- a/lib/db/blockmap_test.go
+++ b/lib/db/blockmap_test.go
@@ -73,8 +73,8 @@ func addToBlockMap(db *instance, folder []byte, fs []protocol.FileInfo) {
 			name := []byte(f.Name)
 			for i, block := range f.Blocks {
 				binary.BigEndian.PutUint32(blockBuf, uint32(i))
-				keyBuf = t.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
-				t.Put(keyBuf, blockBuf)
+				keyBuf = db.keyer.GenerateBlockMapKey(t, keyBuf, folder, block.Hash, name)
+				t.Put(keyBuf, blockBuf, nil)
 			}
 		}
 	}
@@ -89,8 +89,8 @@ func discardFromBlockMap(db *instance, folder []byte, fs []protocol.FileInfo) {
 		if !ef.IsDirectory() && !ef.IsDeleted() && !ef.IsInvalid() {
 			name := []byte(ef.Name)
 			for _, block := range ef.Blocks {
-				keyBuf = t.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
-				t.Delete(keyBuf)
+				keyBuf = db.keyer.GenerateBlockMapKey(t, keyBuf, folder, block.Hash, name)
+				t.Delete(keyBuf, nil)
 			}
 		}
 	}

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -150,11 +150,11 @@ func TestUpdate0to3(t *testing.T) {
 
 	updater.updateSchema0to1()
 
-	if _, ok := db.getFileDirty(folder, protocol.LocalDeviceID[:], []byte(slashPrefixed)); ok {
+	if _, ok := getFile(db, db.keyer, folder, protocol.LocalDeviceID[:], []byte(slashPrefixed)); ok {
 		t.Error("File prefixed by '/' was not removed during transition to schema 1")
 	}
 
-	if _, err := db.Get(db.keyer.GenerateGlobalVersionKey(nil, folder, []byte(invalid)), nil); err != nil {
+	if _, err := db.Get(db.keyer.GenerateGlobalVersionKey(db, nil, folder, []byte(invalid)), nil); err != nil {
 		t.Error("Invalid file wasn't added to global list")
 	}
 

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syndtr/goleveldb/leveldb"
 )
 
 func TestIgnoredFiles(t *testing.T) {
@@ -218,5 +219,31 @@ func TestDowngrade(t *testing.T) {
 		t.Fatal("Expected error due to database downgrade, got", err)
 	} else if err.minSyncthingVersion != dbMinSyncthingVersion {
 		t.Fatalf("Error has %v as min Syncthing version, expected %v", err.minSyncthingVersion, dbMinSyncthingVersion)
+	}
+}
+
+func TestBatchLen(t *testing.T) {
+	// This test verifies that we understand how Len() works on a batch.
+
+	batch := new(leveldb.Batch)
+	if batch.Len() != 0 {
+		t.Error("empty batch should be zero length")
+	}
+
+	batch = new(leveldb.Batch)
+	batch.Delete([]byte("asdf"))
+	if batch.Len() == 0 {
+		t.Error("batch with delete is not empty")
+	}
+
+	batch = new(leveldb.Batch)
+	batch.Put([]byte("a key"), []byte("and some data"))
+	if batch.Len() != 1 {
+		t.Error("batch with put should contain one operation")
+	}
+
+	batch.Put([]byte("a key"), []byte("and some data"))
+	if batch.Len() != 2 {
+		t.Error("batch with two put to the same key contains two operations")
 	}
 }

--- a/lib/db/keyer.go
+++ b/lib/db/keyer.go
@@ -63,36 +63,36 @@ const (
 
 type keyer interface {
 	// device file key stuff
-	GenerateDeviceFileKey(key, folder, device, name []byte) deviceFileKey
+	GenerateDeviceFileKey(w writer, key, folder, device, name []byte) deviceFileKey
 	NameFromDeviceFileKey(key []byte) []byte
 	DeviceFromDeviceFileKey(key []byte) ([]byte, bool)
 	FolderFromDeviceFileKey(key []byte) ([]byte, bool)
 
 	// global version key stuff
-	GenerateGlobalVersionKey(key, folder, name []byte) globalVersionKey
+	GenerateGlobalVersionKey(w writer, key, folder, name []byte) globalVersionKey
 	NameFromGlobalVersionKey(key []byte) []byte
 	FolderFromGlobalVersionKey(key []byte) ([]byte, bool)
 
 	// block map key stuff (former BlockMap)
-	GenerateBlockMapKey(key, folder, hash, name []byte) blockMapKey
+	GenerateBlockMapKey(w writer, key, folder, hash, name []byte) blockMapKey
 	NameFromBlockMapKey(key []byte) []byte
 
 	// file need index
-	GenerateNeedFileKey(key, folder, name []byte) needFileKey
+	GenerateNeedFileKey(w writer, key, folder, name []byte) needFileKey
 
 	// file sequence index
-	GenerateSequenceKey(key, folder []byte, seq int64) sequenceKey
+	GenerateSequenceKey(w writer, key, folder []byte, seq int64) sequenceKey
 	SequenceFromSequenceKey(key []byte) int64
 
 	// index IDs
-	GenerateIndexIDKey(key, device, folder []byte) indexIDKey
+	GenerateIndexIDKey(w writer, key, device, folder []byte) indexIDKey
 	DeviceFromIndexIDKey(key []byte) ([]byte, bool)
 
 	// Mtimes
-	GenerateMtimesKey(key, folder []byte) mtimesKey
+	GenerateMtimesKey(w writer, key, folder []byte) mtimesKey
 
 	// Folder metadata
-	GenerateFolderMetaKey(key, folder []byte) folderMetaKey
+	GenerateFolderMetaKey(w writer, key, folder []byte) folderMetaKey
 }
 
 // defaultKeyer implements our key scheme. It needs folder and device
@@ -115,11 +115,11 @@ func (k deviceFileKey) WithoutNameAndDevice() []byte {
 	return k[:keyPrefixLen+keyFolderLen]
 }
 
-func (k defaultKeyer) GenerateDeviceFileKey(key, folder, device, name []byte) deviceFileKey {
+func (k defaultKeyer) GenerateDeviceFileKey(w writer, key, folder, device, name []byte) deviceFileKey {
 	key = resize(key, keyPrefixLen+keyFolderLen+keyDeviceLen+len(name))
 	key[0] = KeyTypeDevice
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(folder))
-	binary.BigEndian.PutUint32(key[keyPrefixLen+keyFolderLen:], k.deviceIdx.ID(device))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(w, folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen+keyFolderLen:], k.deviceIdx.ID(w, device))
 	copy(key[keyPrefixLen+keyFolderLen+keyDeviceLen:], name)
 	return key
 }
@@ -142,10 +142,10 @@ func (k globalVersionKey) WithoutName() []byte {
 	return k[:keyPrefixLen+keyFolderLen]
 }
 
-func (k defaultKeyer) GenerateGlobalVersionKey(key, folder, name []byte) globalVersionKey {
+func (k defaultKeyer) GenerateGlobalVersionKey(w writer, key, folder, name []byte) globalVersionKey {
 	key = resize(key, keyPrefixLen+keyFolderLen+len(name))
 	key[0] = KeyTypeGlobal
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(w, folder))
 	copy(key[keyPrefixLen+keyFolderLen:], name)
 	return key
 }
@@ -160,10 +160,10 @@ func (k defaultKeyer) FolderFromGlobalVersionKey(key []byte) ([]byte, bool) {
 
 type blockMapKey []byte
 
-func (k defaultKeyer) GenerateBlockMapKey(key, folder, hash, name []byte) blockMapKey {
+func (k defaultKeyer) GenerateBlockMapKey(w writer, key, folder, hash, name []byte) blockMapKey {
 	key = resize(key, keyPrefixLen+keyFolderLen+keyHashLen+len(name))
 	key[0] = KeyTypeBlock
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(w, folder))
 	copy(key[keyPrefixLen+keyFolderLen:], hash)
 	copy(key[keyPrefixLen+keyFolderLen+keyHashLen:], name)
 	return key
@@ -183,10 +183,10 @@ func (k needFileKey) WithoutName() []byte {
 	return k[:keyPrefixLen+keyFolderLen]
 }
 
-func (k defaultKeyer) GenerateNeedFileKey(key, folder, name []byte) needFileKey {
+func (k defaultKeyer) GenerateNeedFileKey(w writer, key, folder, name []byte) needFileKey {
 	key = resize(key, keyPrefixLen+keyFolderLen+len(name))
 	key[0] = KeyTypeNeed
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(w, folder))
 	copy(key[keyPrefixLen+keyFolderLen:], name)
 	return key
 }
@@ -197,10 +197,10 @@ func (k sequenceKey) WithoutSequence() []byte {
 	return k[:keyPrefixLen+keyFolderLen]
 }
 
-func (k defaultKeyer) GenerateSequenceKey(key, folder []byte, seq int64) sequenceKey {
+func (k defaultKeyer) GenerateSequenceKey(w writer, key, folder []byte, seq int64) sequenceKey {
 	key = resize(key, keyPrefixLen+keyFolderLen+keySequenceLen)
 	key[0] = KeyTypeSequence
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(w, folder))
 	binary.BigEndian.PutUint64(key[keyPrefixLen+keyFolderLen:], uint64(seq))
 	return key
 }
@@ -211,11 +211,11 @@ func (k defaultKeyer) SequenceFromSequenceKey(key []byte) int64 {
 
 type indexIDKey []byte
 
-func (k defaultKeyer) GenerateIndexIDKey(key, device, folder []byte) indexIDKey {
+func (k defaultKeyer) GenerateIndexIDKey(w writer, key, device, folder []byte) indexIDKey {
 	key = resize(key, keyPrefixLen+keyDeviceLen+keyFolderLen)
 	key[0] = KeyTypeIndexID
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.deviceIdx.ID(device))
-	binary.BigEndian.PutUint32(key[keyPrefixLen+keyDeviceLen:], k.folderIdx.ID(folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.deviceIdx.ID(w, device))
+	binary.BigEndian.PutUint32(key[keyPrefixLen+keyDeviceLen:], k.folderIdx.ID(w, folder))
 	return key
 }
 
@@ -225,19 +225,19 @@ func (k defaultKeyer) DeviceFromIndexIDKey(key []byte) ([]byte, bool) {
 
 type mtimesKey []byte
 
-func (k defaultKeyer) GenerateMtimesKey(key, folder []byte) mtimesKey {
+func (k defaultKeyer) GenerateMtimesKey(w writer, key, folder []byte) mtimesKey {
 	key = resize(key, keyPrefixLen+keyFolderLen)
 	key[0] = KeyTypeVirtualMtime
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(w, folder))
 	return key
 }
 
 type folderMetaKey []byte
 
-func (k defaultKeyer) GenerateFolderMetaKey(key, folder []byte) folderMetaKey {
+func (k defaultKeyer) GenerateFolderMetaKey(w writer, key, folder []byte) folderMetaKey {
 	key = resize(key, keyPrefixLen+keyFolderLen)
 	key[0] = KeyTypeFolderMeta
-	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(folder))
+	binary.BigEndian.PutUint32(key[keyPrefixLen:], k.folderIdx.ID(w, folder))
 	return key
 }
 

--- a/lib/db/keyer_test.go
+++ b/lib/db/keyer_test.go
@@ -18,7 +18,7 @@ func TestDeviceKey(t *testing.T) {
 
 	db := newInstance(OpenMemory())
 
-	key := db.keyer.GenerateDeviceFileKey(nil, fld, dev, name)
+	key := db.keyer.GenerateDeviceFileKey(db, nil, fld, dev, name)
 
 	fld2, ok := db.keyer.FolderFromDeviceFileKey(key)
 	if !ok {
@@ -46,7 +46,7 @@ func TestGlobalKey(t *testing.T) {
 
 	db := newInstance(OpenMemory())
 
-	key := db.keyer.GenerateGlobalVersionKey(nil, fld, name)
+	key := db.keyer.GenerateGlobalVersionKey(db, nil, fld, name)
 
 	fld2, ok := db.keyer.FolderFromGlobalVersionKey(key)
 	if !ok {
@@ -72,7 +72,7 @@ func TestSequenceKey(t *testing.T) {
 	db := newInstance(OpenMemory())
 
 	const seq = 1234567890
-	key := db.keyer.GenerateSequenceKey(nil, fld, seq)
+	key := db.keyer.GenerateSequenceKey(db, nil, fld, seq)
 	outSeq := db.keyer.SequenceFromSequenceKey(key)
 	if outSeq != seq {
 		t.Errorf("sequence number mangled, %d != %d", outSeq, seq)

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -57,7 +57,7 @@ func (m *metadataTracker) Marshal() ([]byte, error) {
 // toDB saves the marshalled metadataTracker to the given db, under the key
 // corresponding to the given folder
 func (m *metadataTracker) toDB(db *instance, folder []byte) error {
-	key := db.keyer.GenerateFolderMetaKey(nil, folder)
+	key := db.keyer.GenerateFolderMetaKey(db, nil, folder)
 
 	m.mut.RLock()
 	defer m.mut.RUnlock()
@@ -81,7 +81,7 @@ func (m *metadataTracker) toDB(db *instance, folder []byte) error {
 // fromDB initializes the metadataTracker from the marshalled data found in
 // the database under the key corresponding to the given folder
 func (m *metadataTracker) fromDB(db *instance, folder []byte) error {
-	key := db.keyer.GenerateFolderMetaKey(nil, folder)
+	key := db.keyer.GenerateFolderMetaKey(db, nil, folder)
 	bs, err := db.Get(key, nil)
 	if err != nil {
 		return err

--- a/lib/db/namespaced.go
+++ b/lib/db/namespaced.go
@@ -40,7 +40,7 @@ func (n *NamespacedKV) Reset() {
 	defer it.Release()
 	batch := n.db.newBatch()
 	for it.Next() {
-		batch.Delete(it.Key())
+		batch.Delete(it.Key(), nil)
 		batch.checkFlush()
 	}
 	batch.flush()

--- a/lib/db/smallindex.go
+++ b/lib/db/smallindex.go
@@ -87,6 +87,18 @@ func (i *smallIndex) ID(w writer, val []byte) uint32 {
 	return id
 }
 
+// IDRO returns the index number for the given byte slice, *without*
+// allocating a new one if it wasn't present.
+func (i *smallIndex) IDRO(val []byte) (uint32, bool) {
+	i.mut.Lock()
+	id, ok := i.val2id[string(val)]
+	i.mut.Unlock()
+	if !ok {
+		return 0, false
+	}
+	return id, true
+}
+
 // Val returns the value for the given index number, or (nil, false) if there
 // is no such index number.
 func (i *smallIndex) Val(id uint32) ([]byte, bool) {

--- a/lib/db/smallindex_test.go
+++ b/lib/db/smallindex_test.go
@@ -18,7 +18,7 @@ func TestSmallIndex(t *testing.T) {
 	}
 
 	// A new key should get ID zero
-	if id := idx.ID([]byte("hello")); id != 0 {
+	if id := idx.ID(db, []byte("hello")); id != 0 {
 		t.Fatal("Expected 0, not", id)
 	}
 	// Looking up ID zero should work
@@ -27,10 +27,10 @@ func TestSmallIndex(t *testing.T) {
 	}
 
 	// Delete the key
-	idx.Delete([]byte("hello"))
+	idx.Delete(db, []byte("hello"))
 
 	// Next ID should be one
-	if id := idx.ID([]byte("key2")); id != 1 {
+	if id := idx.ID(db, []byte("key2")); id != 1 {
 		t.Fatal("Expected 1, not", id)
 	}
 
@@ -41,12 +41,12 @@ func TestSmallIndex(t *testing.T) {
 	if val, ok := idx.Val(0); ok || val != nil {
 		t.Fatal("Unexpected return for deleted ID 0")
 	}
-	if id := idx.ID([]byte("key2")); id != 1 {
+	if id := idx.ID(db, []byte("key2")); id != 1 {
 		t.Fatal("Expected 1, not", id)
 	}
 
 	// Setting "hello" again should get us ID 2, not 0 as it was originally.
-	if id := idx.ID([]byte("hello")); id != 2 {
+	if id := idx.ID(db, []byte("hello")); id != 2 {
 		t.Fatal("Expected 2, not", id)
 	}
 }

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -164,7 +164,7 @@ func (vl VersionList) String() string {
 // update brings the VersionList up to date with file. It returns the updated
 // VersionList, a potentially removed old FileVersion and its index, as well as
 // the index where the new FileVersion was inserted.
-func (vl VersionList) update(folder, device []byte, file protocol.FileInfo, t readOnlyTransaction) (_ VersionList, removedFV FileVersion, removedAt int, insertedAt int) {
+func (vl VersionList) update(rw readWriter, k keyer, folder, device []byte, file protocol.FileInfo) (_ VersionList, removedFV FileVersion, removedAt int, insertedAt int) {
 	vl, removedFV, removedAt = vl.pop(device)
 
 	nv := FileVersion{
@@ -198,7 +198,7 @@ func (vl VersionList) update(folder, device []byte, file protocol.FileInfo, t re
 			// to determine the winner.)
 			//
 			// A surprise missing file entry here is counted as a win for us.
-			if of, ok := t.getFile(folder, vl.Versions[i].Device, []byte(file.Name)); !ok || file.WinsConflict(of) {
+			if of, ok := getFile(rw, k, folder, vl.Versions[i].Device, []byte(file.Name)); !ok || file.WinsConflict(of) {
 				vl = vl.insertAt(i, nv)
 				return vl, removedFV, removedAt, i
 			}

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -101,7 +101,11 @@ func getFileTrunc(r reader, key []byte, trunc bool) (FileIntf, bool) {
 }
 
 func getGlobal(r reader, k keyer, keyBuf, folder, file []byte, truncate bool) ([]byte, FileIntf, bool) {
-	keyBuf = k.GenerateGlobalVersionKey(errorWriter{}, keyBuf, folder, file)
+	var ok bool
+	keyBuf, ok = k.GenerateGlobalVersionKeyRO(keyBuf, folder, file)
+	if !ok {
+		return keyBuf, nil, false
+	}
 
 	bs, err := r.Get(keyBuf, nil)
 	if err != nil {

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -130,8 +130,7 @@ func getGlobal(r reader, k keyer, keyBuf, folder, file []byte, truncate bool) ([
 // batch size.
 type readWriteTransaction struct {
 	readOnlyTransaction
-	*batch
-	tran *leveldb.Transaction
+	*leveldb.Transaction
 }
 
 func (db *instance) newReadWriteTransaction() readWriteTransaction {
@@ -141,14 +140,12 @@ func (db *instance) newReadWriteTransaction() readWriteTransaction {
 	}
 	return readWriteTransaction{
 		readOnlyTransaction: newReadOnlyTransaction(tran),
-		batch:               newBatch(tran),
-		tran:                tran,
+		Transaction:         tran,
 	}
 }
 
 func (t readWriteTransaction) close() {
-	t.batch.flush()
-	if err := t.tran.Commit(); err != nil && err != leveldb.ErrClosed {
+	if err := t.Transaction.Commit(); err != nil && err != leveldb.ErrClosed {
 		panic(err)
 	}
 }


### PR DESCRIPTION
We use batches when we care about correctness, and try to get the right
write ordering in those batches. But there's nothing to say we don't
shut down (or crash) halfway through writing a batch and end up with
(for example) a FileInfo but no need index, or vice versa (I don't
remember the order but both are bad).

This should make sure than as long as we put all the relevant things in
one batch, that batch should be written atomically.
