### PR TITLE
lib/api: Report actual listener address (fixes #6049)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -85,6 +85,7 @@ type service struct {
 	started              chan string   // signals startup complete by sending the listener address, for testing only
 	startedOnce          chan struct{} // the service has started successfully at least once
 	startupErr           error
+	listenerAddr         net.Addr
 
 	guiErrors logger.Recorder
 	systemLog logger.Recorder
@@ -222,6 +223,7 @@ func (s *service) serve(stop chan struct{}) {
 		return
 	}
 
+	s.listenerAddr = listener.Addr()
 	defer listener.Close()
 
 	s.cfg.Subscribe(s)
@@ -913,7 +915,7 @@ func (s *service) getSystemStatus(w http.ResponseWriter, r *http.Request) {
 	res["uptime"] = s.urService.UptimeS()
 	res["startTime"] = ur.StartTime
 	res["guiAddressOverridden"] = s.cfg.GUI().IsOverridden()
-	res["guiAddressUsed"] = s.cfg.GUI().Address()
+	res["guiAddressUsed"] = s.listenerAddr.String()
 
 	sendJSON(w, res)
 }


### PR DESCRIPTION
### Purpose

Report what we're actually listening on, not just the string we were told to listen on.

### Testing

Verified that it behaves as expected with `:1234` (gets auth warning) and `localhost:1234` (no auth warning). Also looked at the output of /rest/system/status.

### Ehm

New struct attribute isn't super pretty. It's race free because it's set in serve() and only accessed from routines started by server(). I tried the alternative to make the system status handler a closure that takes the address but that was more changes and even uglier.