### PR TITLE
lib/model: Less locking in ClusterConfig

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1064,8 +1064,7 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 		}
 	}
 
-	m.fmut.Lock()
-	defer m.fmut.Unlock()
+	m.fmut.RLock()
 	var paused []string
 	for _, folder := range cm.Folders {
 		cfg, ok := m.cfg.Folder(folder.ID)
@@ -1186,6 +1185,7 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 		// implementing suture.IsCompletable).
 		m.Add(is)
 	}
+	m.fmut.RUnlock()
 
 	m.pmut.Lock()
 	m.remotePausedFolders[deviceID] = paused


### PR DESCRIPTION
Looking at the trace in https://github.com/syncthing/syncthing/issues/5929 again, `ClusterConfig` is waiting to acquire a write-lock - this seems like a very good candidate for causing the unresponsiveness/lots of goroutines trying to acquire a lock. I don't see any reason for it to be a write lock, nor for holding the lock over the entire function - the only protected thing that's accessed is `m.folderFiles` in the first loop. So essentially this seems like a correct and obvious change to me, but still a somewhat scary one.