### PR TITLE
lib/model: Optimise locking around conn-close and puller states

### DIFF
--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -257,6 +257,7 @@ func TestCopierFinder(t *testing.T) {
 
 	pulls := []pullBlockState{<-pullChan, <-pullChan, <-pullChan, <-pullChan}
 	finish := <-finisherChan
+	defer cleanupSharedPullerState(finish)
 
 	select {
 	case <-pullChan:
@@ -296,7 +297,6 @@ func TestCopierFinder(t *testing.T) {
 			t.Errorf("Block %d mismatch: %s != %s", eq, blks[eq-1].String(), blocks[eq].String())
 		}
 	}
-	finish.fd.Close()
 }
 
 func TestWeakHash(t *testing.T) {
@@ -395,7 +395,7 @@ func TestWeakHash(t *testing.T) {
 	default:
 	}
 
-	finish.fd.Close()
+	cleanupSharedPullerState(finish)
 	if err := ffs.Remove(tempFile); err != nil {
 		t.Fatal(err)
 	}
@@ -415,7 +415,7 @@ func TestWeakHash(t *testing.T) {
 	}
 
 	finish = <-finisherChan
-	finish.fd.Close()
+	cleanupSharedPullerState(finish)
 
 	expectShifted := expectBlocks - expectPulls
 	if finish.copyOriginShifted != expectShifted {
@@ -528,9 +528,9 @@ func TestDeregisterOnFailInCopy(t *testing.T) {
 		t.Log("event took", time.Since(t0))
 
 		state.mut.Lock()
-		stateFd := state.fd
+		stateWriter := state.writer
 		state.mut.Unlock()
-		if stateFd != nil {
+		if stateWriter != nil {
 			t.Fatal("File not closed?")
 		}
 
@@ -609,9 +609,9 @@ func TestDeregisterOnFailInPull(t *testing.T) {
 		t.Log("event took", time.Since(t0))
 
 		state.mut.Lock()
-		stateFd := state.fd
+		stateWriter := state.writer
 		state.mut.Unlock()
-		if stateFd != nil {
+		if stateWriter != nil {
 			t.Fatal("File not closed?")
 		}
 
@@ -932,4 +932,15 @@ func TestSRConflictReplaceFileByLink(t *testing.T) {
 	} else if scan := <-scanChan; confls[0] != scan {
 		t.Fatal("Expected request to scan", confls[0], "got", scan)
 	}
+}
+
+func cleanupSharedPullerState(s *sharedPullerState) {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	if s.writer == nil {
+		return
+	}
+	s.writer.mut.Lock()
+	s.writer.fd.Close()
+	s.writer.mut.Unlock()
 }

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -69,7 +69,7 @@ type lockedWriterAt struct {
 	fd  fs.File
 }
 
-func (w lockedWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
+func (w *lockedWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
 	w.mut.Lock()
 	defer w.mut.Unlock()
 	return w.fd.WriteAt(p, off)
@@ -266,7 +266,6 @@ func (s *sharedPullerState) finalClose() (bool, error) {
 	}
 
 	if s.writer != nil {
-		s.writer.mut.Lock()
 		if err := s.writer.fd.Sync(); err != nil {
 			// Sync() is nice if it works but not worth failing the
 			// operation over if it fails.
@@ -277,7 +276,6 @@ func (s *sharedPullerState) finalClose() (bool, error) {
 			// This is our error as we weren't errored before.
 			s.err = err
 		}
-		s.writer.mut.Unlock()
 		s.writer = nil
 	}
 


### PR DESCRIPTION
There is no deadlock here, but if a write operation takes really long, that can block `model.pmut` (see https://forum.syncthing.net/t/new-panic-v1-2-2-rc2/13647/2). This PR breaks this "lock-linking" in two places:

1. Separate locks for `sharedPullerState` and the contained file-descriptor. Thus really long writes do not block simple, but often used methods like `.Updated` or `Progress`.

2. Release `pmut` before calling `progressemitter.temporaryIndexUnsubscribe`.