### PR TITLE
lib/model: Remove some testing deadlocks

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3224,7 +3224,7 @@ func TestRequestLimit(t *testing.T) {
 	go func() {
 		second, err := m.Request(device1, "default", file, 2000, 0, nil, 0, false)
 		if err != nil {
-			t.Fatalf("Second request failed: %v", err)
+			t.Errorf("Second request failed: %v", err)
 		}
 		close(returned)
 		second.Close()


### PR DESCRIPTION
This is in reaction to these test timeouts:

https://build.syncthing.net/viewLog.html?buildId=49063&buildTypeId=Syncthing_BuildLinuxCross
https://build.syncthing.net/viewLog.html?buildId=49063&buildTypeId=Syncthing_BuildLinuxCross

It does not fix any flakyness (couldn't repro locally), but at least now these tests fail quickly instead of blocking everything until the global test timeout kicks in.