### PR TITLE
gui, lib/api: Adds support for prefers-color-scheme (fixes #6115)

### DIFF
--- a/gui/default/assets/css/theme.css
+++ b/gui/default/assets/css/theme.css
@@ -7,5 +7,5 @@
 
 */
 
-@import "/dark/assets/css/theme.css" (prefers-color-scheme: dark);
-@import "/light/assets/css/theme.css" (prefers-color-scheme: light), (prefers-color-scheme: no-preference);
+@import "/theme-assets/dark/assets/css/theme.css" (prefers-color-scheme: dark);
+@import "/theme-assets/light/assets/css/theme.css" (prefers-color-scheme: light), (prefers-color-scheme: no-preference);

--- a/gui/default/assets/css/theme.css
+++ b/gui/default/assets/css/theme.css
@@ -7,5 +7,5 @@
 
 */
 
-@import "/theme-assets/dark/assets/css/theme.css" (prefers-color-scheme: dark);
+@import "/theme-assets/dark/assets/css/theme.css" screen and (prefers-color-scheme: dark);
 @import "/theme-assets/light/assets/css/theme.css" (prefers-color-scheme: light), (prefers-color-scheme: no-preference);

--- a/gui/default/assets/css/theme.css
+++ b/gui/default/assets/css/theme.css
@@ -7,29 +7,5 @@
 
 */
 
-.panel-progress {
-    background: #3498db;
-}
-
-.identicon rect {
-    fill: #333;
-}
-
-.panel-warning .identicon rect {
-    fill: #fff;
-}
-
-.li-column {
-    background-color: rgb(236, 240, 241);
-    border-radius: 3px;
-}
-
-.panel-heading:hover, .panel-heading:focus {
-    text-decoration: none;
-}
-
-.fancytree-ext-filter-hide tr.fancytree-submatch span.fancytree-title,
-.fancytree-ext-filter-hide span.fancytree-node.fancytree-submatch span.fancytree-title {
-    color: black !important;
-    font-weight: lighter !important;
-}
+@import "/dark/assets/css/theme.css" (prefers-color-scheme: dark);
+@import "/light/assets/css/theme.css" (prefers-color-scheme: light), (prefers-color-scheme: no-preference);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -389,6 +389,7 @@ angular.module('syncthing.core')
             });
 
             refreshNoAuthWarning();
+            setDefaultTheme();
 
             if (!hasConfig) {
                 $scope.$emit('ConfigLoaded');
@@ -649,6 +650,17 @@ angular.module('syncthing.core')
             $scope.remoteNeed = {};
             $scope.remoteNeedFolders = [];
             $scope.remoteNeedDevice = undefined;
+        }
+
+        function setDefaultTheme(){
+          // If theme is default and there is no support for prefers-color-scheme
+          if ($scope.config.gui.theme === "default" && window.matchMedia('(prefers-color-scheme: dark)').media === 'not all') {
+            document.documentElement.style.display = 'none';
+            document.head.insertAdjacentHTML(
+              'beforeend',
+              '<link rel="stylesheet" href="/theme-assets/light/assets/css/theme.css" onload="document.documentElement.style.display = \'\'">'
+            );
+          }
         }
 
         function saveIgnores(ignores, cb) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -652,15 +652,21 @@ angular.module('syncthing.core')
             $scope.remoteNeedDevice = undefined;
         }
 
-        function setDefaultTheme(){
-          // If theme is default and there is no support for prefers-color-scheme
-          if ($scope.config.gui.theme === "default" && window.matchMedia('(prefers-color-scheme: dark)').media === 'not all') {
-            document.documentElement.style.display = 'none';
-            document.head.insertAdjacentHTML(
-              'beforeend',
-              '<link rel="stylesheet" href="/theme-assets/light/assets/css/theme.css" onload="document.documentElement.style.display = \'\'">'
-            );
-          }
+
+        function setDefaultTheme() {
+            if (!document.getElementById("fallback-theme-css")){
+
+                // check if no support for prefers-color-scheme
+                var colorSchemeNotSupported = typeof window.matchMedia === "undefined" || window.matchMedia('(prefers-color-scheme: dark)').media === 'not all';
+
+                if ($scope.config.gui.theme === "default" && colorSchemeNotSupported) {
+                    document.documentElement.style.display = 'none';
+                    document.head.insertAdjacentHTML(
+                      'beforeend',
+                      '<link id="fallback-theme-css" rel="stylesheet" href="/theme-assets/light/assets/css/theme.css" onload="document.documentElement.style.display = \'\'">'
+                    );
+                }
+            }
         }
 
         function saveIgnores(ignores, cb) {

--- a/gui/light/assets/css/theme.css
+++ b/gui/light/assets/css/theme.css
@@ -1,0 +1,35 @@
+/*
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+*/
+
+.panel-progress {
+    background: #3498db;
+}
+
+.identicon rect {
+    fill: #333;
+}
+
+.panel-warning .identicon rect {
+    fill: #fff;
+}
+
+.li-column {
+    background-color: rgb(236, 240, 241);
+    border-radius: 3px;
+}
+
+.panel-heading:hover, .panel-heading:focus {
+    text-decoration: none;
+}
+
+.fancytree-ext-filter-hide tr.fancytree-submatch span.fancytree-title,
+.fancytree-ext-filter-hide span.fancytree-node.fancytree-submatch span.fancytree-title {
+    color: black !important;
+    font-weight: lighter !important;
+}

--- a/lib/api/api_statics.go
+++ b/lib/api/api_statics.go
@@ -23,6 +23,8 @@ import (
 	"github.com/syncthing/syncthing/lib/sync"
 )
 
+const themePrefix = "theme-assets/"
+
 type staticsServer struct {
 	assetDir        string
 	assets          map[string][]byte
@@ -89,7 +91,6 @@ func (s *staticsServer) serveAsset(w http.ResponseWriter, r *http.Request) {
 	s.mut.RUnlock()
 
 	// If path starts with special prefix, get theme and file from path
-	const themePrefix = "theme-assets/"
 	if strings.HasPrefix(file, themePrefix) {
 		path := file[len(themePrefix):]
 		i := strings.IndexRune(path, '/')

--- a/lib/api/api_statics.go
+++ b/lib/api/api_statics.go
@@ -120,8 +120,13 @@ func (s *staticsServer) serveAsset(w http.ResponseWriter, r *http.Request) {
 		// Check for a compiled in default asset.
 		bs, ok = s.assets[config.DefaultTheme+"/"+file]
 		if !ok {
-			http.NotFound(w, r)
-			return
+
+			// Check for a compiled outside of current theme
+			bs, ok = s.assets[file]
+			if !ok {
+				http.NotFound(w, r)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
### Purpose

Fixes #6115. In particular:

- moves the default theme into a new "light" theme,
- serves assets from other themes when the path starts with `theme-assets` and
- on the default theme, load the correct style depending on `prefers-color-scheme`.

### Testing

*Instructions on how to activate dark mode on Firefox for testing are available [here](https://stackoverflow.com/a/56757527).*

- Open web UI with `prefers-color-scheme` set to `light` or `no-preference` → it has the light theme
- Open web UI with `prefers-color-scheme` set to `dark` → it has the dark theme
- Open web UI in a browser without support for `prefers-color-scheme` → it has the light theme
- Set "Light" theme → the web UI has the current default theme (regardless of `prefers-color-scheme`)
- Set a custom theme → the web UI has the custom theme (regardless of `prefers-color-scheme` or whether it is supported)