### PR TITLE
lib/model: Also cover ServeBackground

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -317,8 +317,14 @@ func setupROFolder() (*model, *sendOnlyFolder) {
 	w.SetFolder(fcfg)
 
 	m := newModel(w, myID, "syncthing", "dev", db.OpenMemory(), nil)
+
+	m.ServeBackground()
+
+	// Folder should only be added, not started.
+	m.removeFolder(fcfg)
 	m.addFolder(fcfg)
 
+	m.fmut.RLock()
 	f := &sendOnlyFolder{
 		folder: folder{
 			stateTracker:        newStateTracker(fcfg.ID, m.evLogger),
@@ -326,8 +332,7 @@ func setupROFolder() (*model, *sendOnlyFolder) {
 			FolderConfiguration: fcfg,
 		},
 	}
-
-	m.ServeBackground()
+	m.fmut.RUnlock()
 
 	return m, f
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -219,6 +219,16 @@ func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersio
 }
 
 func (m *model) Serve() {
+	m.onServe()
+	m.Supervisor.Serve()
+}
+
+func (m *model) ServeBackground() {
+	m.onServe()
+	m.Supervisor.ServeBackground()
+}
+
+func (m *model) onServe() {
 	// Add and start folders
 	for _, folderCfg := range m.cfg.Folders() {
 		if folderCfg.Paused {
@@ -227,7 +237,6 @@ func (m *model) Serve() {
 		}
 		m.newFolder(folderCfg)
 	}
-	m.Supervisor.Serve()
 }
 
 func (m *model) Stop() {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -406,9 +406,11 @@ func TestClusterConfig(t *testing.T) {
 
 	wrapper := createTmpWrapper(cfg)
 	m := newModel(wrapper, myID, "syncthing", "dev", db, nil)
-	m.addFolder(cfg.Folders[0])
-	m.addFolder(cfg.Folders[1])
 	m.ServeBackground()
+	for _, fcfg := range cfg.Folders {
+		m.removeFolder(fcfg)
+		m.addFolder(fcfg)
+	}
 	defer cleanupModel(m)
 
 	cm := m.generateClusterConfig(device2)
@@ -1556,8 +1558,6 @@ func TestROScanRecovery(t *testing.T) {
 	testOs.RemoveAll(fcfg.Path)
 
 	m := newModel(cfg, myID, "syncthing", "dev", ldb, nil)
-	m.addFolder(fcfg)
-	m.startFolder("default")
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -1609,8 +1609,6 @@ func TestRWScanRecovery(t *testing.T) {
 	testOs.RemoveAll(fcfg.Path)
 
 	m := newModel(cfg, myID, "syncthing", "dev", ldb, nil)
-	m.addFolder(fcfg)
-	m.startFolder("default")
 	m.ServeBackground()
 	defer cleanupModel(m)
 
@@ -1637,8 +1635,9 @@ func TestRWScanRecovery(t *testing.T) {
 func TestGlobalDirectoryTree(t *testing.T) {
 	db := db.OpenMemory()
 	m := newModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
-	m.addFolder(defaultFolderConfig)
 	m.ServeBackground()
+	m.removeFolder(defaultFolderConfig)
+	m.addFolder(defaultFolderConfig)
 	defer cleanupModel(m)
 
 	b := func(isfile bool, path ...string) protocol.FileInfo {
@@ -1889,8 +1888,9 @@ func TestGlobalDirectoryTree(t *testing.T) {
 func TestGlobalDirectorySelfFixing(t *testing.T) {
 	db := db.OpenMemory()
 	m := newModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
-	m.addFolder(defaultFolderConfig)
 	m.ServeBackground()
+	m.removeFolder(defaultFolderConfig)
+	m.addFolder(defaultFolderConfig)
 	defer cleanupModel(m)
 
 	b := func(isfile bool, path ...string) protocol.FileInfo {
@@ -2065,8 +2065,9 @@ func BenchmarkTree_100_10(b *testing.B) {
 func benchmarkTree(b *testing.B, n1, n2 int) {
 	db := db.OpenMemory()
 	m := newModel(defaultCfgWrapper, myID, "syncthing", "dev", db, nil)
-	m.addFolder(defaultFolderConfig)
 	m.ServeBackground()
+	m.removeFolder(defaultFolderConfig)
+	m.addFolder(defaultFolderConfig)
 	defer cleanupModel(m)
 
 	m.ScanFolder("default")
@@ -2270,8 +2271,8 @@ func TestIndexesForUnknownDevicesDropped(t *testing.T) {
 	// Remote sequence is cached, hence need to recreated.
 	files = db.NewFileSet("default", defaultFs, dbi)
 
-	if len(files.ListDevices()) != 1 {
-		t.Error("Expected one device")
+	if l := len(files.ListDevices()); l != 1 {
+		t.Errorf("Expected one device got %v", l)
 	}
 }
 
@@ -2702,8 +2703,6 @@ func TestCustomMarkerName(t *testing.T) {
 	defer testOs.RemoveAll(fcfg.Path)
 
 	m := newModel(cfg, myID, "syncthing", "dev", ldb, nil)
-	m.addFolder(fcfg)
-	m.startFolder("default")
 	m.ServeBackground()
 	defer cleanupModel(m)
 

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -105,12 +105,6 @@ func setupModel(w config.Wrapper) *model {
 	db := db.OpenMemory()
 	m := newModel(w, myID, "syncthing", "dev", db, nil)
 	m.ServeBackground()
-	for id, cfg := range w.Folders() {
-		if !cfg.Paused {
-			m.addFolder(cfg)
-			m.startFolder(id)
-		}
-	}
 
 	m.ScanFolders()
 


### PR DESCRIPTION
### Purpose

When internalizing handling of folders in the model (https://github.com/syncthing/syncthing/pull/6135) I missed that it is a supervisor, not "merely" a service. This did not lead to problems as apparently internally suture uses `Serve`. However in principle it could just as well use `ServeBackground`, and that's also what we do in tests.

### Testing

In some tests the folder was just added, not started. As folders now automatically get added and started when the model is started, the folders then need to be removed and readded (without starting) in those tests.