### PR TITLE
Add desktop plug

### DIFF
--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -20,6 +20,7 @@ apps:
       HOME: ${SNAP_USER_COMMON}
       XDG_CONFIG_HOME: ${SNAP_USER_COMMON}
     plugs:
+    - desktop
     - home
     - network
     - network-bind


### PR DESCRIPTION
Without the desktop plug, launching the syncthing snap will not launch a browser window to the admin UI. Adding this one line will fix that. Tested here on my Ubuntu system with a build from tip of master.

### Purpose

When launching syncthing from the snap, the web UI admin tool is not launched. This is due to a missing security interface called `desktop`. Adding this interface (plug) grants permission to enable syncthing to launch xdg-open which in turn opens the web UI in a browser tab. 

### Testing

I built the snap in a clean Ubuntu 16.04 lxc container, and installed the resulting snap on my Ubuntu 19.10 laptop. The resulting build successfully launches the web UI in a new tab on my default browser. 
I used the following command to build the snap
`go run build.go -goos linux -goarch amd64 snap`
Then installed the snap via:
`snap install syncthing_1.3.1-rc.1+2-g6b570ee-dirty-wat_amd64.snap --dangerous`
I launched the snap via:
`/snap/bin/syncthing`
At this point, the browser tab opened
`[XPUFK] 11:37:43 INFO: Access the GUI via the following URL: http://127.0.0.1:8384/`

### Documentation

I don't believe documentation is required. The web UI tool should have been launching anyway, and is an expected feature of syncthing, so we're really just ensuring syncthing works as you'd expect, when installed as a snap.

