### PR TITLE
lib/model: Reset queue after all pulling is done (fixes #5867)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -302,12 +302,12 @@ func (f *sendReceiveFolder) pullerIteration(scanChan chan<- string) int {
 	f.oldPullErrors = nil
 	f.pullErrorsMut.Unlock()
 
+	f.queue.Reset()
+
 	return changed
 }
 
 func (f *sendReceiveFolder) processNeeded(dbUpdateChan chan<- dbUpdateJob, copyChan chan<- copyBlocksState, scanChan chan<- string) (int, map[string]protocol.FileInfo, []protocol.FileInfo, error) {
-	defer f.queue.Reset()
-
 	changed := 0
 	var dirDeletions []protocol.FileInfo
 	fileDeletions := map[string]protocol.FileInfo{}


### PR DESCRIPTION
### Purpose

As @AndrewSav stated in https://github.com/syncthing/syncthing/pull/5626#discussion_r363060566 (thanks for the persistence) the queue was reset too early, i.e. when the last files enter the copiers they are still in progress, but as `processNeeded` returns, they are no longer in the queue.

### Testing

Added a new test that checks that there is an item in progress for a single item.