### PR TITLE
lib/model: Prevent cleanup-race in testing (ref #6152)

### DIFF
--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -565,7 +565,7 @@ func TestDeregisterOnFailInCopy(t *testing.T) {
 			t.Fatal("Still registered", f.model.progressEmitter.lenRegistry(), f.queue.lenProgress(), f.queue.lenQueued())
 		}
 
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatal("Didn't get anything to the finisher")
 	}
 }
@@ -653,7 +653,7 @@ func TestDeregisterOnFailInPull(t *testing.T) {
 		if f.model.progressEmitter.lenRegistry() != 0 || f.queue.lenProgress() != 0 || f.queue.lenQueued() != 0 {
 			t.Fatal("Still registered", f.model.progressEmitter.lenRegistry(), f.queue.lenProgress(), f.queue.lenQueued())
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(20 * time.Second):
 		t.Fatal("Didn't get anything to the finisher")
 	}
 }

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -66,6 +66,7 @@ func TestProgressEmitter(t *testing.T) {
 
 	p := NewProgressEmitter(c, evLogger)
 	go p.Serve()
+	defer p.Stop()
 	p.interval = 0
 
 	expectTimeout(w, t)


### PR DESCRIPTION
This is a followup to #6152: While preventing leaked goroutines is good, just closing all the channels results in races. So I added a wait group where necessary. And I found another leak in the progress emitter tests.