### PR TITLE
all: Remove potentially problematic errors from panics (fixes #5839)

### DIFF
--- a/cmd/syncthing/blockprof.go
+++ b/cmd/syncthing/blockprof.go
@@ -22,11 +22,15 @@ func init() {
 			panic("Couldn't find block profiler")
 		}
 		l.Debugln("Starting block profiling")
-		go saveBlockingProfiles(profiler)
+		go func() {
+			err := saveBlockingProfiles(profiler) // Only returns on error
+			l.Warnln("Block profiler failed:", err)
+			panic("Block profiler failed")
+		}()
 	}
 }
 
-func saveBlockingProfiles(profiler *pprof.Profile) {
+func saveBlockingProfiles(profiler *pprof.Profile) error {
 	runtime.SetBlockProfileRate(1)
 
 	t0 := time.Now()
@@ -35,16 +39,16 @@ func saveBlockingProfiles(profiler *pprof.Profile) {
 
 		fd, err := os.Create(fmt.Sprintf("block-%05d-%07d.pprof", syscall.Getpid(), startms))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		err = profiler.WriteTo(fd, 0)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		err = fd.Close()
 		if err != nil {
-			panic(err)
+			return err
 		}
-
 	}
+	return nil
 }

--- a/cmd/syncthing/heapprof.go
+++ b/cmd/syncthing/heapprof.go
@@ -23,11 +23,15 @@ func init() {
 			rate = i
 		}
 		l.Debugln("Starting heap profiling")
-		go saveHeapProfiles(rate)
+		go func() {
+			err := saveHeapProfiles(rate) // Only returns on error
+			l.Warnln("Heap profiler failed:", err)
+			panic("Heap profiler failed")
+		}()
 	}
 }
 
