### PR TITLE
gui/default: Fix a typo in a class name

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -105,7 +105,7 @@ angular.module('syncthing.core')
         $scope.needIcons = {
             'rm': 'far fa-fw fa-trash-alt',
             'rmdir': 'far fa-fw fa-trash-alt',
-            'sync': 'far fa-fw arrow-alt-circle-down',
+            'sync': 'far fa-fw fa-arrow-alt-circle-down',
             'touch': 'fas fa-fw fa-asterisk'
         };
 


### PR DESCRIPTION
Fix for a small typo in a class name. Now it properly displays the 'arrow-down' icon next to a word 'Sync'.

![image](https://user-images.githubusercontent.com/22799031/70585119-72fd5880-1bc3-11ea-9417-184b85ea0b4c.png)