### PR TITLE
Bump Syncthing version in GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -36,7 +36,7 @@ its entirety.
 
 ### Version Information
 
-Syncthing Version: v0.x.y
+Syncthing Version: v1.x.y
 OS Version: Windows 7 / Ubuntu 14.04 / ...
 Browser Version: (if applicable, for GUI issues)
 


### PR DESCRIPTION
Since Syncthing current version is v1.3.1, the current proposal is that the GitHub issue template shows `v1.x.y` instead of `v0.x.y`.