### PR TITLE
Remove stun.voxgratia.org STUN server

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -87,7 +87,6 @@ var (
 		"stun.voiparound.com:3478",
 		"stun.voipbuster.com:3478",
 		"stun.voipstunt.com:3478",
-		"stun.voxgratia.org:3478",
 		"stun.xten.com:3478",
 	}
 )


### PR DESCRIPTION
### Purpose

fixes #6010
Remove stun.voxgratia.org from the list of secondary STUN servers.
