### PR TITLE
gui, lib/model: Prevent negative sync completion (fixes #4570)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -849,10 +849,15 @@ angular.module('syncthing.core')
             if (typeof $scope.model[folder] === 'undefined') {
                 return 100;
             }
-            if ($scope.model[folder].globalBytes === 0) {
+            if ($scope.model[folder].needTotalItems === 0) {
                 return 100;
             }
-
+            if ($scope.model[folder].needBytes == 0 && $scope.model[folder].needDeletes > 0) {
+                // We don't need any data, but we have deletes that we need
+                // to do. Drop down the completion percentage to indicate
+                // that we have stuff to do.
+                return 95;
+            }
             var pct = 100 * $scope.model[folder].inSyncBytes / $scope.model[folder].globalBytes;
             return Math.floor(pct);
         };

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -894,6 +894,11 @@ func (m *model) NeedSize(folder string) db.Counts {
 		})
 	}
 	result.Bytes -= m.progressEmitter.BytesCompleted(folder)
+	// This may happen if we are in progress of pulling files that were
+	// deleted globally after the pull started.
+	if result.Bytes < 0 {
+		result.Bytes = 0
+	}
 	l.Debugf("%v NeedSize(%q): %v", m, folder, result)
 	return result
 }


### PR DESCRIPTION
Another shot at the problem coming up every now and then (https://github.com/syncthing/syncthing/issues/4570 for history and https://forum.syncthing.net/t/syncing-percentage-out-of-scale/14249 for the most recent case). It does two things: In the folder summary make sure the reported needed bytes is never negative and in the web UI use the same logic as on remote device, i.e. when there's deletes only display 95%. As to why the needed bytes should be negative:

> This is essentially files becoming deleted while they are being downloaded.  
> https://forum.syncthing.net/t/syncing-percentage-out-of-scale/14249/2

As for testing: None. However it sounds plausible and even if it isn't actually the cause, it's a good safety measure in my opinion. If negative percentages come up again we can always reopen the issue and start thinking again :)