### PR TITLE
gui: Prevent spurious api call (fixes #6222)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -690,7 +690,7 @@ angular.module('syncthing.core')
         };
 
         $scope.refreshFailed = function (page, perpage) {
-            if (!$scope.failed) {
+            if (!$scope.failed || !$scope.failed.folder) {
                 return;
             }
             var url = urlbase + '/folder/errors?folder=' + encodeURIComponent($scope.failed.folder);


### PR DESCRIPTION
This is essentially a follow up to https://github.com/syncthing/syncthing/pull/5759/files as the new issue (#6222) has the same underlying reason as https://github.com/syncthing/syncthing/issues/5652: Spurious api calls from angular land. The mitigation put in place fails in this specific case, as an empty object apparently isn't false in JS, so that check alone isn't enough.