### PR TITLE
gui/default: Add upgrade confirmation dialog (fixes #5887)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -42,7 +42,7 @@
       <p class="navbar-text hidden-xs" ng-class="{'hidden-sm':upgradeInfo && upgradeInfo.newer}">{{thisDeviceName()}}</p>
       <ul class="nav navbar-nav navbar-right">
         <li ng-if="upgradeInfo && upgradeInfo.newer" class="upgrade-newer">
-          <button type="button" class="btn navbar-btn btn-primary btn-sm" ng-click="upgrade()">
+          <button type="button" class="btn navbar-btn btn-primary btn-sm" data-toggle="modal" data-target="#upgrade">
             <span class="fas fa-arrow-circle-up"></span>
             <span class="hidden-xs" translate translate-value-version="{{upgradeInfo.latest}}">Upgrade To {%version%}</span>
           </button>
@@ -841,6 +841,7 @@
   <ng-include src="'syncthing/transfer/failedFilesModalView.html'"></ng-include>
   <ng-include src="'syncthing/transfer/remoteNeededFilesModalView.html'"></ng-include>
   <ng-include src="'syncthing/transfer/localChangedFilesModalView.html'"></ng-include>
+  <ng-include src="'syncthing/core/upgradeModalView.html'"></ng-include>
   <ng-include src="'syncthing/core/majorUpgradeModalView.html'"></ng-include>
   <ng-include src="'syncthing/core/aboutModalView.html'"></ng-include>
   <ng-include src="'syncthing/core/discoveryFailuresModalView.html'"></ng-include>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1387,6 +1387,7 @@ angular.module('syncthing.core')
 
         $scope.upgrade = function () {
             restarting = true;
+            $('#upgrade').modal('hide');
             $('#majorUpgrade').modal('hide');
             $('#upgrading').modal();
             $http.post(urlbase + '/system/upgrade').success(function () {

--- a/gui/default/syncthing/core/upgradeModalView.html
+++ b/gui/default/syncthing/core/upgradeModalView.html
@@ -1,0 +1,18 @@
+<modal id="upgrade" status="warning" icon="fas fa-arrow-circle-up" heading="{{'Upgrade' | translate}}" large="no" closeable="yes">
+    <div class="modal-body">
+      <p>
+        <span translate>Are you sure you want to upgrade?</span>
+      </p>
+      <p>
+        <a ng-href="https://github.com/syncthing/syncthing/releases/tag/{{upgradeInfo.latest}}" target="_blank" translate>Release Notes</a>
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-primary btn-sm" ng-click="upgrade()">
+        <span class="fas fa-check"></span>&nbsp;<span translate>Upgrade</span>
+      </button>
+      <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">
+        <span class="fas fa-times"></span>&nbsp;<span translate>Close</span>
+      </button>
+    </div>
+  </modal>


### PR DESCRIPTION
### Purpose

When clicking on upgrade button confirmation dialog will now appear (fixes #5887).

### Screenshots

![upgradewar](https://user-images.githubusercontent.com/38809160/69185055-413e2800-0b16-11ea-9271-6da6831df02d.png)

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

