### PR TITLE
lib/model: Remove unneccessary panic handling indexes

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -52,9 +52,6 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 		t.Fatalf("Global: expected 1 file and 1 directory: %+v", size)
 	}
 
-	// Start the folder. This will cause a scan, should discover the other stuff in the folder
-
-	m.startFolder("ro")
 	m.ScanFolder("ro")
 
 	// We should now have two files and two directories.
@@ -123,9 +120,6 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	m.Index(device1, "ro", knownFiles)
 	f.updateLocalsFromScanning(knownFiles)
 
-	// Start the folder. This will cause a scan.
-
-	m.startFolder("ro")
 	m.ScanFolder("ro")
 
 	// Everything should be in sync.
@@ -219,9 +213,6 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	m.Index(device1, "ro", knownFiles)
 	f.updateLocalsFromScanning(knownFiles)
 
-	// Start the folder. This will cause a scan.
-
-	m.startFolder("ro")
 	m.ScanFolder("ro")
 
 	// Everything should be in sync.

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -52,6 +52,9 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 		t.Fatalf("Global: expected 1 file and 1 directory: %+v", size)
 	}
 
+	// Start the folder. This will cause a scan, should discover the other stuff in the folder
+
+	startROFolder(m, f)
 	m.ScanFolder("ro")
 
 	// We should now have two files and two directories.
@@ -120,6 +123,9 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	m.Index(device1, "ro", knownFiles)
 	f.updateLocalsFromScanning(knownFiles)
 
+	// Start the folder. This will cause a scan.
+
+	startROFolder(m, f)
 	m.ScanFolder("ro")
 
 	// Everything should be in sync.
@@ -213,6 +219,9 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	m.Index(device1, "ro", knownFiles)
 	f.updateLocalsFromScanning(knownFiles)
 
+	// Start the folder. This will cause a scan.
+
+	startROFolder(m, f)
 	m.ScanFolder("ro")
 
 	// Everything should be in sync.
