### PR TITLE
add support for Traefik 2 as reverse proxy

### DIFF
--- a/cmd/stdiscosrv/apisrv.go
+++ b/cmd/stdiscosrv/apisrv.go
@@ -295,28 +295,66 @@ func certificateBytes(req *http.Request) []byte {
 		return req.TLS.PeerCertificates[0].Raw
 	}
 
+	var bs []byte
+
 	if hdr := req.Header.Get("X-SSL-Cert"); hdr != "" {
-		bs := []byte(hdr)
-		// The certificate is in PEM format but with spaces for newlines. We
-		// need to reinstate the newlines for the PEM decoder. But we need to
-		// leave the spaces in the BEGIN and END lines - the first and last
-		// space - alone.
-		firstSpace := bytes.Index(bs, []byte(" "))
-		lastSpace := bytes.LastIndex(bs, []byte(" "))
-		for i := firstSpace + 1; i < lastSpace; i++ {
-			if bs[i] == ' ' {
-				bs[i] = '\n'
+		if strings.Contains(hdr, "%") {
+			// Nginx using $ssl_client_escaped_cert
+			// The certificate is in PEM format with url encoding.
+			// We need to decode for the PEM decoder
+			hdr, err := url.QueryUnescape(hdr)
+			if err != nil {
+				// Decoding failed
+				return nil
+			}
+
+			bs = []byte(hdr)
+		} else {
+			// Nginx using $ssl_client_cert
+			// The certificate is in PEM format but with spaces for newlines. We
+			// need to reinstate the newlines for the PEM decoder. But we need to
+			// leave the spaces in the BEGIN and END lines - the first and last
+			// space - alone.
+			bs = []byte(hdr)
+			firstSpace := bytes.Index(bs, []byte(" "))
+			lastSpace := bytes.LastIndex(bs, []byte(" "))
+			for i := firstSpace + 1; i < lastSpace; i++ {
+				if bs[i] == ' ' {
+					bs[i] = '\n'
+				}
 			}
 		}
-		block, _ := pem.Decode(bs)
-		if block == nil {
+	} else if hdr := req.Header.Get("X-Forwarded-Tls-Client-Cert"); hdr != "" {
+		// Traefik 2 passtlsclientcert
+		// The certificate is in PEM format with url encoding but without newlines
+		// and start/end statements. We need to decode, reinstate the newlines every 64
+		// character and add statements for the PEM decoder
+		hdr, err := url.QueryUnescape(hdr)
+		if err != nil {
 			// Decoding failed
 			return nil
 		}
-		return block.Bytes
+
+		for i := 64; i < len(hdr); i += 65 {
+			hdr = hdr[:i] + "\n" + hdr[i:]
+		}
+
+		hdr = "-----BEGIN CERTIFICATE-----\n" + hdr
+		hdr = hdr + "\n-----END CERTIFICATE-----\n"
+		bs = []byte(hdr)
 	}
 
-	return nil
+	if bs == nil {
+		return nil
+	}
+
+	block, _ := pem.Decode(bs)
+	if block == nil {
+		// Decoding failed
+		return nil
+	}
+
+	return block.Bytes
 }
 
 // fixupAddresses checks the list of addresses, removing invalid ones and


### PR DESCRIPTION
### Purpose

Traefik 2 do not use the same header as nginx to pass client tls certificate (https://docs.traefik.io/middlewares/passtlsclientcert/). This PR add support for Traefik 2.

Also improve Nginx compatibility by adding $ssl_client_escaped_cert support (http://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_escaped_cert replacement for $ssl_client_cert http://nginx.org/en/docs/http/ngx_http_ssl_module.html#var_ssl_client_cert which is deprecated).

### Testing

Has been tested with a discovery server and both Traefik and Nginx reverse proxy.
Config file as below (client can use port 8443 to test Traefik and 9443 to test with Nginx) except certificate for nginx.

Docker image could be found here: https://hub.docker.com/r/cyprienoccitech/docker-discosrv

docker-compose.yml
```
version: '3.4'

services:
  traefik:
    image: "traefik:v2.0"
    ports:
     - "80:80"
     - "8443:8443"
    volumes:
      - "/var/run/docker.sock:/var/run/docker.sock:ro"
      - "./traefik.toml:/traefik.toml"
      - "./common.toml:/common.toml"

  nginx:
    image: nginx
    volumes:
     - "./nginx.conf:/etc/nginx/conf.d/default.conf:ro"
     - "./ssl:/etc/nginx/ssl"
    ports:
     - "9443:9443"

  discovr:
    image: cyprienoccitech/docker-discosrv:latest
    command: "-http -debug"
    labels:
      traefik.enable: "true"
      traefik.port: "8443"
      traefik.backend: "syncthing-discovr"
      traefik.frontend.rule: "Host:discovr.example.com"
      traefik.http.routers.syncthing_discovr_tls.rule: "Host(`discovr.example.com`)"
      traefik.http.routers.syncthing_discovr_tls.entryPoints: "discovr"
      traefik.http.routers.syncthing_discovr_tls.tls: "true"
      traefik.http.routers.syncthing_discovr_tls.tls.certresolver: "default"
      traefik.http.routers.syncthing_discovr_tls.service: "syncthing_discovr_tls"
      traefik.http.routers.syncthing_discovr_tls.middlewares: 'syncthing_discovr_passtls'
      traefik.http.routers.syncthing_discovr_tls.tls.options: 'syncthing_discovr@file'
      traefik.http.middlewares.syncthing_discovr_passtls.passtlsclientcert.pem: "true"
      traefik.http.services.syncthing_discovr_tls.loadbalancer.server.port: "8443"
```

traefik.toml
```
[global]
  sendAnonymousUsage = false
  checkNewVersion = true

[log]
  level = "info"

[entryPoints]
  [entryPoints.http]
  address = ":80"
  [entryPoints.discovr]
  address = ":8443"

[http.middlewares]
  [http.middlewares.test-redirect.redirectScheme]
    scheme = "https"

[accessLog]
  filePath = "/var/log/traefik/access.log"

[api]
  insecure = true
  dashboard = true

[providers]
  [providers.docker]
  endpoint = "unix:///var/run/docker.sock"
  exposedbydefault = false
  watch = true
  swarmMode = false
  network = "traefik"
  [providers.file]
  filename = "/common.toml"

[certificatesResolvers.default.acme]
  email = "acmin@example.com"
  storage = "acme.json"
  [certificatesResolvers.default.acme.httpChallenge]
    entryPoint = "http"
```

common.toml
```
[tls]
  [tls.options]
    [tls.options.syncthing_discovr]
      [tls.options.syncthing_discovr.clientAuth]
        clientAuthType = "RequireAnyClientCert"
```

nginx.conf
```
# HTTP 1.1 support
proxy_http_version 1.1;
proxy_buffering off;
proxy_set_header Host $http_host;
proxy_set_header Upgrade $http_upgrade;
proxy_set_header Connection $http_connection;
proxy_set_header X-Real-IP $remote_addr;
proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
#proxy_set_header X-SSL-Cert $ssl_client_cert;
proxy_set_header X-SSL-Cert $ssl_client_escaped_cert;
upstream discovr.example.com {
    # Local IP address:port for discovery server
    server discovr:8443;
}
server {
        server_name discovr.example.com;
        listen 9080 default_server;
        access_log /var/log/nginx/access.log;
        return 301 https://$host$request_uri;
}
server {
        server_name discovr.example.com;
        listen 9443 ssl http2 default_server;
        access_log /var/log/nginx/access.log;
        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
        ssl_prefer_server_ciphers on;
        ssl_session_timeout 5m;
        ssl_session_cache shared:SSL:50m;
        ssl_certificate /etc/nginx/ssl/certs/discovr.example.com.crt;
        ssl_certificate_key /etc/nginx/ssl/private/discovr.example.com.key;
        add_header Strict-Transport-Security "max-age=31536000";
        ssl_verify_client optional_no_ca;
        location / {
                proxy_pass http://discovr.example.com;
        }
}
```


