### PR TITLE
build: Upgrade github.com/gogo/protobuf

### DIFF
--- a/build.go
+++ b/build.go
@@ -34,23 +34,22 @@ import (
 )
 
 var (
-	versionRe        = regexp.MustCompile(`-[0-9]{1,3}-g[0-9a-f]{5,10}`)
-	goarch           string
-	goos             string
-	noupgrade        bool
-	version          string
-	goCmd            string
-	goVersion        float64
-	race             bool
-	debug            = os.Getenv("BUILDDEBUG") != ""
-	extraTags        string
-	installSuffix    string
-	pkgdir           string
-	cc               string
-	debugBinary      bool
-	coverage         bool
-	timeout          = "120s"
-	gogoProtoVersion = "v1.2.0"
+	versionRe     = regexp.MustCompile(`-[0-9]{1,3}-g[0-9a-f]{5,10}`)
+	goarch        string
+	goos          string
+	noupgrade     bool
+	version       string
+	goCmd         string
+	goVersion     float64
+	race          bool
+	debug         = os.Getenv("BUILDDEBUG") != ""
+	extraTags     string
+	installSuffix string
+	pkgdir        string
+	cc            string
+	debugBinary   bool
+	coverage      bool
+	timeout       = "120s"
 )
 
 type target struct {
@@ -214,7 +213,6 @@ type dependencyRepo struct {
 }
 
 var dependencyRepos = []dependencyRepo{
-	{path: "protobuf", repo: "https://github.com/gogo/protobuf.git", commit: gogoProtoVersion},
 	{path: "xdr", repo: "https://github.com/calmh/xdr.git", commit: "08e072f9cb16"},
 }
 
@@ -756,7 +754,12 @@ func shouldRebuildAssets(target, srcdir string) bool {
 }
 
 func proto() {
-	runPrint(goCmd, "get", fmt.Sprintf("github.com/gogo/protobuf/protoc-gen-gogofast@%v", gogoProtoVersion))
+	pv := protobufVersion()
+	dependencyRepos = append(dependencyRepos,
+		dependencyRepo{path: "protobuf", repo: "https://github.com/gogo/protobuf.git", commit: pv},
+	)
+
+	runPrint(goCmd, "get", fmt.Sprintf("github.com/gogo/protobuf/protoc-gen-gogofast@%v", pv))
 	os.MkdirAll("repos", 0755)
 	for _, dep := range dependencyRepos {
 		path := filepath.Join("repos", dep.path)
@@ -1251,4 +1254,12 @@ func (t target) BinaryName() string {
 		return t.binaryName + ".exe"
 	}
 	return t.binaryName
+}
+
+func protobufVersion() string {
+	bs, err := runError(goCmd, "list", "-f", "{{.Version}}", "-m", "github.com/gogo/protobuf")
+	if err != nil {
+		log.Fatal("Getting protobuf version:", err)
+	}
+	return string(bs)
 }

--- a/build.go
+++ b/build.go
@@ -765,8 +765,10 @@ func proto() {
 		path := filepath.Join("repos", dep.path)
 		if _, err := os.Stat(path); err != nil {
 			runPrintInDir("repos", "git", "clone", dep.repo, dep.path)
-			runPrintInDir(path, "git", "checkout", dep.commit)
+		} else {
+			runPrintInDir(path, "git", "fetch")
 		}
+		runPrintInDir(path, "git", "checkout", dep.commit)
 	}
 	runPrint(goCmd, "generate", "github.com/syncthing/syncthing/lib/...", "github.com/syncthing/syncthing/cmd/stdiscosrv")
 }

--- a/cmd/stdiscosrv/database.pb.go
+++ b/cmd/stdiscosrv/database.pb.go
@@ -3,12 +3,14 @@
 
 package main
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-
-import io "io"
+import (
+	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -19,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type DatabaseRecord struct {
 	Addresses []DatabaseAddress `protobuf:"bytes,1,rep,name=addresses,proto3" json:"addresses"`
@@ -32,7 +34,7 @@ func (m *DatabaseRecord) Reset()         { *m = DatabaseRecord{} }
 func (m *DatabaseRecord) String() string { return proto.CompactTextString(m) }
 func (*DatabaseRecord) ProtoMessage()    {}
 func (*DatabaseRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_database_0f49e029703a04f5, []int{0}
+	return fileDescriptor_b90fe3356ea5df07, []int{0}
 }
 func (m *DatabaseRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -42,15 +44,15 @@ func (m *DatabaseRecord) XXX_Marshal(b []byte, deterministic bool) ([]byte, erro
 		return xxx_messageInfo_DatabaseRecord.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *DatabaseRecord) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DatabaseRecord.Merge(dst, src)
+func (m *DatabaseRecord) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DatabaseRecord.Merge(m, src)
 }
 func (m *DatabaseRecord) XXX_Size() int {
 	return m.Size()
@@ -71,7 +73,7 @@ func (m *ReplicationRecord) Reset()         { *m = ReplicationRecord{} }
 func (m *ReplicationRecord) String() string { return proto.CompactTextString(m) }
 func (*ReplicationRecord) ProtoMessage()    {}
 func (*ReplicationRecord) Descriptor() ([]byte, []int) {
-	return fileDescriptor_database_0f49e029703a04f5, []int{1}
+	return fileDescriptor_b90fe3356ea5df07, []int{1}
 }
 func (m *ReplicationRecord) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -81,15 +83,15 @@ func (m *ReplicationRecord) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return xxx_messageInfo_ReplicationRecord.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *ReplicationRecord) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ReplicationRecord.Merge(dst, src)
+func (m *ReplicationRecord) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ReplicationRecord.Merge(m, src)
 }
 func (m *ReplicationRecord) XXX_Size() int {
 	return m.Size()
@@ -109,7 +111,7 @@ func (m *DatabaseAddress) Reset()         { *m = DatabaseAddress{} }
 func (m *DatabaseAddress) String() string { return proto.CompactTextString(m) }
 func (*DatabaseAddress) ProtoMessage()    {}
 func (*DatabaseAddress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_database_0f49e029703a04f5, []int{2}
+	return fileDescriptor_b90fe3356ea5df07, []int{2}
 }
 func (m *DatabaseAddress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -119,15 +121,15 @@ func (m *DatabaseAddress) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return xxx_messageInfo_DatabaseAddress.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *DatabaseAddress) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DatabaseAddress.Merge(dst, src)
+func (m *DatabaseAddress) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DatabaseAddress.Merge(m, src)
 }
 func (m *DatabaseAddress) XXX_Size() int {
 	return m.Size()
@@ -143,10 +145,34 @@ func init() {
 	proto.RegisterType((*ReplicationRecord)(nil), "main.ReplicationRecord")
 	proto.RegisterType((*DatabaseAddress)(nil), "main.DatabaseAddress")
 }
+
+func init() { proto.RegisterFile("database.proto", fileDescriptor_b90fe3356ea5df07) }
+
+var fileDescriptor_b90fe3356ea5df07 = []byte{
+	// 270 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x90, 0x41, 0x4a, 0xc4, 0x30,
+	0x18, 0x85, 0x9b, 0x49, 0x1d, 0x99, 0x08, 0xa3, 0x06, 0x94, 0x20, 0x12, 0x4b, 0xdd, 0x74, 0xd5,
+	0x01, 0x5d, 0xb9, 0x74, 0xd0, 0x0b, 0xe4, 0x06, 0xe9, 0xe4, 0x77, 0x08, 0x3a, 0x4d, 0x49, 0x2a,
+	0xe8, 0x29, 0xf4, 0x58, 0x5d, 0xce, 0xd2, 0x95, 0x68, 0x7b, 0x11, 0x69, 0x26, 0x55, 0x14, 0x37,
+	0xb3, 0x7b, 0xdf, 0xff, 0xbf, 0x97, 0xbc, 0x84, 0x4c, 0x95, 0xac, 0x65, 0x21, 0x1d, 0xe4, 0x95,
+	0x35, 0xb5, 0xa1, 0xf1, 0x4a, 0xea, 0xf2, 0xe4, 0xdc, 0x42, 0x65, 0xdc, 0xcc, 0x8f, 0x8a, 0xc7,
+	0xbb, 0xd9, 0xd2, 0x2c, 0x8d, 0x07, 0xaf, 0x36, 0xd6, 0xf4, 0x05, 0x91, 0xe9, 0x4d, 0x48, 0x0b,
+	0x58, 0x18, 0xab, 0xe8, 0x15, 0x99, 0x48, 0xa5, 0x2c, 0x38, 0x07, 0x8e, 0xa1, 0x04, 0x67, 0x7b,
+	0x17, 0x47, 0x79, 0x7f, 0x62, 0x3e, 0x18, 0xaf, 0x37, 0xeb, 0x79, 0xdc, 0xbc, 0x9f, 0x45, 0xe2,
+	0xc7, 0x4d, 0x8f, 0xc9, 0x78, 0xa5, 0x7d, 0x6e, 0x94, 0xa0, 0x6c, 0x47, 0x04, 0xa2, 0x94, 0xc4,
+	0x0e, 0xa0, 0x64, 0x38, 0x41, 0x19, 0x16, 0x5e, 0x7f, 0x7b, 0x15, 0x8b, 0xfd, 0x34, 0x50, 0x5a,
+	0x93, 0x43, 0x01, 0xd5, 0x83, 0x5e, 0xc8, 0x5a, 0x9b, 0x32, 0x74, 0x3a, 0x20, 0xf8, 0x1e, 0x9e,
+	0x19, 0x4a, 0x50, 0x36, 0x11, 0xbd, 0xfc, 0xdd, 0x72, 0xb4, 0x55, 0xcb, 0x7f, 0xda, 0xa4, 0xb7,
+	0x64, 0xff, 0x4f, 0x8e, 0x32, 0xb2, 0x1b, 0x32, 0xe1, 0xde, 0x01, 0xfb, 0x0d, 0x3c, 0x55, 0xda,
+	0x86, 0x77, 0x62, 0x31, 0xe0, 0xfc, 0xb4, 0xf9, 0xe4, 0x51, 0xd3, 0x72, 0xb4, 0x6e, 0x39, 0xfa,
+	0x68, 0x39, 0x7a, 0xed, 0x78, 0xb4, 0xee, 0x78, 0xf4, 0xd6, 0xf1, 0xa8, 0x18, 0xfb, 0x3f, 0xbf,
+	0xfc, 0x0a, 0x00, 0x00, 0xff, 0xff, 0x7a, 0xa2, 0xf6, 0x1e, 0xb0, 0x01, 0x00, 0x00,
+}
+
 func (m *DatabaseRecord) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -154,44 +180,51 @@ func (m *DatabaseRecord) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *DatabaseRecord) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *DatabaseRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Addresses) > 0 {
-		for _, msg := range m.Addresses {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintDatabase(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if m.Misses != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintDatabase(dAtA, i, uint64(m.Misses))
+	if m.Missed != 0 {
+		i = encodeVarintDatabase(dAtA, i, uint64(m.Missed))
+		i--
+		dAtA[i] = 0x20
 	}
 	if m.Seen != 0 {
-		dAtA[i] = 0x18
-		i++
 		i = encodeVarintDatabase(dAtA, i, uint64(m.Seen))
+		i--
+		dAtA[i] = 0x18
 	}
-	if m.Missed != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintDatabase(dAtA, i, uint64(m.Missed))
+	if m.Misses != 0 {
+		i = encodeVarintDatabase(dAtA, i, uint64(m.Misses))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if len(m.Addresses) > 0 {
+		for iNdEx := len(m.Addresses) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Addresses[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintDatabase(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0xa
+		}
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *ReplicationRecord) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -199,40 +232,48 @@ func (m *ReplicationRecord) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ReplicationRecord) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ReplicationRecord) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Key) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintDatabase(dAtA, i, uint64(len(m.Key)))
-		i += copy(dAtA[i:], m.Key)
+	if m.Seen != 0 {
+		i = encodeVarintDatabase(dAtA, i, uint64(m.Seen))
+		i--
+		dAtA[i] = 0x18
 	}
 	if len(m.Addresses) > 0 {
-		for _, msg := range m.Addresses {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintDatabase(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Addresses) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Addresses[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintDatabase(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x12
 		}
 	}
-	if m.Seen != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintDatabase(dAtA, i, uint64(m.Seen))
+	if len(m.Key) > 0 {
+		i -= len(m.Key)
+		copy(dAtA[i:], m.Key)
+		i = encodeVarintDatabase(dAtA, i, uint64(len(m.Key)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *DatabaseAddress) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -240,32 +281,40 @@ func (m *DatabaseAddress) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *DatabaseAddress) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *DatabaseAddress) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Address) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintDatabase(dAtA, i, uint64(len(m.Address)))
-		i += copy(dAtA[i:], m.Address)
-	}
 	if m.Expires != 0 {
-		dAtA[i] = 0x10
-		i++
 		i = encodeVarintDatabase(dAtA, i, uint64(m.Expires))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if len(m.Address) > 0 {
+		i -= len(m.Address)
+		copy(dAtA[i:], m.Address)
+		i = encodeVarintDatabase(dAtA, i, uint64(len(m.Address)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintDatabase(dAtA []byte, offset int, v uint64) int {
+	offset -= sovDatabase(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *DatabaseRecord) Size() (n int) {
 	if m == nil {
@@ -330,14 +379,7 @@ func (m *DatabaseAddress) Size() (n int) {
 }
 
 func sovDatabase(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozDatabase(x uint64) (n int) {
 	return sovDatabase(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -357,7 +399,7 @@ func (m *DatabaseRecord) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -385,7 +427,7 @@ func (m *DatabaseRecord) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -394,6 +436,9 @@ func (m *DatabaseRecord) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthDatabase
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthDatabase
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -416,7 +461,7 @@ func (m *DatabaseRecord) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Misses |= (int32(b) & 0x7F) << shift
+				m.Misses |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -435,7 +480,7 @@ func (m *DatabaseRecord) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Seen |= (int64(b) & 0x7F) << shift
+				m.Seen |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -454,7 +499,7 @@ func (m *DatabaseRecord) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Missed |= (int64(b) & 0x7F) << shift
+				m.Missed |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -466,6 +511,9 @@ func (m *DatabaseRecord) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthDatabase
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthDatabase
 			}
 			if (iNdEx + skippy) > l {
@@ -495,7 +543,7 @@ func (m *ReplicationRecord) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -523,7 +571,7 @@ func (m *ReplicationRecord) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -533,6 +581,9 @@ func (m *ReplicationRecord) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthDatabase
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthDatabase
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -552,7 +603,7 @@ func (m *ReplicationRecord) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -561,6 +612,9 @@ func (m *ReplicationRecord) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthDatabase
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthDatabase
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -583,7 +637,7 @@ func (m *ReplicationRecord) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Seen |= (int64(b) & 0x7F) << shift
+				m.Seen |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -595,6 +649,9 @@ func (m *ReplicationRecord) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthDatabase
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthDatabase
 			}
 			if (iNdEx + skippy) > l {
@@ -624,7 +681,7 @@ func (m *DatabaseAddress) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -652,7 +709,7 @@ func (m *DatabaseAddress) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -662,6 +719,9 @@ func (m *DatabaseAddress) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthDatabase
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthDatabase
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -681,7 +741,7 @@ func (m *DatabaseAddress) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Expires |= (int64(b) & 0x7F) << shift
+				m.Expires |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -693,6 +753,9 @@ func (m *DatabaseAddress) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthDatabase
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthDatabase
 			}
 			if (iNdEx + skippy) > l {
@@ -761,8 +824,11 @@ func skipDatabase(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthDatabase
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthDatabase
 			}
 			return iNdEx, nil
@@ -793,6 +859,9 @@ func skipDatabase(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthDatabase
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -811,26 +880,3 @@ var (
 	ErrInvalidLengthDatabase = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowDatabase   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("database.proto", fileDescriptor_database_0f49e029703a04f5) }
-
-var fileDescriptor_database_0f49e029703a04f5 = []byte{
-	// 270 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x90, 0x41, 0x4a, 0xc4, 0x30,
-	0x18, 0x85, 0x9b, 0x49, 0x1d, 0x99, 0x08, 0xa3, 0x06, 0x94, 0x20, 0x12, 0x4b, 0xdd, 0x74, 0xd5,
-	0x01, 0x5d, 0xb9, 0x74, 0xd0, 0x0b, 0xe4, 0x06, 0xe9, 0xe4, 0x77, 0x08, 0x3a, 0x4d, 0x49, 0x2a,
-	0xe8, 0x29, 0xf4, 0x58, 0x5d, 0xce, 0xd2, 0x95, 0x68, 0x7b, 0x11, 0x69, 0x26, 0x55, 0x14, 0x37,
-	0xb3, 0x7b, 0xdf, 0xff, 0xbf, 0x97, 0xbc, 0x84, 0x4c, 0x95, 0xac, 0x65, 0x21, 0x1d, 0xe4, 0x95,
-	0x35, 0xb5, 0xa1, 0xf1, 0x4a, 0xea, 0xf2, 0xe4, 0xdc, 0x42, 0x65, 0xdc, 0xcc, 0x8f, 0x8a, 0xc7,
-	0xbb, 0xd9, 0xd2, 0x2c, 0x8d, 0x07, 0xaf, 0x36, 0xd6, 0xf4, 0x05, 0x91, 0xe9, 0x4d, 0x48, 0x0b,
-	0x58, 0x18, 0xab, 0xe8, 0x15, 0x99, 0x48, 0xa5, 0x2c, 0x38, 0x07, 0x8e, 0xa1, 0x04, 0x67, 0x7b,
-	0x17, 0x47, 0x79, 0x7f, 0x62, 0x3e, 0x18, 0xaf, 0x37, 0xeb, 0x79, 0xdc, 0xbc, 0x9f, 0x45, 0xe2,
-	0xc7, 0x4d, 0x8f, 0xc9, 0x78, 0xa5, 0x7d, 0x6e, 0x94, 0xa0, 0x6c, 0x47, 0x04, 0xa2, 0x94, 0xc4,
-	0x0e, 0xa0, 0x64, 0x38, 0x41, 0x19, 0x16, 0x5e, 0x7f, 0x7b, 0x15, 0x8b, 0xfd, 0x34, 0x50, 0x5a,
-	0x93, 0x43, 0x01, 0xd5, 0x83, 0x5e, 0xc8, 0x5a, 0x9b, 0x32, 0x74, 0x3a, 0x20, 0xf8, 0x1e, 0x9e,
-	0x19, 0x4a, 0x50, 0x36, 0x11, 0xbd, 0xfc, 0xdd, 0x72, 0xb4, 0x55, 0xcb, 0x7f, 0xda, 0xa4, 0xb7,
-	0x64, 0xff, 0x4f, 0x8e, 0x32, 0xb2, 0x1b, 0x32, 0xe1, 0xde, 0x01, 0xfb, 0x0d, 0x3c, 0x55, 0xda,
-	0x86, 0x77, 0x62, 0x31, 0xe0, 0xfc, 0xb4, 0xf9, 0xe4, 0x51, 0xd3, 0x72, 0xb4, 0x6e, 0x39, 0xfa,
-	0x68, 0x39, 0x7a, 0xed, 0x78, 0xb4, 0xee, 0x78, 0xf4, 0xd6, 0xf1, 0xa8, 0x18, 0xfb, 0x3f, 0xbf,
-	0xfc, 0x0a, 0x00, 0x00, 0xff, 0xff, 0x7a, 0xa2, 0xf6, 0x1e, 0xb0, 0x01, 0x00, 0x00,
-}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/getsentry/raven-go v0.2.0
 	github.com/gobwas/glob v0.0.0-20170212200151-51eb1ee00b6d
-	github.com/gogo/protobuf v1.2.1
+	github.com/gogo/protobuf v1.3.0
 	github.com/golang/groupcache v0.0.0-20171101203131-84a468cf14b4
 	github.com/golang/mock v1.3.1 // indirect
 	github.com/golang/protobuf v1.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/gobwas/glob v0.0.0-20170212200151-51eb1ee00b6d/go.mod h1:d3Ez4x06l9bZ
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
+github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/groupcache v0.0.0-20171101203131-84a468cf14b4 h1:6o8aP0LGMKzo3NzwhhX6EJsiJ3ejmj+9yA/3p8Fjjlw=
 github.com/golang/groupcache v0.0.0-20171101203131-84a468cf14b4/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
@@ -70,6 +72,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/kballard/go-shellquote v0.0.0-20170619183022-cd60e84ee657 h1:vE7J1m7cCpiRVEIr1B5ccDxRpbPsWT5JU3if2Di5nE4=
 github.com/kballard/go-shellquote v0.0.0-20170619183022-cd60e84ee657/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
@@ -200,6 +203,7 @@ golang.org/x/time v0.0.0-20170927054726-6dc17368e09b h1:3X+R0qq1+64izd8es+EttB6q
 golang.org/x/time v0.0.0-20170927054726-6dc17368e09b/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 google.golang.org/genproto v0.0.0-20180831171423-11092d34479b/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/lib/db/structs.pb.go
+++ b/lib/db/structs.pb.go
@@ -3,15 +3,16 @@
 
 package db
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-import protocol "github.com/syncthing/syncthing/lib/protocol"
-
-import github_com_syncthing_syncthing_lib_protocol "github.com/syncthing/syncthing/lib/protocol"
-
-import io "io"
+import (
+	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_syncthing_syncthing_lib_protocol "github.com/syncthing/syncthing/lib/protocol"
+	protocol "github.com/syncthing/syncthing/lib/protocol"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -22,7 +23,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type FileVersion struct {
 	Version protocol.Vector `protobuf:"bytes,1,opt,name=version,proto3" json:"version"`
@@ -34,7 +35,7 @@ func (m *FileVersion) Reset()         { *m = FileVersion{} }
 func (m *FileVersion) String() string { return proto.CompactTextString(m) }
 func (*FileVersion) ProtoMessage()    {}
 func (*FileVersion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structs_6691fa5e0cf0de4d, []int{0}
+	return fileDescriptor_e774e8f5f348d14d, []int{0}
 }
 func (m *FileVersion) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -44,15 +45,15 @@ func (m *FileVersion) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_FileVersion.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *FileVersion) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileVersion.Merge(dst, src)
+func (m *FileVersion) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FileVersion.Merge(m, src)
 }
 func (m *FileVersion) XXX_Size() int {
 	return m.ProtoSize()
@@ -70,7 +71,7 @@ type VersionList struct {
 func (m *VersionList) Reset()      { *m = VersionList{} }
 func (*VersionList) ProtoMessage() {}
 func (*VersionList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structs_6691fa5e0cf0de4d, []int{1}
+	return fileDescriptor_e774e8f5f348d14d, []int{1}
 }
 func (m *VersionList) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -80,15 +81,15 @@ func (m *VersionList) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_VersionList.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *VersionList) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VersionList.Merge(dst, src)
+func (m *VersionList) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_VersionList.Merge(m, src)
 }
 func (m *VersionList) XXX_Size() int {
 	return m.ProtoSize()
@@ -123,7 +124,7 @@ type FileInfoTruncated struct {
 func (m *FileInfoTruncated) Reset()      { *m = FileInfoTruncated{} }
 func (*FileInfoTruncated) ProtoMessage() {}
 func (*FileInfoTruncated) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structs_6691fa5e0cf0de4d, []int{2}
+	return fileDescriptor_e774e8f5f348d14d, []int{2}
 }
 func (m *FileInfoTruncated) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -133,15 +134,15 @@ func (m *FileInfoTruncated) XXX_Marshal(b []byte, deterministic bool) ([]byte, e
 		return xxx_messageInfo_FileInfoTruncated.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *FileInfoTruncated) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileInfoTruncated.Merge(dst, src)
+func (m *FileInfoTruncated) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FileInfoTruncated.Merge(m, src)
 }
 func (m *FileInfoTruncated) XXX_Size() int {
 	return m.ProtoSize()
@@ -169,7 +170,7 @@ func (m *Counts) Reset()         { *m = Counts{} }
 func (m *Counts) String() string { return proto.CompactTextString(m) }
 func (*Counts) ProtoMessage()    {}
 func (*Counts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structs_6691fa5e0cf0de4d, []int{3}
+	return fileDescriptor_e774e8f5f348d14d, []int{3}
 }
 func (m *Counts) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -179,15 +180,15 @@ func (m *Counts) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Counts.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Counts) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Counts.Merge(dst, src)
+func (m *Counts) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Counts.Merge(m, src)
 }
 func (m *Counts) XXX_Size() int {
 	return m.ProtoSize()
@@ -207,7 +208,7 @@ func (m *CountsSet) Reset()         { *m = CountsSet{} }
 func (m *CountsSet) String() string { return proto.CompactTextString(m) }
 func (*CountsSet) ProtoMessage()    {}
 func (*CountsSet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_structs_6691fa5e0cf0de4d, []int{4}
+	return fileDescriptor_e774e8f5f348d14d, []int{4}
 }
 func (m *CountsSet) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -217,15 +218,15 @@ func (m *CountsSet) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_CountsSet.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *CountsSet) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CountsSet.Merge(dst, src)
+func (m *CountsSet) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_CountsSet.Merge(m, src)
 }
 func (m *CountsSet) XXX_Size() int {
 	return m.ProtoSize()
@@ -243,10 +244,60 @@ func init() {
 	proto.RegisterType((*Counts)(nil), "db.Counts")
 	proto.RegisterType((*CountsSet)(nil), "db.CountsSet")
 }
+
+func init() { proto.RegisterFile("structs.proto", fileDescriptor_e774e8f5f348d14d) }
+
+var fileDescriptor_e774e8f5f348d14d = []byte{
+	// 683 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0x4f, 0x6b, 0xdb, 0x4e,
+	0x10, 0xb5, 0x62, 0xf9, 0xdf, 0xd8, 0xce, 0x2f, 0x59, 0x42, 0x10, 0x86, 0x9f, 0x2c, 0x5c, 0x0a,
+	0xa2, 0x07, 0xbb, 0x4d, 0x6e, 0xed, 0xcd, 0x0d, 0x01, 0x43, 0x69, 0xcb, 0x3a, 0xe4, 0x54, 0x30,
+	0xfa, 0xb3, 0x76, 0x96, 0xc8, 0x5a, 0x47, 0xbb, 0x4e, 0x70, 0x3e, 0x45, 0x8f, 0x3d, 0xe6, 0xe3,
+	0xe4, 0x98, 0x63, 0xe9, 0xc1, 0xa4, 0x76, 0x0f, 0xfd, 0x18, 0x65, 0x77, 0x25, 0x45, 0xcd, 0xa9,
+	0xb7, 0x79, 0x6f, 0x66, 0x77, 0x67, 0xe6, 0xbd, 0x85, 0x36, 0x17, 0xc9, 0x32, 0x10, 0xbc, 0xbf,
+	0x48, 0x98, 0x60, 0x68, 0x27, 0xf4, 0x3b, 0x2f, 0x12, 0xb2, 0x60, 0x7c, 0xa0, 0x08, 0x7f, 0x39,
+	0x1d, 0xcc, 0xd8, 0x8c, 0x29, 0xa0, 0x22, 0x5d, 0xd8, 0x39, 0x8c, 0xa8, 0xaf, 0x4b, 0x02, 0x16,
+	0x0d, 0x7c, 0xb2, 0xd0, 0x7c, 0xef, 0x0a, 0x9a, 0xa7, 0x34, 0x22, 0xe7, 0x24, 0xe1, 0x94, 0xc5,
+	0xe8, 0x35, 0xd4, 0xae, 0x75, 0x68, 0x19, 0x8e, 0xe1, 0x36, 0x8f, 0xf6, 0xfa, 0xd9, 0xa1, 0xfe,
+	0x39, 0x09, 0x04, 0x4b, 0x86, 0xe6, 0xfd, 0xba, 0x5b, 0xc2, 0x59, 0x19, 0x3a, 0x84, 0x6a, 0x48,
+	0xae, 0x69, 0x40, 0xac, 0x1d, 0xc7, 0x70, 0x5b, 0x38, 0x45, 0xc8, 0x82, 0x1a, 0x8d, 0xaf, 0xbd,
+	0x88, 0x86, 0x56, 0xd9, 0x31, 0xdc, 0x3a, 0xce, 0x60, 0xef, 0x14, 0x9a, 0xe9, 0x73, 0x1f, 0x28,
+	0x17, 0xe8, 0x0d, 0xd4, 0xd3, 0xbb, 0xb8, 0x65, 0x38, 0x65, 0xb7, 0x79, 0xf4, 0x5f, 0x3f, 0xf4,
+	0xfb, 0x85, 0xae, 0xd2, 0x27, 0xf3, 0xb2, 0xb7, 0xe6, 0xb7, 0xbb, 0x6e, 0xa9, 0xf7, 0x68, 0xc2,
+	0xbe, 0xac, 0x1a, 0xc5, 0x53, 0x76, 0x96, 0x2c, 0xe3, 0xc0, 0x13, 0x24, 0x44, 0x08, 0xcc, 0xd8,
+	0x9b, 0x13, 0xd5, 0x7e, 0x03, 0xab, 0x18, 0xbd, 0x02, 0x53, 0xac, 0x16, 0xba, 0xc3, 0xdd, 0xa3,
+	0xc3, 0xa7, 0x91, 0xf2, 0xe3, 0xab, 0x05, 0xc1, 0xaa, 0x46, 0x9e, 0xe7, 0xf4, 0x96, 0xa8, 0xa6,
+	0xcb, 0x58, 0xc5, 0xc8, 0x81, 0xe6, 0x82, 0x24, 0x73, 0xca, 0x75, 0x97, 0xa6, 0x63, 0xb8, 0x6d,
+	0x5c, 0xa4, 0xd0, 0xff, 0x00, 0x73, 0x16, 0xd2, 0x29, 0x25, 0xe1, 0x84, 0x5b, 0x15, 0x75, 0xb6,
+	0x91, 0x31, 0x63, 0xd4, 0x85, 0x66, 0x9e, 0x8e, 0xb9, 0xd5, 0x74, 0x0c, 0xb7, 0x82, 0xf3, 0x13,
+	0x1f, 0x39, 0xfa, 0x52, 0x28, 0xf0, 0x57, 0x56, 0xcb, 0x31, 0x5c, 0x73, 0xf8, 0x4e, 0x8e, 0xfd,
+	0x63, 0xdd, 0x3d, 0x9e, 0x51, 0x71, 0xb1, 0xf4, 0xfb, 0x01, 0x9b, 0x0f, 0xf8, 0x2a, 0x0e, 0xc4,
+	0x05, 0x8d, 0x67, 0x85, 0xa8, 0x28, 0x6d, 0x7f, 0x7c, 0xc1, 0x12, 0x31, 0x3a, 0x79, 0xba, 0x7d,
+	0xb8, 0x92, 0x5a, 0x84, 0x24, 0x22, 0x82, 0x84, 0x56, 0x55, 0x6b, 0x91, 0x42, 0xe4, 0x3e, 0xa9,
+	0x54, 0x93, 0x99, 0xe1, 0xee, 0x66, 0xdd, 0x05, 0xec, 0xdd, 0x8c, 0x34, 0x9b, 0xab, 0x86, 0x5e,
+	0xc2, 0x6e, 0xcc, 0x26, 0xc5, 0x35, 0xd4, 0xd5, 0x55, 0xed, 0x98, 0x7d, 0x2e, 0x2c, 0xa2, 0x60,
+	0xa0, 0xc6, 0xbf, 0x19, 0xa8, 0x03, 0x75, 0x4e, 0xae, 0x96, 0x24, 0x0e, 0x88, 0x05, 0x6a, 0x71,
+	0x39, 0x46, 0x03, 0x00, 0x3f, 0x62, 0xc1, 0xe5, 0x44, 0x49, 0xd2, 0x96, 0x6b, 0x1b, 0xee, 0x6d,
+	0xd6, 0xdd, 0x16, 0xf6, 0x6e, 0x86, 0x32, 0x31, 0xa6, 0xb7, 0x04, 0x37, 0xfc, 0x2c, 0x94, 0x5d,
+	0xf2, 0xd5, 0x3c, 0xa2, 0xf1, 0xe5, 0x44, 0x78, 0xc9, 0x8c, 0x08, 0x6b, 0x5f, 0xf9, 0xa0, 0x9d,
+	0xb2, 0x67, 0x8a, 0x94, 0x82, 0x46, 0x2c, 0xf0, 0xa2, 0xc9, 0x34, 0xf2, 0x66, 0xdc, 0xfa, 0x5d,
+	0x53, 0x8a, 0x82, 0xe2, 0x4e, 0x25, 0x95, 0x5a, 0xec, 0x97, 0x01, 0xd5, 0xf7, 0x6c, 0x19, 0x0b,
+	0x8e, 0x0e, 0xa0, 0x32, 0xa5, 0x11, 0xe1, 0xca, 0x58, 0x15, 0xac, 0x81, 0xbc, 0x28, 0xa4, 0x89,
+	0x9a, 0x8b, 0x12, 0xae, 0x0c, 0x56, 0xc1, 0x45, 0x4a, 0x8d, 0xa7, 0xdf, 0xe6, 0xca, 0x53, 0x15,
+	0x9c, 0xe3, 0xa2, 0x2e, 0xa6, 0x4a, 0xe5, 0xba, 0x1c, 0x40, 0xc5, 0x5f, 0x09, 0x92, 0x59, 0x49,
+	0x83, 0xbf, 0x56, 0x55, 0x7d, 0xb6, 0xaa, 0x0e, 0xd4, 0xf5, 0xcf, 0x1b, 0x9d, 0xa8, 0x99, 0x5b,
+	0x38, 0xc7, 0xc8, 0x86, 0xc2, 0x68, 0x16, 0x7a, 0x3e, 0x6c, 0xef, 0x13, 0x34, 0xf4, 0x94, 0x63,
+	0x22, 0x90, 0x0b, 0xd5, 0x40, 0x81, 0xf4, 0x37, 0x82, 0xfc, 0x8d, 0x3a, 0x9d, 0x4a, 0x97, 0xe6,
+	0x65, 0xfb, 0x41, 0x42, 0xe4, 0xaf, 0x53, 0x83, 0x97, 0x71, 0x06, 0x87, 0xce, 0xfd, 0x4f, 0xbb,
+	0x74, 0xbf, 0xb1, 0x8d, 0x87, 0x8d, 0x6d, 0x3c, 0x6e, 0xec, 0xd2, 0xd7, 0xad, 0x5d, 0xba, 0xdb,
+	0xda, 0xc6, 0xc3, 0xd6, 0x2e, 0x7d, 0xdf, 0xda, 0x25, 0xbf, 0xaa, 0x5c, 0x71, 0xfc, 0x27, 0x00,
+	0x00, 0xff, 0xff, 0x38, 0xe1, 0x29, 0xbf, 0xd0, 0x04, 0x00, 0x00,
+}
+
 func (m *FileVersion) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -254,41 +305,49 @@ func (m *FileVersion) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *FileVersion) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *FileVersion) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintStructs(dAtA, i, uint64(m.Version.ProtoSize()))
-	n1, err := m.Version.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if len(m.Device) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(len(m.Device)))
-		i += copy(dAtA[i:], m.Device)
-	}
 	if m.Invalid {
-		dAtA[i] = 0x18
-		i++
+		i--
 		if m.Invalid {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x18
 	}
-	return i, nil
+	if len(m.Device) > 0 {
+		i -= len(m.Device)
+		copy(dAtA[i:], m.Device)
+		i = encodeVarintStructs(dAtA, i, uint64(len(m.Device)))
+		i--
+		dAtA[i] = 0x12
+	}
+	{
+		size, err := m.Version.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintStructs(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func (m *VersionList) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -296,29 +355,36 @@ func (m *VersionList) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *VersionList) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *VersionList) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if len(m.Versions) > 0 {
-		for _, msg := range m.Versions {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintStructs(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Versions) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Versions[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintStructs(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *FileInfoTruncated) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -326,116 +392,125 @@ func (m *FileInfoTruncated) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *FileInfoTruncated) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *FileInfoTruncated) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
+	if m.LocalFlags != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.LocalFlags))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xc0
 	}
-	if m.Type != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Type))
+	if len(m.SymlinkTarget) > 0 {
+		i -= len(m.SymlinkTarget)
+		copy(dAtA[i:], m.SymlinkTarget)
+		i = encodeVarintStructs(dAtA, i, uint64(len(m.SymlinkTarget)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
 	}
-	if m.Size != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Size))
+	if m.RawBlockSize != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.RawBlockSize))
+		i--
+		dAtA[i] = 0x68
 	}
-	if m.Permissions != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Permissions))
+	if m.ModifiedBy != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.ModifiedBy))
+		i--
+		dAtA[i] = 0x60
 	}
