### PR TITLE
Ensure uPnP http requests have trailing \r\n

### DIFF
--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -150,7 +150,7 @@ USER-AGENT: syncthing/1.0
 `
 	searchStr := fmt.Sprintf(tpl, deviceType, timeout/time.Second)
 
-	search := []byte(strings.Replace(searchStr, "\n", "\r\n", -1))
+	search := []byte(strings.Replace(searchStr, "\n", "\r\n", -1) + "\r\n")
 
 	l.Debugln("Starting discovery of device type", deviceType, "on", intf.Name)
 


### PR DESCRIPTION
The http request used for upnp discovery was malformed.

See https://play.golang.org/p/-S2WDBwK29m and notice the request ends in `\r\n` instead of `\r\n\r\n`