### PR TITLE
lib: Consistently unsubscribe from config-wrapper (fixes #6133)

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -193,6 +193,12 @@ func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *t
 	return service
 }
 
+func (s *service) Stop() {
+	s.cfg.Unsubscribe(s.limiter)
+	s.cfg.Unsubscribe(s)
+	s.Supervisor.Stop()
+}
+
 func (s *service) handle(ctx context.Context) {
 	var c internalConn
 	for {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -217,7 +217,6 @@ func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersio
 	}
 	m.Add(m.progressEmitter)
 	scanLimiter.setCapacity(cfg.Options().MaxConcurrentScans)
-	cfg.Subscribe(m)
 
 	return m
 }
@@ -241,9 +240,11 @@ func (m *model) onServe() {
 		}
 		m.newFolder(folderCfg)
 	}
+	m.cfg.Subscribe(m)
 }
 
 func (m *model) Stop() {
+	m.cfg.Unsubscribe(m)
 	m.Supervisor.Stop()
 	devs := m.cfg.Devices()
 	ids := make([]protocol.DeviceID, 0, len(devs))

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -58,7 +58,6 @@ func New(cfg config.Wrapper, m model.Model, connectionsService connections.Servi
 		forceRun:           make(chan struct{}, 1), // Buffered to prevent locking
 	}
 	svc.Service = util.AsService(svc.serve, svc.String())
-	cfg.Subscribe(svc)
 	return svc
 }
 
@@ -385,6 +384,9 @@ func (s *Service) sendUsageReport() error {
 }
 
 func (s *Service) serve(ctx context.Context) {
+	s.cfg.Subscribe(s)
+	defer s.cfg.Unsubscribe(s)
+
 	t := time.NewTimer(time.Duration(s.cfg.Options().URInitialDelayS) * time.Second)
 	for {
 		select {


### PR DESCRIPTION
### Purpose

`db.NewFileSet` returns a `nil` object without error if the underlying db was closed. We ensure that all services are stopped when we close the db, but that doesn't guarantee that "nothing is happening anymore" for two reasons:

 - Many (most?) services don't unsubscribe themselves on the config wrapper.
 - Unsubscribing returns even if there is still an ongoing config change.

### Testing

I consistently got panics locally (see https://github.com/syncthing/syncthing/issues/6133#issuecomment-559978898) which are now gone.