### PR TITLE
lib/db: Update db when only local flags change (fixes #6008)

### DIFF
--- a/lib/db/instance.go
+++ b/lib/db/instance.go
@@ -562,7 +562,7 @@ func (e errorSuggestion) Error() string {
 
 // unchanged checks if two files are the same and thus don't need to be updated.
 // Local flags or the invalid bit might change without the version
-// being bumped. The IsInvalid() method handles both.
+// being bumped.
 func unchanged(nf, ef FileIntf) bool {
-	return ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid()
+	return ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid() && ef.FileLocalFlags() == nf.FileLocalFlags()
 }

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -478,7 +478,7 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 					return true
 				}
 
-				l.Debugln("marking file as ignored", f)
+				l.Debugln("marking file as ignored", file)
 				nf := file.ConvertToIgnoredFileInfo(f.shortID)
 				batch.append(nf)
 				changes++


### PR DESCRIPTION
This PR fixes a bug reported in https://forum.syncthing.net/t/problem-with-post-ignoring-a-file-sendonly-recvonly/13749, the issue should be created soon. It's here: #6008

The problem is, that it's not enough to check `IsInvalid` to decide whether a file info has changed, as it remains true if local flags change from local changed to ignored. However the difference is relevant and should be committed.

I added a unit test.

And the debug log fix in model is just something I noticed when reproducing the issue.