### PR TITLE
lib/connections: Log errors in relay clients

### DIFF
--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -42,11 +42,11 @@ type relayListener struct {
 
 func (t *relayListener) serve(stop chan struct{}) error {
 	clnt, err := client.NewClient(t.uri, t.tlsCfg.Certificates, nil, 10*time.Second)
-	invitations := clnt.Invitations()
 	if err != nil {
 		l.Infoln("Listen (BEP/relay):", err)
 		return err
 	}
+	invitations := clnt.Invitations()
 
 	t.mut.Lock()
 	t.client = clnt


### PR DESCRIPTION
Currently a fatal relay listening error can go undetected (well maybe debug logging in lib/relay, but even if), and the only indication the user is presented with is the suture supervisor logging like in https://github.com/syncthing/syncthing/issues/5915:

```
2019-07-31 16:01:30 c.S.listenerSupervisor: Failed service 'dynamic+https://relays.syncthing.net/endpoint' (2.745697 failures of 2.000000), restarting: false, error: "{dynamic+https://relays.syncthing.net/endpoint dynamic+https://relays.syncthing.net/endpoint} returned unexpectedly", stacktrace: [unknown stack trace]
```

This adds logging of an error at `Info` level, and "demotes" the existing logging on relay client creation error from `Warning` to `Info` level. It is just a failing relay, not really something to notify the user with a big banner.

And I took the opportunity to do some housekeeping too.