### PR TITLE
lib/scanner: Don't scan if input path is below symlink (fixes #6090)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,6 @@ require (
 	github.com/vitrun/qart v0.0.0-20160531060029-bf64b92db6b0
 	golang.org/x/crypto v0.0.0-20190829043050-9756ffdc2472
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
-	golang.org/x/sys v0.0.0-20190904154756-749cb33beabd // indirect
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -21,6 +21,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
+	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"golang.org/x/text/unicode/norm"
 )
@@ -113,6 +114,10 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 			w.Filesystem.Walk(".", hashFiles)
 		} else {
 			for _, sub := range w.Subs {
+				if err := osutil.TraversesSymlink(w.Filesystem, filepath.Dir(sub)); err != nil {
+					l.Debugf("Skip walking %v as it is below a symlink", sub)
+					continue
+				}
 				w.Filesystem.Walk(sub, hashFiles)
 			}
 		}

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -333,7 +333,7 @@ func TestWalkRootSymlink(t *testing.T) {
 		}
 	}
 
-	// Scan it
+	// Scan root with symlink at FS root
 	files := walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, link), ".", nil, nil, 0)
 
 	// Verify that we got two files
@@ -341,7 +341,15 @@ func TestWalkRootSymlink(t *testing.T) {
 		t.Errorf("expected two files, not %d", len(files))
 	}
 
-	// Scan below it
+	// Scan symlink below FS root
+	files = walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, tmp), "link", nil, nil, 0)
+
+	// Verify that we got the one symlink
+	if len(files) != 1 {
+		t.Errorf("expected two files, not %d", len(files))
+	}
+
+	// Scan path below symlink
 	files = walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, tmp), filepath.Join("link", "cfile"), nil, nil, 0)
 
 	// Verify that we get nothing

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -344,9 +344,11 @@ func TestWalkRootSymlink(t *testing.T) {
 	// Scan symlink below FS root
 	files = walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, tmp), "link", nil, nil, 0)
 
-	// Verify that we got the one symlink
-	if len(files) != 1 {
-		t.Errorf("expected two files, not %d", len(files))
+	// Verify that we got the one symlink, except on windows
+	if runtime.GOOS == "windows" && len(files) != 0 {
+		t.Errorf("expected no files, not %d", len(files))
+	} else if len(files) != 1 {
+		t.Errorf("expected one file, not %d", len(files))
 	}
 
 	// Scan path below symlink

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -345,8 +345,10 @@ func TestWalkRootSymlink(t *testing.T) {
 	files = walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, tmp), "link", nil, nil, 0)
 
 	// Verify that we got the one symlink, except on windows
-	if runtime.GOOS == "windows" && len(files) != 0 {
-		t.Errorf("expected no files, not %d", len(files))
+	if runtime.GOOS == "windows" {
+		if len(files) != 0 {
+			t.Errorf("expected no files, not %d", len(files))
+		}
 	} else if len(files) != 1 {
 		t.Errorf("expected one file, not %d", len(files))
 	}

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -322,7 +322,7 @@ func TestWalkRootSymlink(t *testing.T) {
 	}
 	defer os.RemoveAll(tmp)
 
-	link := tmp + "/link"
+	link := filepath.Join(tmp, "link")
 	dest, _ := filepath.Abs("testdata/dir1")
 	if err := osutil.DebugSymlinkForTestsOnly(dest, link); err != nil {
 		if runtime.GOOS == "windows" {
@@ -339,6 +339,14 @@ func TestWalkRootSymlink(t *testing.T) {
 	// Verify that we got two files
 	if len(files) != 2 {
 		t.Errorf("expected two files, not %d", len(files))
+	}
+
+	// Scan below it
+	files = walkDir(fs.NewFilesystem(fs.FilesystemTypeBasic, tmp), filepath.Join("link", "cfile"), nil, nil, 0)
+
+	// Verify that we get nothing
+	if len(files) != 0 {
+		t.Errorf("expected no files, not %d", len(files))
 	}
 }
 


### PR DESCRIPTION
### Purpose

If the path to be scanned is below a symlink, the scanner goes ahead walking that path, as it never by itself needed to traverse the symlink. Now it checks before walking that the path given is not traversing any symlinks.

### Testing

Get no results when scanning a path behind a symlink.