### PR TITLE
Implement basic push notification logic

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -876,6 +876,7 @@
   <script type="text/javascript" src="syncthing/core/notificationDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/pathIsSubDirDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/popoverDirective.js"></script>
+  <script type="text/javascript" src="syncthing/core/pushNotificationsService.js"></script>
   <script type="text/javascript" src="syncthing/core/selectOnClickDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/syncthingController.js"></script>
   <script type="text/javascript" src="syncthing/core/tooltipDirective.js"></script>

--- a/gui/default/syncthing/core/pushNotificationsService.js
+++ b/gui/default/syncthing/core/pushNotificationsService.js
@@ -1,5 +1,5 @@
 angular.module('syncthing.core')
-    .service('PushNotifications', ['Events', function (Events) {
+    .service('PushNotifications', function() {
         'use strict';
 
         var self = this;
@@ -14,39 +14,23 @@ angular.module('syncthing.core')
             return true;
         }
 
-        function detectLocalStorage() {
-            // Feature detect localStorage; https://mathiasbynens.be/notes/localstorage-pattern
-            try {
-                var uid = new Date();
-                var storage = window.localStorage;
-                storage.setItem(uid, uid);
-                storage.removeItem(uid);
-                return storage;
-            } catch (exception) {
-                return undefined;
-            }
-        }
-
-        var _localStorage = detectLocalStorage();
-        var _SYNPN = "SYN_PN"; // const key for localStorage
-
         angular.extend(self, {
+            enabled: null,
             isEnabled: function () {
-                return  self.isSupported() &&_localStorage && _localStorage[_SYNPN] === 'true'
+                return self.isSupported() && self.enabled;
             },
-            setEnabled: function (enabled) {
-                if (!_localStorage || !self.isSupported()) return;
+            setEnabled: function (newEnabled) {
+                if(!self.isSupported()) return;
 
-                var showWelcomeNotification = false;
-                if (enabled && !self.isEnabled())
-                    showWelcomeNotification = true;
+                console.log('setNotifications', newEnabled);
 
-                _localStorage[_SYNPN] = enabled;
+                if (newEnabled && self.enabled === false)
+                    self.notify('Notifications will be shown like this');
 
-                if (showWelcomeNotification) self.notify('Notifications will be shown like this')
+                self.enabled = newEnabled;
             },
-            isSupported: function() {
-              return "Notification" in window && Notification.permission !== 'denied';
+            isSupported: function () {
+                return "Notification" in window && Notification.permission !== 'denied';
             },
             checkPermission: function () {
                 function handlePermission(permission) {
@@ -58,7 +42,7 @@ angular.module('syncthing.core')
 
                 return new Promise(function (resolve) {
                     // Let's check if the browser supports notifications and user has enabled them
-                   if (!self.isEnabled() || !self.isSupported()) {
+                    if (!self.isEnabled() || !self.isSupported()) {
                         resolve(false)
                     } else {
                         // Check if browser uses Promises or callbacks (Safari)
@@ -83,4 +67,4 @@ angular.module('syncthing.core')
                 })
             }
         })
-    }]);
+    });

--- a/gui/default/syncthing/core/pushNotificationsService.js
+++ b/gui/default/syncthing/core/pushNotificationsService.js
@@ -1,0 +1,86 @@
+angular.module('syncthing.core')
+    .service('PushNotifications', ['Events', function (Events) {
+        'use strict';
+
+        var self = this;
+
+        function checkNotificationPromise() {
+            try {
+                Notification.requestPermission().then();
+            } catch (e) {
+                return false;
+            }
+
+            return true;
+        }
+
+        function detectLocalStorage() {
+            // Feature detect localStorage; https://mathiasbynens.be/notes/localstorage-pattern
+            try {
+                var uid = new Date();
+                var storage = window.localStorage;
+                storage.setItem(uid, uid);
+                storage.removeItem(uid);
+                return storage;
+            } catch (exception) {
+                return undefined;
+            }
+        }
+
+        var _localStorage = detectLocalStorage();
+        var _SYNPN = "SYN_PN"; // const key for localStorage
+
+        angular.extend(self, {
+            isEnabled: function () {
+                return  self.isSupported() &&_localStorage && _localStorage[_SYNPN] === 'true'
+            },
+            setEnabled: function (enabled) {
+                if (!_localStorage || !self.isSupported()) return;
+
+                var showWelcomeNotification = false;
+                if (enabled && !self.isEnabled())
+                    showWelcomeNotification = true;
+
+                _localStorage[_SYNPN] = enabled;
+
+                if (showWelcomeNotification) self.notify('Notifications will be shown like this')
+            },
+            isSupported: function() {
+              return "Notification" in window && Notification.permission !== 'denied';
+            },
+            checkPermission: function () {
+                function handlePermission(permission) {
+                    // Whatever the user answers, we make sure Chrome stores the information
+                    if (!('permission' in Notification)) {
+                        Notification.permission = permission;
+                    }
+                }
+
+                return new Promise(function (resolve) {
+                    // Let's check if the browser supports notifications and user has enabled them
+                   if (!self.isEnabled() || !self.isSupported()) {
+                        resolve(false)
+                    } else {
+                        // Check if browser uses Promises or callbacks (Safari)
+                        if (checkNotificationPromise()) {
+                            Notification.requestPermission()
+                                .then((permission) => {
+                                    handlePermission(permission);
+                                    resolve(permission === 'granted');
+                                })
+                        } else {
+                            Notification.requestPermission(function (permission) {
+                                handlePermission(permission);
+                                resolve(permission === 'granted');
+                            });
+                        }
+                    }
+                })
+            },
+            notify: function (message) {
+                self.checkPermission().then(function (canNotify) {
+                    if (canNotify) new Notification('Syncthing', {body: message});
+                })
+            }
+        })
+    }]);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -267,6 +267,12 @@ angular.module('syncthing.core')
             }
 
             PushNotifications.setEnabled($scope.config.gui.enableNotifications);
+
+            $scope.config.devices.forEach(function(device) {
+                device.pendingFolders.forEach(function(pendingFolder) {
+                    PushNotifications.notify(`${device.name} want to share folder "${pendingFolder.label}" (${pendingFolder.id})`);
+                });
+            });
         });
 
         $scope.$on(Events.CONFIG_SAVED, function (event, arg) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -54,6 +54,7 @@ angular.module('syncthing.core')
         $scope.folderPathErrors = {};
         $scope.currentFolder = {};
         resetRemoteNeed();
+        $scope.deviceNeeds = {};
 
         try {
             $scope.metricRates = (window.localStorage["metricRates"] == "true");
@@ -508,6 +509,17 @@ angular.module('syncthing.core')
                 needed += $scope.completion[device][folder].needBytes;
                 items += $scope.completion[device][folder].needItems;
                 deletes += $scope.completion[device][folder].needDeletes;
+
+                if (!$scope.deviceNeeds[device])
+                    $scope.deviceNeeds[device] = {};
+                if (!$scope.deviceNeeds[device][folder])
+                    $scope.deviceNeeds[device][folder] = 0;
+
+                if (items == 0 && $scope.deviceNeeds[device][folder] > 0) {
+                    PushNotifications.notify(`Sent ${$scope.deviceNeeds[device][folder]} items to ${$scope.friendlyNameFromID(device)} from folder ${$scope.folders[folder].label}.`);
+                    $scope.deviceNeeds[device][folder] = 0;
+                } else
+                    $scope.deviceNeeds[device][folder] = Math.max($scope.deviceNeeds[device][folder], items);
             }
             if (total == 0) {
                 $scope.completion[device]._total = 100;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -265,6 +265,8 @@ angular.module('syncthing.core')
                     }
                 }
             }
