### PR TITLE
lib/model: Add folders on start in model

### DIFF
--- a/lib/api/mocked_model_test.go
+++ b/lib/api/mocked_model_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/connections"
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/model"
@@ -179,11 +178,5 @@ func (m *mockedModel) OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult)
 func (m *mockedModel) GetHello(protocol.DeviceID) protocol.HelloIntf {
 	return nil
 }
-
-func (m *mockedModel) AddFolder(cfg config.FolderConfiguration) {}
-
-func (m *mockedModel) RestartFolder(from, to config.FolderConfiguration) {}
-
-func (m *mockedModel) StartFolder(folder string) {}
 
 func (m *mockedModel) StartDeadlockDetector(timeout time.Duration) {}

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -54,7 +54,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 
 	// Start the folder. This will cause a scan, should discover the other stuff in the folder
 
-	m.StartFolder("ro")
+	m.startFolder("ro")
 	m.ScanFolder("ro")
 
 	// We should now have two files and two directories.
@@ -125,7 +125,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 
 	// Start the folder. This will cause a scan.
 
-	m.StartFolder("ro")
+	m.startFolder("ro")
 	m.ScanFolder("ro")
 
 	// Everything should be in sync.
@@ -221,7 +221,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 
 	// Start the folder. This will cause a scan.
 
-	m.StartFolder("ro")
+	m.startFolder("ro")
 	m.ScanFolder("ro")
 
 	// Everything should be in sync.
