### PR TITLE
lib/sync: Cleanly fail instead of panic in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/vitrun/qart v0.0.0-20160531060029-bf64b92db6b0
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
-	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd // indirect
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/lib/sync/sync_test.go
+++ b/lib/sync/sync_test.go
@@ -152,8 +152,7 @@ func TestRWMutex(t *testing.T) {
 
 	if len(messages) != 2 {
 		t.Errorf("Unexpected message count")
-	}
-	if !strings.Contains(messages[1], "RUnlockers while locking:\nat sync") || !strings.Contains(messages[1], "sync_test.go:") {
+	} else if !strings.Contains(messages[1], "RUnlockers while locking:\nat sync") || !strings.Contains(messages[1], "sync_test.go:") {
 		t.Error("Unexpected message")
 	}
 


### PR DESCRIPTION
`TestRWMutex` failed recently (https://build.syncthing.net/viewLog.html?buildId=47579&buildTypeId=Syncthing_Coverage). This change does not address the (flaky) test failure, merely prevents a panic due to the failure (because the panic is just confusing/a red herring).

And running any go command cleans this indirect entry from go.mod, so I'm trying to sneak that in too.