### PR TITLE
test: Update integration tests (config, build and test fixes)

### DIFF
--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -155,6 +155,11 @@ func (p *Process) Stop() (*os.ProcessState, error) {
 	return p.cmd.ProcessState, p.stopErr
 }
 
+// Stopped returns a channel that will be closed when Syncthing has stopped.
+func (p *Process) Stopped() chan struct{} {
+	return p.stopped
+}
+
 // Get performs an HTTP GET and returns the bytes and/or an error. Any non-200
 // return code is returned as an error.
 func (p *Process) Get(path string) ([]byte, error) {

--- a/test/filetype_test.go
+++ b/test/filetype_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rc"
 )
@@ -21,7 +22,7 @@ import (
 func TestFileTypeChange(t *testing.T) {
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id)
+	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{}
 	cfg.SetFolder(fld)
@@ -35,7 +36,7 @@ func TestFileTypeChange(t *testing.T) {
 func TestFileTypeChangeSimpleVersioning(t *testing.T) {
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id)
+	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type:   "simple",
@@ -52,7 +53,7 @@ func TestFileTypeChangeSimpleVersioning(t *testing.T) {
 func TestFileTypeChangeStaggeredVersioning(t *testing.T) {
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id)
+	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type: "staggered",

--- a/test/h1/config.xml
+++ b/test/h1/config.xml
@@ -1,4 +1,4 @@
-<configuration version="28">
+<configuration version="29">
     <folder id="default" label="" path="s1/" type="sendreceive" rescanIntervalS="10" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
@@ -20,7 +20,8 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>true</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
     <folder id="¯\_(ツ)_/¯ Räksmörgås 动作 Адрес" label="" path="s12-1/" type="sendreceive" rescanIntervalS="10" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -41,7 +42,8 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>true</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
     <device id="EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK" name="s4" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22004</address>
@@ -129,6 +131,10 @@
         <defaultFolderPath>~</defaultFolderPath>
         <setLowPriority>true</setLowPriority>
         <maxConcurrentScans>0</maxConcurrentScans>
-        <minHomeDiskFreePct>0</minHomeDiskFreePct>
+        <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
+        <crashReportingEnabled>true</crashReportingEnabled>
+        <stunKeepaliveStartS>180</stunKeepaliveStartS>
+        <stunKeepaliveMinS>20</stunKeepaliveMinS>
+        <stunServer>default</stunServer>
     </options>
 </configuration>

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -1,4 +1,4 @@
-<configuration version="28">
+<configuration version="29">
     <folder id="default" label="" path="s2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
@@ -19,7 +19,8 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>true</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
     <folder id="s23" label="" path="s23-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -40,7 +41,8 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>true</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
     <folder id="¯\_(ツ)_/¯ Räksmörgås 动作 Адрес" label="" path="s12-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -61,7 +63,8 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>true</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
     <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" name="s1" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22001</address>
@@ -132,6 +135,10 @@
         <defaultFolderPath>~</defaultFolderPath>
         <setLowPriority>true</setLowPriority>
         <maxConcurrentScans>0</maxConcurrentScans>
-        <minHomeDiskFreePct>0</minHomeDiskFreePct>
+        <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
+        <crashReportingEnabled>true</crashReportingEnabled>
+        <stunKeepaliveStartS>180</stunKeepaliveStartS>
+        <stunKeepaliveMinS>20</stunKeepaliveMinS>
+        <stunServer>default</stunServer>
     </options>
 </configuration>

--- a/test/h3/config.xml
+++ b/test/h3/config.xml
@@ -1,4 +1,4 @@
-<configuration version="28">
+<configuration version="29">
     <folder id="default" label="" path="s3" type="sendreceive" rescanIntervalS="20" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
@@ -21,7 +21,8 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>true</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
     <folder id="s23" label="" path="s23-3" type="sendreceive" rescanIntervalS="20" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -42,7 +43,8 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>true</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
     </folder>
     <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" name="s1" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22001</address>
@@ -113,6 +115,10 @@
         <defaultFolderPath>~</defaultFolderPath>
         <setLowPriority>true</setLowPriority>
         <maxConcurrentScans>0</maxConcurrentScans>
-        <minHomeDiskFreePct>0</minHomeDiskFreePct>
+        <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
+        <crashReportingEnabled>true</crashReportingEnabled>
+        <stunKeepaliveStartS>180</stunKeepaliveStartS>
+        <stunKeepaliveMinS>20</stunKeepaliveMinS>
+        <stunServer>default</stunServer>
     </options>
 </configuration>

--- a/test/override_test.go
+++ b/test/override_test.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rc"
 )
@@ -24,7 +25,7 @@ import (
 func TestOverride(t *testing.T) {
 	// Enable "send-only" on s1/default
 	id, _ := protocol.DeviceIDFromString(id1)
-	cfg, _ := config.Load("h1/config.xml", id)
+	cfg, _ := config.Load("h1/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Type = config.FolderTypeSendOnly
 	cfg.SetFolder(fld)
@@ -156,7 +157,7 @@ get to completion when in sendOnly/sendRecv mode. Needs fixing.
 func TestOverrideIgnores(t *testing.T) {
 	// Enable "sendOnly" on s1/default
 	id, _ := protocol.DeviceIDFromString(id1)
-	cfg, _ := config.Load("h1/config.xml", id)
+	cfg, _ := config.Load("h1/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.ReadOnly = true
 	cfg.SetFolder(fld)

--- a/test/reset_test.go
+++ b/test/reset_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestReset(t *testing.T) {
@@ -76,6 +77,11 @@ func TestReset(t *testing.T) {
 	}
 
 	// ---- Syncthing exits here ----
+	select {
+	case <-p.Stopped():
+	case <-time.After(20 * time.Second):
+		t.Fatal("timed out before Syncthing stopped")
+	}
 
 	p = startInstance(t, 1)
 	defer p.Stop() // Not checkedStop, because Syncthing will exit on its own
@@ -115,6 +121,11 @@ func TestReset(t *testing.T) {
 	}
 
 	// ---- Syncthing exits here ----
+	select {
+	case <-p.Stopped():
+	case <-time.After(20 * time.Second):
+		t.Fatal("timed out before Syncthing stopped")
+	}
 
 	p = startInstance(t, 1)
 	defer checkedStop(t, p)

--- a/test/symlink_test.go
+++ b/test/symlink_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rc"
 )
@@ -25,7 +26,7 @@ func TestSymlinks(t *testing.T) {
 
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id)
+	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{}
 	cfg.SetFolder(fld)
@@ -43,7 +44,7 @@ func TestSymlinksSimpleVersioning(t *testing.T) {
 
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id)
+	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type:   "simple",
@@ -64,7 +65,7 @@ func TestSymlinksStaggeredVersioning(t *testing.T) {
 
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id)
+	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type: "staggered",


### PR DESCRIPTION
Integrations tests were broken due to removing the global event logging. And after fixing that, TestReset failed. Turns out it was racy between the first instance stopping and the second starting and the recent changes that wait for services to terminate before exiting made that race tip towards failure -> added a method to rc wait for Syncthing to stop. Also took the opportunity to update configs.