### PR TITLE
UI enhancements on mobile

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -356,6 +356,12 @@ ul.three-columns li, ul.two-columns li {
         * columns. */
         white-space: normal;
     }
+
+    .two-columns {
+        -webkit-column-count: 1;
+        -moz-column-count: 1;
+        column-count: 1;
+    }
 }
 
 @media (max-width:479px) {

--- a/gui/default/syncthing/core/aboutModalView.html
+++ b/gui/default/syncthing/core/aboutModalView.html
@@ -1,7 +1,7 @@
 <modal id="about" status="info" icon="far fa-heart" heading="{{'About' | translate}}" large="yes" closeable="yes">
   <div class="modal-body">
     <h1 class="text-center">
-      <img alt="Syncthing" src="assets/img/logo-horizontal.svg" style="vertical-align: -16px" height="100" width="366" />
+      <img alt="Syncthing" src="assets/img/logo-horizontal.svg" style="max-width: 366px; vertical-align: -16px" />
       <br />
       <small>{{versionString()}}</small>
       <br />

--- a/gui/default/syncthing/core/logViewerModalView.html
+++ b/gui/default/syncthing/core/logViewerModalView.html
@@ -8,7 +8,7 @@
 
       <div id="log-viewer-log" class="tab-pane in active">
         <label translate ng-if="logging.logEntries.length == 0">Loading...</label>
-        <textarea id="logViewerText" class="form-control" rows="20" ng-if="logging.logEntries.length != 0" readonly style="font-family: Consolas; font-size: 11px; overflow: auto;">{{ logging.content() }}</textarea>
+        <textarea id="logViewerText" class="form-control" rows="20" ng-if="logging.logEntries.length != 0" readonly style="font-family: Consolas, monospace; font-size: 11px; overflow: auto;">{{ logging.content() }}</textarea>
         <p translate class="help-block" ng-style="{'visibility': logging.paused ? 'visible' : 'hidden'}">Log tailing paused. Scroll to the bottom to continue.</p>
       </div>
 


### PR DESCRIPTION
### Purpose

Fixes #6178 

### Testing

1. Go to "Logs" view with removed font called "Consolas" in system. You should see default monospace font from OS.
2. Go to "About" page and resize it to less than 768px. You should properly see Syncthing logo and "dependency list" in one column instead of two.

### Screenshots

![c](https://user-images.githubusercontent.com/17083034/69478296-0f1c1700-0df1-11ea-87ec-f3f54920a0a0.png)
![d](https://user-images.githubusercontent.com/17083034/69478298-12170780-0df1-11ea-986a-9ff9a27d5f50.png)
![e](https://user-images.githubusercontent.com/17083034/69478299-14796180-0df1-11ea-97e7-22aa63432fbe.png)