### PR TITLE
Add NATSymmetricUDPFirewall to punchable NATs

### DIFF
--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -304,7 +304,7 @@ func (s *Service) String() string {
 }
 
 func (s *Service) isCurrentNATTypePunchable() bool {
-	return s.natType == NATNone || s.natType == NATPortRestricted || s.natType == NATRestricted || s.natType == NATFull
+	return s.natType == NATNone || s.natType == NATPortRestricted || s.natType == NATRestricted || s.natType == NATFull || s.natType == NATSymmetricUDPFirewall
 }
 
 func areDifferent(first, second *Host) bool {


### PR DESCRIPTION
NATSymmetricUDPFirewall actually is not NAT at all, but means the machine has a global IP address and an UDP firewall in front (RFC calls it Symmetric UDP Firewall). This is punchable fine, both theoretically and also practically in testing.

### Purpose

See https://forum.syncthing.net/t/issues-with-quic-transport/13590/6 , this allows to use QUIC also for hosts which are behind an UDP firewall with a global IP address. 

### Testing

I tested with a host behind a `NATSymmetricUDPFirewall` and after the change, punching worked fine. 

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

