### PR TITLE
lib/model: Add initial deviceStatRefs on model creation (fixes #6136)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -207,6 +207,9 @@ func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersio
 		fmut:                sync.NewRWMutex(),
 		pmut:                sync.NewRWMutex(),
 	}
+	for devID := range cfg.Devices() {
+		m.deviceStatRefs[devID] = stats.NewDeviceStatisticsReference(m.db, devID.String())
+	}
 	m.Add(m.progressEmitter)
 	scanLimiter.setCapacity(cfg.Options().MaxConcurrentScans)
 	cfg.Subscribe(m)


### PR DESCRIPTION
This is a regression introduced in PR #6005 / commit
f7b2e79fdcff1ce45d42e38d3fa446cf6de2efc8

The reference are create in `CommitConfiguration`, however that only handles updated devices. Devices that are present at model creation were never added (unless you removed and readded them).
