### PR TITLE
gui, lib/model: Add new state FolderPreparingSync (fixes #6027)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -323,7 +323,7 @@
                     <span class="visible-xs" aria-label="{{'Scanning' | translate}}"><i class="fas fa-fw fa-search"></i></span>
                   </span>
                   <span ng-switch-when="idle"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs" aria-label="{{'Up to Date' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
-                  <span ng-switch-when="preparing-sync">
+                  <span ng-switch-when="sync-preparing">
                     <span class="hidden-xs" translate>Preparing to Sync</span>
                     <span class="visible-xs" aria-label="{{'Preparing to Sync' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span>
                   </span>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -323,6 +323,10 @@
                     <span class="visible-xs" aria-label="{{'Scanning' | translate}}"><i class="fas fa-fw fa-search"></i></span>
                   </span>
                   <span ng-switch-when="idle"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs" aria-label="{{'Up to Date' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
+                  <span ng-switch-when="preparing-sync">
+                    <span class="hidden-xs" translate>Preparing to Sync</span>
+                    <span class="visible-xs" aria-label="{{'Preparing to Sync' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span>
+                  </span>
                   <span ng-switch-when="syncing">
                     <span class="hidden-xs" translate>Syncing</span>
                     <span>({{syncPercentage(folder.id) | percent}}, {{model[folder.id].needBytes | binary}}B)</span>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -802,7 +802,7 @@ angular.module('syncthing.core')
             if (status == 'paused') {
                 return 'default';
             }
-            if (status === 'syncing' || status === 'preparing-sync' || status === 'scanning') {
+            if (status === 'syncing' || status === 'sync-preparing' || status === 'scanning') {
                 return 'primary';
             }
             if (status === 'unknown') {
@@ -961,7 +961,7 @@ angular.module('syncthing.core')
             for (var i = 0; i < folderListCache.length; i++) {
                 var status = $scope.folderStatus(folderListCache[i]);
                 switch (status) {
-                    case 'preparing-sync':
+                    case 'sync-preparing':
                     case 'syncing':
                         syncCount++;
                         break;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -802,7 +802,7 @@ angular.module('syncthing.core')
             if (status == 'paused') {
                 return 'default';
             }
-            if (status === 'syncing' || status === 'scanning') {
+            if (status === 'syncing' || status === 'preparing-sync' || status === 'scanning') {
                 return 'primary';
             }
             if (status === 'unknown') {
@@ -961,6 +961,7 @@ angular.module('syncthing.core')
             for (var i = 0; i < folderListCache.length; i++) {
                 var status = $scope.folderStatus(folderListCache[i]);
                 switch (status) {
+                    case 'preparing-sync':
                     case 'syncing':
                         syncCount++;
                         break;

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -19,6 +19,7 @@ const (
 	FolderIdle folderState = iota
 	FolderScanning
 	FolderScanWaiting
+	FolderPreparingSync
 	FolderSyncing
 	FolderError
 )
@@ -31,6 +32,8 @@ func (s folderState) String() string {
 		return "scanning"
 	case FolderScanWaiting:
 		return "scan-waiting"
+	case FolderPreparingSync:
+		return "preparing-sync"
 	case FolderSyncing:
 		return "syncing"
 	case FolderError:
@@ -65,29 +68,32 @@ func (s *stateTracker) setState(newState folderState) {
 	}
 
 	s.mut.Lock()
-	if newState != s.current {
-		/* This should hold later...
-		if s.current != FolderIdle && (newState == FolderScanning || newState == FolderSyncing) {
-			panic("illegal state transition " + s.current.String() + " -> " + newState.String())
-		}
-		*/
+	defer s.mut.Unlock()
 
-		eventData := map[string]interface{}{
-			"folder": s.folderID,
-			"to":     newState.String(),
-			"from":   s.current.String(),
-		}
-
-		if !s.changed.IsZero() {
-			eventData["duration"] = time.Since(s.changed).Seconds()
-		}
-
-		s.current = newState
-		s.changed = time.Now()
-
-		s.evLogger.Log(events.StateChanged, eventData)
+	if newState == s.current {
+		return
 	}
-	s.mut.Unlock()
+
+	/* This should hold later...
+	if s.current != FolderIdle && (newState == FolderScanning || newState == FolderSyncing) {
+		panic("illegal state transition " + s.current.String() + " -> " + newState.String())
+	}
+	*/
+
+	eventData := map[string]interface{}{
+		"folder": s.folderID,
+		"to":     newState.String(),
+		"from":   s.current.String(),
+	}
+
+	if !s.changed.IsZero() {
+		eventData["duration"] = time.Since(s.changed).Seconds()
+	}
+
+	s.current = newState
+	s.changed = time.Now()
+
+	s.evLogger.Log(events.StateChanged, eventData)
 }
 
 // getState returns the current state, the time when it last changed, and the

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -19,7 +19,7 @@ const (
 	FolderIdle folderState = iota
 	FolderScanning
 	FolderScanWaiting
-	FolderPreparingSync
+	FolderSyncPreparing
 	FolderSyncing
 	FolderError
 )
@@ -32,8 +32,8 @@ func (s folderState) String() string {
 		return "scanning"
 	case FolderScanWaiting:
 		return "scan-waiting"
-	case FolderPreparingSync:
-		return "preparing-sync"
+	case FolderSyncPreparing:
+		return "sync-preparing"
 	case FolderSyncing:
 		return "syncing"
 	case FolderError:


### PR DESCRIPTION
### Purpose

See #6027:

> This issue is a companion to https://forum.syncthing.net/t/i-want-to-get-rid-of-the-syncing-status/13793/18. Basically every so often a user gets confused by Syncthing saying it's syncing, while they made sure manually that the data is already the same. The proposed solution is an additional state before "Syncing", while Syncthing is traversing the database to make a list of stuff it needs etc. Details in the forum or PR (incoming).

### Testing

Copied a lot of testfiles and saw it stay in the new state for a short moment before going back to idle.

### Screenshots

![Screenshot_2019-09-23_15-04-26](https://user-images.githubusercontent.com/15955093/65428710-1fc20800-de15-11e9-9077-1b5272b38345.png)

(Unrelated: Looks like pulling is faster than updating the global state in the web UI, which rises to 23 during/after pulling - however getting this screenshot required sub-second timing, so it's definitely not an issue.)