### PR TITLE
lib/syncthing: Wait for actual termination on Stop()

### DIFF
--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -404,6 +404,7 @@ func (a *App) stopWithErr(stopReason ExitStatus, err error) ExitStatus {
 		a.err = err
 		close(a.stop)
 	})
+	<-a.stopped
 	return a.exitStatus
 }
 


### PR DESCRIPTION
<strike>When Syncthing is stopped externally (i.e. ctrl-c or signal), it is immediately terminated instead of waiting for service and db shutdown.</strike> This is not true: Due to the wait call in main we do not terminate immediately - <strike>I don't know what weird experiments I did before that made me believe it did</strike> I likely stumbled over https://github.com/syncthing/syncthing/issues/4774 (unrelated). Anyway I still think it is the right thing to do to only return from `Stop` once the app has fully terminated in terms of "least surprising behaviour".