### PR TITLE
Fix removal of a marker when there are still folders referencing it (fixes #6106)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -389,8 +389,17 @@ func (m *model) RemoveFolder(cfg config.FolderConfiguration) {
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
 
-	// Delete syncthing specific files
-	cfg.Filesystem().RemoveAll(config.DefaultMarkerName)
+	isPathUnique := true
+	for folderID, folderCfg := range m.folderCfgs {
+		if folderID != cfg.ID && folderCfg.Path == cfg.Path {
+			isPathUnique = false
+			break
+		}
+	}
+	if isPathUnique {
+		// Delete syncthing specific files
+		cfg.Filesystem().RemoveAll(config.DefaultMarkerName)
+	}
 
 	m.tearDownFolderLocked(cfg, fmt.Errorf("removing folder %v", cfg.Description()))
 	// Remove it from the database


### PR DESCRIPTION
### Purpose

I modified RemoveFolder to fix #6106 
After the changes, if someone tries to remove a folder, path of which is still referenced, the `.stfolder` won't be removed.

### Testing

I checked changes manually. I'm not sure if unit tests are needed.