### PR TITLE
Add missing binaries to snap - fixes #5288

### DIFF
--- a/build.go
+++ b/build.go
@@ -630,9 +630,9 @@ func buildSnap(target target) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	runPrint("snapcraft", "clean")
+	runPrint("snapcraft", "clean", "--destructive-mode")
 	build(target, []string{"noupgrade"})
-	runPrint("snapcraft")
+	runPrint("snapcraft", "--destructive-mode")
 }
 
 func shouldBuildSyso(dir string) (string, error) {

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -29,7 +29,16 @@ parts:
   syncthing:
     source: .
     plugin: dump
+    stage-packages:
+      - iproute2
+      - net-tools
     stage:
       - syncthing
+      - sbin/route
+      - sbin/ip
+      - bin/ip
     prime:
       - syncthing
+      - sbin/route
+      - sbin/ip
+      - bin/ip

--- a/snapcraft.yaml.template
+++ b/snapcraft.yaml.template
@@ -9,6 +9,7 @@ description: |
 architectures: 
   - build-on: [{{.HostArchitecture}}]
     run-on: [{{.TargetArchitecture}}]
+base: core18
 
 grade: {{.Grade}}
 confinement: strict


### PR DESCRIPTION
This adds the ip and route binaries to the snap. This resolves #5288, suppressing the security audit errors seen in the syslog. Built this on an Ubuntu 16.04 VM and tested on my Ubuntu 19.10 workstation.

### Purpose

Syncthing expects to be able (via a sub-module) to call unix commands `ip` and `route` as part of normal operation. When packaged as a snap, those commands are unavailable. As a result, errors appear in the syslog whenever syncthing attempts to use these binaries. While this doesn't hamper significantly the operation of syncthing, it results in spam in the syslog, which can be offputting. 

### Testing

I build the snap in a clean Ubuntu 16.04 lxc container and transferred the result to my Ubuntu 19.10 laptop for testing. The snap produced did indeed no longer produce spam in the syslog regarding the `ip` and `route` commands. (Other, unrelated things may be shown in the syslog, which may be fixed in a subsequent PR :) ).
Build:
`go run build.go -goos linux -goarch amd64 snap`
Install:
`snap install syncthing_1.3.1-rc.1+2-g6b570ee-dirty-wat_amd64.snap --dangerous`
Test - in another two terminals run the following commands:

`dmesg -Tw`
and
`snappy-debug.security scanlog` (this will require you to have `snap install snappy-debug` already.

Run the new syncthing snap with `/snap/bin/syncthing` and observe the lack of complaints in the output of the two other commands. It should suppress the following in syslog:
```
[Tue Oct  8 10:58:25 2019] audit: type=1400 audit(1570528705.738:868): apparmor="DENIED" operation="exec" profile="snap.syncthing.syncthing" name="/sbin/route" pid=6956 comm="syncthing" requested_mask="x" 
denied_mask="x" fsuid=1000 ouid=0                                                                                                                                                                            
[Tue Oct  8 10:58:25 2019] audit: type=1400 audit(1570528705.746:869): apparmor="DENIED" operation="exec" profile="snap.syncthing.syncthing" name="/bin/ip" pid=6957 comm="syncthing" requested_mask="x" deni
ed_mask="x" fsuid=1000 ouid=0 
```
And the following should be gone from `snappy-debug`
```
= AppArmor =
Time: Oct  8 10:58:25
Log: apparmor="DENIED" operation="exec" profile="snap.syncthing.syncthing" name="/sbin/route" pid=6956 comm="syncthing" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0
File: /sbin/route (exec)
Suggestions:
* adjust snap to ship 'route'
* adjust program to use relative paths if the snap already ships 'route'                                                                                                                                     
                                                   
= AppArmor =
Time: Oct  8 10:58:25                                                                                                                                                                                        
Log: apparmor="DENIED" operation="exec" profile="snap.syncthing.syncthing" name="/bin/ip" pid=6957 comm="syncthing" requested_mask="x" denied_mask="x" fsuid=1000 ouid=0
File: /bin/ip (exec)
Suggestions:         
* adjust snap to ship 'ip'                                                                                                                                                                                   
* adjust program to use relative paths if the snap already ships 'ip'
```