-	if m.ModifiedS != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.ModifiedS))
+	if m.ModifiedNs != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.ModifiedNs))
+		i--
+		dAtA[i] = 0x58
 	}
-	if m.Deleted {
-		dAtA[i] = 0x30
-		i++
-		if m.Deleted {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
+	if m.Sequence != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Sequence))
+		i--
+		dAtA[i] = 0x50
+	}
+	{
+		size, err := m.Version.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
 		}
-		i++
+		i -= size
+		i = encodeVarintStructs(dAtA, i, uint64(size))
 	}
-	if m.RawInvalid {
-		dAtA[i] = 0x38
-		i++
-		if m.RawInvalid {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
+	i--
+	dAtA[i] = 0x4a
 	if m.NoPermissions {
-		dAtA[i] = 0x40
-		i++
+		i--
 		if m.NoPermissions {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x40
 	}
-	dAtA[i] = 0x4a
-	i++
-	i = encodeVarintStructs(dAtA, i, uint64(m.Version.ProtoSize()))
-	n2, err := m.Version.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.RawInvalid {
+		i--
+		if m.RawInvalid {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
 	}
-	i += n2
-	if m.Sequence != 0 {
-		dAtA[i] = 0x50
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Sequence))
+	if m.Deleted {
+		i--
+		if m.Deleted {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
 	}
-	if m.ModifiedNs != 0 {
-		dAtA[i] = 0x58
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.ModifiedNs))
+	if m.ModifiedS != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.ModifiedS))
+		i--
+		dAtA[i] = 0x28
 	}
-	if m.ModifiedBy != 0 {
-		dAtA[i] = 0x60
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.ModifiedBy))
+	if m.Permissions != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Permissions))
+		i--
+		dAtA[i] = 0x20
 	}
-	if m.RawBlockSize != 0 {
-		dAtA[i] = 0x68
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.RawBlockSize))
+	if m.Size != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Size))
+		i--
+		dAtA[i] = 0x18
 	}
-	if len(m.SymlinkTarget) > 0 {
-		dAtA[i] = 0x8a
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(len(m.SymlinkTarget)))
-		i += copy(dAtA[i:], m.SymlinkTarget)
+	if m.Type != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x10
 	}
-	if m.LocalFlags != 0 {
-		dAtA[i] = 0xc0
-		i++
-		dAtA[i] = 0x3e
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.LocalFlags))
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintStructs(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Counts) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -443,62 +518,68 @@ func (m *Counts) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Counts) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Counts) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Files != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Files))
-	}
-	if m.Directories != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Directories))
-	}
-	if m.Symlinks != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Symlinks))
-	}
-	if m.Deleted != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Deleted))
-	}
-	if m.Bytes != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Bytes))
-	}
-	if m.Sequence != 0 {
-		dAtA[i] = 0x30
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Sequence))
+	if m.LocalFlags != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.LocalFlags))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x90
 	}
 	if len(m.DeviceID) > 0 {
-		dAtA[i] = 0x8a
-		i++
-		dAtA[i] = 0x1
-		i++
+		i -= len(m.DeviceID)
+		copy(dAtA[i:], m.DeviceID)
 		i = encodeVarintStructs(dAtA, i, uint64(len(m.DeviceID)))
-		i += copy(dAtA[i:], m.DeviceID)
-	}
-	if m.LocalFlags != 0 {
-		dAtA[i] = 0x90
-		i++
+		i--
 		dAtA[i] = 0x1
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.LocalFlags))
+		i--
+		dAtA[i] = 0x8a
 	}
