### PR TITLE
lib: Replace done channel with contexts in and add names to util services

### DIFF
--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -80,7 +80,7 @@ func (c *cast) createService(svc func(context.Context) error, suffix string) uti
 		err := svc(ctx)
 		l.Debugf("Stopped %v %v: %v", c.name, suffix, err)
 		return err
-	}, c.String())
+	}, fmt.Sprintf("%s/%s", c, suffix))
 }
 
 func (c *cast) Stop() {

--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -7,6 +7,7 @@
 package beacon
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -63,23 +64,23 @@ func newCast(name string) *cast {
 	}
 }
 
-func (c *cast) addReader(svc func(chan struct{}) error) {
+func (c *cast) addReader(svc func(context.Context) error) {
 	c.reader = c.createService(svc, "reader")
 	c.Add(c.reader)
 }
 
-func (c *cast) addWriter(svc func(stop chan struct{}) error) {
+func (c *cast) addWriter(svc func(ctx context.Context) error) {
 	c.writer = c.createService(svc, "writer")
 	c.Add(c.writer)
 }
 
-func (c *cast) createService(svc func(chan struct{}) error, suffix string) util.ServiceWithError {
-	return util.AsServiceWithError(func(stop chan struct{}) error {
+func (c *cast) createService(svc func(context.Context) error, suffix string) util.ServiceWithError {
+	return util.AsServiceWithError(func(ctx context.Context) error {
 		l.Debugln("Starting", c.name, suffix)
-		err := svc(stop)
+		err := svc(ctx)
 		l.Debugf("Stopped %v %v: %v", c.name, suffix, err)
 		return err
-	})
+	}, c.String())
 }
 
 func (c *cast) Stop() {

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -29,13 +29,10 @@ func writeBroadcasts(ctx context.Context, inbox <-chan []byte, port int) error {
 		l.Debugln(err)
 		return err
 	}
-	done := make(chan struct{})
-	defer close(done)
+	doneCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		select {
-		case <-ctx.Done():
-		case <-done:
-		}
+		<-doneCtx.Done()
 		conn.Close()
 	}()
 
@@ -106,13 +103,11 @@ func readBroadcasts(ctx context.Context, outbox chan<- recv, port int) error {
 		l.Debugln(err)
 		return err
 	}
-	done := make(chan struct{})
-	defer close(done)
+
+	doneCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		select {
-		case <-ctx.Done():
-		case <-done:
-		}
+		<-doneCtx.Done()
 		conn.Close()
 	}()
 

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -40,7 +40,7 @@ func writeBroadcasts(ctx context.Context, inbox <-chan []byte, port int) error {
 		var bs []byte
 		select {
 		case bs = <-inbox:
-		case <-ctx.Done():
+		case <-doneCtx.Done():
 			return nil
 		}
 
@@ -125,7 +125,7 @@ func readBroadcasts(ctx context.Context, outbox chan<- recv, port int) error {
 		copy(c, bs)
 		select {
 		case outbox <- recv{c, addr}:
-		case <-ctx.Done():
+		case <-doneCtx.Done():
 			return nil
 		default:
 			l.Debugln("dropping message")

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -7,22 +7,23 @@
 package beacon
 
 import (
+	"context"
 	"net"
 	"time"
 )
 
 func NewBroadcast(port int) Interface {
 	c := newCast("broadcastBeacon")
-	c.addReader(func(stop chan struct{}) error {
-		return readBroadcasts(c.outbox, port, stop)
+	c.addReader(func(ctx context.Context) error {
+		return readBroadcasts(ctx, c.outbox, port)
 	})
-	c.addWriter(func(stop chan struct{}) error {
-		return writeBroadcasts(c.inbox, port, stop)
+	c.addWriter(func(ctx context.Context) error {
+		return writeBroadcasts(ctx, c.inbox, port)
 	})
 	return c
 }
 
-func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
+func writeBroadcasts(ctx context.Context, inbox <-chan []byte, port int) error {
 	conn, err := net.ListenUDP("udp4", nil)
 	if err != nil {
 		l.Debugln(err)
@@ -32,7 +33,7 @@ func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
 	defer close(done)
 	go func() {
 		select {
-		case <-stop:
+		case <-ctx.Done():
 		case <-done:
 		}
 		conn.Close()
@@ -42,7 +43,7 @@ func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
 		var bs []byte
 		select {
 		case bs = <-inbox:
-		case <-stop:
+		case <-ctx.Done():
 			return nil
 		}
 
@@ -99,7 +100,7 @@ func writeBroadcasts(inbox <-chan []byte, port int, stop chan struct{}) error {
 	}
 }
 
-func readBroadcasts(outbox chan<- recv, port int, stop chan struct{}) error {
+func readBroadcasts(ctx context.Context, outbox chan<- recv, port int) error {
 	conn, err := net.ListenUDP("udp4", &net.UDPAddr{Port: port})
 	if err != nil {
 		l.Debugln(err)
@@ -109,7 +110,7 @@ func readBroadcasts(outbox chan<- recv, port int, stop chan struct{}) error {
 	defer close(done)
 	go func() {
 		select {
-		case <-stop:
+		case <-ctx.Done():
 		case <-done:
 		}
 		conn.Close()
@@ -129,7 +130,7 @@ func readBroadcasts(outbox chan<- recv, port int, stop chan struct{}) error {
 		copy(c, bs)
 		select {
 		case outbox <- recv{c, addr}:
-		case <-stop:
+		case <-ctx.Done():
 			return nil
 		default:
 			l.Debugln("dropping message")

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -38,13 +38,10 @@ func writeMulticasts(ctx context.Context, inbox <-chan []byte, addr string) erro
 		l.Debugln(err)
 		return err
 	}
-	done := make(chan struct{})
-	defer close(done)
+	doneCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		select {
-		case <-ctx.Done():
-		case <-done:
-		}
+		<-doneCtx.Done()
 		conn.Close()
 	}()
 
@@ -109,13 +106,10 @@ func readMulticasts(ctx context.Context, outbox chan<- recv, addr string) error 
 		l.Debugln(err)
 		return err
 	}
-	done := make(chan struct{})
-	defer close(done)
+	doneCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	go func() {
-		select {
-		case <-ctx.Done():
-		case <-done:
-		}
+		<-doneCtx.Done()
 		conn.Close()
 	}()
 

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -55,7 +55,7 @@ func writeMulticasts(ctx context.Context, inbox <-chan []byte, addr string) erro
 		var bs []byte
 		select {
 		case bs = <-inbox:
-		case <-ctx.Done():
+		case <-doneCtx.Done():
 			return nil
 		}
 
@@ -82,7 +82,7 @@ func writeMulticasts(ctx context.Context, inbox <-chan []byte, addr string) erro
 			success++
 
 			select {
-			case <-ctx.Done():
+			case <-doneCtx.Done():
 				return nil
 			default:
 			}
@@ -139,7 +139,7 @@ func readMulticasts(ctx context.Context, outbox chan<- recv, addr string) error 
 	bs := make([]byte, 65536)
 	for {
 		select {
-		case <-ctx.Done():
+		case <-doneCtx.Done():
 			return nil
 		default:
 		}

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -78,12 +78,8 @@ func (t *quicListener) OnExternalAddressChanged(address *stun.Host, via string) 
 	}
 }
 
-func (t *quicListener) serve(stop chan struct{}) error {
+func (t *quicListener) serve(ctx context.Context) error {
 	network := strings.Replace(t.uri.Scheme, "quic", "udp", -1)
-
-	// Convert the stop channel into a context
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() { <-stop; cancel() }()
 
 	packetConn, err := net.ListenPacket(network, t.uri.Host)
 	if err != nil {
@@ -205,7 +201,7 @@ func (f *quicListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls.
 		conns:   conns,
 		factory: f,
 	}
-	l.ServiceWithError = util.AsServiceWithError(l.serve)
+	l.ServiceWithError = util.AsServiceWithError(l.serve, l.String())
 	l.nat.Store(stun.NATUnknown)
 	return l
 }

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -186,8 +186,8 @@ func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *t
 	// the common handling regardless of whether the connection was
 	// incoming or outgoing.
 
-	service.Add(util.AsService(service.connect, service.String()))
-	service.Add(util.AsService(service.handle, service.String()))
+	service.Add(util.AsService(service.connect, fmt.Sprintf("%s/connect", service)))
+	service.Add(util.AsService(service.handle, fmt.Sprintf("%s/handle", service)))
 	service.Add(service.listenerSupervisor)
 
 	return service

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -8,6 +8,7 @@ package discover
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -128,7 +129,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 		noLookup:       opts.noLookup,
 		evLogger:       evLogger,
 	}
-	cl.Service = util.AsService(cl.serve)
+	cl.Service = util.AsService(cl.serve, cl.String())
 	if !opts.noAnnounce {
 		// If we are supposed to annonce, it's an error until we've done so.
 		cl.setError(errors.New("not announced"))
@@ -188,11 +189,11 @@ func (c *globalClient) String() string {
 	return "global@" + c.server
 }
 
-func (c *globalClient) serve(stop chan struct{}) {
+func (c *globalClient) serve(ctx context.Context) {
 	if c.noAnnounce {
 		// We're configured to not do announcements, only lookups. To maintain
 		// the same interface, we just pause here if Serve() is run.
-		<-stop
+		<-ctx.Done()
 		return
 	}
 
@@ -212,7 +213,7 @@ func (c *globalClient) serve(stop chan struct{}) {
 		case <-timer.C:
 			c.sendAnnouncement(timer)
 
-		case <-stop:
+		case <-ctx.Done():
 			return
 		}
 	}

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -10,6 +10,7 @@
 package discover
 
 import (
+	"context"
 	"encoding/binary"
 	"encoding/hex"
 	"io"
@@ -81,9 +82,9 @@ func NewLocal(id protocol.DeviceID, addr string, addrList AddressLister, evLogge
 		c.beacon = beacon.NewMulticast(addr)
 	}
 	c.Add(c.beacon)
-	c.Add(util.AsService(c.recvAnnouncements))
+	c.Add(util.AsService(c.recvAnnouncements, c.String()))
 
-	c.Add(util.AsService(c.sendLocalAnnouncements))
+	c.Add(util.AsService(c.sendLocalAnnouncements, c.String()))
 
 	return c, nil
 }
@@ -135,7 +136,7 @@ func (c *localClient) announcementPkt(instanceID int64, msg []byte) ([]byte, boo
 	return msg, true
 }
 
-func (c *localClient) sendLocalAnnouncements(stop chan struct{}) {
+func (c *localClient) sendLocalAnnouncements(ctx context.Context) {
 	var msg []byte
 	var ok bool
 	instanceID := rand.Int63()
@@ -147,18 +148,18 @@ func (c *localClient) sendLocalAnnouncements(stop chan struct{}) {
 		select {
 		case <-c.localBcastTick:
 		case <-c.forcedBcastTick:
-		case <-stop:
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (c *localClient) recvAnnouncements(stop chan struct{}) {
+func (c *localClient) recvAnnouncements(ctx context.Context) {
 	b := c.beacon
 	warnedAbout := make(map[string]bool)
 	for {
 		select {
-		case <-stop:
+		case <-ctx.Done():
 			return
 		default:
 		}

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -82,9 +83,9 @@ func NewLocal(id protocol.DeviceID, addr string, addrList AddressLister, evLogge
 		c.beacon = beacon.NewMulticast(addr)
 	}
 	c.Add(c.beacon)
-	c.Add(util.AsService(c.recvAnnouncements, c.String()))
+	c.Add(util.AsService(c.recvAnnouncements, fmt.Sprintf("%s/recv", c)))
 
-	c.Add(util.AsService(c.sendLocalAnnouncements, c.String()))
+	c.Add(util.AsService(c.sendLocalAnnouncements, fmt.Sprintf("%s/sendLocal", c)))
 
 	return c, nil
 }

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -55,12 +55,12 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 	}
 
 	errChan := make(chan error)
-	go f.watchLoop(name, roots, backendChan, outChan, errChan, ignore, ctx)
+	go f.watchLoop(ctx, name, roots, backendChan, outChan, errChan, ignore)
 
 	return outChan, errChan, nil
 }
 
-func (f *BasicFilesystem) watchLoop(name string, roots []string, backendChan chan notify.EventInfo, outChan chan<- Event, errChan chan<- error, ignore Matcher, ctx context.Context) {
+func (f *BasicFilesystem) watchLoop(ctx context.Context, name string, roots []string, backendChan chan notify.EventInfo, outChan chan<- Event, errChan chan<- error, ignore Matcher) {
 	for {
 		// Detect channel overflow
 		if len(backendChan) == backendBuffer {

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -178,7 +178,7 @@ func TestWatchWinRoot(t *testing.T) {
 			}
 			cancel()
 		}()
-		fs.watchLoop(".", roots, backendChan, outChan, errChan, fakeMatcher{}, ctx)
+		fs.watchLoop(ctx, ".", roots, backendChan, outChan, errChan, fakeMatcher{})
 	}()
 
 	// filepath.Dir as watch has a /... suffix
@@ -219,7 +219,7 @@ func expectErrorForPath(t *testing.T, path string) {
 	// testFs is Filesystem, but we need BasicFilesystem here
 	fs := newBasicFilesystem(testDirAbs)
 
-	go fs.watchLoop(".", []string{testDirAbs}, backendChan, outChan, errChan, fakeMatcher{}, ctx)
+	go fs.watchLoop(ctx, ".", []string{testDirAbs}, backendChan, outChan, errChan, fakeMatcher{})
 
 	backendChan <- fakeEventInfo(path)
 
@@ -244,7 +244,7 @@ func TestWatchSubpath(t *testing.T) {
 	fs := newBasicFilesystem(testDirAbs)
 
 	abs, _ := fs.rooted("sub")
-	go fs.watchLoop("sub", []string{testDirAbs}, backendChan, outChan, errChan, fakeMatcher{}, ctx)
+	go fs.watchLoop(ctx, "sub", []string{testDirAbs}, backendChan, outChan, errChan, fakeMatcher{})
 
 	backendChan <- fakeEventInfo(filepath.Join(abs, "file"))
 

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -30,7 +30,7 @@ func newSendOnlyFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, 
 		folder: newFolder(model, fset, ignores, cfg, evLogger),
 	}
 	f.folder.puller = f
-	f.folder.Service = util.AsService(f.serve)
+	f.folder.Service = util.AsService(f.serve, f.String())
 	return f
 }
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -118,7 +118,7 @@ func newSendReceiveFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 		pullErrorsMut: sync.NewMutex(),
 	}
 	f.folder.puller = f
-	f.folder.Service = util.AsService(f.serve)
+	f.folder.Service = util.AsService(f.serve, f.String())
 
 	if f.Copiers == 0 {
 		f.Copiers = defaultCopiers

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -7,6 +7,7 @@
 package model
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -63,8 +64,8 @@ func NewFolderSummaryService(cfg config.Wrapper, m Model, id protocol.DeviceID, 
 		lastEventReqMut: sync.NewMutex(),
 	}
 
-	service.Add(util.AsService(service.listenForUpdates))
-	service.Add(util.AsService(service.calculateSummaries))
+	service.Add(util.AsService(service.listenForUpdates, service.String()))
+	service.Add(util.AsService(service.calculateSummaries, service.String()))
 
 	return service
 }
@@ -145,7 +146,7 @@ func (c *folderSummaryService) OnEventRequest() {
 
 // listenForUpdates subscribes to the event bus and makes note of folders that
 // need their data recalculated.
-func (c *folderSummaryService) listenForUpdates(stop chan struct{}) {
+func (c *folderSummaryService) listenForUpdates(ctx context.Context) {
 	sub := c.evLogger.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged | events.RemoteDownloadProgress | events.DeviceConnected | events.FolderWatchStateChanged | events.DownloadProgress)
 	defer sub.Unsubscribe()
 
@@ -155,7 +156,7 @@ func (c *folderSummaryService) listenForUpdates(stop chan struct{}) {
 		select {
 		case ev := <-sub.C():
 			c.processUpdate(ev)
-		case <-stop:
+		case <-ctx.Done():
 			return
 		}
 	}
@@ -234,7 +235,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 
 // calculateSummaries periodically recalculates folder summaries and
 // completion percentage, and sends the results on the event bus.
-func (c *folderSummaryService) calculateSummaries(stop chan struct{}) {
+func (c *folderSummaryService) calculateSummaries(ctx context.Context) {
 	const pumpInterval = 2 * time.Second
 	pump := time.NewTimer(pumpInterval)
 
@@ -255,7 +256,7 @@ func (c *folderSummaryService) calculateSummaries(stop chan struct{}) {
 		case folder := <-c.immediate:
 			c.sendSummary(folder)
 
-		case <-stop:
+		case <-ctx.Done():
 			return
 		}
 	}

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -64,8 +64,8 @@ func NewFolderSummaryService(cfg config.Wrapper, m Model, id protocol.DeviceID, 
 		lastEventReqMut: sync.NewMutex(),
 	}
 
-	service.Add(util.AsService(service.listenForUpdates, service.String()))
-	service.Add(util.AsService(service.calculateSummaries, service.String()))
+	service.Add(util.AsService(service.listenForUpdates, fmt.Sprintf("%s/listenForUpdates", service)))
+	service.Add(util.AsService(service.calculateSummaries, fmt.Sprintf("%s/calculateSummaries", service)))
 
 	return service
 }

--- a/lib/relay/client/client.go
+++ b/lib/relay/client/client.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/url"
@@ -51,16 +52,16 @@ type commonClient struct {
 	mut                      sync.RWMutex
 }
 
-func newCommonClient(invitations chan protocol.SessionInvitation, serve func(chan struct{}) error) commonClient {
+func newCommonClient(invitations chan protocol.SessionInvitation, serve func(context.Context) error) commonClient {
 	c := commonClient{
 		invitations: invitations,
 		mut:         sync.NewRWMutex(),
 	}
-	newServe := func(stop chan struct{}) error {
+	newServe := func(ctx context.Context) error {
 		defer c.cleanup()
-		return serve(stop)
+		return serve(ctx)
 	}
-	c.ServiceWithError = util.AsServiceWithError(newServe)
+	c.ServiceWithError = util.AsServiceWithError(newServe, c.String())
 	if c.invitations == nil {
 		c.closeInvitationsOnFinish = true
 		c.invitations = make(chan protocol.SessionInvitation)
@@ -80,4 +81,8 @@ func (c *commonClient) Invitations() chan protocol.SessionInvitation {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
 	return c.invitations
+}
+
+func (c *commonClient) String() string {
+	return fmt.Sprintf("commonClient/@%p", c)
 }

--- a/lib/relay/client/client.go
+++ b/lib/relay/client/client.go
@@ -52,7 +52,7 @@ type commonClient struct {
 	mut                      sync.RWMutex
 }
 
-func newCommonClient(invitations chan protocol.SessionInvitation, serve func(context.Context) error) commonClient {
+func newCommonClient(invitations chan protocol.SessionInvitation, serve func(context.Context) error, creator string) commonClient {
 	c := commonClient{
 		invitations: invitations,
 		mut:         sync.NewRWMutex(),
@@ -61,7 +61,7 @@ func newCommonClient(invitations chan protocol.SessionInvitation, serve func(con
 		defer c.cleanup()
 		return serve(ctx)
 	}
-	c.ServiceWithError = util.AsServiceWithError(newServe, c.String())
+	c.ServiceWithError = util.AsServiceWithError(newServe, creator)
 	if c.invitations == nil {
 		c.closeInvitationsOnFinish = true
 		c.invitations = make(chan protocol.SessionInvitation)
@@ -81,8 +81,4 @@ func (c *commonClient) Invitations() chan protocol.SessionInvitation {
 	c.mut.RLock()
 	defer c.mut.RUnlock()
 	return c.invitations
-}
-
-func (c *commonClient) String() string {
-	return fmt.Sprintf("commonClient/@%p", c)
 }

--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -33,7 +33,7 @@ func newDynamicClient(uri *url.URL, certs []tls.Certificate, invitations chan pr
 		certs:    certs,
 		timeout:  timeout,
 	}
-	c.commonClient = newCommonClient(invitations, c.serve)
+	c.commonClient = newCommonClient(invitations, c.serve, c.String())
 	return c
 }
 

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -40,7 +40,7 @@ func newStaticClient(uri *url.URL, certs []tls.Certificate, invitations chan pro
 		messageTimeout: time.Minute * 2,
 		connectTimeout: timeout,
 	}
-	c.commonClient = newCommonClient(invitations, c.serve)
+	c.commonClient = newCommonClient(invitations, c.serve, c.String())
 	return c
 }
 

--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -7,6 +7,7 @@
 package stun
 
 import (
+	"context"
 	"net"
 	"sync/atomic"
 	"time"
@@ -104,7 +105,7 @@ func New(cfg config.Wrapper, subscriber Subscriber, conn net.PacketConn) (*Servi
 		natType: NATUnknown,
 		addr:    nil,
 	}
-	s.Service = util.AsService(s.serve)
+	s.Service = util.AsService(s.serve, s.String())
 	return s, otherDataConn
 }
 
@@ -113,7 +114,7 @@ func (s *Service) Stop() {
 	s.Service.Stop()
 }
 
-func (s *Service) serve(stop chan struct{}) {
+func (s *Service) serve(ctx context.Context) {
 	for {
 	disabled:
 		s.setNATType(NATUnknown)
@@ -121,7 +122,7 @@ func (s *Service) serve(stop chan struct{}) {
 
 		if s.cfg.Options().IsStunDisabled() {
 			select {
-			case <-stop:
+			case <-ctx.Done():
 				return
 			case <-time.After(time.Second):
 				continue
@@ -134,12 +135,12 @@ func (s *Service) serve(stop chan struct{}) {
 			// This blocks until we hit an exit condition or there are issues with the STUN server.
 			// This returns a boolean signifying if a different STUN server should be tried (oppose to the whole thing
 			// shutting down and this winding itself down.
-			if !s.runStunForServer(addr, stop) {
+			if !s.runStunForServer(ctx, addr) {
 				// Check exit conditions.
 
 				// Have we been asked to stop?
 				select {
-				case <-stop:
+				case <-ctx.Done():
 					return
 				default:
 				}
@@ -165,13 +166,13 @@ func (s *Service) serve(stop chan struct{}) {
 		// Chillout for a while.
 		select {
 		case <-time.After(stunRetryInterval):
-		case <-stop:
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (s *Service) runStunForServer(addr string, stop chan struct{}) (tryNext bool) {
+func (s *Service) runStunForServer(ctx context.Context, addr string) (tryNext bool) {
 	l.Debugf("Running stun for %s via %s", s, addr)
 
 	// Resolve the address, so that in case the server advertises two
@@ -209,10 +210,10 @@ func (s *Service) runStunForServer(addr string, stop chan struct{}) (tryNext boo
 		return false
 	}
 
-	return s.stunKeepAlive(addr, extAddr, stop)
+	return s.stunKeepAlive(ctx, addr, extAddr)
 }
 
-func (s *Service) stunKeepAlive(addr string, extAddr *Host, stop chan struct{}) (tryNext bool) {
+func (s *Service) stunKeepAlive(ctx context.Context, addr string, extAddr *Host) (tryNext bool) {
 	var err error
 	nextSleep := time.Duration(s.cfg.Options().StunKeepaliveStartS) * time.Second
 
@@ -255,7 +256,7 @@ func (s *Service) stunKeepAlive(addr string, extAddr *Host, stop chan struct{}) 
 
 		select {
 		case <-time.After(sleepFor):
-		case <-stop:
+		case <-ctx.Done():
 			l.Debugf("%s stopping, aborting stun", s)
 			return false
 		}

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -7,6 +7,7 @@
 package syncthing
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/thejerf/suture"
@@ -26,12 +27,12 @@ func newVerboseService(evLogger events.Logger) *verboseService {
 	s := &verboseService{
 		sub: evLogger.Subscribe(events.AllEvents),
 	}
-	s.Service = util.AsService(s.serve)
+	s.Service = util.AsService(s.serve, s.String())
 	return s
 }
 
 // serve runs the verbose logging service.
-func (s *verboseService) serve(stop chan struct{}) {
+func (s *verboseService) serve(ctx context.Context) {
 	for {
 		select {
 		case ev := <-s.sub.C():
@@ -39,7 +40,7 @@ func (s *verboseService) serve(stop chan struct{}) {
 			if formatted != "" {
 				l.Verboseln(formatted)
 			}
-		case <-stop:
+		case <-ctx.Done():
 			return
 		}
 	}
@@ -186,4 +187,8 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 	}
 
 	return fmt.Sprintf("%s %#v", ev.Type, ev)
+}
+
+func (s *verboseService) String() string {
+	return fmt.Sprintf("verboseService@%p", s)
 }

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -57,7 +57,7 @@ func New(cfg config.Wrapper, m model.Model, connectionsService connections.Servi
 		noUpgrade:          noUpgrade,
 		forceRun:           make(chan struct{}, 1), // Buffered to prevent locking
 	}
-	svc.Service = util.AsService(svc.serve)
+	svc.Service = util.AsService(svc.serve, svc.String())
 	cfg.Subscribe(svc)
 	return svc
 }
@@ -384,11 +384,11 @@ func (s *Service) sendUsageReport() error {
 	return err
 }
 
-func (s *Service) serve(stop chan struct{}) {
+func (s *Service) serve(ctx context.Context) {
 	t := time.NewTimer(time.Duration(s.cfg.Options().URInitialDelayS) * time.Second)
 	for {
 		select {
-		case <-stop:
+		case <-ctx.Done():
 			return
 		case <-s.forceRun:
 			t.Reset(0)

--- a/lib/util/utils_test.go
+++ b/lib/util/utils_test.go
@@ -7,6 +7,7 @@
 package util
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -227,17 +228,17 @@ func TestCopyMatching(t *testing.T) {
 }
 
 func TestUtilStopTwicePanic(t *testing.T) {
-	s := AsService(func(stop chan struct{}) {
-		<-stop
-	})
+	name := "foo"
+	s := AsService(func(ctx context.Context) {
+		<-ctx.Done()
+	}, name)
 
 	go s.Serve()
 	s.Stop()
 
 	defer func() {
-		expected := "lib/util.TestUtilStopTwicePanic"
-		if r := recover(); r == nil || !strings.Contains(r.(string), expected) {
-			t.Fatalf(`expected panic containing "%v", got "%v"`, expected, r)
+		if r := recover(); r == nil || !strings.Contains(r.(string), name) {
+			t.Fatalf(`expected panic containing "%v", got "%v"`, name, r)
 		}
 	}()
 	s.Stop()

--- a/lib/versioner/trashcan.go
+++ b/lib/versioner/trashcan.go
@@ -7,6 +7,7 @@
 package versioner
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -38,7 +39,7 @@ func NewTrashcan(folderID string, folderFs fs.Filesystem, params map[string]stri
 		versionsFs:   fsFromParams(folderFs, params),
 		cleanoutDays: cleanoutDays,
 	}
-	s.Service = util.AsService(s.serve)
+	s.Service = util.AsService(s.serve, s.String())
 
 	l.Debugf("instantiated %#v", s)
 	return s
@@ -52,7 +53,7 @@ func (t *Trashcan) Archive(filePath string) error {
 	})
 }
 
-func (t *Trashcan) serve(stop chan struct{}) {
+func (t *Trashcan) serve(ctx context.Context) {
 	l.Debugln(t, "starting")
 	defer l.Debugln(t, "stopping")
 
@@ -62,7 +63,7 @@ func (t *Trashcan) serve(stop chan struct{}) {
 
 	for {
 		select {
-		case <-stop:
+		case <-ctx.Done():
 			return
 
 		case <-timer.C:

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -109,7 +109,7 @@ type aggregator struct {
 	ctx                   context.Context
 }
 
-func newAggregator(folderCfg config.FolderConfiguration, ctx context.Context) *aggregator {
+func newAggregator(ctx context.Context, folderCfg config.FolderConfiguration) *aggregator {
 	a := &aggregator{
 		folderID:              folderCfg.ID,
 		folderCfgUpdate:       make(chan config.FolderConfiguration),
@@ -125,8 +125,8 @@ func newAggregator(folderCfg config.FolderConfiguration, ctx context.Context) *a
 	return a
 }
 
-func Aggregate(in <-chan fs.Event, out chan<- []string, folderCfg config.FolderConfiguration, cfg config.Wrapper, evLogger events.Logger, ctx context.Context) {
-	a := newAggregator(folderCfg, ctx)
+func Aggregate(ctx context.Context, in <-chan fs.Event, out chan<- []string, folderCfg config.FolderConfiguration, cfg config.Wrapper, evLogger events.Logger) {
+	a := newAggregator(ctx, folderCfg)
 
 	// Necessary for unit tests where the backend is mocked
 	go a.mainLoop(in, out, cfg, evLogger)

--- a/lib/watchaggregator/aggregator_test.go
+++ b/lib/watchaggregator/aggregator_test.go
@@ -67,7 +67,7 @@ func TestAggregate(t *testing.T) {
 	folderCfg.ID = "Aggregate"
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	a := newAggregator(folderCfg, ctx)
+	a := newAggregator(ctx, folderCfg)
 
 	// checks whether maxFilesPerDir events in one dir are kept as is
 	for i := 0; i < maxFilesPerDir; i++ {
@@ -95,7 +95,7 @@ func TestAggregate(t *testing.T) {
 	compareBatchToExpectedDirect(t, getEventPaths(a.root, ".", a), []string{"parent"})
 
 	// again test aggregation in "parent" but with event in subdirs
-	a = newAggregator(folderCfg, ctx)
+	a = newAggregator(ctx, folderCfg)
 	for i := 0; i < maxFilesPerDir; i++ {
 		a.newEvent(fs.Event{
 			Name: filepath.Join("parent", strconv.Itoa(i)),
@@ -109,7 +109,7 @@ func TestAggregate(t *testing.T) {
 	compareBatchToExpectedDirect(t, getEventPaths(a.root, ".", a), []string{"parent"})
 
 	// test aggregation in root
-	a = newAggregator(folderCfg, ctx)
+	a = newAggregator(ctx, folderCfg)
 	for i := 0; i < maxFiles; i++ {
 		a.newEvent(fs.Event{
 			Name: strconv.Itoa(i),
@@ -132,7 +132,7 @@ func TestAggregate(t *testing.T) {
 	}, inProgress)
 	compareBatchToExpectedDirect(t, getEventPaths(a.root, ".", a), []string{"."})
 
-	a = newAggregator(folderCfg, ctx)
+	a = newAggregator(ctx, folderCfg)
 	filesPerDir := maxFilesPerDir / 2
 	dirs := make([]string, maxFiles/filesPerDir+1)
 	for i := 0; i < maxFiles/filesPerDir+1; i++ {
@@ -293,7 +293,7 @@ func testScenario(t *testing.T, name string, testCase func(c chan<- fs.Event), e
 
 	folderCfg := defaultFolderCfg.Copy()
 	folderCfg.ID = name
-	a := newAggregator(folderCfg, ctx)
+	a := newAggregator(ctx, folderCfg)
 	a.notifyTimeout = testNotifyTimeout
 
 	startTime := time.Now()


### PR DESCRIPTION
### Purpose

This is the straighforward, tedious change to make the util services take an identifying string as parameter and use contexts instead of a close channel (see https://github.com/syncthing/syncthing/pull/5973#discussion_r316135960 and https://github.com/syncthing/syncthing/pull/5863#discussion_r304234063). This hasn't been utilized yet except for `model.folder`, where the context from the service is used instead of the existing, newly created context, and quic_listen, where the done channel was "converted" to a context. Also I needed to add a few `.String` methods.

More PRs making use of the contexts to follow.

### Testing

Still pass.