-func saveHeapProfiles(rate int) {
+func saveHeapProfiles(rate int) error {
 	runtime.MemProfileRate = rate
 	var memstats, prevMemstats runtime.MemStats
 
@@ -38,21 +42,21 @@ func saveHeapProfiles(rate int) {
 		if memstats.HeapInuse > prevMemstats.HeapInuse {
 			fd, err := os.Create(name + ".tmp")
 			if err != nil {
-				panic(err)
+				return err
 			}
 			err = pprof.WriteHeapProfile(fd)
 			if err != nil {
-				panic(err)
+				return err
 			}
 			err = fd.Close()
 			if err != nil {
-				panic(err)
+				return err
 			}
 
 			os.Remove(name) // Error deliberately ignored
 			err = os.Rename(name+".tmp", name)
 			if err != nil {
-				panic(err)
+				return err
 			}
 
 			prevMemstats = memstats
@@ -60,4 +64,5 @@ func saveHeapProfiles(rate int) {
 
 		time.Sleep(250 * time.Millisecond)
 	}
+	return nil
 }

--- a/cmd/syncthing/heapprof.go
+++ b/cmd/syncthing/heapprof.go
@@ -64,5 +64,4 @@ func saveHeapProfiles(rate int) error {
 
 		time.Sleep(250 * time.Millisecond)
 	}
-	return nil
 }

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -102,7 +102,8 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 		l.Infoln("Starting syncthing")
 		err = cmd.Start()
 		if err != nil {
-			panic(err)
+			l.Warnln("Error starting the main Syncthing process:", err)
+			panic("Error starting the main Syncthing process")
 		}
 
 		stdoutMut.Lock()

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -109,7 +109,8 @@ func New(myID protocol.DeviceID) Configuration {
 
 	// Can't happen.
 	if err := cfg.prepare(myID); err != nil {
-		panic("bug: error in preparing new folder: " + err.Error())
+		l.Warnln("bug: error in preparing new folder:", err)
+		panic("error in preparing new folder")
 	}
 
 	return cfg

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -46,7 +46,8 @@ const (
 func init() {
 	err := expandLocations()
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
+		panic("Failed to expand locations at init time")
 	}
 }
 
@@ -124,7 +125,8 @@ func defaultConfigDir() string {
 	case "darwin":
 		dir, err := fs.ExpandTilde("~/Library/Application Support/Syncthing")
 		if err != nil {
-			panic(err)
+			fmt.Println(err)
+			panic("Failed to get default config dir")
 		}
 		return dir
 
@@ -134,7 +136,8 @@ func defaultConfigDir() string {
 		}
 		dir, err := fs.ExpandTilde("~/.config/syncthing")
 		if err != nil {
-			panic(err)
+			fmt.Println(err)
+			panic("Failed to get default config dir")
 		}
 		return dir
 	}
@@ -144,7 +147,8 @@ func defaultConfigDir() string {
 func homeDir() string {
 	home, err := fs.ExpandTilde("~")
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
+		panic("Failed to get user home dir")
 	}
 	return home
 }

--- a/lib/model/utils_test.go
+++ b/lib/model/utils_test.go
@@ -35,35 +35,35 @@ func TestInWriteableDir(t *testing.T) {
 
 	// These should succeed
 
-	err := inWritableDir(create, fs, "testdata/file")
+	err := inWritableDir(create, fs, "testdata/file", false)
 	if err != nil {
 		t.Error("testdata/file:", err)
 	}
-	err = inWritableDir(create, fs, "testdata/rw/foo")
+	err = inWritableDir(create, fs, "testdata/rw/foo", false)
 	if err != nil {
 		t.Error("testdata/rw/foo:", err)
 	}
-	err = inWritableDir(fs.Remove, fs, "testdata/rw/foo")
+	err = inWritableDir(fs.Remove, fs, "testdata/rw/foo", false)
 	if err != nil {
 		t.Error("testdata/rw/foo:", err)
 	}
 
-	err = inWritableDir(create, fs, "testdata/ro/foo")
+	err = inWritableDir(create, fs, "testdata/ro/foo", false)
 	if err != nil {
 		t.Error("testdata/ro/foo:", err)
 	}
-	err = inWritableDir(fs.Remove, fs, "testdata/ro/foo")
+	err = inWritableDir(fs.Remove, fs, "testdata/ro/foo", false)
 	if err != nil {
 		t.Error("testdata/ro/foo:", err)
 	}
 
 	// These should not
 
-	err = inWritableDir(create, fs, "testdata/nonexistent/foo")
+	err = inWritableDir(create, fs, "testdata/nonexistent/foo", false)
 	if err == nil {
 		t.Error("testdata/nonexistent/foo returned nil error")
 	}
-	err = inWritableDir(create, fs, "testdata/file/foo")
+	err = inWritableDir(create, fs, "testdata/file/foo", false)
 	if err == nil {
 		t.Error("testdata/file/foo returned nil error")
 	}
@@ -100,7 +100,7 @@ func TestOSWindowsRemove(t *testing.T) {
 	fs.Chmod("testdata/windows/ro/readonly", 0500)
 
 	for _, path := range []string{"testdata/windows/ro/readonly", "testdata/windows/ro", "testdata/windows"} {
-		err := inWritableDir(fs.Remove, fs, path)
+		err := inWritableDir(fs.Remove, fs, path, false)
 		if err != nil {
 			t.Errorf("Unexpected error %s: %s", path, err)
 		}
@@ -183,7 +183,7 @@ func TestInWritableDirWindowsRename(t *testing.T) {
 	}
 
 	for _, path := range []string{"testdata/windows/ro/readonly", "testdata/windows/ro", "testdata/windows"} {
-		err := inWritableDir(rename, fs, path)
+		err := inWritableDir(rename, fs, path, false)
 		if err != nil {
 			t.Errorf("Unexpected error %s: %s", path, err)
 		}


### PR DESCRIPTION
I replaced all panics containing an error in any form, except for serialization and db stuff.

The first commit is entirely dedicated to shared puller states, where a comment claims that it needs to duplicate `inWritableDir`, but I fail to see how. They do use `fs.ModePerm` and do not change permissions if they are ignored, but the fromer is something that should also happen in all other places and the latter is in my opinion wrong: We should still try to follow "leave no trace", but not complain if it fails.

And `lib/locations` does not use logger, so I used plain `fmt.Println` to emit the error before panicking for simplicity. Is that fine or might the crash parsing choke on that?