### PR TITLE
lib/config: Add some info to the folder marker missing (ref #5207)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -23,7 +23,7 @@ import (
 var (
 	ErrPathNotDirectory = errors.New("folder path not a directory")
 	ErrPathMissing      = errors.New("folder path missing")
-	ErrMarkerMissing    = errors.New("folder marker missing")
+	ErrMarkerMissing    = errors.New("folder marker missing (this indicates potential data loss, search docs/forum to get information about how to proceed)")
 )
 
 const DefaultMarkerName = ".stfolder"

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1610,7 +1610,7 @@ func TestROScanRecovery(t *testing.T) {
 
 	testOs.Mkdir(fcfg.Path, 0700)
 
-	waitForState(t, sub, "default", "folder marker missing")
+	waitForState(t, sub, "default", config.ErrMarkerMissing.Error())
 
 	fd := testOs.Create(filepath.Join(fcfg.Path, config.DefaultMarkerName))
 	fd.Close()
@@ -1619,7 +1619,7 @@ func TestROScanRecovery(t *testing.T) {
 
 	testOs.Remove(filepath.Join(fcfg.Path, config.DefaultMarkerName))
 
-	waitForState(t, sub, "default", "folder marker missing")
+	waitForState(t, sub, "default", config.ErrMarkerMissing.Error())
 
 	testOs.Remove(fcfg.Path)
 
@@ -1663,7 +1663,7 @@ func TestRWScanRecovery(t *testing.T) {
 
 	testOs.Mkdir(fcfg.Path, 0700)
 
-	waitForState(t, sub, "default", "folder marker missing")
+	waitForState(t, sub, "default", config.ErrMarkerMissing.Error())
 
 	fd := testOs.Create(filepath.Join(fcfg.Path, config.DefaultMarkerName))
 	fd.Close()
@@ -1672,7 +1672,7 @@ func TestRWScanRecovery(t *testing.T) {
 
 	testOs.Remove(filepath.Join(fcfg.Path, config.DefaultMarkerName))
 
-	waitForState(t, sub, "default", "folder marker missing")
+	waitForState(t, sub, "default", config.ErrMarkerMissing.Error())
 
 	testOs.Remove(fcfg.Path)
 


### PR DESCRIPTION
What should really happen is good documentation on the folder marker, why it's there and what it's disappearance, and then put a link to that into the error message. However I don't have the time for that and don't particularly feel like it either, especially after the insistent, and in my totally personal, potentially entirely unjustified view, quite entitled demand for a "solution. Nevertheless this has been on my todo list so I'd like to at least do a partial solution (and hey, maybe it actually happens for once that someone else than a maintainer steps up to write that particular bit of documentation that is so important (I agree)).