### PR TITLE
lib: Unify JSON marshalling of file infos in api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/vitrun/qart v0.0.0-20160531060029-bf64b92db6b0
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
-	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd // indirect
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -51,6 +51,10 @@ type FileIntf interface {
 	SequenceNo() int64
 	BlockSize() int
 	FileVersion() protocol.Vector
+	FileType() protocol.FileInfoType
+	FilePermissions() uint32
+	FileModifiedBy() protocol.ShortID
+	ModTime() time.Time
 }
 
 // The Iterator is called with either a protocol.FileInfo or a

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -116,6 +116,17 @@ func (f FileInfoTruncated) FileVersion() protocol.Vector {
 	return f.Version
 }
 
+func (f FileInfoTruncated) FileType() protocol.FileInfoType {
+	return f.Type
+}
+
+func (f FileInfoTruncated) FilePermissions() uint32 {
+	return f.Permissions
+}
+
+func (f FileInfoTruncated) FileModifiedBy() protocol.ShortID {
+	return f.ModifiedBy
+}
 func (f FileInfoTruncated) ConvertToIgnoredFileInfo(by protocol.ShortID) protocol.FileInfo {
 	return protocol.FileInfo{
 		Name:         f.Name,

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -124,6 +124,18 @@ func (f FileInfo) FileVersion() Vector {
 	return f.Version
 }
 
+func (f FileInfo) FileType() FileInfoType {
+	return f.Type
+}
+
+func (f FileInfo) FilePermissions() uint32 {
+	return f.Permissions
+}
+
+func (f FileInfo) FileModifiedBy() ShortID {
+	return f.ModifiedBy
+}
+
 // WinsConflict returns true if "f" is the one to choose when it is in
 // conflict with "other".
 func (f FileInfo) WinsConflict(other FileInfo) bool {


### PR DESCRIPTION
### Purpose

This should have been a tiny change to make `/rest/db/file` output a string for the file-type, like e.g. `/rest/db/need` already does. On the way I got rid of some duplication, which required extending `db.FileIntf`. And while at it I renamed `JSONDBFileInfo` to `JSONFileInfoTrunc`.

### Testing

Checked that output of `/rest/db/file` indeed does print the file info as a string. 