### PR TITLE
Added a help-block string to the 'File Versioning' tab

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -373,6 +373,7 @@
    "Watch for Changes": "Watch for Changes",
    "Watching for Changes": "Watching for Changes",
    "Watching for changes discovers most changes without periodic scanning.": "Watching for changes discovers most changes without periodic scanning.",
+   "What to do if files are replaced or deleted, either locally, or on remote devices.": "What to do if files are replaced or deleted, either locally, or on remote devices.",
    "When adding a new device, keep in mind that this device must be added on the other side too.": "When adding a new device, keep in mind that this device must be added on the other side too.",
    "When adding a new folder, keep in mind that the Folder ID is used to tie folders together between devices. They are case sensitive and must match exactly between all devices.": "When adding a new folder, keep in mind that the Folder ID is used to tie folders together between devices. They are case sensitive and must match exactly between all devices.",
    "Yes": "Yes",

--- a/gui/default/assets/lang/lang-ru.json
+++ b/gui/default/assets/lang/lang-ru.json
@@ -368,6 +368,7 @@
     "Watch for Changes": "Следить за изменениями",
     "Watching for Changes": "Слежение за изменениями",
     "Watching for changes discovers most changes without periodic scanning.": "Отслеживание изменений обнаруживает большинство изменений без периодического сканирования.",
+    "What to do if files are replaced or deleted, either locally, or on remote devices.": "Как реагировать на изменение или удаление файла.",
     "When adding a new device, keep in mind that this device must be added on the other side too.": "Когда добавляете устройство, помните о том, что это же устройство должно быть добавлено и другой стороной.",
     "When adding a new folder, keep in mind that the Folder ID is used to tie folders together between devices. They are case sensitive and must match exactly between all devices.": "Когда добавляете новую папку, помните, что ID папок используются для того, чтобы связывать папки между всеми устройствами. Они чувствительны к регистру и должны совпадать на всех используемых устройствах.",
     "Yes": "Да",

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -65,6 +65,9 @@
         <div id="folder-versioning" class="tab-pane">
           <div class="form-group">
             <label translate>File Versioning</label>&emsp;<a href="https://docs.syncthing.net/users/versioning.html" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
+            <p class="help-block">
+              <span translate>What to do if files are replaced or deleted, either locally, or on remote devices.</span>&emsp;
+            </p>
             <select class="form-control" ng-model="currentFolder.fileVersioningSelector">
               <option value="none" translate>No File Versioning</option>
               <option value="trashcan" translate>Trash Can File Versioning</option>


### PR DESCRIPTION
### Purpose

Provide a bit more information to users when they create new folders, to clarify that "File versioning" can be related to file deletion, not just overwriting. 

A broader context is available on the forum: https://forum.syncthing.net/t/missing-syncthing-directory-missing-data-on-devices/13684/9?u=ralienpp

### Testing

None, I looked at the code of the page and added this string, in a way analogous to other tabs.