### PR TITLE
Allow extending of LDFLAGS in build.go

### DIFF
--- a/build.go
+++ b/build.go
@@ -801,6 +801,9 @@ func ldflags() string {
 	fmt.Fprintf(b, " -X github.com/syncthing/syncthing/lib/build.Stamp%c%d", sep, buildStamp())
 	fmt.Fprintf(b, " -X github.com/syncthing/syncthing/lib/build.User%c%s", sep, buildUser())
 	fmt.Fprintf(b, " -X github.com/syncthing/syncthing/lib/build.Host%c%s", sep, buildHost())
+	if v := os.Getenv("EXTRA_LDFLAGS"); v != "" {
+		fmt.Fprintf(b, " %s", v);
+	}
 	return b.String()
 }
 


### PR DESCRIPTION
Allow extending LDFALGS by setting EXTRA_LDFLAGS to be able to pass
-extldflags=-zrelro -ldflags=-extldflags=-znow for Arch Linux packaging
to get full relro.

Implements: #5999

### Purpose

fixes #5999 

### Testing

Detect that relro is fully enabled.
```
checksec --file=./bin/syncthing
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	Symbols		FORTIFY	Fortified	Fortifiable  FILE
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   28521 Symbols     Yes	0		2	./bin/syncthing
```

### Documentation

Adds an EXTRA_LDFLAGS env variable which is able to extend the passed LDFLAGS to go build.
