### PR TITLE
gui/default: Make 'Nearby devices' look like links (fixes #6057)

### DIFF
--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -15,10 +15,10 @@
               <datalist id="discovery-list">
                 <option ng-repeat="id in discovery" value="{{id}}" />
               </datalist>
-              <p class="help-block" ng-if="discovery">
+              <p class="help-block" ng-if="discovery && discovery.length !== 0">
                 <span translate>You can also select one of these nearby devices:</span>
                 <ul>
-                  <li ng-repeat="id in discovery"><a ng-click="currentDevice.deviceID = id">{{id}}</a></li>
+                  <li ng-repeat="id in discovery"><a href="#" ng-click="currentDevice.deviceID = id">{{id}}</a></li>
                 </ul>
               </p>
               <p class="help-block">


### PR DESCRIPTION
### Purpose

When adding a device, the list with nearby devices won't appear anymore, unless there are any such devices. Also, IDs of those devices will look more like links. Solves #6057 

### Testing

Only manual testing has been done. This change can be tested by adding 'dummy' IDs to the `$scope.discovery` array in [`gui/default/syncthing/core/syncthingController.js:1442`](https://github.com/syncthing/syncthing/blob/0d14ee4142cf9f8cd4d2e037f545619562154c2b/gui/default/syncthing/core/syncthingController.js#L1442) and rebuilding.
