### PR TITLE
lib/model: Return paused summary instead of error on paused folders

### DIFF
--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -78,8 +78,8 @@ func (c *folderSummaryService) Summary(folder string) (map[string]interface{}, e
 	var res = make(map[string]interface{})
 
 	errors, err := c.model.FolderErrors(folder)
-	if err != nil && err != ErrFolderPaused {
-		// Stats from the db can still be obtained if the folder is just paused
+	if err != nil && err != ErrFolderPaused && err != errFolderNotRunning {
+		// Stats from the db can still be obtained if the folder is just paused/being started
 		return nil, err
 	}
 	res["errors"] = len(errors)


### PR DESCRIPTION
See https://forum.syncthing.net/t/rest-db-status-returns-404-on-startup/14329

If the api starts while the folder is not yet running or generally when querying `/rest/db/status` for a an about to be started folder, we return a 404. Now it is treated the same as a paused folder, i.e. send a valid folder summary. However the comment was wrong: We can't get any info from db for a paused folder, nevertheless it's important to get valid entries with zero values, otherwise the UI blows up.