### PR TITLE
lib/model: Fix flakyness of TestRequestRemoteRenameChanged

### DIFF
--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -704,6 +704,8 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 	}
 
 	var gotA, gotB, gotConfl bool
+	bIntermediateVersion := protocol.Vector{}.Update(fc.id.Short()).Update(myID.Short())
+	bFinalVersion := bIntermediateVersion.Copy().Update(fc.id.Short())
 	done = make(chan struct{})
 	fc.mut.Lock()
 	fc.indexFn = func(folder string, fs []protocol.FileInfo) {
@@ -723,7 +725,16 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 				if gotB {
 					t.Error("Got more than one index update for", f.Name)
 				}
-				gotB = true
+				if f.Version.Equal(bIntermediateVersion) {
+					// This index entry might be superseeded
+					// by the final one or sent before it separately.
+					break
+				}
+				if f.Version.Equal(bFinalVersion) {
+					gotB = true
+					break
+				}
+				t.Errorf("Got unexpected version %v for file %v in index update", f.Version, f.Name)
 			case strings.HasPrefix(f.Name, "b.sync-conflict-"):
 				if gotConfl {
 					t.Error("Got more than one index update for conflicts of", f.Name)


### PR DESCRIPTION
https://build.syncthing.net/project.html?projectId=Syncthing&testNameId=-1297911307479147500&tab=testDetails

When pulling the test encounters a file that has changed, thus scanning is scheduled before pulling again and getting the remote file. This means for the same file there's two updates locally, one from scanning that's immediately superseded with one from pulling. In a reasonably fast scenario the index update is only sent for the final version, but it's totally fine if the intermediate version is sent too, but that wasn't allowed in the tests before. 