### PR TITLE
lib/upgrade: Let Mac load .zip archives

### DIFF
--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -223,8 +223,8 @@ func readRelease(archiveName, dir, url string) (string, error) {
 	}
 	defer resp.Body.Close()
 
-	switch runtime.GOOS {
-	case "windows":
+	switch path.Ext(archiveName) {
+	case ".zip":
 		return readZip(archiveName, dir, io.LimitReader(resp.Body, maxArchiveSize))
 	default:
 		return readTarGz(archiveName, dir, io.LimitReader(resp.Body, maxArchiveSize))


### PR DESCRIPTION
There is no need to do this switch based on the current OS, instead do
it based on what the archive actually appears to be.

(Tested; works.)


