### PR TITLE
Disable automatic upgrades via command line argument (fixes #6079)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -219,6 +219,7 @@ func parseCommandLineOptions() RuntimeOptions {
 	flag.BoolVar(&options.noBrowser, "no-browser", false, "Do not start browser")
 	flag.BoolVar(&options.browserOnly, "browser-only", false, "Open GUI in browser")
 	flag.BoolVar(&options.noRestart, "no-restart", options.noRestart, "Disable monitor process, managed restarts and log file writing")
+	flag.BoolVar(&options.NoUpgrade, "no-upgrade", false, "Do not perform automatic upgrades")
 	flag.BoolVar(&options.resetDatabase, "reset-database", false, "Reset the database, forcing a full rescan and resync")
 	flag.BoolVar(&options.ResetDeltaIdxs, "reset-deltas", false, "Reset delta index IDs, forcing a full index exchange")
 	flag.BoolVar(&options.doUpgrade, "upgrade", false, "Perform upgrade")
@@ -641,7 +642,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	if opts := cfg.Options(); opts.AutoUpgradeIntervalH > 0 {
 		if runtimeOptions.NoUpgrade {
-			l.Infof("No automatic upgrades; STNOUPGRADE environment variable defined.")
+			l.Infof("No automatic upgrades; STNOUPGRADE environment variable defined or 'no-upgrade' command line argument was used.")
 		} else {
 			go autoUpgrade(cfg, app, evLogger)
 		}


### PR DESCRIPTION
### Purpose

The purpose of this PR is to provide the user with an additional method for disabling the automatic upgrade of syncthing. This is an alternative to the environment variable method in the case that it is not possible to use or it is not desired to use the variable. A similar alternative exists for the `STNORESTART` environment variable.

### Testing

Testing has been preform by building and running the executable with and without the new command line argument. I verified that the change has done what I have expected by verifying the syncthing logs upon launching the executable

### Documentation

The required document changes would be to update this page to include the new command line argument and some details behind it: https://docs.syncthing.net/users/syncthing.html

