### PR TITLE
cmd/stupgrades: Generate appropriate upgrade data (fixes #5924)

### DIFF
--- a/cmd/stupgrades/main.go
+++ b/cmd/stupgrades/main.go
@@ -30,7 +30,9 @@ func main() {
 	sort.Sort(upgrade.SortByRelease(rels))
 	rels = filterForLatest(rels)
 
-	json.NewEncoder(os.Stdout).Encode(rels)
+	if err := json.NewEncoder(os.Stdout).Encode(rels); err != nil {
+		os.Exit(1)
+	}
 }
 
 // filterForLatest returns the latest stable and prerelease only. If the

--- a/cmd/stupgrades/main.go
+++ b/cmd/stupgrades/main.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2019 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"sort"
+
+	"github.com/syncthing/syncthing/lib/upgrade"
+)
+
+const defaultURL = "https://api.github.com/repos/syncthing/syncthing/releases?per_page=25"
+
+func main() {
+	url := flag.String("u", defaultURL, "GitHub releases url")
+	flag.Parse()
+
+	rels := upgrade.FetchLatestReleases(*url, "")
+	if rels == nil {
+		// An error was already logged
+		os.Exit(1)
+	}
+
+	sort.Sort(upgrade.SortByRelease(rels))
+	rels = filterForLatest(rels)
+
+	json.NewEncoder(os.Stdout).Encode(rels)
+}
+
+// filterForLatest returns the latest stable and prerelease only
+func filterForLatest(rels []upgrade.Release) []upgrade.Release {
+	var filtered []upgrade.Release
+	var havePre, haveStable bool
+	for _, rel := range rels {
+		if rel.Prerelease && !havePre {
+			filtered = append(filtered, rel)
+			havePre = true
+		} else if !rel.Prerelease && !haveStable {
+			filtered = append(filtered, rel)
+			haveStable = true
+		}
+		if havePre && haveStable {
+			break
+		}
+	}
+	return filtered
+}

--- a/cmd/stupgrades/main.go
+++ b/cmd/stupgrades/main.go
@@ -33,20 +33,22 @@ func main() {
 	json.NewEncoder(os.Stdout).Encode(rels)
 }
 
-// filterForLatest returns the latest stable and prerelease only
+// filterForLatest returns the latest stable and prerelease only. If the
+// stable version is newer (comes first in the list) there is no need to go
+// looking for a prerelease at all.
 func filterForLatest(rels []upgrade.Release) []upgrade.Release {
 	var filtered []upgrade.Release
-	var havePre, haveStable bool
+	var havePre bool
 	for _, rel := range rels {
+		if !rel.Prerelease {
+			// We found a stable version, we're good now.
+			filtered = append(filtered, rel)
+			break
+		}
 		if rel.Prerelease && !havePre {
+			// We remember the first prerelease we find.
 			filtered = append(filtered, rel)
 			havePre = true
-		} else if !rel.Prerelease && !haveStable {
-			filtered = append(filtered, rel)
-			haveStable = true
-		}
-		if havePre && haveStable {
-			break
 		}
 	}
 	return filtered


### PR DESCRIPTION
This is a tiny tool to grab the GitHub releases info and generate a
more concise version of it. The conciseness comes from two aspects:

- We select only the latest stable and pre. There is no need to offer
  upgrades to versions that are older than the latest. (There might be, in
  the future, when we hit 2.0. We can revisit this at that time.)

- We use our structs to deserialize and reserialize the data. This means
  we remove all attributes that we don't understand and hence don't
  require.

All in all the new response is about 10% the size of the previous one and
avoids the issue where we only serve a bunch of release candidates and
no stable.
