### PR TITLE
Decrease padding on the panel and modal bodies.

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -247,6 +247,18 @@ a.toggler:hover {
 }
 
 /**
+ * Panel and Modal body padding decrease
+ */
+
+.panel-collapse .panel-body {
+    padding: 0;
+}
+
+.modal-body {
+    padding: 5px;
+}
+
+/**
  * Progress bars with centered text
  */
 


### PR DESCRIPTION
This allows better viewing when on a condensed screen, and reduces screen real estate slightly.

### Purpose

On smaller screens the padding of 15px is too much in these panels and modals. I have reduced them accordingly.

### Testing

Built using docker.

### Screenshots

New Panels:
![image](https://user-images.githubusercontent.com/293107/68770987-1b220f00-0662-11ea-94ba-7c61156947bf.png)

Old Panels:
![image](https://user-images.githubusercontent.com/293107/68771015-29702b00-0662-11ea-97e0-326da0e174fc.png)

New Modal:
![image](https://user-images.githubusercontent.com/293107/68771121-57ee0600-0662-11ea-885c-a643327fa30d.png)

Old Modal:
![image](https://user-images.githubusercontent.com/293107/68771132-5e7c7d80-0662-11ea-8d8a-bfd1651ac5f1.png)

### Documentation

I added a comment on the CSS I added, but none really required.

## Authorship

me, domenic@tgxn.net

