### PR TITLE
cmd/syncthing: Always use monitor process (fixes #4774, fixes #5786)

### DIFF
--- a/etc/linux-desktop/syncthing-start.desktop
+++ b/etc/linux-desktop/syncthing-start.desktop
@@ -2,7 +2,7 @@
 Name=Start Syncthing
 GenericName=File synchronization
 Comment=Starts the main syncthing process in the background.
-Exec=/usr/bin/syncthing -no-browser
+Exec=/usr/bin/syncthing -no-browser -logfile=~/.config/syncthing/syncthing.log
 Icon=syncthing
 Terminal=false
 Type=Application


### PR DESCRIPTION
### Purpose

Syncthing is now always run through a monitor process. Reasons found in #5786 and it also fixes #4774 as predicted there :)

This will lead to a >20% increase in reports to sentry (according to data.syncthing.net and assuming most apt/arch/fedora/... use some kind of service manager) and an initial spike of old reports, just in case that needs some precautionary measures.

I also took the opportunity to add logging to the desktop entry (also tested to work).

### Testing

I manually tested the following that without `-no-restart` it restarts on ctrl-c in subshell, on restart in UI and on auto-update and it does not restart on shutdown in UI, and with `-no-restart` it doesn't restart in any of the aforementioned cases.