-	return i, nil
+	if m.Sequence != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Sequence))
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.Bytes != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Bytes))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.Deleted != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Deleted))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Symlinks != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Symlinks))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Directories != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Directories))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Files != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Files))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *CountsSet) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -506,38 +587,47 @@ func (m *CountsSet) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *CountsSet) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *CountsSet) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if m.Created != 0 {
+		i = encodeVarintStructs(dAtA, i, uint64(m.Created))
+		i--
+		dAtA[i] = 0x10
+	}
 	if len(m.Counts) > 0 {
-		for _, msg := range m.Counts {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintStructs(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Counts) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Counts[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintStructs(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	if m.Created != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintStructs(dAtA, i, uint64(m.Created))
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintStructs(dAtA []byte, offset int, v uint64) int {
+	offset -= sovStructs(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *FileVersion) ProtoSize() (n int) {
 	if m == nil {
@@ -680,14 +770,7 @@ func (m *CountsSet) ProtoSize() (n int) {
 }
 
 func sovStructs(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozStructs(x uint64) (n int) {
 	return sovStructs(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -707,7 +790,7 @@ func (m *FileVersion) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -735,7 +818,7 @@ func (m *FileVersion) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -744,6 +827,9 @@ func (m *FileVersion) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -765,7 +851,7 @@ func (m *FileVersion) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -774,6 +860,9 @@ func (m *FileVersion) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -796,7 +885,7 @@ func (m *FileVersion) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -809,6 +898,9 @@ func (m *FileVersion) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthStructs
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthStructs
 			}
 			if (iNdEx + skippy) > l {
@@ -838,7 +930,7 @@ func (m *VersionList) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -866,7 +958,7 @@ func (m *VersionList) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -875,6 +967,9 @@ func (m *VersionList) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -890,6 +985,9 @@ func (m *VersionList) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthStructs
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthStructs
 			}
 			if (iNdEx + skippy) > l {
@@ -919,7 +1017,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -947,7 +1045,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -957,6 +1055,9 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -976,7 +1077,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Type |= (protocol.FileInfoType(b) & 0x7F) << shift
+				m.Type |= protocol.FileInfoType(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -995,7 +1096,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Size |= (int64(b) & 0x7F) << shift
+				m.Size |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1014,7 +1115,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Permissions |= (uint32(b) & 0x7F) << shift
+				m.Permissions |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1033,7 +1134,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ModifiedS |= (int64(b) & 0x7F) << shift
+				m.ModifiedS |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1052,7 +1153,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1072,7 +1173,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1092,7 +1193,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1112,7 +1213,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1121,6 +1222,9 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1142,7 +1246,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Sequence |= (int64(b) & 0x7F) << shift
+				m.Sequence |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1161,7 +1265,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ModifiedNs |= (int32(b) & 0x7F) << shift
+				m.ModifiedNs |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1180,7 +1284,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ModifiedBy |= (github_com_syncthing_syncthing_lib_protocol.ShortID(b) & 0x7F) << shift
+				m.ModifiedBy |= github_com_syncthing_syncthing_lib_protocol.ShortID(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1199,7 +1303,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.RawBlockSize |= (int32(b) & 0x7F) << shift
+				m.RawBlockSize |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1218,7 +1322,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1228,6 +1332,9 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1247,7 +1354,7 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.LocalFlags |= (uint32(b) & 0x7F) << shift
+				m.LocalFlags |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1259,6 +1366,9 @@ func (m *FileInfoTruncated) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthStructs
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthStructs
 			}
 			if (iNdEx + skippy) > l {
@@ -1288,7 +1398,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1316,7 +1426,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Files |= (int32(b) & 0x7F) << shift
+				m.Files |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1335,7 +1445,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Directories |= (int32(b) & 0x7F) << shift
+				m.Directories |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1354,7 +1464,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Symlinks |= (int32(b) & 0x7F) << shift
+				m.Symlinks |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1373,7 +1483,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Deleted |= (int32(b) & 0x7F) << shift
+				m.Deleted |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1392,7 +1502,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Bytes |= (int64(b) & 0x7F) << shift
+				m.Bytes |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1411,7 +1521,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Sequence |= (int64(b) & 0x7F) << shift
+				m.Sequence |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1430,7 +1540,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1439,6 +1549,9 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1461,7 +1574,7 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.LocalFlags |= (uint32(b) & 0x7F) << shift
+				m.LocalFlags |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1473,6 +1586,9 @@ func (m *Counts) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthStructs
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthStructs
 			}
 			if (iNdEx + skippy) > l {
@@ -1502,7 +1618,7 @@ func (m *CountsSet) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1530,7 +1646,7 @@ func (m *CountsSet) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1539,6 +1655,9 @@ func (m *CountsSet) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthStructs
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthStructs
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1561,7 +1680,7 @@ func (m *CountsSet) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Created |= (int64(b) & 0x7F) << shift
+				m.Created |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1573,6 +1692,9 @@ func (m *CountsSet) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthStructs
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthStructs
 			}
 			if (iNdEx + skippy) > l {
@@ -1641,8 +1763,11 @@ func skipStructs(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthStructs
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthStructs
 			}
 			return iNdEx, nil
@@ -1673,6 +1798,9 @@ func skipStructs(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthStructs
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -1691,52 +1819,3 @@ var (
 	ErrInvalidLengthStructs = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowStructs   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("structs.proto", fileDescriptor_structs_6691fa5e0cf0de4d) }
-
-var fileDescriptor_structs_6691fa5e0cf0de4d = []byte{
-	// 684 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x53, 0x4f, 0x6b, 0xdb, 0x4e,
-	0x10, 0xb5, 0x62, 0xf9, 0xdf, 0xd8, 0xce, 0x2f, 0x59, 0x42, 0x10, 0x86, 0x9f, 0x2c, 0x5c, 0x0a,
-	0xa2, 0x07, 0xbb, 0x4d, 0x6e, 0xed, 0xcd, 0x0d, 0x01, 0x43, 0x69, 0xcb, 0x3a, 0xe4, 0x54, 0x30,
-	0xfa, 0xb3, 0x76, 0x96, 0xc8, 0x5a, 0x47, 0xbb, 0x4e, 0x70, 0x3e, 0x45, 0x8f, 0x3d, 0xe6, 0xe3,
-	0xe4, 0x98, 0x63, 0xe9, 0xc1, 0xa4, 0x76, 0x0f, 0xfd, 0x18, 0x65, 0x77, 0x25, 0x45, 0xcd, 0xa9,
-	0xb7, 0x79, 0x6f, 0x67, 0x77, 0xde, 0xcc, 0xbc, 0x85, 0x36, 0x17, 0xc9, 0x32, 0x10, 0xbc, 0xbf,
-	0x48, 0x98, 0x60, 0x68, 0x27, 0xf4, 0x3b, 0x2f, 0x12, 0xb2, 0x60, 0x7c, 0xa0, 0x08, 0x7f, 0x39,
-	0x1d, 0xcc, 0xd8, 0x8c, 0x29, 0xa0, 0x22, 0x9d, 0xd8, 0x39, 0x8c, 0xa8, 0xaf, 0x53, 0x02, 0x16,
-	0x0d, 0x7c, 0xb2, 0xd0, 0x7c, 0xef, 0x0a, 0x9a, 0xa7, 0x34, 0x22, 0xe7, 0x24, 0xe1, 0x94, 0xc5,
-	0xe8, 0x35, 0xd4, 0xae, 0x75, 0x68, 0x19, 0x8e, 0xe1, 0x36, 0x8f, 0xf6, 0xfa, 0xd9, 0xa5, 0xfe,
-	0x39, 0x09, 0x04, 0x4b, 0x86, 0xe6, 0xfd, 0xba, 0x5b, 0xc2, 0x59, 0x1a, 0x3a, 0x84, 0x6a, 0x48,
-	0xae, 0x69, 0x40, 0xac, 0x1d, 0xc7, 0x70, 0x5b, 0x38, 0x45, 0xc8, 0x82, 0x1a, 0x8d, 0xaf, 0xbd,
-	0x88, 0x86, 0x56, 0xd9, 0x31, 0xdc, 0x3a, 0xce, 0x60, 0xef, 0x14, 0x9a, 0x69, 0xb9, 0x0f, 0x94,
-	0x0b, 0xf4, 0x06, 0xea, 0xe9, 0x5b, 0xdc, 0x32, 0x9c, 0xb2, 0xdb, 0x3c, 0xfa, 0xaf, 0x1f, 0xfa,
-	0xfd, 0x82, 0xaa, 0xb4, 0x64, 0x9e, 0xf6, 0xd6, 0xfc, 0x76, 0xd7, 0x2d, 0xf5, 0x1e, 0x4d, 0xd8,
-	0x97, 0x59, 0xa3, 0x78, 0xca, 0xce, 0x92, 0x65, 0x1c, 0x78, 0x82, 0x84, 0x08, 0x81, 0x19, 0x7b,
-	0x73, 0xa2, 0xe4, 0x37, 0xb0, 0x8a, 0xd1, 0x2b, 0x30, 0xc5, 0x6a, 0xa1, 0x15, 0xee, 0x1e, 0x1d,
-	0x3e, 0xb5, 0x94, 0x5f, 0x5f, 0x2d, 0x08, 0x56, 0x39, 0xf2, 0x3e, 0xa7, 0xb7, 0x44, 0x89, 0x2e,
-	0x63, 0x15, 0x23, 0x07, 0x9a, 0x0b, 0x92, 0xcc, 0x29, 0xd7, 0x2a, 0x4d, 0xc7, 0x70, 0xdb, 0xb8,
-	0x48, 0xa1, 0xff, 0x01, 0xe6, 0x2c, 0xa4, 0x53, 0x4a, 0xc2, 0x09, 0xb7, 0x2a, 0xea, 0x6e, 0x23,
-	0x63, 0xc6, 0x72, 0x18, 0x21, 0x89, 0x88, 0x20, 0xa1, 0x55, 0xd5, 0xc3, 0x48, 0x21, 0x72, 0x9f,
-	0xc6, 0x54, 0x93, 0x27, 0xc3, 0xdd, 0xcd, 0xba, 0x0b, 0xd8, 0xbb, 0x19, 0x69, 0x36, 0x1f, 0x1b,
-	0x7a, 0x09, 0xbb, 0x31, 0x9b, 0x14, 0x75, 0xd4, 0xd5, 0x53, 0xed, 0x98, 0x7d, 0x2e, 0x28, 0x29,
-	0x6c, 0xb0, 0xf1, 0x6f, 0x1b, 0xec, 0x40, 0x9d, 0x93, 0xab, 0x25, 0x89, 0x03, 0x62, 0x81, 0x52,
-	0x9e, 0x63, 0xd4, 0x85, 0x66, 0xde, 0x57, 0xcc, 0xad, 0xa6, 0x63, 0xb8, 0x15, 0x9c, 0xb7, 0xfa,
-	0x91, 0xa3, 0x2f, 0x85, 0x04, 0x7f, 0x65, 0xb5, 0x1c, 0xc3, 0x35, 0x87, 0xef, 0x64, 0x81, 0x1f,
-	0xeb, 0xee, 0xf1, 0x8c, 0x8a, 0x8b, 0xa5, 0xdf, 0x0f, 0xd8, 0x7c, 0xc0, 0x57, 0x71, 0x20, 0x2e,
-	0x68, 0x3c, 0x2b, 0x44, 0x45, 0x4f, 0xf6, 0xc7, 0x17, 0x2c, 0x11, 0xa3, 0x93, 0xa7, 0xd7, 0x87,
-	0x2b, 0x34, 0x00, 0xf0, 0x23, 0x16, 0x5c, 0x4e, 0xd4, 0x4a, 0xda, 0xb2, 0xfa, 0x70, 0x6f, 0xb3,
-	0xee, 0xb6, 0xb0, 0x77, 0x33, 0x94, 0x07, 0x63, 0x7a, 0x4b, 0x70, 0xc3, 0xcf, 0x42, 0x39, 0x24,
-	0xbe, 0x9a, 0x47, 0x34, 0xbe, 0x9c, 0x08, 0x2f, 0x99, 0x11, 0x61, 0xed, 0x2b, 0x1f, 0xb4, 0x53,
-	0xf6, 0x4c, 0x91, 0x72, 0xa1, 0x11, 0x0b, 0xbc, 0x68, 0x32, 0x8d, 0xbc, 0x19, 0xb7, 0x7e, 0xd7,
-	0xd4, 0x46, 0x41, 0x71, 0xa7, 0x92, 0x4a, 0x2d, 0xf6, 0xcb, 0x80, 0xea, 0x7b, 0xb6, 0x8c, 0x05,
-	0x47, 0x07, 0x50, 0x99, 0xd2, 0x88, 0x70, 0x65, 0xac, 0x0a, 0xd6, 0x40, 0x3e, 0x14, 0xd2, 0x44,
-	0x8d, 0x95, 0x12, 0xae, 0x0c, 0x56, 0xc1, 0x45, 0x4a, 0x4d, 0x57, 0xd7, 0xe6, 0xca, 0x53, 0x15,
-	0x9c, 0xe3, 0xa2, 0x2d, 0x4c, 0x75, 0x94, 0xdb, 0xe2, 0x00, 0x2a, 0xfe, 0x4a, 0x90, 0xcc, 0x4a,
-	0x1a, 0xfc, 0xb5, 0xa9, 0xea, 0xb3, 0x4d, 0x75, 0xa0, 0xae, 0x7f, 0xde, 0xe8, 0x44, 0xf5, 0xdc,
-	0xc2, 0x39, 0x46, 0x36, 0x14, 0x5a, 0xb3, 0xd0, 0xf3, 0x66, 0x7b, 0x9f, 0xa0, 0xa1, 0xbb, 0x1c,
-	0x13, 0x81, 0x5c, 0xa8, 0x06, 0x0a, 0xa4, 0xbf, 0x11, 0xe4, 0x6f, 0xd4, 0xc7, 0xa9, 0x73, 0xd2,
-	0x73, 0x29, 0x3f, 0x48, 0x88, 0xfc, 0x75, 0xaa, 0xf1, 0x32, 0xce, 0xe0, 0xd0, 0xb9, 0xff, 0x69,
-	0x97, 0xee, 0x37, 0xb6, 0xf1, 0xb0, 0xb1, 0x8d, 0xc7, 0x8d, 0x5d, 0xfa, 0xba, 0xb5, 0x4b, 0x77,
-	0x5b, 0xdb, 0x78, 0xd8, 0xda, 0xa5, 0xef, 0x5b, 0xbb, 0xe4, 0x57, 0xd5, 0xde, 0x8f, 0xff, 0x04,
-	0x00, 0x00, 0xff, 0xff, 0x26, 0xe4, 0x54, 0xca, 0xd0, 0x04, 0x00, 0x00,
-}

--- a/lib/discover/local.pb.go
+++ b/lib/discover/local.pb.go
@@ -3,14 +3,15 @@
 
 package discover
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-
-import github_com_syncthing_syncthing_lib_protocol "github.com/syncthing/syncthing/lib/protocol"
-
-import io "io"
+import (
+	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	github_com_syncthing_syncthing_lib_protocol "github.com/syncthing/syncthing/lib/protocol"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -21,7 +22,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Announce struct {
 	ID         github_com_syncthing_syncthing_lib_protocol.DeviceID `protobuf:"bytes,1,opt,name=id,proto3,customtype=github.com/syncthing/syncthing/lib/protocol.DeviceID" json:"id"`
@@ -33,7 +34,7 @@ func (m *Announce) Reset()         { *m = Announce{} }
 func (m *Announce) String() string { return proto.CompactTextString(m) }
 func (*Announce) ProtoMessage()    {}
 func (*Announce) Descriptor() ([]byte, []int) {
-	return fileDescriptor_local_652287d527eec38f, []int{0}
+	return fileDescriptor_aaf1a48d01603033, []int{0}
 }
 func (m *Announce) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -43,15 +44,15 @@ func (m *Announce) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Announce.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Announce) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Announce.Merge(dst, src)
+func (m *Announce) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Announce.Merge(m, src)
 }
 func (m *Announce) XXX_Size() int {
 	return m.ProtoSize()
@@ -65,10 +66,33 @@ var xxx_messageInfo_Announce proto.InternalMessageInfo
 func init() {
 	proto.RegisterType((*Announce)(nil), "discover.Announce")
 }
+
+func init() { proto.RegisterFile("local.proto", fileDescriptor_aaf1a48d01603033) }
+
+var fileDescriptor_aaf1a48d01603033 = []byte{
+	// 252 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x4c, 0x8e, 0x31, 0x4e, 0x84, 0x40,
+	0x14, 0x86, 0x67, 0x20, 0x31, 0xbb, 0xb3, 0xc6, 0x82, 0x8a, 0x18, 0x33, 0x10, 0x6d, 0xa8, 0xa0,
+	0xd0, 0x0b, 0x48, 0x68, 0xa6, 0xe5, 0x02, 0x06, 0x66, 0x46, 0xf6, 0x25, 0x38, 0x6f, 0xc3, 0xc0,
+	0x26, 0xde, 0xc2, 0x23, 0x78, 0x01, 0xef, 0x41, 0xb9, 0xa5, 0xb1, 0x20, 0x3a, 0x5c, 0xc4, 0x04,
+	0x34, 0xda, 0x7d, 0xef, 0xcb, 0x97, 0xbc, 0x9f, 0xed, 0x5a, 0x94, 0x55, 0x9b, 0x1e, 0x3a, 0xec,
+	0x31, 0xd8, 0x28, 0xb0, 0x12, 0x8f, 0xba, 0xbb, 0xbc, 0xe9, 0xf4, 0x01, 0x6d, 0xb6, 0xe8, 0x7a,
+	0x78, 0xcc, 0x1a, 0x6c, 0x70, 0x39, 0x16, 0x5a, 0xf3, 0xeb, 0x37, 0xca, 0x36, 0xf7, 0xc6, 0xe0,
+	0x60, 0xa4, 0x0e, 0x4a, 0xe6, 0x81, 0x0a, 0x69, 0x4c, 0x93, 0xf3, 0x3c, 0x1f, 0xa7, 0x88, 0x7c,
+	0x4c, 0xd1, 0x5d, 0x03, 0xfd, 0x7e, 0xa8, 0x53, 0x89, 0x4f, 0x99, 0x7d, 0x36, 0xb2, 0xdf, 0x83,
+	0x69, 0xfe, 0x51, 0x0b, 0xf5, 0xfa, 0x42, 0x62, 0x9b, 0x16, 0xfa, 0x08, 0x52, 0x8b, 0xc2, 0x4d,
+	0x91, 0x27, 0x8a, 0xd2, 0x03, 0x15, 0x5c, 0xb1, 0x6d, 0xa5, 0x54, 0xa7, 0xad, 0xd5, 0x36, 0xf4,
+	0x62, 0x3f, 0xd9, 0x96, 0x7f, 0x22, 0xc8, 0xd8, 0x0e, 0x8c, 0xed, 0x2b, 0x23, 0xf5, 0x03, 0xa8,
+	0xd0, 0x8f, 0x69, 0xe2, 0xe7, 0x17, 0x6e, 0x8a, 0x98, 0xf8, 0xd1, 0xa2, 0x28, 0xd9, 0x6f, 0x22,
+	0x54, 0x1e, 0x8f, 0x5f, 0x9c, 0x8c, 0x8e, 0xd3, 0x93, 0xe3, 0xf4, 0xd3, 0x71, 0xf2, 0x32, 0x73,
+	0xf2, 0x3a, 0x73, 0x7a, 0x9a, 0x39, 0x79, 0x9f, 0x39, 0xa9, 0xcf, 0x96, 0x35, 0xb7, 0xdf, 0x01,
+	0x00, 0x00, 0xff, 0xff, 0xbc, 0x46, 0xaf, 0x1d, 0x16, 0x01, 0x00, 0x00,
+}
+
 func (m *Announce) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -76,49 +100,52 @@ func (m *Announce) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Announce) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Announce) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintLocal(dAtA, i, uint64(m.ID.ProtoSize()))
-	n1, err := m.ID.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	if m.InstanceID != 0 {
+		i = encodeVarintLocal(dAtA, i, uint64(m.InstanceID))
+		i--
+		dAtA[i] = 0x18
 	}
-	i += n1
 	if len(m.Addresses) > 0 {
-		for _, s := range m.Addresses {
+		for iNdEx := len(m.Addresses) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Addresses[iNdEx])
+			copy(dAtA[i:], m.Addresses[iNdEx])
+			i = encodeVarintLocal(dAtA, i, uint64(len(m.Addresses[iNdEx])))
+			i--
 			dAtA[i] = 0x12
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
 		}
 	}
-	if m.InstanceID != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintLocal(dAtA, i, uint64(m.InstanceID))
+	{
+		size := m.ID.ProtoSize()
+		i -= size
+		if _, err := m.ID.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintLocal(dAtA, i, uint64(size))
 	}
-	return i, nil
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintLocal(dAtA []byte, offset int, v uint64) int {
+	offset -= sovLocal(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *Announce) ProtoSize() (n int) {
 	if m == nil {
@@ -141,14 +168,7 @@ func (m *Announce) ProtoSize() (n int) {
 }
 
 func sovLocal(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozLocal(x uint64) (n int) {
 	return sovLocal(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -168,7 +188,7 @@ func (m *Announce) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -196,7 +216,7 @@ func (m *Announce) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -205,6 +225,9 @@ func (m *Announce) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthLocal
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthLocal
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -226,7 +249,7 @@ func (m *Announce) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -236,6 +259,9 @@ func (m *Announce) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthLocal
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthLocal
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -255,7 +281,7 @@ func (m *Announce) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.InstanceID |= (int64(b) & 0x7F) << shift
+				m.InstanceID |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -267,6 +293,9 @@ func (m *Announce) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthLocal
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthLocal
 			}
 			if (iNdEx + skippy) > l {
@@ -335,8 +364,11 @@ func skipLocal(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthLocal
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthLocal
 			}
 			return iNdEx, nil
@@ -367,6 +399,9 @@ func skipLocal(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthLocal
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -385,25 +420,3 @@ var (
 	ErrInvalidLengthLocal = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowLocal   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("local.proto", fileDescriptor_local_652287d527eec38f) }
-
-var fileDescriptor_local_652287d527eec38f = []byte{
-	// 252 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x4c, 0x8e, 0x31, 0x4e, 0x84, 0x40,
-	0x14, 0x86, 0x67, 0x20, 0x31, 0xbb, 0xb3, 0xc6, 0x82, 0x8a, 0x18, 0x33, 0x10, 0x6d, 0xa8, 0xa0,
-	0xd0, 0x0b, 0x48, 0x68, 0xa6, 0xe5, 0x02, 0x06, 0x66, 0x46, 0xf6, 0x25, 0x38, 0x6f, 0xc3, 0xc0,
-	0x26, 0xde, 0xc2, 0x23, 0x78, 0x01, 0xef, 0x41, 0xb9, 0xa5, 0xb1, 0x20, 0x3a, 0x5c, 0xc4, 0x04,
-	0x34, 0xda, 0x7d, 0xef, 0xcb, 0x97, 0xbc, 0x9f, 0xed, 0x5a, 0x94, 0x55, 0x9b, 0x1e, 0x3a, 0xec,
-	0x31, 0xd8, 0x28, 0xb0, 0x12, 0x8f, 0xba, 0xbb, 0xbc, 0xe9, 0xf4, 0x01, 0x6d, 0xb6, 0xe8, 0x7a,
-	0x78, 0xcc, 0x1a, 0x6c, 0x70, 0x39, 0x16, 0x5a, 0xf3, 0xeb, 0x37, 0xca, 0x36, 0xf7, 0xc6, 0xe0,
-	0x60, 0xa4, 0x0e, 0x4a, 0xe6, 0x81, 0x0a, 0x69, 0x4c, 0x93, 0xf3, 0x3c, 0x1f, 0xa7, 0x88, 0x7c,
-	0x4c, 0xd1, 0x5d, 0x03, 0xfd, 0x7e, 0xa8, 0x53, 0x89, 0x4f, 0x99, 0x7d, 0x36, 0xb2, 0xdf, 0x83,
-	0x69, 0xfe, 0x51, 0x0b, 0xf5, 0xfa, 0x42, 0x62, 0x9b, 0x16, 0xfa, 0x08, 0x52, 0x8b, 0xc2, 0x4d,
-	0x91, 0x27, 0x8a, 0xd2, 0x03, 0x15, 0x5c, 0xb1, 0x6d, 0xa5, 0x54, 0xa7, 0xad, 0xd5, 0x36, 0xf4,
-	0x62, 0x3f, 0xd9, 0x96, 0x7f, 0x22, 0xc8, 0xd8, 0x0e, 0x8c, 0xed, 0x2b, 0x23, 0xf5, 0x03, 0xa8,
-	0xd0, 0x8f, 0x69, 0xe2, 0xe7, 0x17, 0x6e, 0x8a, 0x98, 0xf8, 0xd1, 0xa2, 0x28, 0xd9, 0x6f, 0x22,
-	0x54, 0x1e, 0x8f, 0x5f, 0x9c, 0x8c, 0x8e, 0xd3, 0x93, 0xe3, 0xf4, 0xd3, 0x71, 0xf2, 0x32, 0x73,
-	0xf2, 0x3a, 0x73, 0x7a, 0x9a, 0x39, 0x79, 0x9f, 0x39, 0xa9, 0xcf, 0x96, 0x35, 0xb7, 0xdf, 0x01,
-	0x00, 0x00, 0xff, 0xff, 0xbc, 0x46, 0xaf, 0x1d, 0x16, 0x01, 0x00, 0x00,
-}

--- a/lib/protocol/bep.pb.go
+++ b/lib/protocol/bep.pb.go
@@ -3,12 +3,14 @@
 
 package protocol
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-
-import io "io"
+import (
+	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -19,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type MessageType int32
 
@@ -44,6 +46,7 @@ var MessageType_name = map[int32]string{
 	6: "PING",
 	7: "CLOSE",
 }
+
 var MessageType_value = map[string]int32{
 	"CLUSTER_CONFIG":    0,
 	"INDEX":             1,
@@ -58,8 +61,9 @@ var MessageType_value = map[string]int32{
 func (x MessageType) String() string {
 	return proto.EnumName(MessageType_name, int32(x))
 }
+
 func (MessageType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{0}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{0}
 }
 
 type MessageCompression int32
@@ -73,6 +77,7 @@ var MessageCompression_name = map[int32]string{
 	0: "NONE",
 	1: "LZ4",
 }
+
 var MessageCompression_value = map[string]int32{
 	"NONE": 0,
 	"LZ4":  1,
@@ -81,8 +86,9 @@ var MessageCompression_value = map[string]int32{
 func (x MessageCompression) String() string {
 	return proto.EnumName(MessageCompression_name, int32(x))
 }
+
 func (MessageCompression) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{1}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{1}
 }
 
 type Compression int32
@@ -98,6 +104,7 @@ var Compression_name = map[int32]string{
 	1: "NEVER",
 	2: "ALWAYS",
 }
+
 var Compression_value = map[string]int32{
 	"METADATA": 0,
 	"NEVER":    1,
@@ -107,8 +114,9 @@ var Compression_value = map[string]int32{
 func (x Compression) String() string {
 	return proto.EnumName(Compression_name, int32(x))
 }
+
 func (Compression) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{2}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{2}
 }
 
 type FileInfoType int32
@@ -128,6 +136,7 @@ var FileInfoType_name = map[int32]string{
 	3: "SYMLINK_DIRECTORY",
 	4: "SYMLINK",
 }
+
 var FileInfoType_value = map[string]int32{
 	"FILE":              0,
 	"DIRECTORY":         1,
@@ -139,8 +148,9 @@ var FileInfoType_value = map[string]int32{
 func (x FileInfoType) String() string {
 	return proto.EnumName(FileInfoType_name, int32(x))
 }
+
 func (FileInfoType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{3}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{3}
 }
 
 type ErrorCode int32
@@ -158,6 +168,7 @@ var ErrorCode_name = map[int32]string{
 	2: "NO_SUCH_FILE",
 	3: "INVALID_FILE",
 }
+
 var ErrorCode_value = map[string]int32{
 	"NO_ERROR":     0,
 	"GENERIC":      1,
@@ -168,8 +179,9 @@ var ErrorCode_value = map[string]int32{
 func (x ErrorCode) String() string {
 	return proto.EnumName(ErrorCode_name, int32(x))
 }
+
 func (ErrorCode) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{4}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{4}
 }
 
 type FileDownloadProgressUpdateType int32
@@ -183,6 +195,7 @@ var FileDownloadProgressUpdateType_name = map[int32]string{
 	0: "APPEND",
 	1: "FORGET",
 }
+
 var FileDownloadProgressUpdateType_value = map[string]int32{
 	"APPEND": 0,
 	"FORGET": 1,
@@ -191,8 +204,9 @@ var FileDownloadProgressUpdateType_value = map[string]int32{
 func (x FileDownloadProgressUpdateType) String() string {
 	return proto.EnumName(FileDownloadProgressUpdateType_name, int32(x))
 }
+
 func (FileDownloadProgressUpdateType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{5}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{5}
 }
 
 type Hello struct {
@@ -205,7 +219,7 @@ func (m *Hello) Reset()         { *m = Hello{} }
 func (m *Hello) String() string { return proto.CompactTextString(m) }
 func (*Hello) ProtoMessage()    {}
 func (*Hello) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{0}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{0}
 }
 func (m *Hello) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -215,15 +229,15 @@ func (m *Hello) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Hello.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Hello) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Hello.Merge(dst, src)
+func (m *Hello) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Hello.Merge(m, src)
 }
 func (m *Hello) XXX_Size() int {
 	return m.ProtoSize()
@@ -243,7 +257,7 @@ func (m *Header) Reset()         { *m = Header{} }
 func (m *Header) String() string { return proto.CompactTextString(m) }
 func (*Header) ProtoMessage()    {}
 func (*Header) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{1}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{1}
 }
 func (m *Header) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -253,15 +267,15 @@ func (m *Header) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Header.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Header) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Header.Merge(dst, src)
+func (m *Header) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Header.Merge(m, src)
 }
 func (m *Header) XXX_Size() int {
 	return m.ProtoSize()
@@ -280,7 +294,7 @@ func (m *ClusterConfig) Reset()         { *m = ClusterConfig{} }
 func (m *ClusterConfig) String() string { return proto.CompactTextString(m) }
 func (*ClusterConfig) ProtoMessage()    {}
 func (*ClusterConfig) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{2}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{2}
 }
 func (m *ClusterConfig) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -290,15 +304,15 @@ func (m *ClusterConfig) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return xxx_messageInfo_ClusterConfig.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *ClusterConfig) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterConfig.Merge(dst, src)
+func (m *ClusterConfig) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ClusterConfig.Merge(m, src)
 }
 func (m *ClusterConfig) XXX_Size() int {
 	return m.ProtoSize()
@@ -324,7 +338,7 @@ func (m *Folder) Reset()         { *m = Folder{} }
 func (m *Folder) String() string { return proto.CompactTextString(m) }
 func (*Folder) ProtoMessage()    {}
 func (*Folder) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{3}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{3}
 }
 func (m *Folder) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -334,15 +348,15 @@ func (m *Folder) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Folder.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Folder) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Folder.Merge(dst, src)
+func (m *Folder) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Folder.Merge(m, src)
 }
 func (m *Folder) XXX_Size() int {
 	return m.ProtoSize()
@@ -369,7 +383,7 @@ func (m *Device) Reset()         { *m = Device{} }
 func (m *Device) String() string { return proto.CompactTextString(m) }
 func (*Device) ProtoMessage()    {}
 func (*Device) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{4}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{4}
 }
 func (m *Device) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -379,15 +393,15 @@ func (m *Device) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Device.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Device) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Device.Merge(dst, src)
+func (m *Device) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Device.Merge(m, src)
 }
 func (m *Device) XXX_Size() int {
 	return m.ProtoSize()
@@ -407,7 +421,7 @@ func (m *Index) Reset()         { *m = Index{} }
 func (m *Index) String() string { return proto.CompactTextString(m) }
 func (*Index) ProtoMessage()    {}
 func (*Index) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{5}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{5}
 }
 func (m *Index) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -417,15 +431,15 @@ func (m *Index) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Index.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Index) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Index.Merge(dst, src)
+func (m *Index) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Index.Merge(m, src)
 }
 func (m *Index) XXX_Size() int {
 	return m.ProtoSize()
@@ -445,7 +459,7 @@ func (m *IndexUpdate) Reset()         { *m = IndexUpdate{} }
 func (m *IndexUpdate) String() string { return proto.CompactTextString(m) }
 func (*IndexUpdate) ProtoMessage()    {}
 func (*IndexUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{6}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{6}
 }
 func (m *IndexUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -455,15 +469,15 @@ func (m *IndexUpdate) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) 
 		return xxx_messageInfo_IndexUpdate.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *IndexUpdate) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_IndexUpdate.Merge(dst, src)
+func (m *IndexUpdate) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_IndexUpdate.Merge(m, src)
 }
 func (m *IndexUpdate) XXX_Size() int {
 	return m.ProtoSize()
@@ -500,7 +514,7 @@ type FileInfo struct {
 func (m *FileInfo) Reset()      { *m = FileInfo{} }
 func (*FileInfo) ProtoMessage() {}
 func (*FileInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{7}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{7}
 }
 func (m *FileInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -510,15 +524,15 @@ func (m *FileInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_FileInfo.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *FileInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileInfo.Merge(dst, src)
+func (m *FileInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FileInfo.Merge(m, src)
 }
 func (m *FileInfo) XXX_Size() int {
 	return m.ProtoSize()
@@ -539,7 +553,7 @@ type BlockInfo struct {
 func (m *BlockInfo) Reset()      { *m = BlockInfo{} }
 func (*BlockInfo) ProtoMessage() {}
 func (*BlockInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{8}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{8}
 }
 func (m *BlockInfo) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -549,15 +563,15 @@ func (m *BlockInfo) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_BlockInfo.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *BlockInfo) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BlockInfo.Merge(dst, src)
+func (m *BlockInfo) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_BlockInfo.Merge(m, src)
 }
 func (m *BlockInfo) XXX_Size() int {
 	return m.ProtoSize()
@@ -576,7 +590,7 @@ func (m *Vector) Reset()         { *m = Vector{} }
 func (m *Vector) String() string { return proto.CompactTextString(m) }
 func (*Vector) ProtoMessage()    {}
 func (*Vector) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{9}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{9}
 }
 func (m *Vector) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -586,15 +600,15 @@ func (m *Vector) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Vector.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Vector) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Vector.Merge(dst, src)
+func (m *Vector) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Vector.Merge(m, src)
 }
 func (m *Vector) XXX_Size() int {
 	return m.ProtoSize()
@@ -614,7 +628,7 @@ func (m *Counter) Reset()         { *m = Counter{} }
 func (m *Counter) String() string { return proto.CompactTextString(m) }
 func (*Counter) ProtoMessage()    {}
 func (*Counter) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{10}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{10}
 }
 func (m *Counter) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -624,15 +638,15 @@ func (m *Counter) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Counter.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Counter) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Counter.Merge(dst, src)
+func (m *Counter) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Counter.Merge(m, src)
 }
 func (m *Counter) XXX_Size() int {
 	return m.ProtoSize()
@@ -658,7 +672,7 @@ func (m *Request) Reset()         { *m = Request{} }
 func (m *Request) String() string { return proto.CompactTextString(m) }
 func (*Request) ProtoMessage()    {}
 func (*Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{11}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{11}
 }
 func (m *Request) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -668,15 +682,15 @@ func (m *Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Request.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Request.Merge(dst, src)
+func (m *Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Request.Merge(m, src)
 }
 func (m *Request) XXX_Size() int {
 	return m.ProtoSize()
@@ -697,7 +711,7 @@ func (m *Response) Reset()         { *m = Response{} }
 func (m *Response) String() string { return proto.CompactTextString(m) }
 func (*Response) ProtoMessage()    {}
 func (*Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{12}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{12}
 }
 func (m *Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -707,15 +721,15 @@ func (m *Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Response.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Response.Merge(dst, src)
+func (m *Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Response.Merge(m, src)
 }
 func (m *Response) XXX_Size() int {
 	return m.ProtoSize()
@@ -735,7 +749,7 @@ func (m *DownloadProgress) Reset()         { *m = DownloadProgress{} }
 func (m *DownloadProgress) String() string { return proto.CompactTextString(m) }
 func (*DownloadProgress) ProtoMessage()    {}
 func (*DownloadProgress) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{13}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{13}
 }
 func (m *DownloadProgress) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -745,15 +759,15 @@ func (m *DownloadProgress) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return xxx_messageInfo_DownloadProgress.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *DownloadProgress) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_DownloadProgress.Merge(dst, src)
+func (m *DownloadProgress) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_DownloadProgress.Merge(m, src)
 }
 func (m *DownloadProgress) XXX_Size() int {
 	return m.ProtoSize()
@@ -775,7 +789,7 @@ func (m *FileDownloadProgressUpdate) Reset()         { *m = FileDownloadProgress
 func (m *FileDownloadProgressUpdate) String() string { return proto.CompactTextString(m) }
 func (*FileDownloadProgressUpdate) ProtoMessage()    {}
 func (*FileDownloadProgressUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{14}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{14}
 }
 func (m *FileDownloadProgressUpdate) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -785,15 +799,15 @@ func (m *FileDownloadProgressUpdate) XXX_Marshal(b []byte, deterministic bool) (
 		return xxx_messageInfo_FileDownloadProgressUpdate.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *FileDownloadProgressUpdate) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FileDownloadProgressUpdate.Merge(dst, src)
+func (m *FileDownloadProgressUpdate) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_FileDownloadProgressUpdate.Merge(m, src)
 }
 func (m *FileDownloadProgressUpdate) XXX_Size() int {
 	return m.ProtoSize()
@@ -811,7 +825,7 @@ func (m *Ping) Reset()         { *m = Ping{} }
 func (m *Ping) String() string { return proto.CompactTextString(m) }
 func (*Ping) ProtoMessage()    {}
 func (*Ping) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{15}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{15}
 }
 func (m *Ping) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -821,15 +835,15 @@ func (m *Ping) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Ping.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Ping) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Ping.Merge(dst, src)
+func (m *Ping) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Ping.Merge(m, src)
 }
 func (m *Ping) XXX_Size() int {
 	return m.ProtoSize()
@@ -848,7 +862,7 @@ func (m *Close) Reset()         { *m = Close{} }
 func (m *Close) String() string { return proto.CompactTextString(m) }
 func (*Close) ProtoMessage()    {}
 func (*Close) Descriptor() ([]byte, []int) {
-	return fileDescriptor_bep_83d45b003aedf660, []int{16}
+	return fileDescriptor_e3f59eb60afbbc6e, []int{16}
 }
 func (m *Close) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -858,15 +872,15 @@ func (m *Close) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Close.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Close) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Close.Merge(dst, src)
+func (m *Close) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Close.Merge(m, src)
 }
 func (m *Close) XXX_Size() int {
 	return m.ProtoSize()
@@ -878,6 +892,12 @@ func (m *Close) XXX_DiscardUnknown() {
 var xxx_messageInfo_Close proto.InternalMessageInfo
 
 func init() {
+	proto.RegisterEnum("protocol.MessageType", MessageType_name, MessageType_value)
+	proto.RegisterEnum("protocol.MessageCompression", MessageCompression_name, MessageCompression_value)
+	proto.RegisterEnum("protocol.Compression", Compression_name, Compression_value)
+	proto.RegisterEnum("protocol.FileInfoType", FileInfoType_name, FileInfoType_value)
+	proto.RegisterEnum("protocol.ErrorCode", ErrorCode_name, ErrorCode_value)
+	proto.RegisterEnum("protocol.FileDownloadProgressUpdateType", FileDownloadProgressUpdateType_name, FileDownloadProgressUpdateType_value)
 	proto.RegisterType((*Hello)(nil), "protocol.Hello")
 	proto.RegisterType((*Header)(nil), "protocol.Header")
 	proto.RegisterType((*ClusterConfig)(nil), "protocol.ClusterConfig")
@@ -895,17 +915,131 @@ func init() {
 	proto.RegisterType((*FileDownloadProgressUpdate)(nil), "protocol.FileDownloadProgressUpdate")
 	proto.RegisterType((*Ping)(nil), "protocol.Ping")
 	proto.RegisterType((*Close)(nil), "protocol.Close")
-	proto.RegisterEnum("protocol.MessageType", MessageType_name, MessageType_value)
-	proto.RegisterEnum("protocol.MessageCompression", MessageCompression_name, MessageCompression_value)
-	proto.RegisterEnum("protocol.Compression", Compression_name, Compression_value)
-	proto.RegisterEnum("protocol.FileInfoType", FileInfoType_name, FileInfoType_value)
-	proto.RegisterEnum("protocol.ErrorCode", ErrorCode_name, ErrorCode_value)
-	proto.RegisterEnum("protocol.FileDownloadProgressUpdateType", FileDownloadProgressUpdateType_name, FileDownloadProgressUpdateType_value)
 }
+
+func init() { proto.RegisterFile("bep.proto", fileDescriptor_e3f59eb60afbbc6e) }
+
+var fileDescriptor_e3f59eb60afbbc6e = []byte{
+	// 1802 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0xcf, 0x6f, 0xdb, 0xc8,
+	0xf5, 0x17, 0x25, 0x4a, 0xa2, 0x9e, 0x64, 0x2f, 0x3d, 0x49, 0xfc, 0xe5, 0x97, 0x9b, 0x95, 0x18,
+	0x25, 0xd9, 0x68, 0x8d, 0x6d, 0xe2, 0xee, 0x6e, 0x5b, 0xb4, 0x68, 0x0b, 0xe8, 0x07, 0xed, 0x08,
+	0x75, 0x28, 0x77, 0x24, 0x67, 0x9b, 0x3d, 0x94, 0xa0, 0xc5, 0x91, 0x4c, 0x84, 0xe2, 0xa8, 0x24,
+	0x65, 0x47, 0xfb, 0x27, 0xe8, 0xd4, 0x63, 0x2f, 0x02, 0x16, 0xe8, 0xa9, 0xff, 0x49, 0x8e, 0x69,
+	0x0f, 0x45, 0xd1, 0x83, 0xd1, 0x75, 0x2e, 0x7b, 0xec, 0x5f, 0x50, 0x14, 0x9c, 0x21, 0x25, 0xca,
+	0x4e, 0x16, 0x7b, 0xe8, 0x89, 0x33, 0xef, 0x7d, 0xe6, 0x0d, 0xe7, 0xf3, 0xde, 0xfb, 0xcc, 0x40,
+	0xe9, 0x94, 0x4c, 0x1f, 0x4f, 0x7d, 0x1a, 0x52, 0x24, 0xb1, 0xcf, 0x90, 0xba, 0xea, 0x7d, 0x9f,
+	0x4c, 0x69, 0xf0, 0x84, 0xcd, 0x4f, 0x67, 0xa3, 0x27, 0x63, 0x3a, 0xa6, 0x6c, 0xc2, 0x46, 0x1c,
+	0x5e, 0x9f, 0x42, 0xfe, 0x29, 0x71, 0x5d, 0x8a, 0x6a, 0x50, 0xb6, 0xc9, 0xb9, 0x33, 0x24, 0xa6,
+	0x67, 0x4d, 0x88, 0x22, 0x68, 0x42, 0xa3, 0x84, 0x81, 0x9b, 0x0c, 0x6b, 0x42, 0x22, 0xc0, 0xd0,
+	0x75, 0x88, 0x17, 0x72, 0x40, 0x96, 0x03, 0xb8, 0x89, 0x01, 0x1e, 0xc2, 0x76, 0x0c, 0x38, 0x27,
+	0x7e, 0xe0, 0x50, 0x4f, 0xc9, 0x31, 0xcc, 0x16, 0xb7, 0x3e, 0xe7, 0xc6, 0x7a, 0x00, 0x85, 0xa7,
+	0xc4, 0xb2, 0x89, 0x8f, 0x3e, 0x01, 0x31, 0x9c, 0x4f, 0xf9, 0x5e, 0xdb, 0x9f, 0xdd, 0x79, 0x9c,
+	0xfc, 0xf9, 0xe3, 0x67, 0x24, 0x08, 0xac, 0x31, 0x19, 0xcc, 0xa7, 0x04, 0x33, 0x08, 0xfa, 0x35,
+	0x94, 0x87, 0x74, 0x32, 0xf5, 0x49, 0xc0, 0x02, 0x67, 0xd9, 0x8a, 0xbb, 0x37, 0x56, 0xb4, 0xd7,
+	0x18, 0x9c, 0x5e, 0x50, 0x6f, 0xc2, 0x56, 0xdb, 0x9d, 0x05, 0x21, 0xf1, 0xdb, 0xd4, 0x1b, 0x39,
+	0x63, 0xb4, 0x0f, 0xc5, 0x11, 0x75, 0x6d, 0xe2, 0x07, 0x8a, 0xa0, 0xe5, 0x1a, 0xe5, 0xcf, 0xe4,
+	0x75, 0xb0, 0x03, 0xe6, 0x68, 0x89, 0xaf, 0x2f, 0x6b, 0x19, 0x9c, 0xc0, 0xea, 0x7f, 0xce, 0x42,
+	0x81, 0x7b, 0xd0, 0x2e, 0x64, 0x1d, 0x9b, 0x53, 0xd4, 0x2a, 0x5c, 0x5d, 0xd6, 0xb2, 0xdd, 0x0e,
+	0xce, 0x3a, 0x36, 0xba, 0x0d, 0x79, 0xd7, 0x3a, 0x25, 0x6e, 0x4c, 0x0e, 0x9f, 0xa0, 0x0f, 0xa1,
+	0xe4, 0x13, 0xcb, 0x36, 0xa9, 0xe7, 0xce, 0x19, 0x25, 0x12, 0x96, 0x22, 0x43, 0xcf, 0x73, 0xe7,
+	0xe8, 0x47, 0x80, 0x9c, 0xb1, 0x47, 0x7d, 0x62, 0x4e, 0x89, 0x3f, 0x71, 0xd8, 0xdf, 0x06, 0x8a,
+	0xc8, 0x50, 0x3b, 0xdc, 0x73, 0xbc, 0x76, 0xa0, 0xfb, 0xb0, 0x15, 0xc3, 0x6d, 0xe2, 0x92, 0x90,
+	0x28, 0x79, 0x86, 0xac, 0x70, 0x63, 0x87, 0xd9, 0xd0, 0x3e, 0xdc, 0xb6, 0x9d, 0xc0, 0x3a, 0x75,
+	0x89, 0x19, 0x92, 0xc9, 0xd4, 0x74, 0x3c, 0x9b, 0xbc, 0x22, 0x81, 0x52, 0x60, 0x58, 0x14, 0xfb,
+	0x06, 0x64, 0x32, 0xed, 0x72, 0x0f, 0xda, 0x85, 0xc2, 0xd4, 0x9a, 0x05, 0xc4, 0x56, 0x8a, 0x0c,
+	0x13, 0xcf, 0x22, 0x96, 0x78, 0x05, 0x04, 0x8a, 0x7c, 0x9d, 0xa5, 0x0e, 0x73, 0x24, 0x2c, 0xc5,
+	0xb0, 0xfa, 0xbf, 0xb3, 0x50, 0xe0, 0x1e, 0xf4, 0xf1, 0x8a, 0xa5, 0x4a, 0x6b, 0x37, 0x42, 0xfd,
+	0xf3, 0xb2, 0x26, 0x71, 0x5f, 0xb7, 0x93, 0x62, 0x0d, 0x81, 0x98, 0xaa, 0x28, 0x36, 0x46, 0x77,
+	0xa1, 0x64, 0xd9, 0x76, 0x94, 0x3d, 0x12, 0x28, 0x39, 0x2d, 0xd7, 0x28, 0xe1, 0xb5, 0x01, 0xfd,
+	0x6c, 0xb3, 0x1a, 0xc4, 0xeb, 0xf5, 0xf3, 0xbe, 0x32, 0x88, 0x52, 0x31, 0x24, 0x7e, 0x5c, 0xc1,
+	0x79, 0xb6, 0x9f, 0x14, 0x19, 0x58, 0xfd, 0xde, 0x83, 0xca, 0xc4, 0x7a, 0x65, 0x06, 0xe4, 0x0f,
+	0x33, 0xe2, 0x0d, 0x09, 0xa3, 0x2b, 0x87, 0xcb, 0x13, 0xeb, 0x55, 0x3f, 0x36, 0xa1, 0x2a, 0x80,
+	0xe3, 0x85, 0x3e, 0xb5, 0x67, 0x43, 0xe2, 0xc7, 0x5c, 0xa5, 0x2c, 0xe8, 0x27, 0x20, 0x31, 0xb2,
+	0x4d, 0xc7, 0x56, 0x24, 0x4d, 0x68, 0x88, 0x2d, 0x35, 0x3e, 0x78, 0x91, 0x51, 0xcd, 0xce, 0x9d,
+	0x0c, 0x71, 0x91, 0x61, 0xbb, 0x36, 0xfa, 0x25, 0xa8, 0xc1, 0x4b, 0x27, 0x4a, 0x14, 0x8f, 0x14,
+	0x3a, 0xd4, 0x33, 0x7d, 0x32, 0xa1, 0xe7, 0x96, 0x1b, 0x28, 0x25, 0xb6, 0x8d, 0x12, 0x21, 0xba,
+	0x29, 0x00, 0x8e, 0xfd, 0xf5, 0x1e, 0xe4, 0x59, 0xc4, 0x28, 0x8b, 0xbc, 0x58, 0xe3, 0xee, 0x8d,
+	0x67, 0xe8, 0x31, 0xe4, 0x47, 0x8e, 0x4b, 0x02, 0x25, 0xcb, 0x72, 0x88, 0x52, 0x95, 0xee, 0xb8,
+	0xa4, 0xeb, 0x8d, 0x68, 0x9c, 0x45, 0x0e, 0xab, 0x9f, 0x40, 0x99, 0x05, 0x3c, 0x99, 0xda, 0x56,
+	0x48, 0xfe, 0x67, 0x61, 0x2f, 0x45, 0x90, 0x12, 0xcf, 0x2a, 0xe9, 0x42, 0x2a, 0xe9, 0x7b, 0xb1,
+	0x1e, 0xf0, 0xee, 0xde, 0xbd, 0x19, 0x2f, 0x25, 0x08, 0x08, 0xc4, 0xc0, 0xf9, 0x9a, 0xb0, 0x7e,
+	0xca, 0x61, 0x36, 0x46, 0x1a, 0x94, 0xaf, 0x37, 0xd1, 0x16, 0x4e, 0x9b, 0xd0, 0x47, 0x00, 0x13,
+	0x6a, 0x3b, 0x23, 0x87, 0xd8, 0x66, 0xc0, 0x0a, 0x20, 0x87, 0x4b, 0x89, 0xa5, 0x1f, 0x49, 0xdc,
+	0xca, 0xed, 0x05, 0x4a, 0x59, 0x13, 0x1a, 0x79, 0xbc, 0x5a, 0x61, 0x04, 0x68, 0x3f, 0x05, 0x38,
+	0x9d, 0x2b, 0x15, 0x96, 0xe2, 0x0f, 0x92, 0x14, 0xf7, 0xcf, 0xa8, 0x1f, 0x76, 0x3b, 0xeb, 0x15,
+	0xad, 0x39, 0x52, 0xa2, 0x0e, 0x8a, 0xba, 0xd2, 0x8e, 0xdb, 0x2f, 0x99, 0xa2, 0x06, 0x14, 0x1d,
+	0xef, 0xdc, 0x72, 0x9d, 0xb8, 0xe9, 0x5a, 0xdb, 0x57, 0x97, 0x35, 0xc0, 0xd6, 0x45, 0x97, 0x5b,
+	0x71, 0xe2, 0x8e, 0x84, 0xd5, 0xa3, 0x1b, 0xfa, 0x20, 0xb1, 0x50, 0x5b, 0x1e, 0x4d, 0x6b, 0xc3,
+	0x3e, 0x14, 0x13, 0xe1, 0x8d, 0x4a, 0x66, 0xa3, 0x59, 0x9f, 0x93, 0x61, 0x48, 0x57, 0x92, 0x16,
+	0xc3, 0x90, 0x0a, 0xd2, 0xaa, 0xda, 0x81, 0x91, 0xb1, 0x9a, 0xa3, 0x27, 0x00, 0xa7, 0x2e, 0x1d,
+	0xbe, 0x34, 0x19, 0xcd, 0x5b, 0x11, 0x15, 0x2d, 0xf9, 0xea, 0xb2, 0x56, 0xc1, 0xd6, 0x45, 0x2b,
+	0x72, 0xf4, 0x9d, 0xaf, 0x09, 0x2e, 0x9d, 0x26, 0x43, 0xf4, 0x63, 0x28, 0x30, 0x7b, 0x22, 0x15,
+	0xb7, 0xd6, 0xbb, 0x33, 0x7b, 0xaa, 0x20, 0x62, 0x60, 0x74, 0xb0, 0x60, 0x3e, 0x71, 0x1d, 0xef,
+	0xa5, 0x19, 0x5a, 0xfe, 0x98, 0x84, 0xca, 0x0e, 0xbf, 0x31, 0x62, 0xeb, 0x80, 0x19, 0xa3, 0xbc,
+	0xba, 0x74, 0x68, 0xb9, 0xe6, 0xc8, 0xb5, 0xc6, 0x81, 0xf2, 0x5d, 0x91, 0x25, 0x16, 0x98, 0xed,
+	0x20, 0x32, 0xfd, 0x42, 0xfc, 0xd3, 0x37, 0xb5, 0x4c, 0xdd, 0x83, 0xd2, 0x6a, 0xa7, 0xa8, 0x6a,
+	0xe9, 0x68, 0x14, 0x90, 0x90, 0x95, 0x58, 0x0e, 0xc7, 0xb3, 0x55, 0xe1, 0x64, 0x59, 0x72, 0x79,
+	0xe1, 0x20, 0x10, 0xcf, 0xac, 0xe0, 0x8c, 0x15, 0x53, 0x05, 0xb3, 0x71, 0x24, 0x15, 0x17, 0xc4,
+	0x7a, 0x69, 0x32, 0x07, 0x2f, 0x25, 0x29, 0x32, 0x3c, 0xb5, 0x82, 0xb3, 0x78, 0xbf, 0x5f, 0x41,
+	0x81, 0xf3, 0x8a, 0x3e, 0x07, 0x69, 0x48, 0x67, 0x5e, 0xb8, 0xbe, 0x4e, 0x76, 0xd2, 0x6a, 0xc4,
+	0x3c, 0xf1, 0xd9, 0x57, 0xc0, 0xfa, 0x01, 0x14, 0x63, 0x17, 0x7a, 0xb8, 0x92, 0x4a, 0xb1, 0x75,
+	0xe7, 0x5a, 0x39, 0x6d, 0xde, 0x2f, 0xe7, 0x96, 0x3b, 0xe3, 0x3f, 0x2f, 0x62, 0x3e, 0xa9, 0xff,
+	0x55, 0x80, 0x22, 0x8e, 0xd2, 0x16, 0x84, 0xa9, 0x9b, 0x29, 0xbf, 0x71, 0x33, 0xad, 0x7b, 0x38,
+	0xbb, 0xd1, 0xc3, 0x49, 0x1b, 0xe6, 0x52, 0x6d, 0xb8, 0x66, 0x4e, 0x7c, 0x27, 0x73, 0xf9, 0x77,
+	0x30, 0x57, 0x48, 0x31, 0xf7, 0x10, 0xb6, 0x47, 0x3e, 0x9d, 0xb0, 0xbb, 0x87, 0xfa, 0x96, 0x3f,
+	0x8f, 0x85, 0x72, 0x2b, 0xb2, 0x0e, 0x12, 0xe3, 0x26, 0xc1, 0xd2, 0x26, 0xc1, 0x75, 0x13, 0x24,
+	0x4c, 0x82, 0x29, 0xf5, 0x02, 0xf2, 0xde, 0x33, 0x21, 0x10, 0x6d, 0x2b, 0xb4, 0xd8, 0x89, 0x2a,
+	0x98, 0x8d, 0xd1, 0x23, 0x10, 0x87, 0xd4, 0xe6, 0xe7, 0xd9, 0x4e, 0x97, 0xa0, 0xee, 0xfb, 0xd4,
+	0x6f, 0x53, 0x9b, 0x60, 0x06, 0xa8, 0x4f, 0x41, 0xee, 0xd0, 0x0b, 0xcf, 0xa5, 0x96, 0x7d, 0xec,
+	0xd3, 0x71, 0x74, 0x41, 0xbc, 0x57, 0xe8, 0x3a, 0x50, 0x9c, 0x31, 0x29, 0x4c, 0xa4, 0xee, 0xc1,
+	0xa6, 0x34, 0x5d, 0x0f, 0xc4, 0x75, 0x33, 0x69, 0xb6, 0x78, 0x69, 0xfd, 0xef, 0x02, 0xa8, 0xef,
+	0x47, 0xa3, 0x2e, 0x94, 0x39, 0xd2, 0x4c, 0xbd, 0x89, 0x1a, 0x3f, 0x64, 0x23, 0xa6, 0x8a, 0x30,
+	0x5b, 0x8d, 0xdf, 0x79, 0xa1, 0xa6, 0xc4, 0x21, 0xf7, 0xc3, 0xc4, 0xe1, 0x11, 0x6c, 0x71, 0x01,
+	0x48, 0x9e, 0x0f, 0xa2, 0x96, 0x6b, 0xe4, 0x5b, 0x59, 0x39, 0x83, 0x2b, 0xa7, 0xbc, 0xcd, 0x98,
+	0xbd, 0x5e, 0x00, 0xf1, 0xd8, 0xf1, 0xc6, 0xf5, 0x1a, 0xe4, 0xdb, 0x2e, 0x65, 0x09, 0x2b, 0xf8,
+	0xc4, 0x0a, 0xa8, 0x97, 0xf0, 0xc8, 0x67, 0x7b, 0x7f, 0xcb, 0x42, 0x39, 0xf5, 0xb4, 0x43, 0xfb,
+	0xb0, 0xdd, 0x3e, 0x3a, 0xe9, 0x0f, 0x74, 0x6c, 0xb6, 0x7b, 0xc6, 0x41, 0xf7, 0x50, 0xce, 0xa8,
+	0x77, 0x17, 0x4b, 0x4d, 0x99, 0xac, 0x41, 0x9b, 0xaf, 0xb6, 0x1a, 0xe4, 0xbb, 0x46, 0x47, 0xff,
+	0x9d, 0x2c, 0xa8, 0xb7, 0x17, 0x4b, 0x4d, 0x4e, 0x01, 0xf9, 0x15, 0xf8, 0x29, 0x54, 0x18, 0xc0,
+	0x3c, 0x39, 0xee, 0x34, 0x07, 0xba, 0x9c, 0x55, 0xd5, 0xc5, 0x52, 0xdb, 0xbd, 0x8e, 0x8b, 0x39,
+	0xbf, 0x0f, 0x45, 0xac, 0xff, 0xf6, 0x44, 0xef, 0x0f, 0xe4, 0x9c, 0xba, 0xbb, 0x58, 0x6a, 0x28,
+	0x05, 0x4c, 0x5a, 0xea, 0x21, 0x48, 0x58, 0xef, 0x1f, 0xf7, 0x8c, 0xbe, 0x2e, 0x8b, 0xea, 0xff,
+	0x2d, 0x96, 0xda, 0xad, 0x0d, 0x54, 0x5c, 0xa5, 0x3f, 0x85, 0x9d, 0x4e, 0xef, 0x4b, 0xe3, 0xa8,
+	0xd7, 0xec, 0x98, 0xc7, 0xb8, 0x77, 0x88, 0xf5, 0x7e, 0x5f, 0xce, 0xab, 0xb5, 0xc5, 0x52, 0xfb,
+	0x30, 0x85, 0xbf, 0x51, 0x74, 0x1f, 0x81, 0x78, 0xdc, 0x35, 0x0e, 0xe5, 0x82, 0x7a, 0x6b, 0xb1,
+	0xd4, 0x3e, 0x48, 0x41, 0x23, 0x52, 0xa3, 0x13, 0xb7, 0x8f, 0x7a, 0x7d, 0x5d, 0x2e, 0xde, 0x38,
+	0x31, 0x23, 0x7b, 0xef, 0xf7, 0x80, 0x6e, 0x3e, 0x7e, 0xd1, 0x03, 0x10, 0x8d, 0x9e, 0xa1, 0xcb,
+	0x19, 0x7e, 0xfe, 0x9b, 0x08, 0x83, 0x7a, 0x04, 0xd5, 0x21, 0x77, 0xf4, 0xd5, 0x17, 0xb2, 0xa0,
+	0xfe, 0xff, 0x62, 0xa9, 0xdd, 0xb9, 0x09, 0x3a, 0xfa, 0xea, 0x8b, 0x3d, 0x0a, 0xe5, 0x74, 0xe0,
+	0x3a, 0x48, 0xcf, 0xf4, 0x41, 0xb3, 0xd3, 0x1c, 0x34, 0xe5, 0x0c, 0xff, 0xa5, 0xc4, 0xfd, 0x8c,
+	0x84, 0x16, 0x6b, 0xc2, 0xbb, 0x90, 0x37, 0xf4, 0xe7, 0x3a, 0x96, 0x05, 0x75, 0x67, 0xb1, 0xd4,
+	0xb6, 0x12, 0x80, 0x41, 0xce, 0x89, 0x8f, 0xaa, 0x50, 0x68, 0x1e, 0x7d, 0xd9, 0x7c, 0xd1, 0x97,
+	0xb3, 0x2a, 0x5a, 0x2c, 0xb5, 0xed, 0xc4, 0xdd, 0x74, 0x2f, 0xac, 0x79, 0xb0, 0xf7, 0x1f, 0x01,
+	0x2a, 0xe9, 0x0b, 0x1f, 0x55, 0x41, 0x3c, 0xe8, 0x1e, 0xe9, 0xc9, 0x76, 0x69, 0x5f, 0x34, 0x46,
+	0x0d, 0x28, 0x75, 0xba, 0x58, 0x6f, 0x0f, 0x7a, 0xf8, 0x45, 0x72, 0x96, 0x34, 0xa8, 0xe3, 0xf8,
+	0xac, 0xc0, 0xe7, 0xe8, 0xe7, 0x50, 0xe9, 0xbf, 0x78, 0x76, 0xd4, 0x35, 0x7e, 0x63, 0xb2, 0x88,
+	0x59, 0xf5, 0xd1, 0x62, 0xa9, 0xdd, 0xdb, 0x00, 0x93, 0xa9, 0x4f, 0x86, 0x56, 0x48, 0xec, 0x3e,
+	0xbf, 0x83, 0x22, 0xa7, 0x24, 0xa0, 0x36, 0xec, 0x24, 0x4b, 0xd7, 0x9b, 0xe5, 0xd4, 0x4f, 0x17,
+	0x4b, 0xed, 0xe3, 0xef, 0x5d, 0xbf, 0xda, 0x5d, 0x12, 0xd0, 0x03, 0x28, 0xc6, 0x41, 0x92, 0x4a,
+	0x4a, 0x2f, 0x8d, 0x17, 0xec, 0xfd, 0x45, 0x80, 0xd2, 0x4a, 0xae, 0x22, 0xc2, 0x8d, 0x9e, 0xa9,
+	0x63, 0xdc, 0xc3, 0x09, 0x03, 0x2b, 0xa7, 0x41, 0xd9, 0x10, 0xdd, 0x83, 0xe2, 0xa1, 0x6e, 0xe8,
+	0xb8, 0xdb, 0x4e, 0x1a, 0x63, 0x05, 0x39, 0x24, 0x1e, 0xf1, 0x9d, 0x21, 0xfa, 0x04, 0x2a, 0x46,
+	0xcf, 0xec, 0x9f, 0xb4, 0x9f, 0x26, 0x47, 0x67, 0xfb, 0xa7, 0x42, 0xf5, 0x67, 0xc3, 0x33, 0xc6,
+	0xe7, 0x5e, 0xd4, 0x43, 0xcf, 0x9b, 0x47, 0xdd, 0x0e, 0x87, 0xe6, 0x54, 0x65, 0xb1, 0xd4, 0x6e,
+	0xaf, 0xa0, 0xf1, 0xfb, 0x24, 0xc2, 0xee, 0xd9, 0x50, 0xfd, 0x7e, 0x61, 0x42, 0x1a, 0x14, 0x9a,
+	0xc7, 0xc7, 0xba, 0xd1, 0x49, 0xfe, 0x7e, 0xed, 0x6b, 0x4e, 0xa7, 0xc4, 0xb3, 0x23, 0xc4, 0x41,
+	0x0f, 0x1f, 0xea, 0x83, 0xe4, 0xe7, 0xd7, 0x88, 0x03, 0x1a, 0x3d, 0x00, 0x5a, 0x8d, 0xd7, 0xdf,
+	0x56, 0x33, 0x6f, 0xbe, 0xad, 0x66, 0x5e, 0x5f, 0x55, 0x85, 0x37, 0x57, 0x55, 0xe1, 0x5f, 0x57,
+	0xd5, 0xcc, 0x77, 0x57, 0x55, 0xe1, 0x8f, 0x6f, 0xab, 0x99, 0x6f, 0xde, 0x56, 0x85, 0x37, 0x6f,
+	0xab, 0x99, 0x7f, 0xbc, 0xad, 0x66, 0x4e, 0x0b, 0x4c, 0xd4, 0x3e, 0xff, 0x6f, 0x00, 0x00, 0x00,
+	0xff, 0xff, 0x64, 0xa1, 0x2b, 0x55, 0x11, 0x0f, 0x00, 0x00,
+}
+
 func (m *Hello) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -913,35 +1047,43 @@ func (m *Hello) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Hello) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Hello) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.DeviceName) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.DeviceName)))
-		i += copy(dAtA[i:], m.DeviceName)
+	if len(m.ClientVersion) > 0 {
+		i -= len(m.ClientVersion)
+		copy(dAtA[i:], m.ClientVersion)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.ClientVersion)))
+		i--
+		dAtA[i] = 0x1a
 	}
 	if len(m.ClientName) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.ClientName)
+		copy(dAtA[i:], m.ClientName)
 		i = encodeVarintBep(dAtA, i, uint64(len(m.ClientName)))
-		i += copy(dAtA[i:], m.ClientName)
+		i--
+		dAtA[i] = 0x12
 	}
-	if len(m.ClientVersion) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.ClientVersion)))
-		i += copy(dAtA[i:], m.ClientVersion)
+	if len(m.DeviceName) > 0 {
+		i -= len(m.DeviceName)
+		copy(dAtA[i:], m.DeviceName)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.DeviceName)))
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Header) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -949,27 +1091,32 @@ func (m *Header) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Header) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Header) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Type != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Type))
-	}
 	if m.Compression != 0 {
-		dAtA[i] = 0x10
-		i++
 		i = encodeVarintBep(dAtA, i, uint64(m.Compression))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if m.Type != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *ClusterConfig) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -977,29 +1124,36 @@ func (m *ClusterConfig) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *ClusterConfig) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *ClusterConfig) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if len(m.Folders) > 0 {
-		for _, msg := range m.Folders {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Folders) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Folders[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintBep(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Folder) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1007,93 +1161,102 @@ func (m *Folder) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Folder) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Folder) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.ID) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.ID)))
-		i += copy(dAtA[i:], m.ID)
-	}
-	if len(m.Label) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Label)))
-		i += copy(dAtA[i:], m.Label)
-	}
-	if m.ReadOnly {
-		dAtA[i] = 0x18
-		i++
-		if m.ReadOnly {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
+	if len(m.Devices) > 0 {
+		for iNdEx := len(m.Devices) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Devices[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintBep(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0x82
 		}
-		i++
-	}
-	if m.IgnorePermissions {
-		dAtA[i] = 0x20
-		i++
-		if m.IgnorePermissions {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.IgnoreDelete {
-		dAtA[i] = 0x28
-		i++
-		if m.IgnoreDelete {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.DisableTempIndexes {
-		dAtA[i] = 0x30
-		i++
-		if m.DisableTempIndexes {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
 	}
 	if m.Paused {
-		dAtA[i] = 0x38
-		i++
+		i--
 		if m.Paused {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x38
 	}
-	if len(m.Devices) > 0 {
-		for _, msg := range m.Devices {
-			dAtA[i] = 0x82
-			i++
-			dAtA[i] = 0x1
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
+	if m.DisableTempIndexes {
+		i--
+		if m.DisableTempIndexes {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
 		}
+		i--
+		dAtA[i] = 0x30
 	}
-	return i, nil
+	if m.IgnoreDelete {
+		i--
+		if m.IgnoreDelete {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.IgnorePermissions {
+		i--
+		if m.IgnorePermissions {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.ReadOnly {
+		i--
+		if m.ReadOnly {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x18
+	}
+	if len(m.Label) > 0 {
+		i -= len(m.Label)
+		copy(dAtA[i:], m.Label)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Label)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.ID) > 0 {
+		i -= len(m.ID)
+		copy(dAtA[i:], m.ID)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.ID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Device) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1101,87 +1264,90 @@ func (m *Device) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Device) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Device) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintBep(dAtA, i, uint64(m.ID.ProtoSize()))
-	n1, err := m.ID.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n1
-	if len(m.Name) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	if len(m.Addresses) > 0 {
-		for _, s := range m.Addresses {
-			dAtA[i] = 0x1a
-			i++
-			l = len(s)
-			for l >= 1<<7 {
-				dAtA[i] = uint8(uint64(l)&0x7f | 0x80)
-				l >>= 7
-				i++
-			}
-			dAtA[i] = uint8(l)
-			i++
-			i += copy(dAtA[i:], s)
-		}
-	}
-	if m.Compression != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Compression))
-	}
-	if len(m.CertName) > 0 {
-		dAtA[i] = 0x2a
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.CertName)))
-		i += copy(dAtA[i:], m.CertName)
-	}
-	if m.MaxSequence != 0 {
-		dAtA[i] = 0x30
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.MaxSequence))
-	}
-	if m.Introducer {
-		dAtA[i] = 0x38
-		i++
-		if m.Introducer {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
-	if m.IndexID != 0 {
-		dAtA[i] = 0x40
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.IndexID))
-	}
 	if m.SkipIntroductionRemovals {
-		dAtA[i] = 0x48
-		i++
+		i--
 		if m.SkipIntroductionRemovals {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x48
 	}
-	return i, nil
+	if m.IndexID != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.IndexID))
+		i--
+		dAtA[i] = 0x40
+	}
+	if m.Introducer {
+		i--
+		if m.Introducer {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x38
+	}
+	if m.MaxSequence != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.MaxSequence))
+		i--
+		dAtA[i] = 0x30
+	}
+	if len(m.CertName) > 0 {
+		i -= len(m.CertName)
+		copy(dAtA[i:], m.CertName)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.CertName)))
+		i--
+		dAtA[i] = 0x2a
+	}
+	if m.Compression != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Compression))
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.Addresses) > 0 {
+		for iNdEx := len(m.Addresses) - 1; iNdEx >= 0; iNdEx-- {
+			i -= len(m.Addresses[iNdEx])
+			copy(dAtA[i:], m.Addresses[iNdEx])
+			i = encodeVarintBep(dAtA, i, uint64(len(m.Addresses[iNdEx])))
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x12
+	}
+	{
+		size := m.ID.ProtoSize()
+		i -= size
+		if _, err := m.ID.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintBep(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func (m *Index) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1189,35 +1355,43 @@ func (m *Index) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Index) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Index) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Folder) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
-		i += copy(dAtA[i:], m.Folder)
-	}
 	if len(m.Files) > 0 {
-		for _, msg := range m.Files {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Files) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Files[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintBep(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x12
 		}
 	}
-	return i, nil
+	if len(m.Folder) > 0 {
+		i -= len(m.Folder)
+		copy(dAtA[i:], m.Folder)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *IndexUpdate) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1225,35 +1399,43 @@ func (m *IndexUpdate) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *IndexUpdate) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *IndexUpdate) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Folder) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
-		i += copy(dAtA[i:], m.Folder)
-	}
 	if len(m.Files) > 0 {
-		for _, msg := range m.Files {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Files) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Files[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintBep(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x12
 		}
 	}
-	return i, nil
+	if len(m.Folder) > 0 {
+		i -= len(m.Folder)
+		copy(dAtA[i:], m.Folder)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *FileInfo) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1261,130 +1443,141 @@ func (m *FileInfo) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *FileInfo) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *FileInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Name) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
+	if m.LocalFlags != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.LocalFlags))
+		i--
+		dAtA[i] = 0x3e
+		i--
+		dAtA[i] = 0xc0
 	}
