### PR TITLE
lib/syncthing: Prevent hangup on error during startup (fixes #6043)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -647,7 +647,9 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		}
 	}
 
-	app.Start()
+	if err := app.Start(); err != nil {
+		os.Exit(syncthing.ExitError)
+	}
 
 	cleanConfigDirectory()
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -648,7 +648,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	}
 
 	if err := app.Start(); err != nil {
-		os.Exit(syncthing.ExitError)
+		os.Exit(int(syncthing.ExitError))
 	}
 
 	cleanConfigDirectory()

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -92,17 +92,9 @@ func New(cfg config.Wrapper, ll *db.Lowlevel, evLogger events.Logger, cert tls.C
 	return a
 }
 
-// Run does the same as Start, but then does not return until the app stops. It
-// is equivalent to calling Start and then Wait.
-// Either Run or Start may be called once only.
-func (a *App) Run() ExitStatus {
-	a.Start()
-	return a.Wait()
-}
-
 // Start executes the app and returns once all the startup operations are done,
 // e.g. the API is ready for use.
-// Either Run or Start may be called once only.
+// Must be called once only.
 func (a *App) Start() error {
 	if err := a.startup(); err != nil {
 		a.stopWithErr(ExitError, err)

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -88,7 +88,7 @@ func New(cfg config.Wrapper, ll *db.Lowlevel, evLogger events.Logger, cert tls.C
 		stop:     make(chan struct{}),
 		stopped:  make(chan struct{}),
 	}
-	close(a.stopped) // Hasn't been started, so shouldn't
+	close(a.stopped) // Hasn't been started, so shouldn't block on Wait.
 	return a
 }
 
@@ -108,6 +108,7 @@ func (a *App) Start() error {
 		a.stopWithErr(ExitError, err)
 		return err
 	}
+	a.stopped = make(chan struct{})
 	go a.run()
 	return nil
 }
@@ -360,8 +361,6 @@ func (a *App) startup() error {
 }
 
 func (a *App) run() {
-	a.stopped = make(chan struct{})
-
 	<-a.stop
 
 	a.mainService.Stop()

--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -7,20 +7,36 @@
 package syncthing
 
 import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/tlsutil"
 )
 
+func tempCfgFilename(t *testing.T) string {
+	t.Helper()
+	f, err := ioutil.TempFile("", "syncthing-testConfig-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	return f.Name()
+}
+
 func TestShortIDCheck(t *testing.T) {
-	cfg := config.Wrap("/tmp/test", config.Configuration{
+	cfg := config.Wrap(tempCfgFilename(t), config.Configuration{
 		Devices: []config.DeviceConfiguration{
 			{DeviceID: protocol.DeviceID{8, 16, 24, 32, 40, 48, 56, 0, 0}},
 			{DeviceID: protocol.DeviceID{8, 16, 24, 32, 40, 48, 56, 1, 1}}, // first 56 bits same, differ in the first 64 bits
 		},
 	}, events.NoopLogger)
+	defer os.Remove(cfg.ConfigPath())
 
 	if err := checkShortIDs(cfg); err != nil {
 		t.Error("Unexpected error:", err)
@@ -35,5 +51,59 @@ func TestShortIDCheck(t *testing.T) {
 
 	if err := checkShortIDs(cfg); err == nil {
 		t.Error("Should have gotten an error")
+	}
+}
+
+func TestStartupFail(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "syncthing-TestStartupFail-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cert, err := tlsutil.NewCertificate(filepath.Join(tmpDir, "cert"), filepath.Join(tmpDir, "key"), "syncthing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	id := protocol.NewDeviceID(cert.Certificate[0])
+	conflID := protocol.DeviceID{}
+	copy(conflID[:8], id[:8])
+
+	cfg := config.Wrap(tempCfgFilename(t), config.Configuration{
+		Devices: []config.DeviceConfiguration{
+			{DeviceID: id},
+			{DeviceID: conflID},
+		},
+	}, events.NoopLogger)
+	defer os.Remove(cfg.ConfigPath())
+
+	app := New(cfg, nil, events.NoopLogger, cert, Options{})
+	startErr := app.Start()
+	if startErr == nil {
+		t.Fatal("Expected an error from Start, got nil")
+	}
+
+	done := make(chan struct{})
+	var waitE ExitStatus
+	go func() {
+		waitE = app.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-time.After(time.Second):
+		t.Fatal("Wait did not return within 1s")
+	case <-done:
+	}
+
+	if waitE != ExitError {
+		t.Errorf("Got exit status %v, expected %v", waitE, ExitError)
+	}
+
+	if runE := app.Run(); runE != waitE {
+		t.Errorf(`Got different exit statuses "%v" from Run and "%v" from Wait`, runE, waitE)
+	}
+	if err = app.Error(); err != startErr {
+		t.Errorf(`Got different errors "%v" from Start and "%v" from Error`, startErr, err)
 	}
 }

--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -100,9 +100,6 @@ func TestStartupFail(t *testing.T) {
 		t.Errorf("Got exit status %v, expected %v", waitE, ExitError)
 	}
 
-	if runE := app.Run(); runE != waitE {
-		t.Errorf(`Got different exit statuses "%v" from Run and "%v" from Wait`, runE, waitE)
-	}
 	if err = app.Error(); err != startErr {
 		t.Errorf(`Got different errors "%v" from Start and "%v" from Error`, startErr, err)
 	}


### PR DESCRIPTION
There was already some discussion in IRC, for context:

> 15:32:21 - imsodin: The current mechanism is built around the idea of the whole thing as being a "one-shot" operation. I.e. you start it and then wait for an error, therefore no cleaning up is being done and onces used. And that's mostly due to racyness, as e.g. the api can call `Stop` before `startup` returns. However's first at stopping/producing an error gets to do that. My approach at fixing it would have been to close `stopped` at creation, and re-create it after successful startup.
> 15:45:11 - calmh: we can think about it. i first thought it was an emergency, but it's at least a bit cornercasey so no panic to fix
> 15:47:56 - calmh: however i'm thinking that API wise i'm not super excited about things that start routines in the background and may or may not have done its thing when it returns
> 15:48:22 - calmh: i'd probably rather have seen a synchronous Run() method that blocks (essentially ending in a mainSupervisor.Serve() call)
> 15:48:39 - calmh: and then being able to call Stop() on that thing to make Run() return
> 15:49:16 - calmh: with an API promise that we call Run() and Stop() exactly once each
> 15:49:31 - calmh: obviating the need for sync.Once stuff etc

I then wrote a test to reproduce it and while at it some other behaviour. Besides fixing issues found by the test (error reporting), I added
 - the proposed promise that `Start` and `Run` should be called once only to the api, removing the need for `startOnce`. 
 - an error return value to `Start`.
 - removed a useless check in the `stopOnce`, which is always true (default value is `ExitSuccess` and `a.exitStatus` is only changed within the condition).

I believe `stopOnce` is still required, because even if `syncthing.App.Stop` is promised to be called once only, the app can still be closed from the rest api (and potentially in the future internal failure) - which needs to be race-protected.

And in `cmd/syncthing` I still use a `Start`/`Wait` combi instead of `Run`, as we need to know when the API is running before starting the browser.