### PR TITLE
observe DO_NOT_TRACK per consoledonottrack.com

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -170,10 +170,23 @@ type RuntimeOptions struct {
 }
 
 func defaultRuntimeOptions() RuntimeOptions {
+
+	noUpgrade := false
+
+	if os.Getenv("STNOUPGRADE") != "" {
+		noUpgrade = true
+	}
+
+	if os.Getenv("DO_NOT_TRACK") != "" {
+		// disable autoupdate phone-home per
+		// consoledonottrack.com user opt out setting
+		noUpgrade = true
+	}
+
 	options := RuntimeOptions{
 		Options: syncthing.Options{
 			AssetDir:    os.Getenv("STGUIASSETS"),
-			NoUpgrade:   os.Getenv("STNOUPGRADE") != "",
+			NoUpgrade:   noUpgrade,
 			ProfilerURL: os.Getenv("STPROFILER"),
 		},
 		noRestart:    os.Getenv("STNORESTART") != "",

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -461,6 +461,12 @@ func maybeReportPanics() {
 		return
 	}
 
+	// respect DO_NOT_TRACK opt-out of phone home per
+	// https://consoledonottrack.com
+	if os.Getenv("DO_NOT_TRACK") != "" {
+		return
+	}
+
 	// Set up a timeout on the whole operation.
 	ctx, cancel := context.WithTimeout(context.Background(), panicUploadMaxWait)
 	defer cancel()


### PR DESCRIPTION
* disables phone-home for autoupdate if DO_NOT_TRACK env set
* disables crash reporting if DO_NOT_TRACK env set

### Purpose

https://consoledonottrack.com

This allows for a single environment variable that users can set to explicitly opt out of nonessential phone-home (autoupdates, crash reporting).

### Testing

I have not tested this but have modeled it after the existing code that short-circuits around these functions and it is a very small change.
