### PR TITLE
all, lib/logger: Refactor SetDebug calls

### DIFF
--- a/cmd/syncthing/debug.go
+++ b/cmd/syncthing/debug.go
@@ -7,16 +7,9 @@
 package main
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("main", "Main package")
 )
-
-func init() {
-	l.SetDebug("main", strings.Contains(os.Getenv("STTRACE"), "main") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/api/debug.go
+++ b/lib/api/debug.go
@@ -7,9 +7,6 @@
 package api
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
@@ -24,5 +21,7 @@ func shouldDebugHTTP() bool {
 func init() {
 	// The debug facility was originally named "http", changed in:
 	// https://github.com/syncthing/syncthing/pull/5548
-	l.SetDebug("api", strings.Contains(os.Getenv("STTRACE"), "api") || strings.Contains(os.Getenv("STTRACE"), "http") || os.Getenv("STTRACE") == "all")
+	if l.IsTraced("http") {
+		l.SetDebug("api", true)
+	}
 }

--- a/lib/beacon/debug.go
+++ b/lib/beacon/debug.go
@@ -7,16 +7,9 @@
 package beacon
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("beacon", "Multicast and broadcast discovery")
 )
-
-func init() {
-	l.SetDebug("beacon", strings.Contains(os.Getenv("STTRACE"), "beacon") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/config/debug.go
+++ b/lib/config/debug.go
@@ -7,16 +7,9 @@
 package config
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("config", "Configuration loading and saving")
 )
-
-func init() {
-	l.SetDebug("config", strings.Contains(os.Getenv("STTRACE"), "config") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/connections/debug.go
+++ b/lib/connections/debug.go
@@ -7,16 +7,9 @@
 package connections
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("connections", "Connection handling")
 )
-
-func init() {
-	l.SetDebug("connections", strings.Contains(os.Getenv("STTRACE"), "connections") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/db/debug.go
+++ b/lib/db/debug.go
@@ -7,19 +7,12 @@
 package db
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("db", "The database layer")
 )
-
-func init() {
-	l.SetDebug("db", strings.Contains(os.Getenv("STTRACE"), "db") || os.Getenv("STTRACE") == "all")
-}
 
 func shouldDebug() bool {
 	return l.ShouldDebug("db")

--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	"golang.org/x/net/proxy"
@@ -29,8 +28,6 @@ var (
 type dialFunc func(network, addr string) (net.Conn, error)
 
 func init() {
-	l.SetDebug("dialer", strings.Contains(os.Getenv("STTRACE"), "dialer") || os.Getenv("STTRACE") == "all")
-
 	proxy.RegisterDialerType("socks", socksDialerFunction)
 	proxyDialer = getDialer(proxy.Direct)
 	usingProxy = proxyDialer != proxy.Direct

--- a/lib/discover/debug.go
+++ b/lib/discover/debug.go
@@ -7,16 +7,9 @@
 package discover
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("discover", "Remote device discovery")
 )
-
-func init() {
-	l.SetDebug("discover", strings.Contains(os.Getenv("STTRACE"), "discover") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/events/debug.go
+++ b/lib/events/debug.go
@@ -7,16 +7,9 @@
 package events
 
 import (
-	"os"
-	"strings"
-
 	liblogger "github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	dl = liblogger.DefaultLogger.NewFacility("events", "Event generation and logging")
 )
-
-func init() {
-	dl.SetDebug("events", strings.Contains(os.Getenv("STTRACE"), "events") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/fs/debug.go
+++ b/lib/fs/debug.go
@@ -7,9 +7,6 @@
 package fs
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
@@ -19,11 +16,7 @@ var (
 
 func init() {
 	logger.DefaultLogger.NewFacility("walkfs", "Filesystem access while walking")
-	switch {
-	case strings.Contains(os.Getenv("STTRACE"), "walkfs") || os.Getenv("STTRACE") == "all":
-		l.SetDebug("walkfs", true)
-		fallthrough
-	case strings.Contains(os.Getenv("STTRACE"), "fs"):
+	if logger.DefaultLogger.ShouldDebug("walkfs") {
 		l.SetDebug("fs", true)
 	}
 }

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -244,6 +244,8 @@ func (l *logger) Facilities() map[string]string {
 
 // NewFacility returns a new logger bound to the named facility.
 func (l *logger) NewFacility(facility, description string) Logger {
+	l.SetDebug(facility, l.IsTraced(facility))
+
 	l.mut.Lock()
 	l.facilities[facility] = description
 	l.mut.Unlock()

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -50,6 +50,7 @@ type Logger interface {
 	Warnf(format string, vals ...interface{})
 	ShouldDebug(facility string) bool
 	SetDebug(facility string, enabled bool)
+	IsTraced(facility string) bool
 	Facilities() map[string]string
 	FacilityDebugging() []string
 	NewFacility(facility, description string) Logger
@@ -60,6 +61,7 @@ type logger struct {
 	handlers   [NumLevels][]MessageHandler
 	facilities map[string]string   // facility name => description
 	debug      map[string]struct{} // only facility names with debugging enabled
+	traces     string
 	mut        sync.Mutex
 }
 
@@ -78,6 +80,7 @@ func New() Logger {
 func newLogger(w io.Writer) Logger {
 	return &logger{
 		logger:     log.New(w, "", DefaultFlags),
+		traces:     os.Getenv("STTRACE"),
 		facilities: make(map[string]string),
 		debug:      make(map[string]struct{}),
 	}
@@ -208,6 +211,11 @@ func (l *logger) SetDebug(facility string, enabled bool) {
 			l.SetFlags(DefaultFlags)
 		}
 	}
+}
+
+// IsTraced returns whether the facility name is contained in STTRACE.
+func (l *logger) IsTraced(facility string) bool {
+	return strings.Contains(l.traces, facility) || l.traces == "all"
 }
 
 // FacilityDebugging returns the set of facilities that have debugging

--- a/lib/model/debug.go
+++ b/lib/model/debug.go
@@ -7,19 +7,12 @@
 package model
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("model", "The root hub")
 )
-
-func init() {
-	l.SetDebug("model", strings.Contains(os.Getenv("STTRACE"), "model") || os.Getenv("STTRACE") == "all")
-}
 
 func shouldDebug() bool {
 	return l.ShouldDebug("model")

--- a/lib/nat/debug.go
+++ b/lib/nat/debug.go
@@ -7,16 +7,9 @@
 package nat
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("nat", "NAT discovery and port mapping")
 )
-
-func init() {
-	l.SetDebug("nat", strings.Contains(os.Getenv("STTRACE"), "nat") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/pmp/debug.go
+++ b/lib/pmp/debug.go
@@ -7,16 +7,9 @@
 package pmp
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("pmp", "NAT-PMP discovery and port mapping")
 )
-
-func init() {
-	l.SetDebug("pmp", strings.Contains(os.Getenv("STTRACE"), "pmp") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/protocol/debug.go
+++ b/lib/protocol/debug.go
@@ -3,16 +3,9 @@
 package protocol
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("protocol", "The BEP protocol")
 )
-
-func init() {
-	l.SetDebug("protocol", strings.Contains(os.Getenv("STTRACE"), "protocol") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/rc/debug.go
+++ b/lib/rc/debug.go
@@ -7,16 +7,9 @@
 package rc
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("rc", "Remote control package")
 )
-
-func init() {
-	l.SetDebug("rc", strings.Contains(os.Getenv("STTRACE"), "rc") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/relay/client/debug.go
+++ b/lib/relay/client/debug.go
@@ -3,16 +3,9 @@
 package client
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("relay", "")
 )
-
-func init() {
-	l.SetDebug("relay", strings.Contains(os.Getenv("STTRACE"), "relay") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/scanner/debug.go
+++ b/lib/scanner/debug.go
@@ -7,16 +7,9 @@
 package scanner
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("scanner", "File change detection and hashing")
 )
-
-func init() {
-	l.SetDebug("scanner", strings.Contains(os.Getenv("STTRACE"), "scanner") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/stats/debug.go
+++ b/lib/stats/debug.go
@@ -7,16 +7,9 @@
 package stats
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("stats", "Persistent device and folder statistics")
 )
-
-func init() {
-	l.SetDebug("stats", strings.Contains(os.Getenv("STTRACE"), "stats") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/stun/debug.go
+++ b/lib/stun/debug.go
@@ -7,16 +7,9 @@
 package stun
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("stun", "STUN functionality")
 )
-
-func init() {
-	l.SetDebug("stun", strings.Contains(os.Getenv("STTRACE"), "stun") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/sync/debug.go
+++ b/lib/sync/debug.go
@@ -22,7 +22,7 @@ var (
 	// We make an exception in this package and have an actual "if debug { ...
 	// }" variable, as it may be rather performance critical and does
 	// nonstandard things (from a debug logging PoV).
-	debug       = logger.DefaultLogger.IsTraced("sync")
+	debug       = logger.DefaultLogger.ShouldDebug("sync")
 	useDeadlock = false
 )
 

--- a/lib/sync/debug.go
+++ b/lib/sync/debug.go
@@ -9,7 +9,6 @@ package sync
 import (
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	deadlock "github.com/sasha-s/go-deadlock"
@@ -23,13 +22,11 @@ var (
 	// We make an exception in this package and have an actual "if debug { ...
 	// }" variable, as it may be rather performance critical and does
 	// nonstandard things (from a debug logging PoV).
-	debug       = strings.Contains(os.Getenv("STTRACE"), "sync") || os.Getenv("STTRACE") == "all"
+	debug       = logger.DefaultLogger.IsTraced("sync")
 	useDeadlock = false
 )
 
 func init() {
-	l.SetDebug("sync", strings.Contains(os.Getenv("STTRACE"), "sync") || os.Getenv("STTRACE") == "all")
-
 	if n, _ := strconv.Atoi(os.Getenv("STLOCKTHRESHOLD")); n > 0 {
 		threshold = time.Duration(n) * time.Millisecond
 	}

--- a/lib/syncthing/debug.go
+++ b/lib/syncthing/debug.go
@@ -7,16 +7,9 @@
 package syncthing
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("app", "Main run facility")
 )
-
-func init() {
-	l.SetDebug("app", strings.Contains(os.Getenv("STTRACE"), "app") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/upgrade/debug.go
+++ b/lib/upgrade/debug.go
@@ -7,16 +7,9 @@
 package upgrade
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("upgrade", "Binary upgrades")
 )
-
-func init() {
-	l.SetDebug("upgrade", strings.Contains(os.Getenv("STTRACE"), "upgrade") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/upnp/debug.go
+++ b/lib/upnp/debug.go
@@ -7,16 +7,9 @@
 package upnp
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("upnp", "UPnP discovery and port mapping")
 )
-
-func init() {
-	l.SetDebug("upnp", strings.Contains(os.Getenv("STTRACE"), "upnp") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/ur/debug.go
+++ b/lib/ur/debug.go
@@ -7,16 +7,9 @@
 package ur
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("ur", "Usage reporting")
 )
-
-func init() {
-	l.SetDebug("ur", strings.Contains(os.Getenv("STTRACE"), "ur") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/versioner/debug.go
+++ b/lib/versioner/debug.go
@@ -7,16 +7,9 @@
 package versioner
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
 	l = logger.DefaultLogger.NewFacility("versioner", "File versioning")
 )
-
-func init() {
-	l.SetDebug("versioner", strings.Contains(os.Getenv("STTRACE"), "versioner") || os.Getenv("STTRACE") == "all")
-}

--- a/lib/watchaggregator/debug.go
+++ b/lib/watchaggregator/debug.go
@@ -7,18 +7,9 @@
 package watchaggregator
 
 import (
-	"os"
-	"strings"
-
 	"github.com/syncthing/syncthing/lib/logger"
 )
 
-var facilityName = "watchaggregator"
-
 var (
-	l = logger.DefaultLogger.NewFacility(facilityName, "Filesystem event watcher")
+	l = logger.DefaultLogger.NewFacility("watchaggregator", "Filesystem event watcher")
 )
-
-func init() {
-	l.SetDebug(facilityName, strings.Contains(os.Getenv("STTRACE"), facilityName) || os.Getenv("STTRACE") == "all")
-}


### PR DESCRIPTION
There are a lot of similar SetDebug calls which can be integrated into NewFacility. This pull request should not change behavior. I tested it with some, but not all facilities.