-	if m.Type != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Type))
+	if len(m.SymlinkTarget) > 0 {
+		i -= len(m.SymlinkTarget)
+		copy(dAtA[i:], m.SymlinkTarget)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.SymlinkTarget)))
+		i--
+		dAtA[i] = 0x1
+		i--
+		dAtA[i] = 0x8a
 	}
-	if m.Size != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Size))
-	}
-	if m.Permissions != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Permissions))
-	}
-	if m.ModifiedS != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.ModifiedS))
-	}
-	if m.Deleted {
-		dAtA[i] = 0x30
-		i++
-		if m.Deleted {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
+	if len(m.Blocks) > 0 {
+		for iNdEx := len(m.Blocks) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Blocks[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintBep(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1
+			i--
+			dAtA[i] = 0x82
 		}
-		i++
 	}
-	if m.RawInvalid {
-		dAtA[i] = 0x38
-		i++
-		if m.RawInvalid {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
+	if m.RawBlockSize != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.RawBlockSize))
+		i--
+		dAtA[i] = 0x68
+	}
+	if m.ModifiedBy != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.ModifiedBy))
+		i--
+		dAtA[i] = 0x60
+	}
+	if m.ModifiedNs != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.ModifiedNs))
+		i--
+		dAtA[i] = 0x58
+	}
+	if m.Sequence != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Sequence))
+		i--
+		dAtA[i] = 0x50
+	}
+	{
+		size, err := m.Version.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
 		}
