### PR TITLE
all: Use context in lib/dialer

### DIFF
--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"flag"
@@ -480,7 +481,7 @@ func handleRelayTest(request request) {
 	if debug {
 		log.Println("Request for", request.relay)
 	}
-	if !client.TestRelay(request.relay.uri, []tls.Certificate{testCert}, time.Second, 2*time.Second, 3) {
+	if !client.TestRelay(context.TODO(), request.relay.uri, []tls.Certificate{testCert}, time.Second, 2*time.Second, 3) {
 		if debug {
 			log.Println("Test for relay", request.relay, "failed")
 		}

--- a/cmd/strelaysrv/testutil/main.go
+++ b/cmd/strelaysrv/testutil/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"flag"
 	"log"
@@ -19,6 +20,8 @@ import (
 )
 
 func main() {
+	ctx := context.Background()
+
 	log.SetOutput(os.Stdout)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
@@ -76,7 +79,7 @@ func main() {
 		}()
 
 		for {
-			conn, err := client.JoinSession(<-recv)
+			conn, err := client.JoinSession(ctx, <-recv)
 			if err != nil {
 				log.Fatalln("Failed to join", err)
 			}
@@ -90,13 +93,13 @@ func main() {
 			log.Fatal(err)
 		}
 
-		invite, err := client.GetInvitationFromRelay(uri, id, []tls.Certificate{cert}, 10*time.Second)
+		invite, err := client.GetInvitationFromRelay(ctx, uri, id, []tls.Certificate{cert}, 10*time.Second)
 		if err != nil {
 			log.Fatal(err)
 		}
 
 		log.Println("Received invitation", invite)
-		conn, err := client.JoinSession(invite)
+		conn, err := client.JoinSession(ctx, invite)
 		if err != nil {
 			log.Fatalln("Failed to join", err)
 		}
@@ -104,7 +107,7 @@ func main() {
 		connectToStdio(stdin, conn)
 		log.Println("Finished", conn.RemoteAddr(), conn.LocalAddr())
 	} else if test {
-		if client.TestRelay(uri, []tls.Certificate{cert}, time.Second, 2*time.Second, 4) {
+		if client.TestRelay(ctx, uri, []tls.Certificate{cert}, time.Second, 2*time.Second, 4) {
 			log.Println("OK")
 		} else {
 			log.Println("FAIL")

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -512,7 +512,7 @@ func upgradeViaRest() error {
 	r.Header.Set("X-API-Key", cfg.GUI().APIKey)
 
 	tr := &http.Transport{
-		Dial:            dialer.Dial,
+		DialContext:     dialer.Dial,
 		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -512,7 +512,7 @@ func upgradeViaRest() error {
 	r.Header.Set("X-API-Key", cfg.GUI().APIKey)
 
 	tr := &http.Transport{
-		DialContext:     dialer.Dial,
+		DialContext:     dialer.DialContext,
 		Proxy:           http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}

--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -43,7 +43,7 @@ type quicDialer struct {
 	tlsCfg *tls.Config
 }
 
-func (d *quicDialer) Dial(_ protocol.DeviceID, uri *url.URL) (internalConn, error) {
+func (d *quicDialer) Dial(ctx context.Context, _ protocol.DeviceID, uri *url.URL) (internalConn, error) {
 	uri = fixupPort(uri, config.DefaultQUICPort)
 
 	addr, err := net.ResolveUDPAddr("udp", uri.Host)
@@ -67,7 +67,7 @@ func (d *quicDialer) Dial(_ protocol.DeviceID, uri *url.URL) (internalConn, erro
 		}
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), quicOperationTimeout)
+	ctx, cancel := context.WithTimeout(ctx, quicOperationTimeout)
 	defer cancel()
 
 	session, err := quic.DialContext(ctx, conn, addr, uri.Host, d.tlsCfg, quicConfig)

--- a/lib/connections/relay_dial.go
+++ b/lib/connections/relay_dial.go
@@ -7,6 +7,7 @@
 package connections
 
 import (
+	"context"
 	"crypto/tls"
 	"net/url"
 	"time"
@@ -28,13 +29,13 @@ type relayDialer struct {
 	tlsCfg *tls.Config
 }
 
-func (d *relayDialer) Dial(id protocol.DeviceID, uri *url.URL) (internalConn, error) {
-	inv, err := client.GetInvitationFromRelay(uri, id, d.tlsCfg.Certificates, 10*time.Second)
+func (d *relayDialer) Dial(ctx context.Context, id protocol.DeviceID, uri *url.URL) (internalConn, error) {
+	inv, err := client.GetInvitationFromRelay(ctx, uri, id, d.tlsCfg.Certificates, 10*time.Second)
 	if err != nil {
 		return internalConn{}, err
 	}
 
-	conn, err := client.JoinSession(inv)
+	conn, err := client.JoinSession(ctx, inv)
 	if err != nil {
 		return internalConn{}, err
 	}

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -70,9 +70,11 @@ func (t *relayListener) serve(ctx context.Context) error {
 				return err
 			}
 
-			conn, err := client.JoinSession(inv)
+			conn, err := client.JoinSession(ctx, inv)
 			if err != nil {
-				l.Infoln("Listen (BEP/relay): joining session:", err)
+				if err != context.Canceled {
+					l.Infoln("Listen (BEP/relay): joining session:", err)
+				}
 				continue
 			}
 

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/nat"
@@ -72,7 +74,7 @@ func (t *relayListener) serve(ctx context.Context) error {
 
 			conn, err := client.JoinSession(ctx, inv)
 			if err != nil {
-				if err != context.Canceled {
+				if errors.Cause(err) != context.Canceled {
 					l.Infoln("Listen (BEP/relay): joining session:", err)
 				}
 				continue

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -9,7 +9,6 @@ package connections
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -31,6 +30,7 @@ import (
 	_ "github.com/syncthing/syncthing/lib/pmp"
 	_ "github.com/syncthing/syncthing/lib/upnp"
 
+	"github.com/pkg/errors"
 	"github.com/thejerf/suture"
 	"golang.org/x/time/rate"
 )
@@ -701,7 +701,7 @@ func (s *service) ConnectionStatus() map[string]ConnectionStatusEntry {
 }
 
 func (s *service) setConnectionStatus(address string, err error) {
-	if err == context.Canceled {
+	if errors.Cause(err) != context.Canceled {
 		return
 	}
 

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -7,6 +7,7 @@
 package connections
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -154,7 +155,7 @@ type dialerFactory interface {
 }
 
 type genericDialer interface {
-	Dial(protocol.DeviceID, *url.URL) (internalConn, error)
+	Dial(context.Context, protocol.DeviceID, *url.URL) (internalConn, error)
 	RedialFrequency() time.Duration
 }
 
@@ -213,7 +214,7 @@ type dialTarget struct {
 	deviceID protocol.DeviceID
 }
 
-func (t dialTarget) Dial() (internalConn, error) {
+func (t dialTarget) Dial(ctx context.Context) (internalConn, error) {
 	l.Debugln("dialing", t.deviceID, t.uri, "prio", t.priority)
-	return t.dialer.Dial(t.deviceID, t.uri)
+	return t.dialer.Dial(ctx, t.deviceID, t.uri)
 }

--- a/lib/connections/tcp_dial.go
+++ b/lib/connections/tcp_dial.go
@@ -7,6 +7,7 @@
 package connections
 
 import (
+	"context"
 	"crypto/tls"
 	"net/url"
 	"time"
@@ -30,10 +31,10 @@ type tcpDialer struct {
 	tlsCfg *tls.Config
 }
 
-func (d *tcpDialer) Dial(_ protocol.DeviceID, uri *url.URL) (internalConn, error) {
+func (d *tcpDialer) Dial(ctx context.Context, _ protocol.DeviceID, uri *url.URL) (internalConn, error) {
 	uri = fixupPort(uri, config.DefaultTCPPort)
 
-	conn, err := dialer.DialTimeout(uri.Scheme, uri.Host, 10*time.Second)
+	conn, err := dialer.DialTimeout(ctx, uri.Scheme, uri.Host, 10*time.Second)
 	if err != nil {
 		return internalConn{}, err
 	}

--- a/lib/connections/tcp_dial.go
+++ b/lib/connections/tcp_dial.go
@@ -34,7 +34,9 @@ type tcpDialer struct {
 func (d *tcpDialer) Dial(ctx context.Context, _ protocol.DeviceID, uri *url.URL) (internalConn, error) {
 	uri = fixupPort(uri, config.DefaultTCPPort)
 
-	conn, err := dialer.DialTimeout(ctx, uri.Scheme, uri.Host, 10*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	conn, err := dialer.DialContext(timeoutCtx, uri.Scheme, uri.Host)
 	if err != nil {
 		return internalConn{}, err
 	}

--- a/lib/dialer/debug.go
+++ b/lib/dialer/debug.go
@@ -1,0 +1,23 @@
+// Copyright (C) 2019 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package dialer
+
+import (
+	"os"
+	"strings"
+
+	"github.com/syncthing/syncthing/lib/logger"
+)
+
+var (
+	l = logger.DefaultLogger.NewFacility("dialer", "Dialing connections")
+	// To run before init() of other files that log on init.
+	_ = func() error {
+		l.SetDebug("dialer", strings.Contains(os.Getenv("STTRACE"), "dialer") || os.Getenv("STTRACE") == "all")
+		return nil
+	}()
+)

--- a/lib/dialer/internal.go
+++ b/lib/dialer/internal.go
@@ -7,33 +7,24 @@
 package dialer
 
 import (
-	"context"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"time"
 
 	"golang.org/x/net/proxy"
-
-	"github.com/syncthing/syncthing/lib/logger"
 )
 
 var (
-	l           = logger.DefaultLogger.NewFacility("dialer", "Dialing connections")
-	proxyDialer proxy.ContextDialer
-	usingProxy  bool
-	noFallback  = os.Getenv("ALL_PROXY_NO_FALLBACK") != ""
+	noFallback = os.Getenv("ALL_PROXY_NO_FALLBACK") != ""
 )
 
 func init() {
 	proxy.RegisterDialerType("socks", socksDialerFunction)
-	proxyDialer = getDialer()
-	usingProxy = proxyDialer != proxy.Direct
 
-	if usingProxy {
+	if proxyDialer := proxy.FromEnvironment(); proxyDialer != proxy.Direct {
 		http.DefaultTransport = &http.Transport{
-			DialContext:         Dial,
+			DialContext:         DialContext,
 			Proxy:               http.ProxyFromEnvironment,
 			TLSHandshakeTimeout: 10 * time.Second,
 		}
@@ -54,31 +45,6 @@ func init() {
 	}
 }
 
-func dialWithFallback(ctx context.Context, proxyDialer, fallbackDialer proxy.ContextDialer, network, addr string) (net.Conn, error) {
-	conn, err := proxyDialer.DialContext(ctx, network, addr)
-	if err == nil {
-		l.Debugf("Dialing %s address %s via proxy - success, %s -> %s", network, addr, conn.LocalAddr(), conn.RemoteAddr())
-		SetTCPOptions(conn)
-		return dialerConn{
-			conn, newDialerAddr(network, addr),
-		}, nil
-	}
-	l.Debugf("Dialing %s address %s via proxy - error %s", network, addr, err)
-
-	if noFallback {
-		return conn, err
-	}
-
-	conn, err = fallbackDialer.DialContext(ctx, network, addr)
-	if err == nil {
-		l.Debugf("Dialing %s address %s via fallback - success, %s -> %s", network, addr, conn.LocalAddr(), conn.RemoteAddr())
-		SetTCPOptions(conn)
-	} else {
-		l.Debugf("Dialing %s address %s via fallback - error %s", network, addr, err)
-	}
-	return conn, err
-}
-
 // This is a rip off of proxy.FromURL for "socks" URL scheme
 func socksDialerFunction(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
 	var auth *proxy.Auth
@@ -91,73 +57,4 @@ func socksDialerFunction(u *url.URL, forward proxy.Dialer) (proxy.Dialer, error)
 	}
 
 	return proxy.SOCKS5("tcp", u.Host, auth, forward)
-}
-
-// This is a rip off of proxy.FromEnvironment with a custom forward dialer
-func getDialer() proxy.ContextDialer {
-	forward := proxy.Direct
-	allProxy := os.Getenv("all_proxy")
-	if len(allProxy) == 0 {
-		return forward
-	}
-
-	proxyURL, err := url.Parse(allProxy)
-	if err != nil {
-		return forward
-	}
-	prxy, err := proxy.FromURL(proxyURL, forward)
-	if err != nil {
-		return forward
-	}
-
-	noProxy := os.Getenv("no_proxy")
-	if len(noProxy) == 0 {
-		// Probably due to compatibility promises, proxy.FromURL returns
-		// proxy.Dialer interface. However it returns either
-		// *socks.Dialer, a dialer registered by us or forward, all of
-		// which implement DialContext -> conversion is safe.
-		return prxy.(proxy.ContextDialer)
-	}
-
-	perHost := proxy.NewPerHost(prxy, forward)
-	perHost.AddFromString(noProxy)
-	return perHost
-}
-
-type timeoutDirectDialer struct {
-	timeout time.Duration
-}
-
-func (d *timeoutDirectDialer) Dial(network, addr string) (net.Conn, error) {
-	return net.DialTimeout(network, addr, d.timeout)
-}
-
-type dialerConn struct {
-	net.Conn
-	addr net.Addr
-}
-
-func (c dialerConn) RemoteAddr() net.Addr {
-	return c.addr
-}
-
-func newDialerAddr(network, addr string) net.Addr {
-	netaddr, err := net.ResolveIPAddr(network, addr)
-	if err == nil {
-		return netaddr
-	}
-	return fallbackAddr{network, addr}
-}
-
-type fallbackAddr struct {
-	network string
-	addr    string
-}
-
-func (a fallbackAddr) Network() string {
-	return a.network
-}
-
-func (a fallbackAddr) String() string {
-	return a.addr
 }

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -8,11 +8,11 @@ package dialer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"time"
 
-	"github.com/pkg/errors"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
 	"golang.org/x/net/proxy"

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -87,6 +87,12 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 	}()
 	<-proxyDone
 	if proxyErr == nil {
+		go func() {
+			<-fallbackDone
+			if fallbackErr == nil {
+				fallbackConn.Close()
+			}
+		}()
 		return proxyConn, nil
 	}
 	<-fallbackDone

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -92,8 +92,8 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 	var announceClient httpClient = &http.Client{
 		Timeout: requestTimeout,
 		Transport: &http.Transport{
-			Dial:  dialer.Dial,
-			Proxy: http.ProxyFromEnvironment,
+			DialContext: dialer.Dial,
+			Proxy:       http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: opts.insecure,
 				Certificates:       []tls.Certificate{cert},
@@ -109,8 +109,8 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 	var queryClient httpClient = &http.Client{
 		Timeout: requestTimeout,
 		Transport: &http.Transport{
-			Dial:  dialer.Dial,
-			Proxy: http.ProxyFromEnvironment,
+			DialContext: dialer.Dial,
+			Proxy:       http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: opts.insecure,
 			},

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -92,7 +92,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 	var announceClient httpClient = &http.Client{
 		Timeout: requestTimeout,
 		Transport: &http.Transport{
-			DialContext: dialer.Dial,
+			DialContext: dialer.DialContext,
 			Proxy:       http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: opts.insecure,
@@ -109,7 +109,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 	var queryClient httpClient = &http.Client{
 		Timeout: requestTimeout,
 		Transport: &http.Transport{
-			DialContext: dialer.Dial,
+			DialContext: dialer.DialContext,
 			Proxy:       http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: opts.insecure,

--- a/lib/nat/registry.go
+++ b/lib/nat/registry.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-type DiscoverFunc func(renewal, timeout time.Duration) []Device
+type DiscoverFunc func(ctx context.Context, renewal, timeout time.Duration) []Device
 
 var providers []DiscoverFunc
 
@@ -30,7 +30,7 @@ func discoverAll(ctx context.Context, renewal, timeout time.Duration) map[string
 	for _, discoverFunc := range providers {
 		go func(f DiscoverFunc) {
 			defer wg.Done()
-			for _, dev := range f(renewal, timeout) {
+			for _, dev := range f(ctx, renewal, timeout) {
 				select {
 				case c <- dev:
 				case <-ctx.Done():

--- a/lib/osutil/ping.go
+++ b/lib/osutil/ping.go
@@ -19,7 +19,9 @@ import (
 // tcp.
 func TCPPing(ctx context.Context, address string) (time.Duration, error) {
 	start := time.Now()
-	conn, err := dialer.DialTimeout(ctx, "tcp", address, time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if conn != nil {
 		conn.Close()
 	}

--- a/lib/osutil/ping.go
+++ b/lib/osutil/ping.go
@@ -7,6 +7,7 @@
 package osutil
 
 import (
+	"context"
 	"net/url"
 	"time"
 
@@ -16,9 +17,9 @@ import (
 // TCPPing returns the duration required to establish a TCP connection
 // to the given host. ICMP packets require root privileges, hence why we use
 // tcp.
-func TCPPing(address string) (time.Duration, error) {
+func TCPPing(ctx context.Context, address string) (time.Duration, error) {
 	start := time.Now()
-	conn, err := dialer.DialTimeout("tcp", address, time.Second)
+	conn, err := dialer.DialTimeout(ctx, "tcp", address, time.Second)
 	if conn != nil {
 		conn.Close()
 	}
@@ -27,11 +28,11 @@ func TCPPing(address string) (time.Duration, error) {
 
 // GetLatencyForURL parses the given URL, tries opening a TCP connection to it
 // and returns the time it took to establish the connection.
-func GetLatencyForURL(addr string) (time.Duration, error) {
+func GetLatencyForURL(ctx context.Context, addr string) (time.Duration, error) {
 	uri, err := url.Parse(addr)
 	if err != nil {
 		return 0, err
 	}
 
-	return TCPPing(uri.Host)
+	return TCPPing(ctx, uri.Host)
 }

--- a/lib/pmp/pmp.go
+++ b/lib/pmp/pmp.go
@@ -45,7 +45,8 @@ func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device 
 
 	var localIP net.IP
 	// Port comes from the natpmp package
-	timeoutCtx, _ := context.WithTimeout(ctx, timeout)
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
 	conn, err := (&net.Dialer{}).DialContext(timeoutCtx, "udp", net.JoinHostPort(ip.String(), "5351"))
 	if err == nil {
 		conn.Close()

--- a/lib/pmp/pmp.go
+++ b/lib/pmp/pmp.go
@@ -7,6 +7,7 @@
 package pmp
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strings"
@@ -21,7 +22,7 @@ func init() {
 	nat.Register(Discover)
 }
 
-func Discover(renewal, timeout time.Duration) []nat.Device {
+func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device {
 	ip, err := gateway.DiscoverGateway()
 	if err != nil {
 		l.Debugln("Failed to discover gateway", err)
@@ -44,7 +45,8 @@ func Discover(renewal, timeout time.Duration) []nat.Device {
 
 	var localIP net.IP
 	// Port comes from the natpmp package
-	conn, err := net.DialTimeout("udp", net.JoinHostPort(ip.String(), "5351"), timeout)
+	timeoutCtx, _ := context.WithTimeout(ctx, timeout)
+	conn, err := (&net.Dialer{}).DialContext(timeoutCtx, "udp", net.JoinHostPort(ip.String(), "5351"))
 	if err == nil {
 		conn.Close()
 		localIPAddress, _, err := net.SplitHostPort(conn.LocalAddr().String())

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -166,7 +166,7 @@ func (p *Process) Get(path string) ([]byte, error) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			DialContext:       dialer.Dial,
+			DialContext:       dialer.DialContext,
 			Proxy:             http.ProxyFromEnvironment,
 			DisableKeepAlives: true,
 		},

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -166,7 +166,7 @@ func (p *Process) Get(path string) ([]byte, error) {
 	client := &http.Client{
 		Timeout: 30 * time.Second,
 		Transport: &http.Transport{
-			Dial:              dialer.Dial,
+			DialContext:       dialer.Dial,
 			Proxy:             http.ProxyFromEnvironment,
 			DisableKeepAlives: true,
 		},

--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -153,7 +153,7 @@ func relayAddressesOrder(ctx context.Context, input []string) []string {
 	buckets := make(map[int][]string)
 
 	for _, relay := range input {
-		latency, err := osutil.GetLatencyForURL(relay)
+		latency, err := osutil.GetLatencyForURL(ctx, relay)
 		if err != nil {
 			latency = time.Hour
 		}

--- a/lib/relay/client/methods.go
+++ b/lib/relay/client/methods.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -16,12 +17,12 @@ import (
 	"github.com/syncthing/syncthing/lib/relay/protocol"
 )
 
-func GetInvitationFromRelay(uri *url.URL, id syncthingprotocol.DeviceID, certs []tls.Certificate, timeout time.Duration) (protocol.SessionInvitation, error) {
+func GetInvitationFromRelay(ctx context.Context, uri *url.URL, id syncthingprotocol.DeviceID, certs []tls.Certificate, timeout time.Duration) (protocol.SessionInvitation, error) {
 	if uri.Scheme != "relay" {
 		return protocol.SessionInvitation{}, fmt.Errorf("Unsupported relay scheme: %v", uri.Scheme)
 	}
 
-	rconn, err := dialer.DialTimeout("tcp", uri.Host, timeout)
+	rconn, err := dialer.DialTimeout(ctx, "tcp", uri.Host, timeout)
 	if err != nil {
 		return protocol.SessionInvitation{}, err
 	}
@@ -63,10 +64,10 @@ func GetInvitationFromRelay(uri *url.URL, id syncthingprotocol.DeviceID, certs [
 	}
 }
 
-func JoinSession(invitation protocol.SessionInvitation) (net.Conn, error) {
+func JoinSession(ctx context.Context, invitation protocol.SessionInvitation) (net.Conn, error) {
 	addr := net.JoinHostPort(net.IP(invitation.Address).String(), strconv.Itoa(int(invitation.Port)))
 
-	conn, err := dialer.Dial("tcp", addr)
+	conn, err := dialer.Dial(ctx, "tcp", addr)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +100,7 @@ func JoinSession(invitation protocol.SessionInvitation) (net.Conn, error) {
 	}
 }
 
-func TestRelay(uri *url.URL, certs []tls.Certificate, sleep, timeout time.Duration, times int) bool {
+func TestRelay(ctx context.Context, uri *url.URL, certs []tls.Certificate, sleep, timeout time.Duration, times int) bool {
 	id := syncthingprotocol.NewDeviceID(certs[0].Certificate[0])
 	invs := make(chan protocol.SessionInvitation, 1)
 	c, err := NewClient(uri, certs, invs, timeout)
@@ -114,7 +115,7 @@ func TestRelay(uri *url.URL, certs []tls.Certificate, sleep, timeout time.Durati
 	}()
 
 	for i := 0; i < times; i++ {
-		_, err := GetInvitationFromRelay(uri, id, certs, timeout)
+		_, err := GetInvitationFromRelay(ctx, uri, id, certs, timeout)
 		if err == nil {
 			return true
 		}

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -150,7 +150,9 @@ func (c *staticClient) connect(ctx context.Context) error {
 	}
 
 	t0 := time.Now()
-	tcpConn, err := dialer.DialTimeout(ctx, "tcp", c.uri.Host, c.connectTimeout)
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	tcpConn, err := dialer.DialContext(timeoutCtx, "tcp", c.uri.Host)
 	if err != nil {
 		return err
 	}

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -45,7 +45,7 @@ func newStaticClient(uri *url.URL, certs []tls.Certificate, invitations chan pro
 }
 
 func (c *staticClient) serve(ctx context.Context) error {
-	if err := c.connect(); err != nil {
+	if err := c.connect(ctx); err != nil {
 		l.Infof("Could not connect to relay %s: %s", c.uri, err)
 		return err
 	}
@@ -144,13 +144,13 @@ func (c *staticClient) URI() *url.URL {
 	return c.uri
 }
 
-func (c *staticClient) connect() error {
+func (c *staticClient) connect(ctx context.Context) error {
 	if c.uri.Scheme != "relay" {
 		return fmt.Errorf("unsupported relay scheme: %v", c.uri.Scheme)
 	}
 
 	t0 := time.Now()
-	tcpConn, err := dialer.DialTimeout("tcp", c.uri.Host, c.connectTimeout)
+	tcpConn, err := dialer.DialTimeout(ctx, "tcp", c.uri.Host, c.connectTimeout)
 	if err != nil {
 		return err
 	}

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -66,8 +66,8 @@ const (
 var insecureHTTP = &http.Client{
 	Timeout: readTimeout,
 	Transport: &http.Transport{
-		Dial:  dialer.Dial,
-		Proxy: http.ProxyFromEnvironment,
+		DialContext: dialer.Dial,
+		Proxy:       http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -66,7 +66,7 @@ const (
 var insecureHTTP = &http.Client{
 	Timeout: readTimeout,
 	Transport: &http.Transport{
-		DialContext: dialer.Dial,
+		DialContext: dialer.DialContext,
 		Proxy:       http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -37,7 +37,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -47,6 +46,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/nat"
@@ -194,7 +195,7 @@ USER-AGENT: syncthing/1.0
 			case *UnsupportedDeviceTypeError:
 				l.Debugln(err.Error())
 			default:
-				if err != context.Canceled {
+				if errors.Cause(err) != context.Canceled {
 					l.Infoln("UPnP parse:", err)
 				}
 			}

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -274,7 +274,9 @@ func parseResponse(ctx context.Context, deviceType string, resp []byte) ([]IGDSe
 }
 
 func localIP(ctx context.Context, url *url.URL) (net.IP, error) {
-	conn, err := dialer.DialTimeout(ctx, "tcp", url.Host, time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	conn, err := dialer.DialContext(timeoutCtx, "tcp", url.Host)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -35,6 +35,7 @@ package upnp
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -83,7 +84,7 @@ func (e UnsupportedDeviceTypeError) Error() string {
 
 // Discover discovers UPnP InternetGatewayDevices.
 // The order in which the devices appear in the results list is not deterministic.
-func Discover(renewal, timeout time.Duration) []nat.Device {
+func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device {
 	var results []nat.Device
 
 	interfaces, err := net.Interfaces()
@@ -105,7 +106,7 @@ func Discover(renewal, timeout time.Duration) []nat.Device {
 		for _, deviceType := range []string{"urn:schemas-upnp-org:device:InternetGatewayDevice:1", "urn:schemas-upnp-org:device:InternetGatewayDevice:2"} {
 			wg.Add(1)
 			go func(intf net.Interface, deviceType string) {
-				discover(&intf, deviceType, timeout, resultChan)
+				discover(ctx, &intf, deviceType, timeout, resultChan)
 				wg.Done()
 			}(intf, deviceType)
 		}
@@ -135,7 +136,7 @@ nextResult:
 
 // Search for UPnP InternetGatewayDevices for <timeout> seconds.
 // The order in which the devices appear in the result list is not deterministic
-func discover(intf *net.Interface, deviceType string, timeout time.Duration, results chan<- nat.Device) {
+func discover(ctx context.Context, intf *net.Interface, deviceType string, timeout time.Duration, results chan<- nat.Device) {
 	ssdp := &net.UDPAddr{IP: []byte{239, 255, 255, 250}, Port: 1900}
 
 	tpl := `M-SEARCH * HTTP/1.1
@@ -187,13 +188,15 @@ USER-AGENT: syncthing/1.0
 			}
 			break
 		}
-		igds, err := parseResponse(deviceType, resp[:n])
+		igds, err := parseResponse(ctx, deviceType, resp[:n])
 		if err != nil {
 			switch err.(type) {
 			case *UnsupportedDeviceTypeError:
 				l.Debugln(err.Error())
 			default:
-				l.Infoln("UPnP parse:", err)
+				if err != context.Canceled {
+					l.Infoln("UPnP parse:", err)
+				}
 			}
 			continue
 		}
@@ -205,7 +208,7 @@ USER-AGENT: syncthing/1.0
 	l.Debugln("Discovery for device type", deviceType, "on", intf.Name, "finished.")
 }
 
-func parseResponse(deviceType string, resp []byte) ([]IGDService, error) {
+func parseResponse(ctx context.Context, deviceType string, resp []byte) ([]IGDService, error) {
 	l.Debugln("Handling UPnP response:\n\n" + string(resp))
 
 	reader := bufio.NewReader(bytes.NewBuffer(resp))
@@ -257,7 +260,7 @@ func parseResponse(deviceType string, resp []byte) ([]IGDService, error) {
 	// We do this in a fairly roundabout way by connecting to the IGD and
 	// checking the address of the local end of the socket. I'm open to
 	// suggestions on a better way to do this...
-	localIPAddress, err := localIP(deviceDescriptionURL)
+	localIPAddress, err := localIP(ctx, deviceDescriptionURL)
 	if err != nil {
 		return nil, err
 	}
@@ -270,8 +273,8 @@ func parseResponse(deviceType string, resp []byte) ([]IGDService, error) {
 	return services, nil
 }
 
-func localIP(url *url.URL) (net.IP, error) {
-	conn, err := dialer.DialTimeout("tcp", url.Host, time.Second)
+func localIP(ctx context.Context, url *url.URL) (net.IP, error) {
+	conn, err := dialer.DialTimeout(ctx, "tcp", url.Host, time.Second)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -373,7 +373,7 @@ func (s *Service) sendUsageReport() error {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			DialContext: dialer.Dial,
+			DialContext: dialer.DialContext,
 			Proxy:       http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: s.cfg.Options().URPostInsecurely,

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -373,8 +373,8 @@ func (s *Service) sendUsageReport() error {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			Dial:  dialer.Dial,
-			Proxy: http.ProxyFromEnvironment,
+			DialContext: dialer.Dial,
+			Proxy:       http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: s.cfg.Options().URPostInsecurely,
 			},

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -236,6 +236,9 @@ func (s *service) Serve() {
 
 	var err error
 	defer func() {
+		if err == context.Canceled {
+			err = nil
+		}
 		s.mut.Lock()
 		s.err = err
 		close(s.stopped)


### PR DESCRIPTION
### Purpose

The main change is using `DialContext` in lib/dialer. All other changes are just about propagating contexts to where dialing happens (which is quite a lot).  
When errors where used (logged, "registered" for web UI, ...), I filtered out `context.Canceled`, as this isn't a fault or in any other way actionable by the user. It's just an expected result of normal termination. 

### Testing

None except for existing tests. It would definitely be nice if someone that uses proxies could test this. I am fairly certain it's ok, but there is one type assertion which could blow up at runtime (at the end of lib/dialer/internal.go - has a comment).
