### PR TITLE
Fix misspellings

### DIFF
--- a/cmd/stfindignored/main.go
+++ b/cmd/stfindignored/main.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Commmand stfindignored lists ignored files under a given folder root.
+// Command stfindignored lists ignored files under a given folder root.
 package main
 
 import (

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -1086,7 +1086,7 @@ func TestBrowse(t *testing.T) {
 		{tmpDir + pathSep + "dir", []string{dirPath}},
 		{tmpDir + pathSep + "f", nil},
 		{tmpDir + pathSep + "q", nil},
-		// Globbing is case-insensitve
+		// Globbing is case-insensitive
 		{tmpDir + pathSep + "mixed", []string{mixedCaseDirPath}},
 	}
 

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -93,7 +93,7 @@ func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
 		}
 
 		if success == 0 {
-			l.Debugln("couldn't send any braodcasts")
+			l.Debugln("couldn't send any broadcasts")
 			return err
 		}
 	}

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -915,7 +915,7 @@ func TestWithHaveSequence(t *testing.T) {
 
 func TestStressWithHaveSequence(t *testing.T) {
 	// This races two loops against each other: one that contiously does
-	// updates, and one that continously does sequence walks. The test fails
+	// updates, and one that continuously does sequence walks. The test fails
 	// if the sequence walker sees a discontinuity.
 
 	if testing.Short() {

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -480,7 +480,7 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			} else {
 				// Wrap the error, as if the include does not exist, we get a
 				// IsNotExists(err) == true error, which we use to check
-				// existance of the .stignore file, and just end up assuming
+				// existence of the .stignore file, and just end up assuming
 				// there is none, rather than a broken include.
 				err = fmt.Errorf("failed to load include file %s: %s", includeFile, err.Error())
 			}

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -74,7 +74,7 @@ type rescanRequest struct {
 }
 
 type puller interface {
-	pull() bool // true when successfull and should not be retried
+	pull() bool // true when successful and should not be retried
 }
 
 func newFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, cfg config.FolderConfiguration, evLogger events.Logger) folder {

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -383,7 +383,7 @@ func (a *aggregator) popOldEventsTo(to map[string]*aggregatedEvent, dir *eventDi
 
 func (a *aggregator) isOld(ev *aggregatedEvent, currTime time.Time, delayRem bool) bool {
 	// Deletes should in general be scanned last, therefore they are delayed by
-	// letting them time out. This behaviour is overriden by delayRem == false.
+	// letting them time out. This behaviour is overridden by delayRem == false.
 	// Refer to following comments as to why.
 	// An event that has not registered any new modifications recently is scanned.
 	// a.notifyDelay is the user facing value signifying the normal delay between
@@ -397,7 +397,7 @@ func (a *aggregator) isOld(ev *aggregatedEvent, currTime time.Time, delayRem boo
 	// is delayed to reduce resource usage, but after a certain time (notifyTimeout)
 	// passed it is scanned anyway.
 	// If only removals are remaining to be scanned, there is no point to delay
-	// removals further, so this behaviour is overriden by delayRem == false.
+	// removals further, so this behaviour is overridden by delayRem == false.
 	return currTime.Sub(ev.firstModTime) > a.notifyTimeout
 }
 


### PR DESCRIPTION
### Purpose
Fix misspellings in the .go files by running misspell -w