### PR TITLE
logger: Fix a typo in a comment

### DIFF
--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -172,7 +172,7 @@ func (l *logger) Infof(format string, vals ...interface{}) {
 	l.callHandlers(LevelInfo, s)
 }
 
-// Warnln logs a formatted line with a WARNING prefix.
+// Warnln logs a line with a WARNING prefix.
 func (l *logger) Warnln(vals ...interface{}) {
 	s := fmt.Sprintln(vals...)
 	l.mut.Lock()


### PR DESCRIPTION
Fix for a small typo in a comment.