@@ -308,7 +317,7 @@ func setupROFolder() (*model, *sendOnlyFolder) {
 	w.SetFolder(fcfg)
 
 	m := newModel(w, myID, "syncthing", "dev", db.OpenMemory(), nil)
-	m.addFolder(fcfg)
+	addFolder(m, fcfg)
 
 	f := &sendOnlyFolder{
 		folder: folder{
@@ -321,4 +330,10 @@ func setupROFolder() (*model, *sendOnlyFolder) {
 	m.ServeBackground()
 
 	return m, f
+}
+
+func startROFolder(m *model, f *sendOnlyFolder) {
+	m.fmut.Lock()
+	m.startFolderLocked(f.FolderConfiguration)
+	m.fmut.Unlock()
 }

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -93,7 +93,7 @@ func setupSendReceiveFolder(files ...protocol.FileInfo) (*model, *sendReceiveFol
 	w := createTmpWrapper(defaultCfg)
 	model := newModel(w, myID, "syncthing", "dev", db.OpenMemory(), nil)
 	fcfg := testFolderConfigTmp()
-	model.addFolder(fcfg)
+	addFolder(model, fcfg)
 
 	f := &sendReceiveFolder{
 		folder: folder{

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -66,6 +66,7 @@ func TestProgressEmitter(t *testing.T) {
 
 	p := NewProgressEmitter(c, evLogger)
 	go p.Serve()
+	defer p.Stop()
 	p.interval = 0
 
 	expectTimeout(w, t)
@@ -103,7 +104,6 @@ func TestProgressEmitter(t *testing.T) {
 
 	expectEvent(w, t, 0)
 	expectTimeout(w, t)
-
 }
 
 func TestSendDownloadProgressMessages(t *testing.T) {

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -301,12 +301,16 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 	m := setupModel(w)
 	defer cleanupModelAndRemoveDir(m, fss.URI())
 
-	// Update the ignore matcher to one that always does
+	m.removeFolder(fcfg)
+	addFolder(m, fcfg)
+	// Reach in and update the ignore matcher to one that always does
 	// reloads when asked to, instead of checking file mtimes. This is
 	// because we might be changing the files on disk often enough that the
 	// mtimes will be unreliable to determine change status.
-	m.removeFolder(fcfg)
-	m.addFolderWithIgnores(fcfg, ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged())))
+	m.fmut.Lock()
+	m.folderIgnores["default"] = ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged()))
+	m.startFolderLocked(fcfg)
+	m.fmut.Unlock()
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"
@@ -1034,12 +1038,16 @@ func TestIgnoreDeleteUnignore(t *testing.T) {
 	tmpDir := fss.URI()
 	defer cleanupModelAndRemoveDir(m, tmpDir)
 
-	// Update the ignore matcher to one that always does
+	m.removeFolder(fcfg)
+	addFolder(m, fcfg)
+	// Reach in and update the ignore matcher to one that always does
 	// reloads when asked to, instead of checking file mtimes. This is
 	// because we might be changing the files on disk often enough that the
 	// mtimes will be unreliable to determine change status.
-	m.removeFolder(fcfg)
-	m.addFolderWithIgnores(fcfg, ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged())))
+	m.fmut.Lock()
+	m.folderIgnores["default"] = ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged()))
+	m.startFolderLocked(fcfg)
+	m.fmut.Unlock()
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -301,16 +301,12 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 	m := setupModel(w)
 	defer cleanupModelAndRemoveDir(m, fss.URI())
 
-	m.removeFolder(fcfg)
-	m.addFolder(fcfg)
-	// Reach in and update the ignore matcher to one that always does
+	// Update the ignore matcher to one that always does
 	// reloads when asked to, instead of checking file mtimes. This is
 	// because we might be changing the files on disk often enough that the
 	// mtimes will be unreliable to determine change status.
-	m.fmut.Lock()
-	m.folderIgnores["default"] = ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged()))
-	m.fmut.Unlock()
-	m.startFolder(fcfg.ID)
+	m.removeFolder(fcfg)
+	m.addFolderWithIgnores(fcfg, ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged())))
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"
@@ -1038,16 +1034,12 @@ func TestIgnoreDeleteUnignore(t *testing.T) {
 	tmpDir := fss.URI()
 	defer cleanupModelAndRemoveDir(m, tmpDir)
 
-	m.removeFolder(fcfg)
-	m.addFolder(fcfg)
-	// Reach in and update the ignore matcher to one that always does
+	// Update the ignore matcher to one that always does
 	// reloads when asked to, instead of checking file mtimes. This is
 	// because we might be changing the files on disk often enough that the
 	// mtimes will be unreliable to determine change status.
-	m.fmut.Lock()
-	m.folderIgnores["default"] = ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged()))
-	m.fmut.Unlock()
-	m.startFolder(fcfg.ID)
+	m.removeFolder(fcfg)
+	m.addFolderWithIgnores(fcfg, ignore.New(fss, ignore.WithChangeDetector(newAlwaysChanged())))
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -107,7 +107,7 @@ func setupModel(w config.Wrapper) *model {
 	m.ServeBackground()
 	for _, cfg := range w.Folders() {
 		if !cfg.Paused {
-			m.addFolder(cfg)
+			m.newFolder(cfg)
 		}
 	}
 
@@ -174,4 +174,11 @@ func (c *alwaysChanged) Seen(fs fs.Filesystem, name string) bool {
 
 func (c *alwaysChanged) Changed() bool {
 	return true
+}
+
+func addFolder(m *model, cfg config.FolderConfiguration) {
+	fset := db.NewFileSet(cfg.ID, cfg.Filesystem(), m.db)
+	m.fmut.Lock()
+	m.addFolderLocked(cfg, fset)
+	m.fmut.Unlock()
 }

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -105,10 +105,9 @@ func setupModel(w config.Wrapper) *model {
 	db := db.OpenMemory()
 	m := newModel(w, myID, "syncthing", "dev", db, nil)
 	m.ServeBackground()
-	for id, cfg := range w.Folders() {
+	for _, cfg := range w.Folders() {
 		if !cfg.Paused {
 			m.addFolder(cfg)
-			m.startFolder(id)
 		}
 	}
 


### PR DESCRIPTION
Initially this was just the first comment, which drops index updates if the folder isn't present in model instead of panicking (as that can happen when config changes happen). However that lead to a test panic. Turns out we do weird stuff in tests, like adding a folder but not starting it - we never do that in production. In production though we sometimes call the `...Locked` methods holding locks over both adding and starting, sometimes the "wrapper-functions" (`addFolder`). That really just introduces needless potential for races. So I removed all of them in favor of a single `addFolder` method, which takes the lock once and also doesn't need to release it in between (by dropping connections in the beginning).

To accommodate for tests that need a special ignores (change detection), I made ignores a parameter to `addFolderWithIgnores`, which isn't used in production (`addFolder` just calls `addFolderWithIgnores`  with the "normal" ignores).

To review look at the first and last commit - the middle one is just copy-pasting to make the diff of the third look nicer.