+
+            PushNotifications.setEnabled($scope.config.gui.enableNotifications);
         });
 
         $scope.$on(Events.CONFIG_SAVED, function (event, arg) {
@@ -380,7 +382,6 @@ angular.module('syncthing.core')
             $scope.config.options._globalAnnounceServersStr = $scope.config.options.globalAnnounceServers.join(', ');
             $scope.config.options._urAcceptedStr = "" + $scope.config.options.urAccepted;
 
-            $scope.config.gui._enableNotifications = PushNotifications.isEnabled();
             $scope.config.gui._supportNotifications = PushNotifications.isSupported();
 
             $scope.devices = $scope.config.devices;
@@ -1341,7 +1342,7 @@ angular.module('syncthing.core')
                 }
 
                 // Save push notifications preferences in LocalStorage
-                PushNotifications.setEnabled($scope.tmpGUI._enableNotifications);
+                PushNotifications.setEnabled($scope.tmpGUI.enableNotifications);
 
                 // Parse strings to arrays before copying over
                 ['listenAddresses', 'globalAnnounceServers'].forEach(function (key) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -156,7 +156,7 @@ angular.module('syncthing.core')
             $('#networkError').modal('hide');
             $('#restarting').modal('hide');
             $('#shutdown').modal('hide');
-            PushNotifications.notify('App is back online');
+            PushNotifications.notify($translate.instant('App is back online'));
         });
 
         $scope.$on(Events.OFFLINE, function () {
@@ -168,7 +168,7 @@ angular.module('syncthing.core')
             online = false;
             if (!restarting) {
                 $('#networkError').modal();
-                PushNotifications.notify('App is offline ;(')
+                PushNotifications.notify($translate.instant('App is offline'));
             }
         });
 
