### PR TITLE
lib/relay: Prevent lock nil deref when creation dynamic client

### DIFF
--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -33,7 +33,7 @@ func newDynamicClient(uri *url.URL, certs []tls.Certificate, invitations chan pr
 		certs:    certs,
 		timeout:  timeout,
 	}
-	c.commonClient = newCommonClient(invitations, c.serve, c.String())
+	c.commonClient = newCommonClient(invitations, c.serve, fmt.Sprintf("dynamicClient@%p", c))
 	return c
 }
 


### PR DESCRIPTION
Detected through https://sentry.syncthing.net/syncthing/syncthing/issues/730.  
Introduced in https://github.com/syncthing/syncthing/pull/6166 (unreleased).

The string method tries to acquire a lock that's not yet created -> pass a "manual" string.