-		i++
+		i -= size
+		i = encodeVarintBep(dAtA, i, uint64(size))
 	}
+	i--
+	dAtA[i] = 0x4a
 	if m.NoPermissions {
-		dAtA[i] = 0x40
-		i++
+		i--
 		if m.NoPermissions {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x40
 	}
-	dAtA[i] = 0x4a
-	i++
-	i = encodeVarintBep(dAtA, i, uint64(m.Version.ProtoSize()))
-	n2, err := m.Version.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n2
-	if m.Sequence != 0 {
-		dAtA[i] = 0x50
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Sequence))
-	}
-	if m.ModifiedNs != 0 {
-		dAtA[i] = 0x58
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.ModifiedNs))
-	}
-	if m.ModifiedBy != 0 {
-		dAtA[i] = 0x60
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.ModifiedBy))
-	}
-	if m.RawBlockSize != 0 {
-		dAtA[i] = 0x68
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.RawBlockSize))
-	}
-	if len(m.Blocks) > 0 {
-		for _, msg := range m.Blocks {
-			dAtA[i] = 0x82
-			i++
-			dAtA[i] = 0x1
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
+	if m.RawInvalid {
+		i--
+		if m.RawInvalid {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
 		}
+		i--
+		dAtA[i] = 0x38
 	}
-	if len(m.SymlinkTarget) > 0 {
-		dAtA[i] = 0x8a
-		i++
-		dAtA[i] = 0x1
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.SymlinkTarget)))
-		i += copy(dAtA[i:], m.SymlinkTarget)
+	if m.Deleted {
+		i--
+		if m.Deleted {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
 	}
-	if m.LocalFlags != 0 {
-		dAtA[i] = 0xc0
-		i++
-		dAtA[i] = 0x3e
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.LocalFlags))
+	if m.ModifiedS != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.ModifiedS))
+		i--
+		dAtA[i] = 0x28
 	}
