### PR TITLE
lib/discover: Don't leak goroutines

### DIFF
--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -7,9 +7,13 @@
 package beacon
 
 import (
+	"fmt"
 	"net"
+	"time"
 
 	"github.com/thejerf/suture"
+
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 type recv struct {
@@ -19,7 +23,84 @@ type recv struct {
 
 type Interface interface {
 	suture.Service
+	fmt.Stringer
 	Send(data []byte)
 	Recv() ([]byte, net.Addr)
 	Error() error
+}
+
+type cast struct {
+	*suture.Supervisor
+	name    string
+	reader  util.ServiceWithError
+	writer  util.ServiceWithError
+	outbox  chan recv
+	inbox   chan []byte
+	stopped chan struct{}
+}
+
+// newCast creates a base object for multi- or broadcasting. Afterwards the
+// caller needs to set reader and writer with the addReader and addWriter
+// methods to get a functional implementation of Interface.
+func newCast(name string) *cast {
+	return &cast{
+		Supervisor: suture.New(name, suture.Spec{
+			// Don't retry too frenetically: an error to open a socket or
+			// whatever is usually something that is either permanent or takes
+			// a while to get solved...
+			FailureThreshold: 2,
+			FailureBackoff:   60 * time.Second,
+			// Only log restarts in debug mode.
+			Log: func(line string) {
+				l.Debugln(line)
+			},
+			PassThroughPanics: true,
+		}),
+		name:    name,
+		inbox:   make(chan []byte),
+		outbox:  make(chan recv, 16),
+		stopped: make(chan struct{}),
+	}
+}
+
+func (c *cast) addReader(r util.ServiceWithError) {
+	c.reader = r
+	c.Add(r)
+}
+
+func (c *cast) addWriter(w util.ServiceWithError) {
+	c.writer = w
+	c.Add(w)
+}
+
+func (c *cast) Stop() {
+	c.Supervisor.Stop()
+	close(c.stopped)
+}
+
+func (c *cast) String() string {
+	return fmt.Sprintf("%s@%p", c.name, c)
+}
+
+func (c *cast) Send(data []byte) {
+	select {
+	case c.inbox <- data:
+	case <-c.stopped:
+	}
+}
+
+func (c *cast) Recv() ([]byte, net.Addr) {
+	select {
+	case recv := <-c.outbox:
+		return recv.data, recv.src
+	case <-c.stopped:
+	}
+	return nil, nil
+}
+
+func (c *cast) Error() error {
+	if err := c.reader.Error(); err != nil {
+		return err
+	}
+	return c.writer.Error()
 }

--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -64,7 +64,7 @@ func newCast(name string) *cast {
 }
 
 func (c *cast) addReader(svc func(chan struct{}) error) {
-	c.writer = c.createService(svc, "reader")
+	c.reader = c.createService(svc, "reader")
 	c.Add(c.reader)
 }
 

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -65,7 +65,10 @@ func (b *Broadcast) Send(data []byte) {
 }
 
 func (b *Broadcast) Recv() ([]byte, net.Addr) {
-	recv := <-b.outbox
+	recv, ok := <-b.outbox
+	if !ok {
+		return nil, nil
+	}
 	return recv.data, recv.src
 }
 
@@ -209,6 +212,7 @@ func (r *broadcastReader) serve(stop chan struct{}) error {
 		select {
 		case r.outbox <- recv{c, addr}:
 		case <-stop:
+			close(r.outbox)
 			return nil
 		default:
 			l.Debugln("dropping message")

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -7,87 +7,26 @@
 package beacon
 
 import (
-	"fmt"
 	"net"
 	"time"
-
-	"github.com/thejerf/suture"
 
 	"github.com/syncthing/syncthing/lib/util"
 )
 
-type Broadcast struct {
-	*suture.Supervisor
-	port   int
-	inbox  chan []byte
-	outbox chan recv
-	br     *broadcastReader
-	bw     *broadcastWriter
+func NewBroadcast(port int) Interface {
+	c := newCast("broadcastBeacon")
+	c.addReader(util.AsServiceWithError(func(stop chan struct{}) error {
+		return writeBroadcasts(c.inbox, port, stop)
+	}))
+	c.addWriter(util.AsServiceWithError(func(stop chan struct{}) error {
+		return readBroadcasts(c.outbox, port, stop)
+	}))
+	return c
 }
 
-func NewBroadcast(port int) *Broadcast {
-	b := &Broadcast{
-		Supervisor: suture.New("broadcastBeacon", suture.Spec{
-			// Don't retry too frenetically: an error to open a socket or
-			// whatever is usually something that is either permanent or takes
-			// a while to get solved...
-			FailureThreshold: 2,
-			FailureBackoff:   60 * time.Second,
-			// Only log restarts in debug mode.
-			Log: func(line string) {
-				l.Debugln(line)
-			},
-			PassThroughPanics: true,
-		}),
-		port:   port,
-		inbox:  make(chan []byte),
-		outbox: make(chan recv, 16),
-	}
-
-	b.br = &broadcastReader{
-		port:   port,
-		outbox: b.outbox,
-	}
-	b.br.ServiceWithError = util.AsServiceWithError(b.br.serve)
-	b.Add(b.br)
-	b.bw = &broadcastWriter{
-		port:  port,
-		inbox: b.inbox,
-	}
-	b.bw.ServiceWithError = util.AsServiceWithError(b.bw.serve)
-	b.Add(b.bw)
-
-	return b
-}
-
-func (b *Broadcast) Send(data []byte) {
-	b.inbox <- data
-}
-
-func (b *Broadcast) Recv() ([]byte, net.Addr) {
-	recv, ok := <-b.outbox
-	if !ok {
-		return nil, nil
-	}
-	return recv.data, recv.src
-}
-
-func (b *Broadcast) Error() error {
-	if err := b.br.Error(); err != nil {
-		return err
-	}
-	return b.bw.Error()
-}
-
-type broadcastWriter struct {
-	util.ServiceWithError
-	port  int
-	inbox chan []byte
-}
-
-func (w *broadcastWriter) serve(stop chan struct{}) error {
-	l.Debugln(w, "starting")
-	defer l.Debugln(w, "stopping")
+func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
+	l.Debugln("starting writeBroadcasts")
+	defer l.Debugln("stopping writeBroadcasts")
 
 	conn, err := net.ListenUDP("udp4", nil)
 	if err != nil {
@@ -107,7 +46,7 @@ func (w *broadcastWriter) serve(stop chan struct{}) error {
 	for {
 		var bs []byte
 		select {
-		case bs = <-w.inbox:
+		case bs = <-inbox:
 		case <-stop:
 			return nil
 		}
@@ -115,8 +54,7 @@ func (w *broadcastWriter) serve(stop chan struct{}) error {
 		addrs, err := net.InterfaceAddrs()
 		if err != nil {
 			l.Debugln(err)
-			w.SetError(err)
-			continue
+			return err
 		}
 
 		var dsts []net.IP
@@ -136,13 +74,13 @@ func (w *broadcastWriter) serve(stop chan struct{}) error {
 
 		success := 0
 		for _, ip := range dsts {
-			dst := &net.UDPAddr{IP: ip, Port: w.port}
+			dst := &net.UDPAddr{IP: ip, Port: port}
 
 			conn.SetWriteDeadline(time.Now().Add(time.Second))
-			_, err := conn.WriteTo(bs, dst)
+			_, err = conn.WriteTo(bs, dst)
 			conn.SetWriteDeadline(time.Time{})
 
-			if err, ok := err.(net.Error); ok && err.Timeout() {
+			if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 				// Write timeouts should not happen. We treat it as a fatal
 				// error on the socket.
 				l.Debugln(err)
@@ -152,7 +90,6 @@ func (w *broadcastWriter) serve(stop chan struct{}) error {
 			if err != nil {
 				// Some other error that we don't expect. Debug and continue.
 				l.Debugln(err)
-				w.SetError(err)
 				continue
 			}
 
@@ -160,27 +97,18 @@ func (w *broadcastWriter) serve(stop chan struct{}) error {
 			success++
 		}
 
-		if success > 0 {
-			w.SetError(nil)
+		if success == 0 {
+			l.Debugln("couldn't send any braodcasts")
+			return err
 		}
 	}
 }
 
-func (w *broadcastWriter) String() string {
-	return fmt.Sprintf("broadcastWriter@%p", w)
-}
+func readBroadcasts(outbox chan<- recv, port int, stop chan struct{}) error {
+	l.Debugln("starting readBroadcasts")
+	defer l.Debugln("stopping readBroadcasts")
 
-type broadcastReader struct {
-	util.ServiceWithError
-	port   int
-	outbox chan recv
-}
-
-func (r *broadcastReader) serve(stop chan struct{}) error {
-	l.Debugln(r, "starting")
-	defer l.Debugln(r, "stopping")
-
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: r.port})
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
 	if err != nil {
 		l.Debugln(err)
 		return err
@@ -203,25 +131,18 @@ func (r *broadcastReader) serve(stop chan struct{}) error {
 			return err
 		}
 
-		r.SetError(nil)
-
 		l.Debugf("recv %d bytes from %s", n, addr)
 
 		c := make([]byte, n)
 		copy(c, bs)
 		select {
-		case r.outbox <- recv{c, addr}:
+		case outbox <- recv{c, addr}:
 		case <-stop:
-			close(r.outbox)
 			return nil
 		default:
 			l.Debugln("dropping message")
 		}
 	}
-}
-
-func (r *broadcastReader) String() string {
-	return fmt.Sprintf("broadcastReader@%p", r)
 }
 
 func bcast(ip *net.IPNet) *net.IPNet {

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -9,25 +9,20 @@ package beacon
 import (
 	"net"
 	"time"
-
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 func NewBroadcast(port int) Interface {
 	c := newCast("broadcastBeacon")
-	c.addReader(util.AsServiceWithError(func(stop chan struct{}) error {
-		return writeBroadcasts(c.inbox, port, stop)
-	}))
-	c.addWriter(util.AsServiceWithError(func(stop chan struct{}) error {
+	c.addReader(func(stop chan struct{}) error {
 		return readBroadcasts(c.outbox, port, stop)
-	}))
+	})
+	c.addWriter(func(stop chan struct{}) error {
+		return writeBroadcasts(c.inbox, port, stop)
+	})
 	return c
 }
 
 func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
-	l.Debugln("starting writeBroadcasts")
-	defer l.Debugln("stopping writeBroadcasts")
-
 	conn, err := net.ListenUDP("udp4", nil)
 	if err != nil {
 		l.Debugln(err)
@@ -105,9 +100,6 @@ func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
 }
 
 func readBroadcasts(outbox chan<- recv, port int, stop chan struct{}) error {
-	l.Debugln("starting readBroadcasts")
-	defer l.Debugln("stopping readBroadcasts")
-
 	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
 	if err != nil {
 		l.Debugln(err)

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -8,89 +8,30 @@ package beacon
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"time"
 
-	"github.com/thejerf/suture"
 	"golang.org/x/net/ipv6"
 
 	"github.com/syncthing/syncthing/lib/util"
 )
 
-type Multicast struct {
-	*suture.Supervisor
-	inbox  chan []byte
-	outbox chan recv
-	mr     *multicastReader
-	mw     *multicastWriter
+func NewMulticast(addr string) Interface {
+	c := newCast("multicastBeacon")
+	c.addReader(util.AsServiceWithError(func(stop chan struct{}) error {
+		return writeMulticasts(c.inbox, addr, stop)
+	}))
+	c.addWriter(util.AsServiceWithError(func(stop chan struct{}) error {
+		return readMulticasts(c.outbox, addr, stop)
+	}))
+	return c
 }
 
-func NewMulticast(addr string) *Multicast {
-	m := &Multicast{
-		Supervisor: suture.New("multicastBeacon", suture.Spec{
-			// Don't retry too frenetically: an error to open a socket or
-			// whatever is usually something that is either permanent or takes
-			// a while to get solved...
-			FailureThreshold: 2,
-			FailureBackoff:   60 * time.Second,
-			// Only log restarts in debug mode.
-			Log: func(line string) {
-				l.Debugln(line)
-			},
-			PassThroughPanics: true,
-		}),
-		inbox:  make(chan []byte),
-		outbox: make(chan recv, 16),
-	}
+func writeMulticasts(inbox <-chan []byte, addr string, stop chan struct{}) error {
+	l.Debugln("starting writeMulticasts")
+	defer l.Debugln("stopping writeMulticasts")
 
-	m.mr = &multicastReader{
-		addr:   addr,
-		outbox: m.outbox,
-	}
-	m.mr.ServiceWithError = util.AsServiceWithError(m.mr.serve)
-	m.Add(m.mr)
-
-	m.mw = &multicastWriter{
-		addr:  addr,
-		inbox: m.inbox,
-	}
-	m.mw.ServiceWithError = util.AsServiceWithError(m.mw.serve)
-	m.Add(m.mw)
-
-	return m
-}
-
-func (m *Multicast) Send(data []byte) {
-	m.inbox <- data
-}
-
-func (m *Multicast) Recv() ([]byte, net.Addr) {
-	recv, ok := <-m.outbox
-	if !ok {
-		return nil, nil
-	}
-	return recv.data, recv.src
-}
-
-func (m *Multicast) Error() error {
-	if err := m.mr.Error(); err != nil {
-		return err
-	}
-	return m.mw.Error()
-}
-
-type multicastWriter struct {
-	util.ServiceWithError
-	addr  string
-	inbox <-chan []byte
-}
-
-func (w *multicastWriter) serve(stop chan struct{}) error {
-	l.Debugln(w, "starting")
-	defer l.Debugln(w, "stopping")
-
-	gaddr, err := net.ResolveUDPAddr("udp6", w.addr)
+	gaddr, err := net.ResolveUDPAddr("udp6", addr)
 	if err != nil {
 		l.Debugln(err)
 		return err
@@ -120,7 +61,7 @@ func (w *multicastWriter) serve(stop chan struct{}) error {
 	for {
 		var bs []byte
 		select {
-		case bs = <-w.inbox:
+		case bs = <-inbox:
 		case <-stop:
 			return nil
 		}
@@ -140,7 +81,6 @@ func (w *multicastWriter) serve(stop chan struct{}) error {
 
 			if err != nil {
 				l.Debugln(err, "on write to", gaddr, intf.Name)
-				w.SetError(err)
 				continue
 			}
 
@@ -155,33 +95,23 @@ func (w *multicastWriter) serve(stop chan struct{}) error {
 			}
 		}
 
-		if success > 0 {
-			w.SetError(nil)
+		if success == 0 {
+			return err
 		}
 	}
 }
 
-func (w *multicastWriter) String() string {
-	return fmt.Sprintf("multicastWriter@%p", w)
-}
+func readMulticasts(outbox chan<- recv, addr string, stop chan struct{}) error {
+	l.Debugln("starting readMulticasts")
+	defer l.Debugln("stopping readMulticasts")
 
-type multicastReader struct {
-	util.ServiceWithError
-	addr   string
-	outbox chan<- recv
-}
-
-func (r *multicastReader) serve(stop chan struct{}) error {
-	l.Debugln(r, "starting")
-	defer l.Debugln(r, "stopping")
-
-	gaddr, err := net.ResolveUDPAddr("udp6", r.addr)
+	gaddr, err := net.ResolveUDPAddr("udp6", addr)
 	if err != nil {
 		l.Debugln(err)
 		return err
 	}
 
-	conn, err := net.ListenPacket("udp6", r.addr)
+	conn, err := net.ListenPacket("udp6", addr)
 	if err != nil {
 		l.Debugln(err)
 		return err
@@ -223,28 +153,22 @@ func (r *multicastReader) serve(stop chan struct{}) error {
 	for {
 		select {
 		case <-stop:
-			close(r.outbox)
 			return nil
 		default:
 		}
 		n, _, addr, err := pconn.ReadFrom(bs)
 		if err != nil {
 			l.Debugln(err)
-			r.SetError(err)
-			continue
+			return err
 		}
 		l.Debugf("recv %d bytes from %s", n, addr)
 
 		c := make([]byte, n)
 		copy(c, bs)
 		select {
-		case r.outbox <- recv{c, addr}:
+		case outbox <- recv{c, addr}:
 		default:
 			l.Debugln("dropping message")
 		}
 	}
-}
-
-func (r *multicastReader) String() string {
-	return fmt.Sprintf("multicastReader@%p", r)
 }

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -12,25 +12,20 @@ import (
 	"time"
 
 	"golang.org/x/net/ipv6"
-
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 func NewMulticast(addr string) Interface {
 	c := newCast("multicastBeacon")
-	c.addReader(util.AsServiceWithError(func(stop chan struct{}) error {
-		return writeMulticasts(c.inbox, addr, stop)
-	}))
-	c.addWriter(util.AsServiceWithError(func(stop chan struct{}) error {
+	c.addReader(func(stop chan struct{}) error {
 		return readMulticasts(c.outbox, addr, stop)
-	}))
+	})
+	c.addWriter(func(stop chan struct{}) error {
+		return writeMulticasts(c.inbox, addr, stop)
+	})
 	return c
 }
 
 func writeMulticasts(inbox <-chan []byte, addr string, stop chan struct{}) error {
-	l.Debugln("starting writeMulticasts")
-	defer l.Debugln("stopping writeMulticasts")
-
 	gaddr, err := net.ResolveUDPAddr("udp6", addr)
 	if err != nil {
 		l.Debugln(err)
@@ -102,9 +97,6 @@ func writeMulticasts(inbox <-chan []byte, addr string, stop chan struct{}) error
 }
 
 func readMulticasts(outbox chan<- recv, addr string, stop chan struct{}) error {
-	l.Debugln("starting readMulticasts")
-	defer l.Debugln("stopping readMulticasts")
-
 	gaddr, err := net.ResolveUDPAddr("udp6", addr)
 	if err != nil {
 		l.Debugln(err)

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -66,7 +66,10 @@ func (m *Multicast) Send(data []byte) {
 }
 
 func (m *Multicast) Recv() ([]byte, net.Addr) {
-	recv := <-m.outbox
+	recv, ok := <-m.outbox
+	if !ok {
+		return nil, nil
+	}
 	return recv.data, recv.src
 }
 
@@ -220,6 +223,7 @@ func (r *multicastReader) serve(stop chan struct{}) error {
 	for {
 		select {
 		case <-stop:
+			close(r.outbox)
 			return nil
 		default:
 		}

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -22,6 +22,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
+	"github.com/syncthing/syncthing/lib/util"
 	"github.com/thejerf/suture"
 )
 
@@ -71,28 +72,18 @@ func NewLocal(id protocol.DeviceID, addr string, addrList AddressLister) (Finder
 		if err != nil {
 			return nil, err
 		}
-		c.startLocalIPv4Broadcasts(bcPort)
+		c.beacon = beacon.NewBroadcast(bcPort)
 	} else {
 		// A multicast client
 		c.name = "IPv6 local"
-		c.startLocalIPv6Multicasts(addr)
+		c.beacon = beacon.NewMulticast(addr)
 	}
+	c.Add(c.beacon)
+	c.Add(util.AsService(c.recvAnnouncements))
 
-	go c.sendLocalAnnouncements()
+	c.Add(util.AsService(c.sendLocalAnnouncements))
 
 	return c, nil
-}
-
-func (c *localClient) startLocalIPv4Broadcasts(localPort int) {
-	c.beacon = beacon.NewBroadcast(localPort)
-	c.Add(c.beacon)
-	go c.recvAnnouncements(c.beacon)
-}
-
-func (c *localClient) startLocalIPv6Multicasts(localMCAddr string) {
-	c.beacon = beacon.NewMulticast(localMCAddr)
-	c.Add(c.beacon)
-	go c.recvAnnouncements(c.beacon)
 }
 
 // Lookup returns a list of addresses the device is available at.
@@ -142,7 +133,7 @@ func (c *localClient) announcementPkt(instanceID int64, msg []byte) ([]byte, boo
 	return msg, true
 }
 
-func (c *localClient) sendLocalAnnouncements() {
+func (c *localClient) sendLocalAnnouncements(stop chan struct{}) {
 	var msg []byte
 	var ok bool
 	instanceID := rand.Int63()
@@ -154,13 +145,22 @@ func (c *localClient) sendLocalAnnouncements() {
 		select {
 		case <-c.localBcastTick:
 		case <-c.forcedBcastTick:
+		case <-stop:
+			return
 		}
 	}
 }
 
-func (c *localClient) recvAnnouncements(b beacon.Interface) {
+func (c *localClient) recvAnnouncements(stop chan struct{}) {
+	b := c.beacon
 	warnedAbout := make(map[string]bool)
 	for {
+		select {
+		case <-stop:
+			return
+		default:
+		}
+
 		buf, addr := b.Recv()
 		if len(buf) < 4 {
 			l.Debugf("discover: short packet from %s")


### PR DESCRIPTION
Run methods as services instead of just kicking off a goroutine that will never stop.