### PR TITLE
lib/syncthing: Expose backend instead of lowlevel

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -486,7 +486,7 @@ func checkUpgrade() upgrade.Release {
 
 func performUpgrade(release upgrade.Release) {
 	// Use leveldb database locks to protect against concurrent upgrades
-	_, err := syncthing.OpenGoleveldb(locations.Get(locations.Database), config.TuningAuto)
+	_, err := syncthing.OpenDBBackend(locations.Get(locations.Database), config.TuningAuto)
 	if err == nil {
 		err = upgrade.To(release)
 		if err != nil {
@@ -578,7 +578,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	}
 
 	dbFile := locations.Get(locations.Database)
-	ldb, err := syncthing.OpenGoleveldb(dbFile, cfg.Options().DatabaseTuning)
+	ldb, err := syncthing.OpenDBBackend(dbFile, cfg.Options().DatabaseTuning)
 	if err != nil {
 		l.Warnln("Error opening database:", err)
 		os.Exit(1)

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -23,6 +23,7 @@ import (
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/connections"
 	"github.com/syncthing/syncthing/lib/db"
+	"github.com/syncthing/syncthing/lib/db/backend"
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/locations"
@@ -84,10 +85,10 @@ type App struct {
 	stopped     chan struct{}
 }
 
-func New(cfg config.Wrapper, ll *db.Lowlevel, evLogger events.Logger, cert tls.Certificate, opts Options) *App {
+func New(cfg config.Wrapper, dbBackend backend.Backend, evLogger events.Logger, cert tls.Certificate, opts Options) *App {
 	a := &App{
 		cfg:      cfg,
-		ll:       ll,
+		ll:       db.NewLowlevel(dbBackend),
 		evLogger: evLogger,
 		opts:     opts,
 		cert:     cert,

--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/db/backend"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/tlsutil"
@@ -77,7 +78,7 @@ func TestStartupFail(t *testing.T) {
 	}, events.NoopLogger)
 	defer os.Remove(cfg.ConfigPath())
 
-	app := New(cfg, nil, events.NoopLogger, cert, Options{})
+	app := New(cfg, backend.OpenMemory(), events.NoopLogger, cert, Options{})
 	startErr := app.Start()
 	if startErr == nil {
 		t.Fatal("Expected an error from Start, got nil")

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/db/backend"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
@@ -124,10 +123,6 @@ func copyFile(src, dst string) error {
 	return nil
 }
 
-func OpenGoleveldb(path string, tuning config.Tuning) (*db.Lowlevel, error) {
-	ldb, err := backend.Open(path, backend.Tuning(tuning))
-	if err != nil {
-		return nil, err
-	}
-	return db.NewLowlevel(ldb), nil
+func OpenDBBackend(path string, tuning config.Tuning) (backend.Backend, error) {
+	return backend.Open(path, backend.Tuning(tuning))
 }


### PR DESCRIPTION
Instead of having the concrete `db.Lowlevel` type in Syncthing's libraries interface, this proposes to expose the `backend.Backend` interface. That's something a library consumer can actually implement themselves if they don't want to use "our" db backend.