-	return i, nil
+	if m.Permissions != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Permissions))
+		i--
+		dAtA[i] = 0x20
+	}
+	if m.Size != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Size))
+		i--
+		dAtA[i] = 0x18
+	}
+	if m.Type != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Type))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *BlockInfo) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1392,38 +1585,44 @@ func (m *BlockInfo) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *BlockInfo) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *BlockInfo) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Offset != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Offset))
-	}
-	if m.Size != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Size))
+	if m.WeakHash != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.WeakHash))
+		i--
+		dAtA[i] = 0x20
 	}
 	if len(m.Hash) > 0 {
-		dAtA[i] = 0x1a
-		i++
+		i -= len(m.Hash)
+		copy(dAtA[i:], m.Hash)
 		i = encodeVarintBep(dAtA, i, uint64(len(m.Hash)))
-		i += copy(dAtA[i:], m.Hash)
+		i--
+		dAtA[i] = 0x1a
 	}
-	if m.WeakHash != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.WeakHash))
+	if m.Size != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Size))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if m.Offset != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Offset))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Vector) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1431,29 +1630,36 @@ func (m *Vector) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Vector) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Vector) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if len(m.Counters) > 0 {
-		for _, msg := range m.Counters {
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Counters) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Counters[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintBep(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0xa
 		}
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Counter) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1461,27 +1667,32 @@ func (m *Counter) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Counter) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Counter) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.ID != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.ID))
-	}
 	if m.Value != 0 {
-		dAtA[i] = 0x10
-		i++
 		i = encodeVarintBep(dAtA, i, uint64(m.Value))
+		i--
+		dAtA[i] = 0x10
 	}
-	return i, nil
+	if m.ID != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.ID))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Request) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1489,65 +1700,73 @@ func (m *Request) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Request) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Request) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.ID != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.ID))
-	}
-	if len(m.Folder) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
-		i += copy(dAtA[i:], m.Folder)
-	}
-	if len(m.Name) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	if m.Offset != 0 {
-		dAtA[i] = 0x20
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Offset))
-	}
-	if m.Size != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Size))
-	}
-	if len(m.Hash) > 0 {
-		dAtA[i] = 0x32
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Hash)))
-		i += copy(dAtA[i:], m.Hash)
+	if m.WeakHash != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.WeakHash))
+		i--
+		dAtA[i] = 0x40
 	}
 	if m.FromTemporary {
-		dAtA[i] = 0x38
-		i++
+		i--
 		if m.FromTemporary {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x38
 	}
-	if m.WeakHash != 0 {
-		dAtA[i] = 0x40
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.WeakHash))
+	if len(m.Hash) > 0 {
+		i -= len(m.Hash)
+		copy(dAtA[i:], m.Hash)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Hash)))
+		i--
+		dAtA[i] = 0x32
 	}
-	return i, nil
+	if m.Size != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Size))
+		i--
+		dAtA[i] = 0x28
+	}
+	if m.Offset != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Offset))
+		i--
+		dAtA[i] = 0x20
+	}
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Folder) > 0 {
+		i -= len(m.Folder)
+		copy(dAtA[i:], m.Folder)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.ID != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.ID))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Response) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1555,33 +1774,39 @@ func (m *Response) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Response) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Response) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.ID != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.ID))
+	if m.Code != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.Code))
+		i--
+		dAtA[i] = 0x18
 	}
 	if len(m.Data) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Data)
+		copy(dAtA[i:], m.Data)
 		i = encodeVarintBep(dAtA, i, uint64(len(m.Data)))
-		i += copy(dAtA[i:], m.Data)
+		i--
+		dAtA[i] = 0x12
 	}
