### PR TITLE
all: Update certificate lifetimes (fixes #6036)

### DIFF
--- a/cmd/stdiscosrv/main.go
+++ b/cmd/stdiscosrv/main.go
@@ -100,7 +100,7 @@ func main() {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		log.Println("Failed to load keypair. Generating one, this might take a while...")
-		cert, err = tlsutil.NewCertificate(certFile, keyFile, "stdiscosrv")
+		cert, err = tlsutil.NewCertificate(certFile, keyFile, "stdiscosrv", 20*365)
 		if err != nil {
 			log.Fatalln("Failed to generate X509 key pair:", err)
 		}

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -633,7 +633,7 @@ func createTestCertificate() tls.Certificate {
 	}
 
 	certFile, keyFile := filepath.Join(tmpDir, "cert.pem"), filepath.Join(tmpDir, "key.pem")
-	cert, err := tlsutil.NewCertificate(certFile, keyFile, "relaypoolsrv")
+	cert, err := tlsutil.NewCertificate(certFile, keyFile, "relaypoolsrv", 20*365)
 	if err != nil {
 		log.Fatalln("Failed to create test X509 key pair:", err)
 	}

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -155,7 +155,7 @@ func main() {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		log.Println("Failed to load keypair. Generating one, this might take a while...")
-		cert, err = tlsutil.NewCertificate(certFile, keyFile, "strelaysrv")
+		cert, err = tlsutil.NewCertificate(certFile, keyFile, "strelaysrv", 20*365)
 		if err != nil {
 			log.Fatalln("Failed to generate X509 key pair:", err)
 		}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -53,11 +53,12 @@ const (
 )
 
 const (
-	bepProtocolName      = "bep/1.0"
-	tlsDefaultCommonName = "syncthing"
-	maxSystemErrors      = 5
-	initialSystemLog     = 10
-	maxSystemLog         = 250
+	bepProtocolName        = "bep/1.0"
+	tlsDefaultCommonName   = "syncthing"
+	maxSystemErrors        = 5
+	initialSystemLog       = 10
+	maxSystemLog           = 250
+	deviceCertLifetimeDays = 20 * 365
 )
 
 const (
@@ -424,7 +425,7 @@ func generate(generateDir string) error {
 	if err == nil {
 		l.Warnln("Key exists; will not overwrite.")
 	} else {
-		cert, err = tlsutil.NewCertificate(certFile, keyFile, tlsDefaultCommonName)
+		cert, err = tlsutil.NewCertificate(certFile, keyFile, tlsDefaultCommonName, deviceCertLifetimeDays)
 		if err != nil {
 			return errors.Wrap(err, "create certificate")
 		}

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1704,8 +1704,10 @@ func checkExpiry(cert tls.Certificate) error {
 		}
 	}
 
-	if leaf.Subject.String() != leaf.Issuer.String() {
-		// The certificate is not self signed, so we leave it alone.
+	if leaf.Subject.String() != leaf.Issuer.String() ||
+		len(leaf.DNSNames) != 0 || len(leaf.IPAddresses) != 0 {
+		// The certificate is not self signed, or has DNS/IP attributes we don't
+		// add, so we leave it alone.
 		return nil
 	}
 

--- a/lib/discover/global_test.go
+++ b/lib/discover/global_test.go
@@ -112,7 +112,7 @@ func TestGlobalOverHTTPS(t *testing.T) {
 	}
 
 	// Generate a server certificate.
-	cert, err := tlsutil.NewCertificate(dir+"/cert.pem", dir+"/key.pem", "syncthing")
+	cert, err := tlsutil.NewCertificate(dir+"/cert.pem", dir+"/key.pem", "syncthing", 30)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +177,7 @@ func TestGlobalAnnounce(t *testing.T) {
 	}
 
 	// Generate a server certificate.
-	cert, err := tlsutil.NewCertificate(dir+"/cert.pem", dir+"/key.pem", "syncthing")
+	cert, err := tlsutil.NewCertificate(dir+"/cert.pem", dir+"/key.pem", "syncthing", 30)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -37,11 +37,12 @@ import (
 )
 
 const (
-	bepProtocolName      = "bep/1.0"
-	tlsDefaultCommonName = "syncthing"
-	maxSystemErrors      = 5
-	initialSystemLog     = 10
-	maxSystemLog         = 250
+	bepProtocolName        = "bep/1.0"
+	tlsDefaultCommonName   = "syncthing"
+	maxSystemErrors        = 5
+	initialSystemLog       = 10
+	maxSystemLog           = 250
+	deviceCertLifetimeDays = 20 * 365
 )
 
 type ExitStatus int

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -35,6 +35,7 @@ func LoadOrGenerateCertificate(certFile, keyFile string) (tls.Certificate, error
 			locations.Get(locations.CertFile),
 			locations.Get(locations.KeyFile),
 			tlsDefaultCommonName,
+			deviceCertLifetimeDays,
 		)
 	}
 	return cert, nil

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -104,6 +104,8 @@ func NewCertificate(certFile, keyFile, commonName string, lifetimeDays int) (tls
 	notBefore := time.Now().Truncate(24 * time.Hour)
 	notAfter := notBefore.Add(time.Duration(lifetimeDays*24) * time.Hour)
 
+	// NOTE: update checkExpiry() appropriately if you add or change attributes
+	// in here, especially DNSNames or IPAddresses.
 	template := x509.Certificate{
 		SerialNumber: new(big.Int).SetInt64(rand.Int63()),
 		Subject: pkix.Name{

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -95,14 +95,14 @@ func SecureDefault() *tls.Config {
 }
 
 // NewCertificate generates and returns a new TLS certificate.
-func NewCertificate(certFile, keyFile, commonName string) (tls.Certificate, error) {
+func NewCertificate(certFile, keyFile, commonName string, lifetimeDays int) (tls.Certificate, error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("generate key: %s", err)
 	}
 
-	notBefore := time.Now()
-	notAfter := time.Date(2049, 12, 31, 23, 59, 59, 0, time.UTC)
+	notBefore := time.Now().Truncate(24 * time.Hour)
+	notAfter := notBefore.Add(time.Duration(lifetimeDays*24) * time.Hour)
 
 	template := x509.Certificate{
 		SerialNumber: new(big.Int).SetInt64(rand.Int63()),


### PR DESCRIPTION
This adds a certificate lifetime parameter to our certificate generation
and hard codes it to twenty years in some uninteresting places. In the
main binary there are a couple of constants but it results in twenty
years for the device certificate and 820 days for the HTTPS one. 820 is
less than the 825 maximum Apple allows nowadays.

This also means we must be prepared for certificates to expire, so I add
some handling for that and generate a new certificate when needed. For
our own certificates (common name Syncthing) we regenerate a month ahead
of time. For other certificates we leave well enough alone.
