### PR TITLE
lib/model: Also send folder summary from sync-preparing (ref #6028)

### DIFF
--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -198,7 +198,10 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 
 	case events.StateChanged:
 		data := ev.Data.(map[string]interface{})
-		if from := data["from"].(string); !(data["to"].(string) == "idle" && (from == "syncing" || from == "sync-preparing")) {
+		if data["to"].(string) != "idle" {
+			return
+		}
+		if from := data["from"].(string); from != "syncing" && from != "sync-preparing" {
 			return
 		}
 

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -198,7 +198,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 
 	case events.StateChanged:
 		data := ev.Data.(map[string]interface{})
-		if !(data["to"].(string) == "idle" && data["from"].(string) == "syncing") {
+		if from := data["from"].(string); !(data["to"].(string) == "idle" && (from == "syncing" || from == "sync-preparing")) {
 			return
 		}
 


### PR DESCRIPTION
This is a regression from #6028: If syncing doesn't actually need to pull any data, the folder summary isn't triggered. This is in principle relevant for the current RC, however it's minor (maybe in practice not noticeable at all - I discovered it in code). It also listens to `LocalIndexUpdated`, which will cause a folder summary the next time the timer fires.