### PR TITLE
gui: Prioritize non-idle folder states (fixes #6169)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -799,20 +799,20 @@ angular.module('syncthing.core')
             if (state === 'error') {
                 return 'stopped'; // legacy, the state is called "stopped" in the GUI
             }
-            if (state === 'idle' && folderInfo.needTotalItems > 0) {
+
+            if (state !== 'idle') {
+                return state;
+            }
+
+            if (folderInfo.needTotalItems > 0) {
                 return 'outofsync';
             }
             if ($scope.hasFailedFiles(folderCfg.id)) {
                 return 'faileditems';
             }
-            if (state === 'scanning') {
-                return state;
-            }
-
             if (folderInfo.receiveOnlyTotalItems) {
                 return 'localadditions';
             }
-
             if (folderCfg.devices.length <= 1) {
                 return 'unshared';
             }


### PR DESCRIPTION
This prioritizes non-idle folder states to fix #6169. The bug was introduced in https://github.com/syncthing/syncthing/pull/6117, making this PR RC material (even though just "cosmetic").