### PR TITLE
gui: Sort versions by date in restore dropdown

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2056,6 +2056,9 @@ angular.module('syncthing.core')
                                     value.modTime = new Date(value.modTime);
                                     value.versionTime = new Date(value.versionTime);
                                 });
+                                values.sort(function (a, b) {
+                                    return b.versionTime - a.versionTime;
+                                });
                             });
                             if (closed) return;
                             $scope.restoreVersions.versions = data;


### PR DESCRIPTION
### Purpose

In the GUI, the versions are not sorted in the restore modal, appearing in whatever random order the API is providing them as.  This is especially annoying to look through if you have a lot of versions for a file.  This PR forces the versions to be sorted by date in reverse order (so that after the current version, the next version is the latest version before that, and so forth).

### Testing

I've tested it with staggered versioning in chrome and firefox, and you can see the change in drop down behavior in the screenshot below.

### Screenshots

Before:
![syncthing-gui-sort-before](https://user-images.githubusercontent.com/507274/69828751-5f70eb80-11da-11ea-87c8-5b67789c8740.png)

After:
![syncthing-gui-sort-after](https://user-images.githubusercontent.com/507274/69828753-613aaf00-11da-11ea-9d8d-7c7d7639c543.png)

### Documentation

I didn't actually see anything about that part of the UI in the docs.