@@ -209,7 +209,7 @@ angular.module('syncthing.core')
                 }
 
                 if (['syncing', 'sync-preparing'].includes(data.from) && data.to === 'idle') {
-                    PushNotifications.notify(`Folder ${$scope.folders[data.folder].label} was synced`)
+                    PushNotifications.notify($translate.instant(`Folder ${$scope.folders[data.folder].label} was synced`))
                 }
 
                 // If a folder finished scanning, then refresh folder stats
@@ -269,9 +269,9 @@ angular.module('syncthing.core')
 
             PushNotifications.setEnabled($scope.config.gui.enableNotifications);
 
-            $scope.config.devices.forEach(function(device) {
-                device.pendingFolders.forEach(function(pendingFolder) {
-                    PushNotifications.notify(`${device.name} want to share folder "${pendingFolder.label}" (${pendingFolder.id})`);
+            $scope.config.devices.forEach(function (device) {
+                device.pendingFolders.forEach(function (pendingFolder) {
+                    PushNotifications.notify($translate.instant(`${device.name} want to share folder "${pendingFolder.label}" (${pendingFolder.id})`));
                 });
             });
         });
@@ -516,7 +516,7 @@ angular.module('syncthing.core')
                     $scope.deviceNeeds[device][folder] = 0;
 
                 if (items == 0 && $scope.deviceNeeds[device][folder] > 0) {
-                    PushNotifications.notify(`Sent ${$scope.deviceNeeds[device][folder]} items to ${$scope.friendlyNameFromID(device)} from folder ${$scope.folders[folder].label}.`);
+                    PushNotifications.notify($translate.instant(`Sent ${$scope.deviceNeeds[device][folder]} items to ${$scope.friendlyNameFromID(device)} from folder ${$scope.folders[folder].label}.`));
                     $scope.deviceNeeds[device][folder] = 0;
                 } else
                     $scope.deviceNeeds[device][folder] = Math.max($scope.deviceNeeds[device][folder], items);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -380,8 +380,8 @@ angular.module('syncthing.core')
             $scope.config.options._globalAnnounceServersStr = $scope.config.options.globalAnnounceServers.join(', ');
             $scope.config.options._urAcceptedStr = "" + $scope.config.options.urAccepted;
 
-            $scope.config.gui.enableNotifications = PushNotifications.isEnabled();
-            $scope.config.gui.supportNotifications = PushNotifications.isSupported();
+            $scope.config.gui._enableNotifications = PushNotifications.isEnabled();
+            $scope.config.gui._supportNotifications = PushNotifications.isSupported();
 
             $scope.devices = $scope.config.devices;
             $scope.devices.forEach(function (deviceCfg) {
@@ -1341,7 +1341,7 @@ angular.module('syncthing.core')
                 }
 
                 // Save push notifications preferences in LocalStorage
-                PushNotifications.setEnabled($scope.tmpGUI.enableNotifications);
+                PushNotifications.setEnabled($scope.tmpGUI._enableNotifications);
 
                 // Parse strings to arrays before copying over
                 ['listenAddresses', 'globalAnnounceServers'].forEach(function (key) {

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -259,9 +259,9 @@
               <div class="form-group">
                 <div class="checkbox">
                   <label>
-                    <input id="EnableNotifications" type="checkbox" ng-model="tmpGUI.enableNotifications" ng-disabled="!tmpGUI.supportNotifications" /> <span translate>Enable push notifications</span>
+                    <input id="EnableNotifications" type="checkbox" ng-model="tmpGUI._enableNotifications" ng-disabled="!tmpGUI._supportNotifications" /> <span translate>Enable push notifications</span>
                   </label>
-                  <p class="help-block" ng-if="!tmpGUI.supportNotifications">
+                  <p class="help-block" ng-if="!tmpGUI._supportNotifications">
                     <span translate>Your browser do not support push notifications or your blocked them</span>
                   </p>
                 </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -256,6 +256,16 @@
               </div>
             </div>
             <div class="col-md-6">
+              <div class="form-group">
+                <div class="checkbox">
+                  <label>
+                    <input id="EnableNotifications" type="checkbox" ng-model="tmpGUI.enableNotifications" ng-disabled="!tmpGUI.supportNotifications" /> <span translate>Enable push notifications</span>
+                  </label>
+                  <p class="help-block" ng-if="!tmpGUI.supportNotifications">
+                    <span translate>Your browser do not support push notifications or your blocked them</span>
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -259,7 +259,7 @@
               <div class="form-group">
                 <div class="checkbox">
                   <label>
-                    <input id="EnableNotifications" type="checkbox" ng-model="tmpGUI._enableNotifications" ng-disabled="!tmpGUI._supportNotifications" /> <span translate>Enable push notifications</span>
+                    <input id="EnableNotifications" type="checkbox" ng-model="tmpGUI.enableNotifications" ng-disabled="!tmpGUI._supportNotifications" /> <span translate>Enable push notifications</span>
                   </label>
                   <p class="help-block" ng-if="!tmpGUI._supportNotifications">
                     <span translate>Your browser do not support push notifications or your blocked them</span>

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -27,7 +27,7 @@ type GUIConfiguration struct {
 	Debugging                 bool     `xml:"debugging,attr" json:"debugging"`
 	InsecureSkipHostCheck     bool     `xml:"insecureSkipHostcheck,omitempty" json:"insecureSkipHostcheck"`
 	InsecureAllowFrameLoading bool     `xml:"insecureAllowFrameLoading,omitempty" json:"insecureAllowFrameLoading"`
-	EnableNotifications 	  bool     `xml:"enableNotifications,omitempty" json:"enableNotifications"`
+	EnableNotifications       bool     `xml:"enableNotifications,omitempty" json:"enableNotifications"`
 }
 
 func (c GUIConfiguration) IsAuthEnabled() bool {

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -27,6 +27,7 @@ type GUIConfiguration struct {
 	Debugging                 bool     `xml:"debugging,attr" json:"debugging"`
 	InsecureSkipHostCheck     bool     `xml:"insecureSkipHostcheck,omitempty" json:"insecureSkipHostcheck"`
 	InsecureAllowFrameLoading bool     `xml:"insecureAllowFrameLoading,omitempty" json:"insecureAllowFrameLoading"`
+	EnableNotifications 	  bool     `xml:"enableNotifications,omitempty" json:"enableNotifications"`
 }
 
 func (c GUIConfiguration) IsAuthEnabled() bool {


### PR DESCRIPTION
### Purpose

Implement native browser push notifications on some important events. Closes #5329.

### Status

For now notifications are handled client-side, the tab must be always open (but not necessarily visible) to receive notifications.

#### Events
As discussed [here](https://github.com/syncthing/syncthing/issues/5329#issuecomment-457835519) some events need to be notified to user.
Here the status of implementation

| Event  | Status | Comments |
| --- | --- | --- |
|  GUI looses connection to Syncthing | ✔ | Also notify when connection is restored
| A error has occurred on the GUI-side (e.g. parsing error when reading the JSON returned by Syncthing's API) | ✔ | Same as network connection losing |
| A notification has been emitted through Syncthing's API (yes, there's already an API for that) | x 
| The synchronization of a local folder has been completed | ✔ 
| The synchronization of a remote folder on device X has been completed | ✔
| A new device wants to connect | x
| A device wants to share a folder | ✔

#### Global

- [x] Add option in setting panel
- [x] Make notifications messages translatable
- [ ] Allow user to filter shown notifications types

### Screenshots

Note: Notifications are shown by the browser and the operating system. Depending of these the style could be different of mine. If you already saw notifications from a website, it will be shown like these.

![screencapture-127-0-0-1-8384-2019-12-28-16_16_34](https://user-images.githubusercontent.com/6941014/71545620-9844e180-298d-11ea-9f05-7ca081ec2f37.png)
![image](https://user-images.githubusercontent.com/6941014/73135041-1b656000-403e-11ea-8877-5314f9d6dd02.png)
![image](https://user-images.githubusercontent.com/6941014/73135050-32a44d80-403e-11ea-959f-a150a7a39b89.png)


### Testing

First, you need to enable notifications in settings panel as show in the screenshot above.
I your browser doesn't support push notification or you've blocked them, the checkbox is disabled.

A notification is shown when :

- The GUI lost connection with the server: turn off the server
- The GUI restore the connection with the server : turn back on the server
- A local folder finish syncing: Add a file on another device in the shared folder 
- A device wants to share a folder: Share a folder from another device. A notification is shown as the GUI alert appears
- The synchronization of a remote folder on device X has been completed : Create a reasonably large file (if it is too small GUI doesn't have time to detect it before it was synced) on your local computed and wait until it was synced to a remote device. You can use `dd if=/dev/random bs=1024 count=50000 iflag=fullblock` to create a 50MB file with random bytes.

I've drafted this PR to have feedback on implementations and priorities before going too deeper in it.
I'll be happy to here back from you about this feature.

