### PR TITLE
docker: Fix HOME setting

### DIFF
--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -4,4 +4,4 @@ set -eu
 
 chown "${PUID}:${PGID}" "${HOME}" \
   && exec su-exec "${PUID}:${PGID}" \
-     "$@"
+     env HOME="$HOME" "$@"


### PR DESCRIPTION
su-exec sets $HOME, and we used to have this env call in there to fix
that up. It disappeared in the latest entrypoint.sh rewrite.
