### PR TITLE
lib: Wrap errors with errors.Wrap instead of fmt.Errorf

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -10,7 +10,6 @@ package config
 import (
 	"encoding/json"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -21,6 +20,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/pkg/errors"
 
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/protocol"
@@ -120,13 +121,13 @@ func NewWithFreePorts(myID protocol.DeviceID) (Configuration, error) {
 
 	port, err := getFreePort("127.0.0.1", DefaultGUIPort)
 	if err != nil {
-		return Configuration{}, fmt.Errorf("get free port (GUI): %v", err)
+		return Configuration{}, errors.Wrap(err, "get free port (GUI)")
 	}
 	cfg.GUI.RawAddress = fmt.Sprintf("127.0.0.1:%d", port)
 
 	port, err = getFreePort("0.0.0.0", DefaultTCPPort)
 	if err != nil {
-		return Configuration{}, fmt.Errorf("get free port (BEP): %v", err)
+		return Configuration{}, errors.Wrap(err, "get free port (BEP)")
 	}
 	if port == DefaultTCPPort {
 		cfg.Options.ListenAddresses = []string{"default"}

--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -11,12 +11,12 @@ package connections
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"net"
 	"net/url"
 	"time"
 
 	"github.com/lucas-clemente/quic-go"
+	"github.com/pkg/errors"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/connections/registry"
@@ -75,7 +75,7 @@ func (d *quicDialer) Dial(_ protocol.DeviceID, uri *url.URL) (internalConn, erro
 		if createdConn != nil {
 			_ = createdConn.Close()
 		}
-		return internalConn{}, fmt.Errorf("dial: %v", err)
+		return internalConn{}, errors.Wrap(err, "dial")
 	}
 
 	stream, err := session.OpenStreamSync(ctx)
@@ -85,7 +85,7 @@ func (d *quicDialer) Dial(_ protocol.DeviceID, uri *url.URL) (internalConn, erro
 		if createdConn != nil {
 			_ = createdConn.Close()
 		}
-		return internalConn{}, fmt.Errorf("open stream: %v", err)
+		return internalConn{}, errors.Wrap(err, "open stream")
 	}
 
 	return internalConn{&quicTlsConn{session, stream, createdConn}, connTypeQUICClient, quicPriority}, nil

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	"github.com/gobwas/glob"
+	"github.com/pkg/errors"
+
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/sync"
@@ -404,14 +406,14 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			// Pattern is rooted in the current dir only
 			pattern.match, err = glob.Compile(line[1:], '/')
 			if err != nil {
-				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
+				return errors.Wrapf(err, "invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, pattern)
 		} else if strings.HasPrefix(line, "**/") {
 			// Add the pattern as is, and without **/ so it matches in current dir
 			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
-				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
+				return errors.Wrapf(err, "invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, pattern)
 
@@ -419,7 +421,7 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			pattern.pattern = line
 			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
-				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
+				return errors.Wrapf(err, "invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, pattern)
 		} else {
@@ -427,7 +429,7 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			// current directory and subdirs.
 			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
-				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
+				return errors.Wrapf(err, "invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, pattern)
 
@@ -435,7 +437,7 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			pattern.pattern = line
 			pattern.match, err = glob.Compile(line, '/')
 			if err != nil {
-				return fmt.Errorf("invalid pattern %q in ignore file (%v)", line, err)
+				return errors.Wrapf(err, "invalid pattern %q in ignore file", line)
 			}
 			patterns = append(patterns, pattern)
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -20,6 +19,9 @@ import (
 	"strings"
 	stdsync "sync"
 	"time"
+
+	"github.com/pkg/errors"
+	"github.com/thejerf/suture"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/connections"
@@ -35,7 +37,6 @@ import (
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/util"
 	"github.com/syncthing/syncthing/lib/versioner"
-	"github.com/thejerf/suture"
 )
 
 // How many files to send in each Index/IndexUpdate message.
@@ -1790,7 +1791,7 @@ func (m *model) SetIgnores(folder string, content []string) error {
 	err := cfg.CheckPath()
 	if err == config.ErrPathMissing {
 		if err = cfg.CreateRoot(); err != nil {
-			return fmt.Errorf("failed to create folder root: %v", err)
+			return errors.Wrap(err, "failed to create folder root")
 		}
 		err = cfg.CheckPath()
 	}

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/syncthing/syncthing/lib/dialer"
 	syncthingprotocol "github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/relay/protocol"
@@ -225,7 +227,7 @@ func performHandshakeAndValidation(conn *tls.Conn, uri *url.URL) error {
 	if relayIDs != "" {
 		relayID, err := syncthingprotocol.DeviceIDFromString(relayIDs)
 		if err != nil {
-			return fmt.Errorf("relay address contains invalid verification id: %s", err)
+			return errors.Wrap(err, "relay address contains invalid verification id")
 		}
 
 		certs := cs.PeerCertificates

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/syncthing/syncthing/lib/rand"
 )
 
@@ -92,7 +94,7 @@ func SecureDefault() *tls.Config {
 func NewCertificate(certFile, keyFile, commonName string, lifetimeDays int) (tls.Certificate, error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("generate key: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "generate key")
 	}
 
 	notBefore := time.Now().Truncate(24 * time.Hour)
@@ -115,39 +117,39 @@ func NewCertificate(certFile, keyFile, commonName string, lifetimeDays int) (tls
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("create cert: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "create cert")
 	}
 
 	certOut, err := os.Create(certFile)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("save cert: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "save cert")
 	}
 	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("save cert: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "save cert")
 	}
 	err = certOut.Close()
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("save cert: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "save cert")
 	}
 
 	keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("save key: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "save key")
 	}
 
 	block, err := pemBlockForKey(priv)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("save key: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "save key")
 	}
 
 	err = pem.Encode(keyOut, block)
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("save key: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "save key")
 	}
 	err = keyOut.Close()
 	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("save key: %s", err)
+		return tls.Certificate{}, errors.Wrap(err, "save key")
 	}
 
 	return tls.LoadX509KeyPair(certFile, keyFile)


### PR DESCRIPTION
This is prompted by concern over wrapped errors when filtering errors in https://github.com/syncthing/syncthing/pull/6177. And it's purely a grep/sed effort. We may still be dropping errors in places that could/should be wrapped.