### PR TITLE
lib/connections: Improve write rate limiting (fixes #5138)

### DIFF
--- a/lib/connections/limiter_test.go
+++ b/lib/connections/limiter_test.go
@@ -246,12 +246,13 @@ func TestLimitedWriterWrite(t *testing.T) {
 		t.Error("results should be equal")
 	}
 
-	// Once more, but making sure the fast path is used for an unlimited rate.
+	// Once more, but making sure the fast path is used for an unlimited
+	// rate, with multiple unlimited raters even (global and per-device).
 	dst = new(bytes.Buffer)
 	cw = &countingWriter{w: dst}
 	lw = &limitedWriter{
 		writer:    cw,
-		waiter:    rate.NewLimiter(rate.Inf, limiterBurstSize),
+		waiter:    totalWaiter{rate.NewLimiter(rate.Inf, limiterBurstSize), rate.NewLimiter(rate.Inf, limiterBurstSize)},
 		limitsLAN: new(atomicBool),
 		isLAN:     false, // enables limiting
 	}

--- a/lib/connections/limiter_test.go
+++ b/lib/connections/limiter_test.go
@@ -207,10 +207,12 @@ func TestLimitedWriterWrite(t *testing.T) {
 	dst := new(bytes.Buffer)
 	cw := &countingWriter{w: dst}
 	lw := &limitedWriter{
-		writer:    cw,
-		waiter:    rate.NewLimiter(rate.Limit(maxSingleWriteSize), limiterBurstSize),
-		limitsLAN: new(atomicBool),
-		isLAN:     false, // enables limiting
+		writer: cw,
+		waiterHolder: waiterHolder{
+			waiter:    rate.NewLimiter(rate.Limit(maxSingleWriteSize), limiterBurstSize),
+			limitsLAN: new(atomicBool),
+			isLAN:     false, // enables limiting
+		},
 	}
 	if _, err := io.Copy(lw, bytes.NewReader(src)); err != nil {
 		t.Fatal(err)
@@ -229,10 +231,12 @@ func TestLimitedWriterWrite(t *testing.T) {
 	dst = new(bytes.Buffer)
 	cw = &countingWriter{w: dst}
 	lw = &limitedWriter{
-		writer:    cw,
-		waiter:    rate.NewLimiter(rate.Limit(maxSingleWriteSize), limiterBurstSize),
-		limitsLAN: new(atomicBool),
-		isLAN:     true, // disables limiting
+		writer: cw,
+		waiterHolder: waiterHolder{
+			waiter:    rate.NewLimiter(rate.Limit(maxSingleWriteSize), limiterBurstSize),
+			limitsLAN: new(atomicBool),
+			isLAN:     true, // disables limiting
+		},
 	}
 	if _, err := io.Copy(lw, bytes.NewReader(src)); err != nil {
 		t.Fatal(err)
@@ -251,10 +255,12 @@ func TestLimitedWriterWrite(t *testing.T) {
 	dst = new(bytes.Buffer)
 	cw = &countingWriter{w: dst}
 	lw = &limitedWriter{
-		writer:    cw,
-		waiter:    totalWaiter{rate.NewLimiter(rate.Inf, limiterBurstSize), rate.NewLimiter(rate.Inf, limiterBurstSize)},
-		limitsLAN: new(atomicBool),
-		isLAN:     false, // enables limiting
+		writer: cw,
+		waiterHolder: waiterHolder{
+			waiter:    totalWaiter{rate.NewLimiter(rate.Inf, limiterBurstSize), rate.NewLimiter(rate.Inf, limiterBurstSize)},
+			limitsLAN: new(atomicBool),
+			isLAN:     false, // enables limiting
+		},
 	}
 	if _, err := io.Copy(lw, bytes.NewReader(src)); err != nil {
 		t.Fatal(err)

--- a/lib/connections/limiter_test.go
+++ b/lib/connections/limiter_test.go
@@ -7,12 +7,16 @@
 package connections
 
 import (
+	"bytes"
+	crand "crypto/rand"
+	"io"
+	"math/rand"
+	"testing"
+
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"golang.org/x/time/rate"
-	"math/rand"
-	"testing"
 )
 
 var device1, device2, device3, device4 protocol.DeviceID
@@ -185,6 +189,64 @@ func TestAddAndRemove(t *testing.T) {
 	checkActualAndExpected(t, actualR, actualW, expectedR, expectedW)
 }
 
+func TestLimitedWriterWrite(t *testing.T) {
+	// Check that the limited writer writes the correct data in the correct manner.
+
+	// A buffer with random data that is larger than the write size and not
+	// a precise multiple either.
+	src := make([]byte, int(12.5*maxSingleWriteSize))
+	if _, err := crand.Reader.Read(src); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write it to the destination using a limited writer, with a wrapper to
+	// count the write calls. The defaults on the limited writer should mean
+	// it is used (and doesn't take the fast path). In practice the limiter
+	// won't delay the test as the burst size is large enough to accommodate
+	// regardless of the rate.
+	dst := new(bytes.Buffer)
+	cw := &countingWriter{w: dst}
+	lw := &limitedWriter{
+		writer:    cw,
+		waiter:    rate.NewLimiter(rate.Limit(maxSingleWriteSize), limiterBurstSize),
+		limitsLAN: new(atomicBool),
+		isLAN:     false, // enables limiting
+	}
+	if _, err := io.Copy(lw, bytes.NewReader(src)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify there were lots of writes and that the end result is identical.
+	if cw.writeCount != 13 {
+		t.Error("expected lots of smaller writes, but not too many")
+	}
+	if !bytes.Equal(src, dst.Bytes()) {
+		t.Error("results should be equal")
+	}
+
+	// Write it to the destination using a limited writer, with a wrapper to
+	// count the write calls. Now we make sure the fast path is used.
+	dst = new(bytes.Buffer)
+	cw = &countingWriter{w: dst}
+	lw = &limitedWriter{
+		writer:    cw,
+		waiter:    rate.NewLimiter(rate.Limit(maxSingleWriteSize), limiterBurstSize),
+		limitsLAN: new(atomicBool),
+		isLAN:     true, // disables limiting
+	}
+	if _, err := io.Copy(lw, bytes.NewReader(src)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify there were a single write and that the end result is identical.
+	if cw.writeCount != 1 {
+		t.Error("expected just the one write")
+	}
+	if !bytes.Equal(src, dst.Bytes()) {
+		t.Error("results should be equal")
+	}
+}
+
 func checkActualAndExpected(t *testing.T, actualR, actualW, expectedR, expectedW map[protocol.DeviceID]*rate.Limiter) {
 	t.Helper()
 	if len(expectedW) != len(actualW) || len(expectedR) != len(actualR) {
@@ -203,4 +265,14 @@ func checkActualAndExpected(t *testing.T, actualR, actualW, expectedR, expectedW
 			t.Errorf("Write limits for device %s differ actual: %f, expected: %f", key, actualW[key].Limit(), expectedW[key].Limit())
 		}
 	}
+}
+
+type countingWriter struct {
+	w          io.Writer
+	writeCount int
+}
+
+func (w *countingWriter) Write(data []byte) (int, error) {
+	w.writeCount++
+	return w.w.Write(data)
 }


### PR DESCRIPTION
This splits large writes into smaller ones when using a rate limit,
making them into a legitimate trickle rather than large bursts with a
long time inbetween.

### Testing

Unit test to make sure the end result is correct and I didn't fumble the offsets or whatnot.