@@ -317,7 +317,7 @@ func setupROFolder() (*model, *sendOnlyFolder) {
 	w.SetFolder(fcfg)
 
 	m := newModel(w, myID, "syncthing", "dev", db.OpenMemory(), nil)
-	m.AddFolder(fcfg)
+	m.addFolder(fcfg)
 
 	f := &sendOnlyFolder{
 		folder: folder{

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -93,7 +93,7 @@ func setupSendReceiveFolder(files ...protocol.FileInfo) (*model, *sendReceiveFol
 	w := createTmpWrapper(defaultCfg)
 	model := newModel(w, myID, "syncthing", "dev", db.OpenMemory(), nil)
 	fcfg := testFolderConfigTmp()
-	model.AddFolder(fcfg)
+	model.addFolder(fcfg)
 
 	f := &sendReceiveFolder{
 		folder: folder{

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -72,9 +72,6 @@ type Model interface {
 
 	connections.Model
 
-	AddFolder(cfg config.FolderConfiguration)
-	RestartFolder(from, to config.FolderConfiguration)
-	StartFolder(folder string)
 	ResetFolder(folder string)
 	DelayScan(folder string, next time.Duration)
 	ScanFolder(folder string) error
@@ -217,6 +214,19 @@ func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersio
 	return m
 }
 
+func (m *model) Serve() {
+	// Add and start folders
+	for _, folderCfg := range m.cfg.Folders() {
+		if folderCfg.Paused {
+			folderCfg.CreateRoot()
+			continue
+		}
+		m.addFolder(folderCfg)
+		m.startFolder(folderCfg.ID)
+	}
+	m.Supervisor.Serve()
+}
+
 func (m *model) Stop() {
 	m.Supervisor.Stop()
 	devs := m.cfg.Devices()
@@ -238,8 +248,8 @@ func (m *model) StartDeadlockDetector(timeout time.Duration) {
 	detector.Watch("pmut", m.pmut)
 }
 
-// StartFolder constructs the folder service and starts it.
-func (m *model) StartFolder(folder string) {
+// startFolder constructs the folder service and starts it.
+func (m *model) startFolder(folder string) {
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
 	folderCfg := m.folderCfgs[folder]
@@ -356,7 +366,7 @@ func (m *model) warnAboutOverwritingProtectedFiles(folder string) {
 	}
 }
 
-func (m *model) AddFolder(cfg config.FolderConfiguration) {
+func (m *model) addFolder(cfg config.FolderConfiguration) {
 	if len(cfg.ID) == 0 {
 		panic("cannot add empty folder id")
 	}
@@ -385,7 +395,7 @@ func (m *model) addFolderLocked(cfg config.FolderConfiguration, fset *db.FileSet
 	m.folderIgnores[cfg.ID] = ignores
 }
 
-func (m *model) RemoveFolder(cfg config.FolderConfiguration) {
+func (m *model) removeFolder(cfg config.FolderConfiguration) {
 	m.fmut.Lock()
 	defer m.fmut.Unlock()
 
@@ -437,7 +447,7 @@ func (m *model) tearDownFolderLocked(cfg config.FolderConfiguration, err error) 
 	delete(m.folderRunnerTokens, cfg.ID)
 }
 
-func (m *model) RestartFolder(from, to config.FolderConfiguration) {
+func (m *model) restartFolder(from, to config.FolderConfiguration) {
 	if len(to.ID) == 0 {
 		panic("bug: cannot restart empty folder ID")
 	}
@@ -2510,8 +2520,8 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 				l.Infoln("Paused folder", cfg.Description())
 			} else {
 				l.Infoln("Adding folder", cfg.Description())
-				m.AddFolder(cfg)
-				m.StartFolder(folderID)
+				m.addFolder(cfg)
+				m.startFolder(folderID)
 			}
 		}
 	}
@@ -2520,7 +2530,7 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 		toCfg, ok := toFolders[folderID]
 		if !ok {
 			// The folder was removed.
-			m.RemoveFolder(fromCfg)
+			m.removeFolder(fromCfg)
 			continue
 		}
 
@@ -2531,7 +2541,7 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 		// This folder exists on both sides. Settings might have changed.
 		// Check if anything differs that requires a restart.
 		if !reflect.DeepEqual(fromCfg.RequiresRestartOnly(), toCfg.RequiresRestartOnly()) {
-			m.RestartFolder(fromCfg, toCfg)
+			m.restartFolder(fromCfg, toCfg)
 		}
 
 		// Emit the folder pause/resume event

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -405,8 +405,8 @@ func TestClusterConfig(t *testing.T) {
 
 	wrapper := createTmpWrapper(cfg)
 	m := newModel(wrapper, myID, "syncthing", "dev", db, nil)
-	m.AddFolder(cfg.Folders[0])
-	m.AddFolder(cfg.Folders[1])
+	m.addFolder(cfg.Folders[0])
+	m.addFolder(cfg.Folders[1])
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -1454,8 +1454,8 @@ func TestIgnores(t *testing.T) {
 	m := setupModel(defaultCfgWrapper)
 	defer cleanupModel(m)
 
-	m.RemoveFolder(defaultFolderConfig)
-	m.AddFolder(defaultFolderConfig)
+	m.removeFolder(defaultFolderConfig)
+	m.addFolder(defaultFolderConfig)
 	// Reach in and update the ignore matcher to one that always does
 	// reloads when asked to, instead of checking file mtimes. This is
 	// because we will be changing the files on disk often enough that the
@@ -1463,7 +1463,7 @@ func TestIgnores(t *testing.T) {
 	m.fmut.Lock()
 	m.folderIgnores["default"] = ignore.New(defaultFs, ignore.WithCache(true), ignore.WithChangeDetector(newAlwaysChanged()))
 	m.fmut.Unlock()
-	m.StartFolder("default")
+	m.startFolder("default")
 
 	// Make sure the initial scan has finished (ScanFolders is blocking)
 	m.ScanFolders()
@@ -1486,7 +1486,7 @@ func TestIgnores(t *testing.T) {
 	}
 
 	// Invalid path, marker should be missing, hence returns an error.
-	m.AddFolder(config.FolderConfiguration{ID: "fresh", Path: "XXX"})
+	m.addFolder(config.FolderConfiguration{ID: "fresh", Path: "XXX"})
 	_, _, err = m.GetIgnores("fresh")
 	if err == nil {
 		t.Error("No error")
@@ -1496,7 +1496,7 @@ func TestIgnores(t *testing.T) {
 	pausedDefaultFolderConfig := defaultFolderConfig
 	pausedDefaultFolderConfig.Paused = true
 
-	m.RestartFolder(defaultFolderConfig, pausedDefaultFolderConfig)
+	m.restartFolder(defaultFolderConfig, pausedDefaultFolderConfig)
 	// Here folder initialization is not an issue as a paused folder isn't
 	// added to the model and thus there is no initial scan happening.
 
@@ -1555,8 +1555,8 @@ func TestROScanRecovery(t *testing.T) {
 	testOs.RemoveAll(fcfg.Path)
 
 	m := newModel(cfg, myID, "syncthing", "dev", ldb, nil)
-	m.AddFolder(fcfg)
-	m.StartFolder("default")
+	m.addFolder(fcfg)
+	m.startFolder("default")
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -1608,8 +1608,8 @@ func TestRWScanRecovery(t *testing.T) {
 	testOs.RemoveAll(fcfg.Path)
 
 	m := newModel(cfg, myID, "syncthing", "dev", ldb, nil)
-	m.AddFolder(fcfg)
-	m.StartFolder("default")
+	m.addFolder(fcfg)
+	m.startFolder("default")
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -1636,7 +1636,7 @@ func TestRWScanRecovery(t *testing.T) {
 func TestGlobalDirectoryTree(t *testing.T) {
 	db := db.OpenMemory()
 	m := newModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
-	m.AddFolder(defaultFolderConfig)
+	m.addFolder(defaultFolderConfig)
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -1888,7 +1888,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 func TestGlobalDirectorySelfFixing(t *testing.T) {
 	db := db.OpenMemory()
 	m := newModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
-	m.AddFolder(defaultFolderConfig)
+	m.addFolder(defaultFolderConfig)
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -2064,7 +2064,7 @@ func BenchmarkTree_100_10(b *testing.B) {
 func benchmarkTree(b *testing.B, n1, n2 int) {
 	db := db.OpenMemory()
 	m := newModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
-	m.AddFolder(defaultFolderConfig)
+	m.addFolder(defaultFolderConfig)
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -2262,8 +2262,8 @@ func TestIndexesForUnknownDevicesDropped(t *testing.T) {
 	}
 
 	m := newModel(defaultCfgWrapper, myID, "syncthing", "dev", dbi, nil)
-	m.AddFolder(defaultFolderConfig)
-	m.StartFolder("default")
+	m.addFolder(defaultFolderConfig)
+	m.startFolder("default")
 	defer cleanupModel(m)
 
 	// Remote sequence is cached, hence need to recreated.
@@ -2701,8 +2701,8 @@ func TestCustomMarkerName(t *testing.T) {
 	defer testOs.RemoveAll(fcfg.Path)
 
 	m := newModel(cfg, myID, "syncthing", "dev", ldb, nil)
-	m.AddFolder(fcfg)
-	m.StartFolder("default")
+	m.addFolder(fcfg)
+	m.startFolder("default")
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -3290,7 +3290,7 @@ func TestConnCloseOnRestart(t *testing.T) {
 	newFcfg.Paused = true
 	done := make(chan struct{})
 	go func() {
-		m.RestartFolder(fcfg, newFcfg)
+		m.restartFolder(fcfg, newFcfg)
 		close(done)
 	}()
 	select {

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -295,8 +295,8 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 	m := setupModel(w)
 	defer cleanupModelAndRemoveDir(m, fss.URI())
 
-	m.RemoveFolder(fcfg)
-	m.AddFolder(fcfg)
+	m.removeFolder(fcfg)
+	m.addFolder(fcfg)
 	// Reach in and update the ignore matcher to one that always does
 	// reloads when asked to, instead of checking file mtimes. This is
 	// because we might be changing the files on disk often enough that the
@@ -304,7 +304,7 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 	m.fmut.Lock()
 	m.folderIgnores["default"] = ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged()))
 	m.fmut.Unlock()
-	m.StartFolder(fcfg.ID)
+	m.startFolder(fcfg.ID)
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"
@@ -1032,8 +1032,8 @@ func TestIgnoreDeleteUnignore(t *testing.T) {
 	tmpDir := fss.URI()
 	defer cleanupModelAndRemoveDir(m, tmpDir)
 
-	m.RemoveFolder(fcfg)
-	m.AddFolder(fcfg)
+	m.removeFolder(fcfg)
+	m.addFolder(fcfg)
 	// Reach in and update the ignore matcher to one that always does
 	// reloads when asked to, instead of checking file mtimes. This is
 	// because we might be changing the files on disk often enough that the
@@ -1041,7 +1041,7 @@ func TestIgnoreDeleteUnignore(t *testing.T) {
 	m.fmut.Lock()
 	m.folderIgnores["default"] = ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged()))
 	m.fmut.Unlock()
-	m.StartFolder(fcfg.ID)
+	m.startFolder(fcfg.ID)
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -107,8 +107,8 @@ func setupModel(w config.Wrapper) *model {
 	m.ServeBackground()
 	for id, cfg := range w.Folders() {
 		if !cfg.Paused {
-			m.AddFolder(cfg)
-			m.StartFolder(id)
+			m.addFolder(cfg)
+			m.startFolder(id)
 		}
 	}
 

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -239,16 +239,6 @@ func (a *App) startup() error {
 		m.StartDeadlockDetector(20 * time.Minute)
 	}
 
-	// Add and start folders
-	for _, folderCfg := range a.cfg.Folders() {
-		if folderCfg.Paused {
-			folderCfg.CreateRoot()
-			continue
-		}
-		m.AddFolder(folderCfg)
-		m.StartFolder(folderCfg.ID)
-	}
-
 	a.mainService.Add(m)
 
 	// Start discovery


### PR DESCRIPTION
Nobody outside of model has any business meddling directly with folders and starting folders together with the model also seems more fitting (and it has an almost neutral/slightly negative line count :) ).

Testing: Folders still start on startup.