### PR TITLE
Cleanup of things we can improve when requiring Go 1.12

### DIFF
--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -151,17 +151,14 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 				// Successful exit indicates an intentional shutdown
 				return
 			} else if exiterr, ok := err.(*exec.ExitError); ok {
-				if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-					switch status.ExitStatus() {
-					case syncthing.ExitUpgrade.AsInt():
-						// Restart the monitor process to release the .old
-						// binary as part of the upgrade process.
-						l.Infoln("Restarting monitor...")
-						if err = restartMonitor(args); err != nil {
-							l.Warnln("Restart:", err)
-						}
-						return
+				if exiterr.ExitCode() == syncthing.ExitUpgrade.AsInt() {
+					// Restart the monitor process to release the .old
+					// binary as part of the upgrade process.
+					l.Infoln("Restarting monitor...")
+					if err = restartMonitor(args); err != nil {
+						l.Warnln("Restart:", err)
 					}
+					return
 				}
 			}
 		}

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -83,7 +83,7 @@ var tlsCipherSuiteNames = map[uint16]string{
 
 var tlsVersionNames = map[uint16]string{
 	tls.VersionTLS12: "TLS1.2",
-	772:              "TLS1.3", // tls.VersionTLS13 constant available in Go 1.12+
+	tls.VersionTLS13: "TLS1.3",
 }
 
 // Service listens and dials all configured unconnected devices, via supported

--- a/lib/fs/util.go
+++ b/lib/fs/util.go
@@ -35,23 +35,16 @@ func ExpandTilde(path string) (string, error) {
 }
 
 func getHomeDir() (string, error) {
-	var home string
-
-	switch runtime.GOOS {
-	case "windows":
-		home = filepath.Join(os.Getenv("HomeDrive"), os.Getenv("HomePath"))
-		if home == "" {
-			home = os.Getenv("UserProfile")
+	if runtime.GOOS == "windows" {
+		// Legacy -- we prioritize this for historical reasons, whereas
+		// os.UserHomeDir uses %USERPROFILE% always.
+		home := filepath.Join(os.Getenv("HomeDrive"), os.Getenv("HomePath"))
+		if home != "" {
+			return home, nil
 		}
-	default:
-		home = os.Getenv("HOME")
 	}
 
-	if home == "" {
-		return "", errNoHome
-	}
-
-	return home, nil
+	return os.UserHomeDir()
 }
 
 var windowsDisallowedCharacters = string([]rune{

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -70,11 +70,6 @@ var (
 func init() {
 	// Creates the list of ciper suites that SecureDefault uses.
 	cipherSuites = buildCipherSuites()
-	if build.IsBeta {
-		// Append "tls13=1" to GODEBUG before starting TLS, to enable TLS
-		// 1.3 in Go 1.12.
-		os.Setenv("GODEBUG", os.Getenv("GODEBUG")+",tls13=1")
-	}
 }
 
 // SecureDefault returns a tls.Config with reasonable, secure defaults set.

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/syncthing/syncthing/lib/build"
 	"github.com/syncthing/syncthing/lib/rand"
 )
 


### PR DESCRIPTION
Home dir, exit code. Also dropping the TLS 1.3 thing since that's enabled by default in Go 1.13 that we normally build with.