### PR TITLE
Fix bufferpool puts (ref #4976)

### DIFF
--- a/lib/protocol/bufferpool.go
+++ b/lib/protocol/bufferpool.go
@@ -30,7 +30,7 @@ func newBufferPool() bufferPool {
 func (p *bufferPool) Get(size int) []byte {
 	// Too big, isn't pooled
 	if size > MaxBlockSize {
-		atomic.AddInt64(&p.misses, 1)
+		atomic.AddInt64(&p.skips, 1)
 		return make([]byte, size)
 	}
 

--- a/lib/protocol/bufferpool.go
+++ b/lib/protocol/bufferpool.go
@@ -35,12 +35,11 @@ func (p *bufferPool) Get(size int) []byte {
 	}
 
 	// Try the fitting and all bigger pools
-	var bs []byte
 	bkt := getBucketForLen(size)
 	for j := bkt; j < len(BlockSizes); j++ {
 		if intf := p.pools[j].Get(); intf != nil {
-			bs = *intf.(*[]byte)
 			atomic.AddInt64(&p.hits[j], 1)
+			bs := *intf.(*[]byte)
 			return bs[:size]
 		}
 	}

--- a/lib/protocol/bufferpool.go
+++ b/lib/protocol/bufferpool.go
@@ -17,7 +17,7 @@ type bufferPool struct {
 	skips  int64
 	misses int64
 	pools  []sync.Pool
-	hits   []int64
+	hits   []int64 // start of slice allocation is always aligned
 }
 
 func newBufferPool() bufferPool {

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -79,7 +79,7 @@ func TestStressBufferPool(t *testing.T) {
 			for time.Since(t0) < runtime {
 				blocks := make([][]byte, 100)
 				for i := range blocks {
-					want := rand.Intn(MaxBlockSize)
+					want := rand.Intn(1.5 * MaxBlockSize)
 					blocks[i] = bp.Get(want)
 					if len(blocks[i]) != want {
 						t.Fatal("wat")

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -26,6 +26,10 @@ func TestBucketNumbers(t *testing.T) {
 
 		// ... and past it.
 		{size: 2*MinBlockSize + 1, put: 1, get: 2},
+
+		// ... and past it some more. We can always put large blocks, but
+		// can't guarantee getting one.
+		{size: 2 * MaxBlockSize, put: len(BlockSizes) - 1, get: -1},
 	}
 
 	for _, tc := range cases {

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2019 The Protocol Authors.
+
+package protocol
+
+import "testing"
+
+func TestBucketNumbers(t *testing.T) {
+	cases := []struct {
+		size int
+		put  int
+		get  int
+	}{
+		// Small blocks are put nowwhere, but can be fetched from bucket 0
+		{size: 1024, put: -1, get: 0},
+
+		// The blocksize for bucket zero  goes there
+		{size: MinBlockSize, put: 0, get: 0},
+
+		// Up to the next blocksize - 1 we still put in the same bucket, but
+		// we look for these blocks in the next bucket where we know they
+		// can be found.
+		{size: 2*MinBlockSize - 1, put: 0, get: 1},
+
+		// Next blocksize at the border...
+		{size: 2 * MinBlockSize, put: 1, get: 1},
+
+		// ... and past it.
+		{size: 2*MinBlockSize + 1, put: 1, get: 2},
+	}
+
+	for _, tc := range cases {
+		getRes := getBucketForSize(tc.size)
+		if getRes != tc.get {
+			t.Errorf("block of size %d should get from bucket %d, not %d", tc.size, tc.get, getRes)
+		}
+		putRes := putBucketForSize(tc.size)
+		if putRes != tc.put {
+			t.Errorf("block of size %d should put into bucket %d, not %d", tc.size, tc.put, putRes)
+		}
+	}
+}

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -93,6 +93,16 @@ func TestStressBufferPool(t *testing.T) {
 	}
 
 	wg.Wait()
+
+	t.Log(bp.puts, bp.skips, bp.misses, bp.hits)
+	if bp.puts == 0 || bp.skips == 0 || bp.misses == 0 {
+		t.Error("didn't exercise some paths")
+	}
+	for _, h := range bp.hits {
+		if h == 0 {
+			t.Error("didn't exercise some paths")
+		}
+	}
 }
 
 func shouldPanic(t *testing.T, fn func()) {

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -84,6 +84,7 @@ func TestStressBufferPool(t *testing.T) {
 					blocks[i] = bp.Get(want)
 					if len(blocks[i]) != want {
 						fail <- struct{}{}
+						return
 					}
 				}
 				for i := range blocks {

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -65,8 +65,8 @@ func TestPutBucketNumbers(t *testing.T) {
 }
 
 func TestStressBufferPool(t *testing.T) {
-	const routines = 100
-	const runtime = time.Second
+	const routines = 10
+	const runtime = 2 * time.Second
 
 	bp := newBufferPool()
 	t0 := time.Now()
@@ -78,7 +78,7 @@ func TestStressBufferPool(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for time.Since(t0) < runtime {
-				blocks := make([][]byte, 100)
+				blocks := make([][]byte, 10)
 				for i := range blocks {
 					want := rand.Intn(1.5 * MaxBlockSize)
 					blocks[i] = bp.Get(want)
@@ -105,10 +105,12 @@ func TestStressBufferPool(t *testing.T) {
 	if bp.puts == 0 || bp.skips == 0 || bp.misses == 0 {
 		t.Error("didn't exercise some paths")
 	}
+	var hits int64
 	for _, h := range bp.hits {
-		if h == 0 {
-			t.Error("didn't exercise some paths")
-		}
+		hits += h
+	}
+	if hits == 0 {
+		t.Error("didn't exercise some paths")
 	}
 }
 

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -28,9 +28,9 @@ func TestGetBucketNumbers(t *testing.T) {
 
 	for _, tc := range cases {
 		if tc.panics {
-			shouldPanic(t, func() { getBucketForSize(tc.size) })
+			shouldPanic(t, func() { getBucketForLen(tc.size) })
 		} else {
-			res := getBucketForSize(tc.size)
+			res := getBucketForLen(tc.size)
 			if res != tc.bkt {
 				t.Errorf("block of size %d should get from bucket %d, not %d", tc.size, tc.bkt, res)
 			}
@@ -54,9 +54,9 @@ func TestPutBucketNumbers(t *testing.T) {
 
 	for _, tc := range cases {
 		if tc.panics {
-			shouldPanic(t, func() { putBucketForSize(tc.size) })
+			shouldPanic(t, func() { putBucketForCap(tc.size) })
 		} else {
-			res := putBucketForSize(tc.size)
+			res := putBucketForCap(tc.size)
 			if res != tc.bkt {
 				t.Errorf("block of size %d should put into bucket %d, not %d", tc.size, tc.bkt, res)
 			}
@@ -65,6 +65,10 @@ func TestPutBucketNumbers(t *testing.T) {
 }
 
 func TestStressBufferPool(t *testing.T) {
+	if testing.Short() {
+		t.Skip()
+	}
+
 	const routines = 10
 	const runtime = 2 * time.Second
 

--- a/lib/protocol/bufferpool_test.go
+++ b/lib/protocol/bufferpool_test.go
@@ -84,6 +84,9 @@ func TestStressBufferPool(t *testing.T) {
 			for time.Since(t0) < runtime {
 				blocks := make([][]byte, 10)
 				for i := range blocks {
+					// Request a block of random size with the range
+					// covering smaller-than-min to larger-than-max and
+					// everything in between.
 					want := rand.Intn(1.5 * MaxBlockSize)
 					blocks[i] = bp.Get(want)
 					if len(blocks[i]) != want {


### PR DESCRIPTION
There was a logic error in Put() which made us put all large blocks into
segment zero, where we subsequently did not look for them.

I also added a lowest threshold, as we otherwise allocate a 128KiB
buffer when we need 24 bytes for a header and such.

After:

```
2019/11/04 18:21:49 Result: Wall time: 2.665497ms / MiB
2019/11/04 18:21:49 Result: 3.84e+05 KiB/s synced
2019/11/04 18:21:49 Receiver: Utime: 4.506592ms / MiB
2019/11/04 18:21:49 Receiver: Stime: 1.126973ms / MiB
2019/11/04 18:21:49 Receiver: MaxRSS: 321632 KiB
2019/11/04 18:21:49 Sender: Utime: 4.163059ms / MiB
2019/11/04 18:21:49 Sender: Stime: 963.312µs / MiB
2019/11/04 18:21:49 Sender: MaxRSS: 113696 KiB
```

Before:

```
2019/11/04 17:16:03 Result: Wall time: 2.77946ms / MiB
2019/11/04 17:16:03 Result: 3.68e+05 KiB/s synced
2019/11/04 17:16:03 Receiver: Utime: 4.580026ms / MiB
2019/11/04 17:16:03 Receiver: Stime: 1.283715ms / MiB
2019/11/04 17:16:03 Receiver: MaxRSS: 644452 KiB
2019/11/04 17:16:03 Sender: Utime: 4.62121ms / MiB
2019/11/04 17:16:03 Sender: Stime: 1.075979ms / MiB
2019/11/04 17:16:03 Sender: MaxRSS: 1790704 KiB
```