-	if m.Code != 0 {
-		dAtA[i] = 0x18
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.Code))
+	if m.ID != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.ID))
+		i--
+		dAtA[i] = 0x8
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *DownloadProgress) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1589,35 +1814,43 @@ func (m *DownloadProgress) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *DownloadProgress) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *DownloadProgress) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Folder) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
-		i += copy(dAtA[i:], m.Folder)
-	}
 	if len(m.Updates) > 0 {
-		for _, msg := range m.Updates {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(msg.ProtoSize()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
+		for iNdEx := len(m.Updates) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Updates[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintBep(dAtA, i, uint64(size))
 			}
-			i += n
+			i--
+			dAtA[i] = 0x12
 		}
 	}
-	return i, nil
+	if len(m.Folder) > 0 {
+		i -= len(m.Folder)
+		copy(dAtA[i:], m.Folder)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Folder)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *FileDownloadProgressUpdate) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1625,43 +1858,51 @@ func (m *FileDownloadProgressUpdate) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *FileDownloadProgressUpdate) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *FileDownloadProgressUpdate) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.UpdateType != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(m.UpdateType))
-	}
-	if len(m.Name) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
-		i += copy(dAtA[i:], m.Name)
-	}
-	dAtA[i] = 0x1a
-	i++
-	i = encodeVarintBep(dAtA, i, uint64(m.Version.ProtoSize()))
-	n3, err := m.Version.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
-	}
-	i += n3
 	if len(m.BlockIndexes) > 0 {
-		for _, num := range m.BlockIndexes {
+		for iNdEx := len(m.BlockIndexes) - 1; iNdEx >= 0; iNdEx-- {
+			i = encodeVarintBep(dAtA, i, uint64(m.BlockIndexes[iNdEx]))
+			i--
 			dAtA[i] = 0x20
-			i++
-			i = encodeVarintBep(dAtA, i, uint64(num))
 		}
 	}
-	return i, nil
+	{
+		size, err := m.Version.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintBep(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0x1a
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintBep(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.UpdateType != 0 {
+		i = encodeVarintBep(dAtA, i, uint64(m.UpdateType))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Ping) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1669,17 +1910,22 @@ func (m *Ping) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Ping) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Ping) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Close) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -1687,27 +1933,35 @@ func (m *Close) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Close) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Close) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if len(m.Reason) > 0 {
-		dAtA[i] = 0xa
-		i++
+		i -= len(m.Reason)
+		copy(dAtA[i:], m.Reason)
 		i = encodeVarintBep(dAtA, i, uint64(len(m.Reason)))
-		i += copy(dAtA[i:], m.Reason)
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintBep(dAtA []byte, offset int, v uint64) int {
+	offset -= sovBep(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *Hello) ProtoSize() (n int) {
 	if m == nil {
@@ -2109,14 +2363,7 @@ func (m *Close) ProtoSize() (n int) {
 }
 
 func sovBep(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozBep(x uint64) (n int) {
 	return sovBep(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -2136,7 +2383,7 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2164,7 +2411,7 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2174,6 +2421,9 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2193,7 +2443,7 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2203,6 +2453,9 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2222,7 +2475,7 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2232,6 +2485,9 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2244,6 +2500,9 @@ func (m *Hello) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -2273,7 +2532,7 @@ func (m *Header) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2301,7 +2560,7 @@ func (m *Header) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Type |= (MessageType(b) & 0x7F) << shift
+				m.Type |= MessageType(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2320,7 +2579,7 @@ func (m *Header) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Compression |= (MessageCompression(b) & 0x7F) << shift
+				m.Compression |= MessageCompression(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2332,6 +2591,9 @@ func (m *Header) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -2361,7 +2623,7 @@ func (m *ClusterConfig) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2389,7 +2651,7 @@ func (m *ClusterConfig) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2398,6 +2660,9 @@ func (m *ClusterConfig) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2413,6 +2678,9 @@ func (m *ClusterConfig) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -2442,7 +2710,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2470,7 +2738,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2480,6 +2748,9 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2499,7 +2770,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2509,6 +2780,9 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2528,7 +2802,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2548,7 +2822,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2568,7 +2842,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2588,7 +2862,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2608,7 +2882,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2628,7 +2902,7 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2637,6 +2911,9 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2652,6 +2929,9 @@ func (m *Folder) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -2681,7 +2961,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2709,7 +2989,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2718,6 +2998,9 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2739,7 +3022,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2749,6 +3032,9 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2768,7 +3054,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2778,6 +3064,9 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2797,7 +3086,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Compression |= (Compression(b) & 0x7F) << shift
+				m.Compression |= Compression(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2816,7 +3105,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2826,6 +3115,9 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -2845,7 +3137,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.MaxSequence |= (int64(b) & 0x7F) << shift
+				m.MaxSequence |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2864,7 +3156,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2884,7 +3176,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.IndexID |= (IndexID(b) & 0x7F) << shift
+				m.IndexID |= IndexID(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2903,7 +3195,7 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2916,6 +3208,9 @@ func (m *Device) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -2945,7 +3240,7 @@ func (m *Index) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -2973,7 +3268,7 @@ func (m *Index) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -2983,6 +3278,9 @@ func (m *Index) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3002,7 +3300,7 @@ func (m *Index) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3011,6 +3309,9 @@ func (m *Index) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3026,6 +3327,9 @@ func (m *Index) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -3055,7 +3359,7 @@ func (m *IndexUpdate) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -3083,7 +3387,7 @@ func (m *IndexUpdate) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3093,6 +3397,9 @@ func (m *IndexUpdate) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3112,7 +3419,7 @@ func (m *IndexUpdate) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3121,6 +3428,9 @@ func (m *IndexUpdate) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3136,6 +3446,9 @@ func (m *IndexUpdate) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -3165,7 +3478,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -3193,7 +3506,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3203,6 +3516,9 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3222,7 +3538,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Type |= (FileInfoType(b) & 0x7F) << shift
+				m.Type |= FileInfoType(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3241,7 +3557,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Size |= (int64(b) & 0x7F) << shift
+				m.Size |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3260,7 +3576,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Permissions |= (uint32(b) & 0x7F) << shift
+				m.Permissions |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3279,7 +3595,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ModifiedS |= (int64(b) & 0x7F) << shift
+				m.ModifiedS |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3298,7 +3614,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3318,7 +3634,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3338,7 +3654,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3358,7 +3674,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3367,6 +3683,9 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3388,7 +3707,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Sequence |= (int64(b) & 0x7F) << shift
+				m.Sequence |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3407,7 +3726,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ModifiedNs |= (int32(b) & 0x7F) << shift
+				m.ModifiedNs |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3426,7 +3745,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ModifiedBy |= (ShortID(b) & 0x7F) << shift
+				m.ModifiedBy |= ShortID(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3445,7 +3764,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.RawBlockSize |= (int32(b) & 0x7F) << shift
+				m.RawBlockSize |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3464,7 +3783,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3473,6 +3792,9 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3495,7 +3817,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3505,6 +3827,9 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3524,7 +3849,7 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.LocalFlags |= (uint32(b) & 0x7F) << shift
+				m.LocalFlags |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3536,6 +3861,9 @@ func (m *FileInfo) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -3565,7 +3893,7 @@ func (m *BlockInfo) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -3593,7 +3921,7 @@ func (m *BlockInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Offset |= (int64(b) & 0x7F) << shift
+				m.Offset |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3612,7 +3940,7 @@ func (m *BlockInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Size |= (int32(b) & 0x7F) << shift
+				m.Size |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3631,7 +3959,7 @@ func (m *BlockInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3640,6 +3968,9 @@ func (m *BlockInfo) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3662,7 +3993,7 @@ func (m *BlockInfo) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.WeakHash |= (uint32(b) & 0x7F) << shift
+				m.WeakHash |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3674,6 +4005,9 @@ func (m *BlockInfo) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -3703,7 +4037,7 @@ func (m *Vector) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -3731,7 +4065,7 @@ func (m *Vector) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3740,6 +4074,9 @@ func (m *Vector) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3755,6 +4092,9 @@ func (m *Vector) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -3784,7 +4124,7 @@ func (m *Counter) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -3812,7 +4152,7 @@ func (m *Counter) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ID |= (ShortID(b) & 0x7F) << shift
+				m.ID |= ShortID(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3831,7 +4171,7 @@ func (m *Counter) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Value |= (uint64(b) & 0x7F) << shift
+				m.Value |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3843,6 +4183,9 @@ func (m *Counter) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -3872,7 +4215,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -3900,7 +4243,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ID |= (int32(b) & 0x7F) << shift
+				m.ID |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3919,7 +4262,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3929,6 +4272,9 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3948,7 +4294,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3958,6 +4304,9 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -3977,7 +4326,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Offset |= (int64(b) & 0x7F) << shift
+				m.Offset |= int64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -3996,7 +4345,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Size |= (int32(b) & 0x7F) << shift
+				m.Size |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4015,7 +4364,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4024,6 +4373,9 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -4046,7 +4398,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4066,7 +4418,7 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.WeakHash |= (uint32(b) & 0x7F) << shift
+				m.WeakHash |= uint32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4078,6 +4430,9 @@ func (m *Request) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -4107,7 +4462,7 @@ func (m *Response) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -4135,7 +4490,7 @@ func (m *Response) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.ID |= (int32(b) & 0x7F) << shift
+				m.ID |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4154,7 +4509,7 @@ func (m *Response) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4163,6 +4518,9 @@ func (m *Response) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -4185,7 +4543,7 @@ func (m *Response) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Code |= (ErrorCode(b) & 0x7F) << shift
+				m.Code |= ErrorCode(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4197,6 +4555,9 @@ func (m *Response) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -4226,7 +4587,7 @@ func (m *DownloadProgress) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -4254,7 +4615,7 @@ func (m *DownloadProgress) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4264,6 +4625,9 @@ func (m *DownloadProgress) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -4283,7 +4647,7 @@ func (m *DownloadProgress) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4292,6 +4656,9 @@ func (m *DownloadProgress) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -4307,6 +4674,9 @@ func (m *DownloadProgress) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -4336,7 +4706,7 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -4364,7 +4734,7 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.UpdateType |= (FileDownloadProgressUpdateType(b) & 0x7F) << shift
+				m.UpdateType |= FileDownloadProgressUpdateType(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4383,7 +4753,7 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4393,6 +4763,9 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -4412,7 +4785,7 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4421,6 +4794,9 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -4440,7 +4816,7 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					v |= (int32(b) & 0x7F) << shift
+					v |= int32(b&0x7F) << shift
 					if b < 0x80 {
 						break
 					}
@@ -4457,7 +4833,7 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					packedLen |= (int(b) & 0x7F) << shift
+					packedLen |= int(b&0x7F) << shift
 					if b < 0x80 {
 						break
 					}
@@ -4466,12 +4842,15 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 					return ErrInvalidLengthBep
 				}
 				postIndex := iNdEx + packedLen
+				if postIndex < 0 {
+					return ErrInvalidLengthBep
+				}
 				if postIndex > l {
 					return io.ErrUnexpectedEOF
 				}
 				var elementCount int
 				var count int
-				for _, integer := range dAtA {
+				for _, integer := range dAtA[iNdEx:postIndex] {
 					if integer < 128 {
 						count++
 					}
@@ -4491,7 +4870,7 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 						}
 						b := dAtA[iNdEx]
 						iNdEx++
-						v |= (int32(b) & 0x7F) << shift
+						v |= int32(b&0x7F) << shift
 						if b < 0x80 {
 							break
 						}
@@ -4508,6 +4887,9 @@ func (m *FileDownloadProgressUpdate) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -4537,7 +4919,7 @@ func (m *Ping) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -4558,6 +4940,9 @@ func (m *Ping) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -4587,7 +4972,7 @@ func (m *Close) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -4615,7 +5000,7 @@ func (m *Close) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				stringLen |= (uint64(b) & 0x7F) << shift
+				stringLen |= uint64(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -4625,6 +5010,9 @@ func (m *Close) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthBep
 			}
 			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthBep
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -4637,6 +5025,9 @@ func (m *Close) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthBep
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthBep
 			}
 			if (iNdEx + skippy) > l {
@@ -4705,8 +5096,11 @@ func skipBep(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthBep
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthBep
 			}
 			return iNdEx, nil
@@ -4737,6 +5131,9 @@ func skipBep(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthBep
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -4755,122 +5152,3 @@ var (
 	ErrInvalidLengthBep = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowBep   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("bep.proto", fileDescriptor_bep_83d45b003aedf660) }
-
-var fileDescriptor_bep_83d45b003aedf660 = []byte{
-	// 1800 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x56, 0x4f, 0x6f, 0xdb, 0xc8,
-	0x15, 0x17, 0x25, 0xea, 0xdf, 0x93, 0xec, 0xa5, 0x27, 0x89, 0xcb, 0x72, 0xb3, 0x12, 0xa3, 0x24,
-	0x1b, 0xad, 0xb1, 0x4d, 0xd2, 0xdd, 0x6d, 0x8b, 0x16, 0x6d, 0x01, 0xfd, 0xa1, 0x1d, 0xa1, 0x8e,
-	0xe4, 0x8e, 0xe4, 0x6c, 0xb3, 0x87, 0x12, 0xb4, 0x38, 0x92, 0x89, 0x50, 0x1c, 0x95, 0xa4, 0xec,
-	0x68, 0x3f, 0x82, 0x4e, 0x3d, 0xf6, 0x22, 0x60, 0x81, 0x9e, 0xfa, 0x4d, 0x72, 0x4c, 0x7b, 0x28,
-	0x8a, 0x1e, 0x8c, 0xae, 0x73, 0xd9, 0x63, 0x3f, 0x41, 0x51, 0xcc, 0x0c, 0x29, 0x51, 0x76, 0xb2,
-	0xc8, 0x61, 0x4f, 0x9c, 0x79, 0xef, 0x37, 0x33, 0x7c, 0xbf, 0xf7, 0x7b, 0x6f, 0x06, 0x8a, 0x27,
-	0x64, 0xfa, 0x70, 0xea, 0xd3, 0x90, 0xa2, 0x02, 0xff, 0x0c, 0xa9, 0xab, 0xdd, 0xf5, 0xc9, 0x94,
-	0x06, 0x8f, 0xf8, 0xfc, 0x64, 0x36, 0x7a, 0x34, 0xa6, 0x63, 0xca, 0x27, 0x7c, 0x24, 0xe0, 0xb5,
-	0x29, 0x64, 0x9f, 0x10, 0xd7, 0xa5, 0xa8, 0x0a, 0x25, 0x9b, 0x9c, 0x39, 0x43, 0x62, 0x7a, 0xd6,
-	0x84, 0xa8, 0x92, 0x2e, 0xd5, 0x8b, 0x18, 0x84, 0xa9, 0x6b, 0x4d, 0x08, 0x03, 0x0c, 0x5d, 0x87,
-	0x78, 0xa1, 0x00, 0xa4, 0x05, 0x40, 0x98, 0x38, 0xe0, 0x3e, 0x6c, 0x47, 0x80, 0x33, 0xe2, 0x07,
-	0x0e, 0xf5, 0xd4, 0x0c, 0xc7, 0x6c, 0x09, 0xeb, 0x33, 0x61, 0xac, 0x05, 0x90, 0x7b, 0x42, 0x2c,
-	0x9b, 0xf8, 0xe8, 0x13, 0x90, 0xc3, 0xf9, 0x54, 0x9c, 0xb5, 0xfd, 0xd9, 0xad, 0x87, 0xf1, 0x9f,
-	0x3f, 0x7c, 0x4a, 0x82, 0xc0, 0x1a, 0x93, 0xc1, 0x7c, 0x4a, 0x30, 0x87, 0xa0, 0xdf, 0x42, 0x69,
-	0x48, 0x27, 0x53, 0x9f, 0x04, 0x7c, 0xe3, 0x34, 0x5f, 0x71, 0xfb, 0xda, 0x8a, 0xd6, 0x1a, 0x83,
-	0x93, 0x0b, 0x6a, 0x0d, 0xd8, 0x6a, 0xb9, 0xb3, 0x20, 0x24, 0x7e, 0x8b, 0x7a, 0x23, 0x67, 0x8c,
-	0x1e, 0x43, 0x7e, 0x44, 0x5d, 0x9b, 0xf8, 0x81, 0x2a, 0xe9, 0x99, 0x7a, 0xe9, 0x33, 0x65, 0xbd,
-	0xd9, 0x3e, 0x77, 0x34, 0xe5, 0x57, 0x17, 0xd5, 0x14, 0x8e, 0x61, 0xb5, 0xbf, 0xa6, 0x21, 0x27,
-	0x3c, 0x68, 0x17, 0xd2, 0x8e, 0x2d, 0x28, 0x6a, 0xe6, 0x2e, 0x2f, 0xaa, 0xe9, 0x4e, 0x1b, 0xa7,
-	0x1d, 0x1b, 0xdd, 0x84, 0xac, 0x6b, 0x9d, 0x10, 0x37, 0x22, 0x47, 0x4c, 0xd0, 0x87, 0x50, 0xf4,
-	0x89, 0x65, 0x9b, 0xd4, 0x73, 0xe7, 0x9c, 0x92, 0x02, 0x2e, 0x30, 0x43, 0xcf, 0x73, 0xe7, 0xe8,
-	0x27, 0x80, 0x9c, 0xb1, 0x47, 0x7d, 0x62, 0x4e, 0x89, 0x3f, 0x71, 0xf8, 0xdf, 0x06, 0xaa, 0xcc,
-	0x51, 0x3b, 0xc2, 0x73, 0xb4, 0x76, 0xa0, 0xbb, 0xb0, 0x15, 0xc1, 0x6d, 0xe2, 0x92, 0x90, 0xa8,
-	0x59, 0x8e, 0x2c, 0x0b, 0x63, 0x9b, 0xdb, 0xd0, 0x63, 0xb8, 0x69, 0x3b, 0x81, 0x75, 0xe2, 0x12,
-	0x33, 0x24, 0x93, 0xa9, 0xe9, 0x78, 0x36, 0x79, 0x49, 0x02, 0x35, 0xc7, 0xb1, 0x28, 0xf2, 0x0d,
-	0xc8, 0x64, 0xda, 0x11, 0x1e, 0xb4, 0x0b, 0xb9, 0xa9, 0x35, 0x0b, 0x88, 0xad, 0xe6, 0x39, 0x26,
-	0x9a, 0x31, 0x96, 0x84, 0x02, 0x02, 0x55, 0xb9, 0xca, 0x52, 0x9b, 0x3b, 0x62, 0x96, 0x22, 0x58,
-	0xed, 0xbf, 0x69, 0xc8, 0x09, 0x0f, 0xfa, 0x78, 0xc5, 0x52, 0xb9, 0xb9, 0xcb, 0x50, 0xff, 0xbe,
-	0xa8, 0x16, 0x84, 0xaf, 0xd3, 0x4e, 0xb0, 0x86, 0x40, 0x4e, 0x28, 0x8a, 0x8f, 0xd1, 0x6d, 0x28,
-	0x5a, 0xb6, 0xcd, 0xb2, 0x47, 0x02, 0x35, 0xa3, 0x67, 0xea, 0x45, 0xbc, 0x36, 0xa0, 0x5f, 0x6c,
-	0xaa, 0x41, 0xbe, 0xaa, 0x9f, 0x77, 0xc9, 0x80, 0xa5, 0x62, 0x48, 0xfc, 0x48, 0xc1, 0x59, 0x7e,
-	0x5e, 0x81, 0x19, 0xb8, 0x7e, 0xef, 0x40, 0x79, 0x62, 0xbd, 0x34, 0x03, 0xf2, 0xa7, 0x19, 0xf1,
-	0x86, 0x84, 0xd3, 0x95, 0xc1, 0xa5, 0x89, 0xf5, 0xb2, 0x1f, 0x99, 0x50, 0x05, 0xc0, 0xf1, 0x42,
-	0x9f, 0xda, 0xb3, 0x21, 0xf1, 0x23, 0xae, 0x12, 0x16, 0xf4, 0x33, 0x28, 0x70, 0xb2, 0x4d, 0xc7,
-	0x56, 0x0b, 0xba, 0x54, 0x97, 0x9b, 0x5a, 0x14, 0x78, 0x9e, 0x53, 0xcd, 0xe3, 0x8e, 0x87, 0x38,
-	0xcf, 0xb1, 0x1d, 0x1b, 0xfd, 0x1a, 0xb4, 0xe0, 0x85, 0xc3, 0x12, 0x25, 0x76, 0x0a, 0x1d, 0xea,
-	0x99, 0x3e, 0x99, 0xd0, 0x33, 0xcb, 0x0d, 0xd4, 0x22, 0x3f, 0x46, 0x65, 0x88, 0x4e, 0x02, 0x80,
-	0x23, 0x7f, 0xad, 0x07, 0x59, 0xbe, 0x23, 0xcb, 0xa2, 0x10, 0x6b, 0x54, 0xbd, 0xd1, 0x0c, 0x3d,
-	0x84, 0xec, 0xc8, 0x71, 0x49, 0xa0, 0xa6, 0x79, 0x0e, 0x51, 0x42, 0xe9, 0x8e, 0x4b, 0x3a, 0xde,
-	0x88, 0x46, 0x59, 0x14, 0xb0, 0xda, 0x31, 0x94, 0xf8, 0x86, 0xc7, 0x53, 0xdb, 0x0a, 0xc9, 0x0f,
-	0xb6, 0xed, 0x85, 0x0c, 0x85, 0xd8, 0xb3, 0x4a, 0xba, 0x94, 0x48, 0xfa, 0x5e, 0xd4, 0x0f, 0x44,
-	0x75, 0xef, 0x5e, 0xdf, 0x2f, 0xd1, 0x10, 0x10, 0xc8, 0x81, 0xf3, 0x35, 0xe1, 0xf5, 0x94, 0xc1,
-	0x7c, 0x8c, 0x74, 0x28, 0x5d, 0x2d, 0xa2, 0x2d, 0x9c, 0x34, 0xa1, 0x8f, 0x00, 0x26, 0xd4, 0x76,
-	0x46, 0x0e, 0xb1, 0xcd, 0x80, 0x0b, 0x20, 0x83, 0x8b, 0xb1, 0xa5, 0x8f, 0x54, 0x26, 0x77, 0x56,
-	0x42, 0x76, 0x54, 0x2b, 0xf1, 0x14, 0xd5, 0x21, 0xef, 0x78, 0x67, 0x96, 0xeb, 0x44, 0x15, 0xd2,
-	0xdc, 0xbe, 0xbc, 0xa8, 0x02, 0xb6, 0xce, 0x3b, 0xc2, 0x8a, 0x63, 0x37, 0xeb, 0x82, 0x1e, 0xdd,
-	0x28, 0xe6, 0x02, 0xdf, 0x6a, 0xcb, 0xa3, 0xc9, 0x42, 0x7e, 0x0c, 0xf9, 0xb8, 0x4b, 0xb2, 0xfc,
-	0x6e, 0x54, 0xd6, 0x33, 0x32, 0x0c, 0xe9, 0xaa, 0xff, 0x44, 0x30, 0xa4, 0x41, 0x61, 0x25, 0x4d,
-	0xe0, 0x7f, 0xbe, 0x9a, 0xb3, 0xde, 0xbc, 0x8a, 0xcb, 0x0b, 0xd4, 0x92, 0x2e, 0xd5, 0xb3, 0x78,
-	0x15, 0x6a, 0x97, 0x1d, 0xb7, 0x06, 0x9c, 0xcc, 0xd5, 0x32, 0xd7, 0xe6, 0x07, 0xb1, 0x36, 0xfb,
-	0xa7, 0xd4, 0x0f, 0x3b, 0xed, 0xf5, 0x8a, 0xe6, 0x1c, 0x3d, 0x02, 0x38, 0x71, 0xe9, 0xf0, 0x85,
-	0xc9, 0x69, 0xde, 0x62, 0x3b, 0x36, 0x95, 0xcb, 0x8b, 0x6a, 0x19, 0x5b, 0xe7, 0x4d, 0xe6, 0xe8,
-	0x3b, 0x5f, 0x13, 0x5c, 0x3c, 0x89, 0x87, 0xe8, 0xa7, 0x90, 0xe3, 0xf6, 0xb8, 0x55, 0xdc, 0x58,
-	0x07, 0xc4, 0xed, 0x09, 0x41, 0x44, 0x40, 0xc6, 0x55, 0x30, 0x9f, 0xb8, 0x8e, 0xf7, 0xc2, 0x0c,
-	0x2d, 0x7f, 0x4c, 0x42, 0x75, 0x47, 0xdc, 0x18, 0x91, 0x75, 0xc0, 0x8d, 0x2c, 0xaf, 0x2e, 0x1d,
-	0x5a, 0xae, 0x39, 0x72, 0xad, 0x71, 0xa0, 0x7e, 0x97, 0xe7, 0x89, 0x05, 0x6e, 0xdb, 0x67, 0xa6,
-	0x5f, 0xc9, 0x7f, 0xf9, 0xa6, 0x9a, 0xaa, 0x79, 0x50, 0x5c, 0x9d, 0xc4, 0x54, 0x4b, 0x47, 0xa3,
-	0x80, 0x84, 0x5c, 0x62, 0x19, 0x1c, 0xcd, 0x56, 0xc2, 0x49, 0x73, 0x8e, 0x84, 0x70, 0x10, 0xc8,
-	0xa7, 0x56, 0x70, 0xca, 0xc5, 0x54, 0xc6, 0x7c, 0xcc, 0x5a, 0xc5, 0x39, 0xb1, 0x5e, 0x98, 0xdc,
-	0x21, 0xa4, 0x54, 0x60, 0x86, 0x27, 0x56, 0x70, 0x1a, 0x9d, 0xf7, 0x1b, 0xc8, 0x89, 0x54, 0xa1,
-	0xcf, 0xa1, 0x30, 0xa4, 0x33, 0x2f, 0x5c, 0x5f, 0x27, 0x3b, 0xc9, 0x6e, 0xc4, 0x3d, 0x51, 0xec,
-	0x2b, 0x60, 0x6d, 0x1f, 0xf2, 0x91, 0x0b, 0xdd, 0x5f, 0xb5, 0x4a, 0xb9, 0x79, 0xeb, 0x4a, 0x56,
-	0x36, 0xef, 0x97, 0x33, 0xcb, 0x9d, 0x89, 0x9f, 0x97, 0xb1, 0x98, 0xd4, 0xfe, 0x2e, 0x41, 0x1e,
-	0x33, 0x25, 0x04, 0x61, 0xe2, 0x66, 0xca, 0x6e, 0xdc, 0x4c, 0xeb, 0x1a, 0x4e, 0x6f, 0xd4, 0x70,
-	0x5c, 0x86, 0x99, 0x44, 0x19, 0xae, 0x99, 0x93, 0xdf, 0xca, 0x5c, 0xf6, 0x2d, 0xcc, 0xe5, 0x12,
-	0xcc, 0xdd, 0x87, 0xed, 0x91, 0x4f, 0x27, 0xfc, 0xee, 0xa1, 0xbe, 0xe5, 0xcf, 0xa3, 0x46, 0xb9,
-	0xc5, 0xac, 0x83, 0xd8, 0xb8, 0x49, 0x70, 0x61, 0x93, 0xe0, 0x9a, 0x09, 0x05, 0x4c, 0x82, 0x29,
-	0xf5, 0x02, 0xf2, 0xce, 0x98, 0x10, 0xc8, 0xb6, 0x15, 0x5a, 0x3c, 0xa2, 0x32, 0xe6, 0x63, 0xf4,
-	0x00, 0xe4, 0x21, 0xb5, 0x45, 0x3c, 0xdb, 0x49, 0x09, 0x1a, 0xbe, 0x4f, 0xfd, 0x16, 0xb5, 0x09,
-	0xe6, 0x80, 0xda, 0x14, 0x94, 0x36, 0x3d, 0xf7, 0x5c, 0x6a, 0xd9, 0x47, 0x3e, 0x1d, 0xb3, 0x0b,
-	0xe2, 0x9d, 0x8d, 0xae, 0x0d, 0xf9, 0x19, 0x6f, 0x85, 0x71, 0xab, 0xbb, 0xb7, 0xd9, 0x9a, 0xae,
-	0x6e, 0x24, 0xfa, 0x66, 0x5c, 0xbf, 0xd1, 0xd2, 0xda, 0x3f, 0x25, 0xd0, 0xde, 0x8d, 0x46, 0x1d,
-	0x28, 0x09, 0xa4, 0x99, 0x78, 0x13, 0xd5, 0xdf, 0xe7, 0x20, 0xde, 0x15, 0x61, 0xb6, 0x1a, 0xbf,
-	0xf5, 0x42, 0x4d, 0xf4, 0x9b, 0xcc, 0xfb, 0xf5, 0x9b, 0x07, 0xb0, 0x25, 0x1a, 0x40, 0xfc, 0x7c,
-	0x90, 0xf5, 0x4c, 0x3d, 0xdb, 0x4c, 0x2b, 0x29, 0x5c, 0x3e, 0x11, 0x65, 0xc6, 0xed, 0xb5, 0x1c,
-	0xc8, 0x47, 0x8e, 0x37, 0xae, 0x55, 0x21, 0xdb, 0x72, 0x29, 0x4f, 0x58, 0xce, 0x27, 0x56, 0x40,
-	0xbd, 0x98, 0x47, 0x31, 0xdb, 0xfb, 0x47, 0x1a, 0x4a, 0x89, 0xa7, 0x1d, 0x7a, 0x0c, 0xdb, 0xad,
-	0xc3, 0xe3, 0xfe, 0xc0, 0xc0, 0x66, 0xab, 0xd7, 0xdd, 0xef, 0x1c, 0x28, 0x29, 0xed, 0xf6, 0x62,
-	0xa9, 0xab, 0x93, 0x35, 0x68, 0xf3, 0xd5, 0x56, 0x85, 0x6c, 0xa7, 0xdb, 0x36, 0xfe, 0xa0, 0x48,
-	0xda, 0xcd, 0xc5, 0x52, 0x57, 0x12, 0x40, 0x71, 0x05, 0x7e, 0x0a, 0x65, 0x0e, 0x30, 0x8f, 0x8f,
-	0xda, 0x8d, 0x81, 0xa1, 0xa4, 0x35, 0x6d, 0xb1, 0xd4, 0x77, 0xaf, 0xe2, 0x22, 0xce, 0xef, 0x42,
-	0x1e, 0x1b, 0xbf, 0x3f, 0x36, 0xfa, 0x03, 0x25, 0xa3, 0xed, 0x2e, 0x96, 0x3a, 0x4a, 0x00, 0xe3,
-	0x92, 0xba, 0x0f, 0x05, 0x6c, 0xf4, 0x8f, 0x7a, 0xdd, 0xbe, 0xa1, 0xc8, 0xda, 0x8f, 0x16, 0x4b,
-	0xfd, 0xc6, 0x06, 0x2a, 0x52, 0xe9, 0xcf, 0x61, 0xa7, 0xdd, 0xfb, 0xb2, 0x7b, 0xd8, 0x6b, 0xb4,
-	0xcd, 0x23, 0xdc, 0x3b, 0xc0, 0x46, 0xbf, 0xaf, 0x64, 0xb5, 0xea, 0x62, 0xa9, 0x7f, 0x98, 0xc0,
-	0x5f, 0x13, 0xdd, 0x47, 0x20, 0x1f, 0x75, 0xba, 0x07, 0x4a, 0x4e, 0xbb, 0xb1, 0x58, 0xea, 0x1f,
-	0x24, 0xa0, 0x8c, 0x54, 0x16, 0x71, 0xeb, 0xb0, 0xd7, 0x37, 0x94, 0xfc, 0xb5, 0x88, 0x39, 0xd9,
-	0x7b, 0x7f, 0x04, 0x74, 0xfd, 0xf1, 0x8b, 0xee, 0x81, 0xdc, 0xed, 0x75, 0x0d, 0x25, 0x25, 0xe2,
-	0xbf, 0x8e, 0xe8, 0x52, 0x8f, 0xa0, 0x1a, 0x64, 0x0e, 0xbf, 0xfa, 0x42, 0x91, 0xb4, 0x1f, 0x2f,
-	0x96, 0xfa, 0xad, 0xeb, 0xa0, 0xc3, 0xaf, 0xbe, 0xd8, 0xa3, 0x50, 0x4a, 0x6e, 0x5c, 0x83, 0xc2,
-	0x53, 0x63, 0xd0, 0x68, 0x37, 0x06, 0x0d, 0x25, 0x25, 0x7e, 0x29, 0x76, 0x3f, 0x25, 0xa1, 0xc5,
-	0x8b, 0xf0, 0x36, 0x64, 0xbb, 0xc6, 0x33, 0x03, 0x2b, 0x92, 0xb6, 0xb3, 0x58, 0xea, 0x5b, 0x31,
-	0xa0, 0x4b, 0xce, 0x88, 0x8f, 0x2a, 0x90, 0x6b, 0x1c, 0x7e, 0xd9, 0x78, 0xde, 0x57, 0xd2, 0x1a,
-	0x5a, 0x2c, 0xf5, 0xed, 0xd8, 0xdd, 0x70, 0xcf, 0xad, 0x79, 0xb0, 0xf7, 0x3f, 0x09, 0xca, 0xc9,
-	0x0b, 0x1f, 0x55, 0x40, 0xde, 0xef, 0x1c, 0x1a, 0xf1, 0x71, 0x49, 0x1f, 0x1b, 0xa3, 0x3a, 0x14,
-	0xdb, 0x1d, 0x6c, 0xb4, 0x06, 0x3d, 0xfc, 0x3c, 0x8e, 0x25, 0x09, 0x6a, 0x3b, 0x3e, 0x17, 0xf8,
-	0x1c, 0xfd, 0x12, 0xca, 0xfd, 0xe7, 0x4f, 0x0f, 0x3b, 0xdd, 0xdf, 0x99, 0x7c, 0xc7, 0xb4, 0xf6,
-	0x60, 0xb1, 0xd4, 0xef, 0x6c, 0x80, 0xc9, 0xd4, 0x27, 0x43, 0x2b, 0x24, 0x76, 0x5f, 0xdc, 0x41,
-	0xcc, 0x59, 0x90, 0x50, 0x0b, 0x76, 0xe2, 0xa5, 0xeb, 0xc3, 0x32, 0xda, 0xa7, 0x8b, 0xa5, 0xfe,
-	0xf1, 0xf7, 0xae, 0x5f, 0x9d, 0x5e, 0x90, 0xd0, 0x3d, 0xc8, 0x47, 0x9b, 0xc4, 0x4a, 0x4a, 0x2e,
-	0x8d, 0x16, 0xec, 0xfd, 0x4d, 0x82, 0xe2, 0xaa, 0x5d, 0x31, 0xc2, 0xbb, 0x3d, 0xd3, 0xc0, 0xb8,
-	0x87, 0x63, 0x06, 0x56, 0xce, 0x2e, 0xe5, 0x43, 0x74, 0x07, 0xf2, 0x07, 0x46, 0xd7, 0xc0, 0x9d,
-	0x56, 0x5c, 0x18, 0x2b, 0xc8, 0x01, 0xf1, 0x88, 0xef, 0x0c, 0xd1, 0x27, 0x50, 0xee, 0xf6, 0xcc,
-	0xfe, 0x71, 0xeb, 0x49, 0x1c, 0x3a, 0x3f, 0x3f, 0xb1, 0x55, 0x7f, 0x36, 0x3c, 0xe5, 0x7c, 0xee,
-	0xb1, 0x1a, 0x7a, 0xd6, 0x38, 0xec, 0xb4, 0x05, 0x34, 0xa3, 0xa9, 0x8b, 0xa5, 0x7e, 0x73, 0x05,
-	0x8d, 0x9e, 0x3c, 0x0c, 0xbb, 0x67, 0x43, 0xe5, 0xfb, 0x1b, 0x13, 0xd2, 0x21, 0xd7, 0x38, 0x3a,
-	0x32, 0xba, 0xed, 0xf8, 0xef, 0xd7, 0xbe, 0xc6, 0x74, 0x4a, 0x3c, 0x9b, 0x21, 0xf6, 0x7b, 0xf8,
-	0xc0, 0x18, 0xc4, 0x3f, 0xbf, 0x46, 0xec, 0x53, 0xf6, 0x00, 0x68, 0xd6, 0x5f, 0x7d, 0x5b, 0x49,
-	0xbd, 0xfe, 0xb6, 0x92, 0x7a, 0x75, 0x59, 0x91, 0x5e, 0x5f, 0x56, 0xa4, 0xff, 0x5c, 0x56, 0x52,
-	0xdf, 0x5d, 0x56, 0xa4, 0x3f, 0xbf, 0xa9, 0xa4, 0xbe, 0x79, 0x53, 0x91, 0x5e, 0xbf, 0xa9, 0xa4,
-	0xfe, 0xf5, 0xa6, 0x92, 0x3a, 0xc9, 0xf1, 0xa6, 0xf6, 0xf9, 0xff, 0x03, 0x00, 0x00, 0xff, 0xff,
-	0x02, 0x4d, 0x9a, 0x1c, 0x11, 0x0f, 0x00, 0x00,
-}

--- a/lib/protocol/deviceid_test.pb.go
+++ b/lib/protocol/deviceid_test.pb.go
@@ -3,12 +3,14 @@
 
 package protocol
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-
-import io "io"
+import (
+	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -19,7 +21,7 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type TestOldDeviceID struct {
 	Test []byte `protobuf:"bytes,1,opt,name=test,proto3" json:"test,omitempty"`
@@ -29,7 +31,7 @@ func (m *TestOldDeviceID) Reset()         { *m = TestOldDeviceID{} }
 func (m *TestOldDeviceID) String() string { return proto.CompactTextString(m) }
 func (*TestOldDeviceID) ProtoMessage()    {}
 func (*TestOldDeviceID) Descriptor() ([]byte, []int) {
-	return fileDescriptor_deviceid_test_36bcb89b605bdafe, []int{0}
+	return fileDescriptor_a5b590761a4231d0, []int{0}
 }
 func (m *TestOldDeviceID) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -39,15 +41,15 @@ func (m *TestOldDeviceID) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return xxx_messageInfo_TestOldDeviceID.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *TestOldDeviceID) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TestOldDeviceID.Merge(dst, src)
+func (m *TestOldDeviceID) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TestOldDeviceID.Merge(m, src)
 }
 func (m *TestOldDeviceID) XXX_Size() int {
 	return m.ProtoSize()
@@ -66,7 +68,7 @@ func (m *TestNewDeviceID) Reset()         { *m = TestNewDeviceID{} }
 func (m *TestNewDeviceID) String() string { return proto.CompactTextString(m) }
 func (*TestNewDeviceID) ProtoMessage()    {}
 func (*TestNewDeviceID) Descriptor() ([]byte, []int) {
-	return fileDescriptor_deviceid_test_36bcb89b605bdafe, []int{1}
+	return fileDescriptor_a5b590761a4231d0, []int{1}
 }
 func (m *TestNewDeviceID) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -76,15 +78,15 @@ func (m *TestNewDeviceID) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return xxx_messageInfo_TestNewDeviceID.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *TestNewDeviceID) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_TestNewDeviceID.Merge(dst, src)
+func (m *TestNewDeviceID) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_TestNewDeviceID.Merge(m, src)
 }
 func (m *TestNewDeviceID) XXX_Size() int {
 	return m.ProtoSize()
@@ -99,10 +101,29 @@ func init() {
 	proto.RegisterType((*TestOldDeviceID)(nil), "protocol.TestOldDeviceID")
 	proto.RegisterType((*TestNewDeviceID)(nil), "protocol.TestNewDeviceID")
 }
+
+func init() { proto.RegisterFile("deviceid_test.proto", fileDescriptor_a5b590761a4231d0) }
+
+var fileDescriptor_a5b590761a4231d0 = []byte{
+	// 182 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4e, 0x49, 0x2d, 0xcb,
+	0x4c, 0x4e, 0xcd, 0x4c, 0x89, 0x2f, 0x49, 0x2d, 0x2e, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17,
+	0xe2, 0x00, 0x53, 0xc9, 0xf9, 0x39, 0x52, 0xca, 0x45, 0xa9, 0x05, 0xf9, 0xc5, 0xfa, 0x60, 0x7e,
+	0x52, 0x69, 0x9a, 0x7e, 0x7a, 0x7e, 0x7a, 0x3e, 0x98, 0x03, 0x66, 0x41, 0x94, 0x2b, 0xa9, 0x72,
+	0xf1, 0x87, 0xa4, 0x16, 0x97, 0xf8, 0xe7, 0xa4, 0xb8, 0x80, 0x0d, 0xf3, 0x74, 0x11, 0x12, 0xe2,
+	0x62, 0x01, 0x99, 0x27, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0x13, 0x04, 0x66, 0x2b, 0x99, 0x43, 0x94,
+	0xf9, 0xa5, 0x96, 0xc3, 0x95, 0xa9, 0x20, 0x2b, 0x73, 0x12, 0x38, 0x71, 0x4f, 0x9e, 0xe1, 0xd6,
+	0x3d, 0x79, 0x0e, 0x98, 0x3c, 0x44, 0xa3, 0x93, 0xc6, 0x89, 0x87, 0x72, 0x0c, 0x17, 0x1e, 0xca,
+	0x31, 0x9c, 0x78, 0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3, 0x83, 0x47, 0x72, 0x0c, 0x2f, 0x1e,
+	0xc9, 0x31, 0x4c, 0x78, 0x2c, 0xc7, 0xb0, 0xe0, 0xb1, 0x1c, 0xe3, 0x85, 0xc7, 0x72, 0x0c, 0x37,
+	0x1e, 0xcb, 0x31, 0x24, 0xb1, 0x81, 0x1d, 0x64, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0xe3, 0x96,
+	0x3e, 0xc0, 0xd6, 0x00, 0x00, 0x00,
+}
+
 func (m *TestOldDeviceID) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -110,23 +131,29 @@ func (m *TestOldDeviceID) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TestOldDeviceID) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TestOldDeviceID) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
 	if len(m.Test) > 0 {
-		dAtA[i] = 0xa
-		i++
+		i -= len(m.Test)
+		copy(dAtA[i:], m.Test)
 		i = encodeVarintDeviceidTest(dAtA, i, uint64(len(m.Test)))
-		i += copy(dAtA[i:], m.Test)
+		i--
+		dAtA[i] = 0xa
 	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *TestNewDeviceID) Marshal() (dAtA []byte, err error) {
 	size := m.ProtoSize()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -134,29 +161,38 @@ func (m *TestNewDeviceID) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *TestNewDeviceID) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.ProtoSize()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *TestNewDeviceID) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	dAtA[i] = 0xa
-	i++
-	i = encodeVarintDeviceidTest(dAtA, i, uint64(m.Test.ProtoSize()))
-	n1, err := m.Test.MarshalTo(dAtA[i:])
-	if err != nil {
-		return 0, err
+	{
+		size := m.Test.ProtoSize()
+		i -= size
+		if _, err := m.Test.MarshalTo(dAtA[i:]); err != nil {
+			return 0, err
+		}
+		i = encodeVarintDeviceidTest(dAtA, i, uint64(size))
 	}
-	i += n1
-	return i, nil
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintDeviceidTest(dAtA []byte, offset int, v uint64) int {
+	offset -= sovDeviceidTest(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *TestOldDeviceID) ProtoSize() (n int) {
 	if m == nil {
@@ -183,14 +219,7 @@ func (m *TestNewDeviceID) ProtoSize() (n int) {
 }
 
 func sovDeviceidTest(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozDeviceidTest(x uint64) (n int) {
 	return sovDeviceidTest(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -210,7 +239,7 @@ func (m *TestOldDeviceID) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -238,7 +267,7 @@ func (m *TestOldDeviceID) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -247,6 +276,9 @@ func (m *TestOldDeviceID) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthDeviceidTest
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthDeviceidTest
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -262,6 +294,9 @@ func (m *TestOldDeviceID) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthDeviceidTest
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthDeviceidTest
 			}
 			if (iNdEx + skippy) > l {
@@ -291,7 +326,7 @@ func (m *TestNewDeviceID) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -319,7 +354,7 @@ func (m *TestNewDeviceID) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -328,6 +363,9 @@ func (m *TestNewDeviceID) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthDeviceidTest
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthDeviceidTest
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -342,6 +380,9 @@ func (m *TestNewDeviceID) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthDeviceidTest
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthDeviceidTest
 			}
 			if (iNdEx + skippy) > l {
@@ -410,8 +451,11 @@ func skipDeviceidTest(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
+				return 0, ErrInvalidLengthDeviceidTest
+			}
+			iNdEx += length
+			if iNdEx < 0 {
 				return 0, ErrInvalidLengthDeviceidTest
 			}
 			return iNdEx, nil
@@ -442,6 +486,9 @@ func skipDeviceidTest(dAtA []byte) (n int, err error) {
 					return 0, err
 				}
 				iNdEx = start + next
+				if iNdEx < 0 {
+					return 0, ErrInvalidLengthDeviceidTest
+				}
 			}
 			return iNdEx, nil
 		case 4:
@@ -460,21 +507,3 @@ var (
 	ErrInvalidLengthDeviceidTest = fmt.Errorf("proto: negative length found during unmarshaling")
 	ErrIntOverflowDeviceidTest   = fmt.Errorf("proto: integer overflow")
 )
-
-func init() { proto.RegisterFile("deviceid_test.proto", fileDescriptor_deviceid_test_36bcb89b605bdafe) }
-
-var fileDescriptor_deviceid_test_36bcb89b605bdafe = []byte{
-	// 182 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x4e, 0x49, 0x2d, 0xcb,
-	0x4c, 0x4e, 0xcd, 0x4c, 0x89, 0x2f, 0x49, 0x2d, 0x2e, 0xd1, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17,
-	0xe2, 0x00, 0x53, 0xc9, 0xf9, 0x39, 0x52, 0xca, 0x45, 0xa9, 0x05, 0xf9, 0xc5, 0xfa, 0x60, 0x7e,
-	0x52, 0x69, 0x9a, 0x7e, 0x7a, 0x7e, 0x7a, 0x3e, 0x98, 0x03, 0x66, 0x41, 0x94, 0x2b, 0xa9, 0x72,
-	0xf1, 0x87, 0xa4, 0x16, 0x97, 0xf8, 0xe7, 0xa4, 0xb8, 0x80, 0x0d, 0xf3, 0x74, 0x11, 0x12, 0xe2,
-	0x62, 0x01, 0x99, 0x27, 0xc1, 0xa8, 0xc0, 0xa8, 0xc1, 0x13, 0x04, 0x66, 0x2b, 0x99, 0x43, 0x94,
-	0xf9, 0xa5, 0x96, 0xc3, 0x95, 0xa9, 0x20, 0x2b, 0x73, 0x12, 0x38, 0x71, 0x4f, 0x9e, 0xe1, 0xd6,
-	0x3d, 0x79, 0x0e, 0x98, 0x3c, 0x44, 0xa3, 0x93, 0xc6, 0x89, 0x87, 0x72, 0x0c, 0x17, 0x1e, 0xca,
-	0x31, 0x9c, 0x78, 0x24, 0xc7, 0x78, 0xe1, 0x91, 0x1c, 0xe3, 0x83, 0x47, 0x72, 0x0c, 0x2f, 0x1e,
-	0xc9, 0x31, 0x4c, 0x78, 0x2c, 0xc7, 0xb0, 0xe0, 0xb1, 0x1c, 0xe3, 0x85, 0xc7, 0x72, 0x0c, 0x37,
-	0x1e, 0xcb, 0x31, 0x24, 0xb1, 0x81, 0x1d, 0x64, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0xe3, 0x96,
-	0x3e, 0xc0, 0xd6, 0x00, 0x00, 0x00,
-}


### PR DESCRIPTION
This is the result of:

- Changing build.go to take the protobuf version from the modules
  instead of hardcoded
- `go get github.com/gogo/protobuf@v1.3.0` to upgrade
- `go run build.go proto` to regenerate our code

### Testing

It could still connect to at least one device using the old code.
