### PR TITLE
build: Update golangci for go v1.13

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - scopelint
 
 service:
-  golangci-lint-version: 1.17.x
+  golangci-lint-version: 1.19.x
   prepare:
     - rm -f go.sum # 1.12 -> 1.13 issues with QUIC-go
     - GO111MODULE=on go mod vendor


### PR DESCRIPTION
### Purpose

Per golang 1.13.1 upgrade, did some cleanup as well as upgrade golangci (v1.18.0 starting supporting go v1.13)

### Testing

n/a

### Screenshots

N/A

### Documentation

No user facing changes.

Relates to https://github.com/Homebrew/homebrew-core/pull/44765
