### PR TITLE
[WIP] View included files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ stage/
 *.snap
 *.bz2
 /repos
+.idea/

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,8 @@ require (
 	github.com/maruel/panicparse v1.3.0
 	github.com/mattn/go-isatty v0.0.11
 	github.com/minio/sha256-simd v0.1.1
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/onsi/ginkgo v1.9.0 // indirect
 	github.com/onsi/gomega v1.6.0 // indirect
 	github.com/oschwald/geoip2-golang v1.4.0

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -206,6 +206,11 @@ table.table-auto td {
     margin-bottom: 0.25em;
 }
 
+#folderFiles .modal-body {
+    height: 300px;
+    overflow-y: scroll;
+}
+
 button.panel-heading {
     display: block;
     position: relative;
@@ -414,4 +419,12 @@ ul.three-columns li, ul.two-columns li {
     .btn:not(.panel-heading) + .btn:not(.panel-heading) {
         margin-bottom: 1rem;
     }
+
+    #folderFiles .modal-header {
+        min-height: 74px;
+    }
+}
+
+#folderFiles .modal-header {
+    min-height: 64px;
 }

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -495,7 +495,7 @@
                       <th><span class="fas fa-fw fa-copy"></span>&nbsp;<span translate>Shared files</span></th>
                       <td class="text-right">
                         <span>
-                          <a href="" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolder(folder.id)">show</a>
+                          <a href="" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolderAndGetContents(folder.id)">show</a>
                         </span>
                       </td>
                     </tr>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -495,7 +495,8 @@
                       <th><span class="fas fa-fw fa-copy"></span>&nbsp;<span translate>Shared files</span></th>
                       <td class="text-right">
                         <span>
-                          <a href="" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolderAndGetContents(folder.id)">show</a>
+                          <a href="#" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolderAndGetContents(folder.id, '')">show</a>
+                        <a href="#" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolderAndGetContents(folder.id, 'neh2')">show neh2</a>
                         </span>
                       </td>
                     </tr>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -492,7 +492,7 @@
                       </td>
                     </tr>
                     <tr>
-                      <th><span class="fas fa-fw fa-copy"></span>&nbsp;<span translate>Shared files</span></th>
+                      <th><span class="fas fa-fw fa-copy"></span>&nbsp;<span translate>Included files</span></th>
                       <td class="text-right">
                         <span>
                           <a href="#" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolderAndGetContents(folder.id, '')">show</a>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -491,6 +491,14 @@
                         </span>
                       </td>
                     </tr>
+                    <tr>
+                      <th><span class="fas fa-fw fa-copy"></span>&nbsp;<span translate>Shared files</span></th>
+                      <td class="text-right">
+                        <span>
+                          <a href="" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolder(folder.id)">show</a>
+                        </span>
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
               </div>
@@ -832,6 +840,7 @@
   <ng-include src="'syncthing/folder/editFolderModalView.html'"></ng-include>
   <ng-include src="'syncthing/folder/restoreVersionsModalView.html'"></ng-include>
   <ng-include src="'syncthing/folder/restoreVersionsConfirmation.html'"></ng-include>
+  <ng-include src="'syncthing/folder/folderFilesModalView.html'"></ng-include>
   <ng-include src="'syncthing/settings/settingsModalView.html'"></ng-include>
   <ng-include src="'syncthing/settings/advancedSettingsModalView.html'"></ng-include>
   <ng-include src="'syncthing/settings/discardChangesConfirmation.html'"></ng-include>
@@ -885,6 +894,7 @@
   <script type="text/javascript" src="syncthing/core/tooltipDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/uncamelFilter.js"></script>
   <script type="text/javascript" src="syncthing/core/uniqueFolderDirective.js"></script>
+  <script type="text/javascript" src="syncthing/core/treeViewDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/validDeviceidDirective.js"></script>
   <script type="text/javascript" src="assets/lang/valid-langs.js"></script>
   <script type="text/javascript" src="assets/lang/prettyprint.js"></script>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -496,7 +496,6 @@
                       <td class="text-right">
                         <span>
                           <a href="#" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolderAndGetContents(folder.id, '')">show</a>
-                        <a href="#" data-toggle="modal" data-target="#folderFiles" ng-click="setCurrentFolderAndGetContents(folder.id, 'neh2')">show neh2</a>
                         </span>
                       </td>
                     </tr>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1098,8 +1098,7 @@ angular.module('syncthing.core')
                 $scope.parentFolderPrefix = null;
             }
 
-            let prefixArg = (prefix !== "") ? "&prefix=" + prefix.substr(1) : "";
-            $http.get(urlbase + '/db/browse?folder=' + id + "&levels=0" + prefixArg).success(function (data) {
+            $http.get(urlbase + '/db/browse?folder=' + id + "&levels=0&prefix=" + prefix.substr(1)).success(function (data) {
                 $scope.currentFolder.content = data;
             }).error($scope.emitHTTPError);
         };

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1085,11 +1085,9 @@ angular.module('syncthing.core')
         };
 
         $scope.setCurrentFolderAndGetContents = function (id) {
-            console.log("going to fetch data from controller")
             $scope.currentFolder = angular.copy($scope.folders[id]);
-            $http.get(urlbase + '/db/browse?folder=' + id + "&levels=0").success(function (data) {
+            $http.get(urlbase + '/db/browse?folder=' + id + "&levels=3").success(function (data) {
                 $scope.currentFolder.content = data;
-                console.log("Data: ", data)
             }).error($scope.emitHTTPError);
         };
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1085,9 +1085,11 @@ angular.module('syncthing.core')
         };
 
         $scope.setCurrentFolderAndGetContents = function (id) {
+            console.log("going to fetch data from controller")
             $scope.currentFolder = angular.copy($scope.folders[id]);
-            $http.get(urlbase + '/rest/db/browse').success(function (data) {
+            $http.get(urlbase + '/db/browse?folder=' + id + "&levels=0").success(function (data) {
                 $scope.currentFolder.content = data;
+                console.log("Data: ", data)
             }).error($scope.emitHTTPError);
         };
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -53,8 +53,8 @@ angular.module('syncthing.core')
         $scope.metricRates = false;
         $scope.folderPathErrors = {};
         $scope.currentFolder = {};
-        $scope.currentPath = '';
-        $scope.backPath = '';
+        $scope.currentFolderPrefix = '';
+        $scope.parentFolderPrefix = null;
 
         resetRemoteNeed();
 
@@ -1088,25 +1088,17 @@ angular.module('syncthing.core')
         };
 
         $scope.setCurrentFolderAndGetContents = function (id, prefix) {
-            console.log($scope.folders);
-            console.log("id", id, "prefix", prefix);
-
-            $scope.currentPath = prefix;
+            $scope.currentFolderPrefix = prefix;
             $scope.currentFolder = angular.copy($scope.folders[id]);
 
             let position = prefix.lastIndexOf("/");
             if (position !== -1) {
-                $scope.backPath = prefix.substr(0, position);
+                $scope.parentFolderPrefix = prefix.substr(0, position);
+            } else {
+                $scope.parentFolderPrefix = null;
             }
 
-            $scope.currentFolder.topLevel = true;
-            let prefixArg = "";
-
-            if (prefix !== "") {
-                $scope.currentFolder.topLevel = false;
-                prefixArg = "&prefix=" + prefix.substr(1);
-            }
-
+            let prefixArg = (prefix !== "") ? "&prefix=" + prefix.substr(1) : "";
             $http.get(urlbase + '/db/browse?folder=' + id + "&levels=0" + prefixArg).success(function (data) {
                 $scope.currentFolder.content = data;
             }).error($scope.emitHTTPError);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -53,6 +53,9 @@ angular.module('syncthing.core')
         $scope.metricRates = false;
         $scope.folderPathErrors = {};
         $scope.currentFolder = {};
+        $scope.currentPath = '';
+        $scope.backPath = '';
+
         resetRemoteNeed();
 
         try {
@@ -1085,9 +1088,24 @@ angular.module('syncthing.core')
         };
 
         $scope.setCurrentFolderAndGetContents = function (id, prefix) {
+            console.log($scope.folders);
+            console.log("id", id, "prefix", prefix);
+
+            $scope.currentPath = prefix;
             $scope.currentFolder = angular.copy($scope.folders[id]);
-            $scope.currentFolder.topLevel = (prefix === "");
-            var prefixArg = (prefix !== "") ? ("&prefix=" + prefix) : "";
+
+            let position = prefix.lastIndexOf("/");
+            if (position !== -1) {
+                $scope.backPath = prefix.substr(0, position);
+            }
+
+            $scope.currentFolder.topLevel = true;
+            let prefixArg = "";
+
+            if (prefix !== "") {
+                $scope.currentFolder.topLevel = false;
+                prefixArg = "&prefix=" + prefix.substr(1);
+            }
 
             $http.get(urlbase + '/db/browse?folder=' + id + "&levels=0" + prefixArg).success(function (data) {
                 $scope.currentFolder.content = data;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1084,6 +1084,13 @@ angular.module('syncthing.core')
             return deviceID.substr(0, 6);
         };
 
+        $scope.setCurrentFolderAndGetContents = function (id) {
+            $scope.currentFolder = angular.copy($scope.folders[id]);
+            $http.get(urlbase + '/rest/db/browse').success(function (data) {
+                $scope.currentFolder.content = data;
+            }).error($scope.emitHTTPError);
+        };
+
         $scope.findDevice = function (deviceID) {
             var matches = $scope.devices.filter(function (n) {
                 return n.deviceID === deviceID;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1084,9 +1084,12 @@ angular.module('syncthing.core')
             return deviceID.substr(0, 6);
         };
 
-        $scope.setCurrentFolderAndGetContents = function (id) {
+        $scope.setCurrentFolderAndGetContents = function (id, prefix) {
             $scope.currentFolder = angular.copy($scope.folders[id]);
-            $http.get(urlbase + '/db/browse?folder=' + id + "&levels=3").success(function (data) {
+            $scope.currentFolder.topLevel = (prefix === "");
+            var prefixArg = (prefix !== "") ? ("&prefix=" + prefix) : "";
+
+            $http.get(urlbase + '/db/browse?folder=' + id + "&levels=0" + prefixArg).success(function (data) {
                 $scope.currentFolder.content = data;
             }).error($scope.emitHTTPError);
         };

--- a/gui/default/syncthing/core/treeViewDirective.js
+++ b/gui/default/syncthing/core/treeViewDirective.js
@@ -1,4 +1,23 @@
 angular.module('syncthing.core')
-    .directive('treeElement', function ($compile) {
-        //todo: handle directive
-})
+    .directive('treeElement', function () {
+        return {
+            restrict: 'EA',
+            scope: {
+                isDirectory: "=",
+                name: "@",
+                folderId: "@"
+            },
+            template: `
+                <div ng-if="isDirectory">
+                    <a href="#" ng-click="setCurrentFolderAndGetContents(folderId, name)">
+                        <span style="margin:10px;" class="fas fa-folder"></span>
+                        <span>{{name}}</span>
+                    </a>
+                </div>
+                <div ng-if="!isDirectory">
+                    <span style="margin:10px;" class="fas fa-file"></span>
+                    <span>{{name}}</span>
+                </div>
+            `
+        }
+});

--- a/gui/default/syncthing/core/treeViewDirective.js
+++ b/gui/default/syncthing/core/treeViewDirective.js
@@ -5,11 +5,11 @@ angular.module('syncthing.core')
             scope: {
                 isDirectory: "=",
                 name: "@",
-                folderId: "@"
+                show: "&",
             },
             template: `
                 <div ng-if="isDirectory">
-                    <a href="#" ng-click="setCurrentFolderAndGetContents(folderId, name)">
+                    <a href="#" ng-click="show()">
                         <span style="margin:10px;" class="fas fa-folder"></span>
                         <span>{{name}}</span>
                     </a>

--- a/gui/default/syncthing/core/treeViewDirective.js
+++ b/gui/default/syncthing/core/treeViewDirective.js
@@ -1,0 +1,4 @@
+angular.module('syncthing.core')
+    .directive('treeElement', function ($compile) {
+        //todo: handle directive
+})

--- a/gui/default/syncthing/core/treeViewDirective.js
+++ b/gui/default/syncthing/core/treeViewDirective.js
@@ -3,19 +3,23 @@ angular.module('syncthing.core')
         return {
             restrict: 'EA',
             scope: {
-                isDirectory: "=",
+                fileType: "=",
                 name: "@",
                 show: "&",
             },
             template: `
-                <div ng-if="isDirectory">
+                <div ng-if="fileType === 0">
+                    <span style="margin:10px;" class="fas fa-file"></span>
+                    <span>{{name}}</span>
+                </div>
+                <div ng-if="fileType === 1">
                     <a href="#" ng-click="show()">
                         <span style="margin:10px;" class="fas fa-folder"></span>
                         <span>{{name}}</span>
                     </a>
                 </div>
-                <div ng-if="!isDirectory">
-                    <span style="margin:10px;" class="fas fa-file"></span>
+                <div ng-if="fileType === 4">
+                    <span style="margin:10px;" class="fa fa-link"></span>
                     <span>{{name}}</span>
                 </div>
             `

--- a/gui/default/syncthing/folder/folderFilesModalView.html
+++ b/gui/default/syncthing/folder/folderFilesModalView.html
@@ -1,20 +1,25 @@
-<modal id="folderFiles" status="default" icon="fas fa-cog" heading="{{'Files setup' | translate}}" large="yes" closeable="yes">
-    <div className="modal-body">
-        <table className="table table-condensed table-striped table-auto">
+<modal id="folderFiles" status="default" icon="fas fa-cog" heading="{{'Included files' | translate}}" large="yes" closeable="yes">
+    <div class="modal-body">
+        <table class="table table-condensed table-striped table-auto">
             <tbody>
             <tr ng-repeat="file in currentFolder.content">
-                <th>{{file}}</th>
-                <th></th>
+                <td tree-element
+                    is-directory="file.isDirectory"
+                    name="{{file.name}}"
+                    folder-id="{{currentFolder.id}}"
+                >
+                </td>
             </tr>
-            nehehehe, {{currentFolder.content}}, {{currentFolder.id}}
             </tbody>
         </table>
 
-        <tree></tree>
     </div>
-    <div className="modal-footer">
-        <button type="button" className="btn btn-default btn-sm" data-dismiss="modal">
-            <span className="fas fa-times"></span>&nbsp;<span translate>Close</span>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-default btn-sm" data-dismiss="modal" ng-if="!currentFolder.topLevel">
+            <span class="fas fa-arrow-left"></span>&nbsp;<span translate>Back</span>
+        </button>
+        <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">
+            <span class="fas fa-times"></span>&nbsp;<span translate>Close</span>
         </button>
     </div>
 </modal>

--- a/gui/default/syncthing/folder/folderFilesModalView.html
+++ b/gui/default/syncthing/folder/folderFilesModalView.html
@@ -1,0 +1,20 @@
+<modal id="folderFiles" status="default" icon="fas fa-cog" heading="{{'Files setup' | translate}}" large="yes" closeable="yes">
+    <div className="modal-body">
+        <table className="table table-condensed table-striped table-auto">
+            <tbody>
+            <tr ng-repeat="file in currentFolder.content">
+                <th>{{file}}</th>
+                <th></th>
+            </tr>
+            nehehehe
+            </tbody>
+        </table>
+
+        <tree></tree>
+    </div>
+    <div className="modal-footer">
+        <button type="button" className="btn btn-default btn-sm" data-dismiss="modal">
+            <span className="fas fa-times"></span>&nbsp;<span translate>Close</span>
+        </button>
+    </div>
+</modal>

--- a/gui/default/syncthing/folder/folderFilesModalView.html
+++ b/gui/default/syncthing/folder/folderFilesModalView.html
@@ -1,13 +1,22 @@
 <modal id="folderFiles" status="default" icon="fas fa-cog" heading="{{'Included files' | translate}}" large="yes" closeable="yes">
+    <div class="modal-header">
+        <div class="pull-left">
+            <strong ng-if="currentFolderPrefix === ''">/</strong>
+            <strong ng-if="currentFolderPrefix !== ''">{{currentFolderPrefix}}</strong>
+        </div>
+        <button type="button" class="btn btn-default btn-sm pull-right" ng-if="parentFolderPrefix !== null"
+                ng-click="setCurrentFolderAndGetContents(currentFolder.id, parentFolderPrefix)">
+            <span class="fas fa-arrow-left"></span>&nbsp;<span translate>Back</span>
+        </button>
+    </div>
     <div class="modal-body">
         <table class="table table-condensed table-striped table-auto">
             <tbody>
             <tr ng-repeat="file in currentFolder.content">
                 <td tree-element
-                    is-directory="file.isDirectory"
+                    file-type="file.fileType"
                     name="{{file.name}}"
-                    show="setCurrentFolderAndGetContents(currentFolder.id, currentFolderPrefix + '/' + file.name)"
-                >
+                    show="setCurrentFolderAndGetContents(currentFolder.id, currentFolderPrefix + '/' + file.name)">
                 </td>
             </tr>
             </tbody>
@@ -15,11 +24,6 @@
 
     </div>
     <div class="modal-footer">
-        <button type="button" class="btn btn-default btn-sm" ng-if="parentFolderPrefix !== null"
-            ng-click="setCurrentFolderAndGetContents(currentFolder.id, parentFolderPrefix)"
-        >
-            <span class="fas fa-arrow-left"></span>&nbsp;<span translate>Back</span>
-        </button>
         <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">
             <span class="fas fa-times"></span>&nbsp;<span translate>Close</span>
         </button>

--- a/gui/default/syncthing/folder/folderFilesModalView.html
+++ b/gui/default/syncthing/folder/folderFilesModalView.html
@@ -6,7 +6,7 @@
                 <th>{{file}}</th>
                 <th></th>
             </tr>
-            nehehehe
+            nehehehe, {{currentFolder.content}}, {{currentFolder.id}}
             </tbody>
         </table>
 

--- a/gui/default/syncthing/folder/folderFilesModalView.html
+++ b/gui/default/syncthing/folder/folderFilesModalView.html
@@ -6,7 +6,7 @@
                 <td tree-element
                     is-directory="file.isDirectory"
                     name="{{file.name}}"
-                    show="setCurrentFolderAndGetContents(currentFolder.id, currentPath + '/' + file.name)"
+                    show="setCurrentFolderAndGetContents(currentFolder.id, currentFolderPrefix + '/' + file.name)"
                 >
                 </td>
             </tr>
@@ -15,8 +15,8 @@
 
     </div>
     <div class="modal-footer">
-        <button type="button" class="btn btn-default btn-sm" ng-if="!currentFolder.topLevel"
-            ng-click="setCurrentFolderAndGetContents(currentFolder.id, backPath)"
+        <button type="button" class="btn btn-default btn-sm" ng-if="parentFolderPrefix !== null"
+            ng-click="setCurrentFolderAndGetContents(currentFolder.id, parentFolderPrefix)"
         >
             <span class="fas fa-arrow-left"></span>&nbsp;<span translate>Back</span>
         </button>

--- a/gui/default/syncthing/folder/folderFilesModalView.html
+++ b/gui/default/syncthing/folder/folderFilesModalView.html
@@ -6,7 +6,7 @@
                 <td tree-element
                     is-directory="file.isDirectory"
                     name="{{file.name}}"
-                    folder-id="{{currentFolder.id}}"
+                    show="setCurrentFolderAndGetContents(currentFolder.id, currentPath + '/' + file.name)"
                 >
                 </td>
             </tr>
@@ -15,7 +15,9 @@
 
     </div>
     <div class="modal-footer">
-        <button type="button" class="btn btn-default btn-sm" data-dismiss="modal" ng-if="!currentFolder.topLevel">
+        <button type="button" class="btn btn-default btn-sm" ng-if="!currentFolder.topLevel"
+            ng-click="setCurrentFolderAndGetContents(currentFolder.id, backPath)"
+        >
             <span class="fas fa-arrow-left"></span>&nbsp;<span translate>Back</span>
         </button>
         <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2455,7 +2455,9 @@ func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsonly 
 			currentPrefix = currentPrefix[:len(currentPrefix)-1]
 		}
 
-		breadcrumbs[len(breadcrumbs)-1].Children = append(breadcrumbs[len(breadcrumbs)-1].Children, &tree)
+		if !dirsonly || f.IsDirectory() {
+			breadcrumbs[len(breadcrumbs)-1].Children = append(breadcrumbs[len(breadcrumbs)-1].Children, &tree)
+		}
 
 		if f.IsDirectory() {
 			breadcrumbs = append(breadcrumbs, &tree)

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1729,15 +1729,15 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		b(true, "rootfile"),
 	}
 
-	mkdir := func(name string, children []*DirectoryTree) *DirectoryTree {
+	mkdir := func(name string, children []*FolderItem) *FolderItem {
 		if children == nil {
-			children = []*DirectoryTree{}
+			children = []*FolderItem{}
 		}
-		return &DirectoryTree{Name: name, IsDirectory: true, Children: children}
+		return &FolderItem{Name: name, FileType: 1, Children: children}
 	}
 
-	mkfile := func(name string) *DirectoryTree {
-		return &DirectoryTree{Name: name, IsDirectory: false, Children: []*DirectoryTree{}}
+	mkfile := func(name string) *FolderItem {
+		return &FolderItem{Name: name, FileType: 0, Children: nil}
 	}
 
 	mm := func(data interface{}) string {
@@ -1748,12 +1748,12 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		return string(bytes)
 	}
 
-	expected := []*DirectoryTree{
-		mkdir("another", []*DirectoryTree{
-			mkdir("directory", []*DirectoryTree{
+	expected := []*FolderItem{
+		mkdir("another", []*FolderItem{
+			mkdir("directory", []*FolderItem{
 				mkfile("afile"),
-				mkdir("with", []*DirectoryTree{
-					mkdir("a", []*DirectoryTree{
+				mkdir("with", []*FolderItem{
+					mkdir("a", []*FolderItem{
 						mkfile("file"),
 					}),
 					mkfile("file"),
@@ -1761,19 +1761,19 @@ func TestGlobalDirectoryTree(t *testing.T) {
 			}),
 			mkfile("file"),
 		}),
-		mkdir("other", []*DirectoryTree{
+		mkdir("other", []*FolderItem{
 			mkdir("rand", nil),
-			mkdir("random", []*DirectoryTree{
+			mkdir("random", []*FolderItem{
 				mkdir("dir", nil),
 				mkdir("dirx", nil),
 			}),
 			mkdir("randomx", nil),
 		}),
 		mkfile("rootfile"), // rootfile is before some as the output is sorted
-		mkdir("some", []*DirectoryTree{
-			mkdir("directory", []*DirectoryTree{
-				mkdir("with", []*DirectoryTree{
-					mkdir("a", []*DirectoryTree{
+		mkdir("some", []*FolderItem{
+			mkdir("directory", []*FolderItem{
+				mkdir("with", []*FolderItem{
+					mkdir("a", []*FolderItem{
 						mkfile("file"),
 					}),
 				}),
@@ -1796,7 +1796,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "", 0, false)
-	expected = []*DirectoryTree{
+	expected = []*FolderItem{
 		mkdir("another", nil),
 		mkdir("other", nil),
 		mkfile("rootfile"),
@@ -1808,18 +1808,18 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "", 1, false)
-	expected = []*DirectoryTree{
-		mkdir("another", []*DirectoryTree{
+	expected = []*FolderItem{
+		mkdir("another", []*FolderItem{
 			mkdir("directory", nil),
 			mkfile("file"),
 		}),
-		mkdir("other", []*DirectoryTree{
+		mkdir("other", []*FolderItem{
 			mkdir("rand", nil),
 			mkdir("random", nil),
 			mkdir("randomx", nil),
 		}),
 		mkfile("rootfile"), // rootfile is before some as the output is sorted
-		mkdir("some", []*DirectoryTree{
+		mkdir("some", []*FolderItem{
 			mkdir("directory", nil),
 		}),
 	}
@@ -1829,25 +1829,25 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "", -1, true)
-	expected = []*DirectoryTree{
-		mkdir("another", []*DirectoryTree{
-			mkdir("directory", []*DirectoryTree{
-				mkdir("with", []*DirectoryTree{
+	expected = []*FolderItem{
+		mkdir("another", []*FolderItem{
+			mkdir("directory", []*FolderItem{
+				mkdir("with", []*FolderItem{
 					mkdir("a", nil),
 				}),
 			}),
 		}),
-		mkdir("other", []*DirectoryTree{
+		mkdir("other", []*FolderItem{
 			mkdir("rand", nil),
-			mkdir("random", []*DirectoryTree{
+			mkdir("random", []*FolderItem{
 				mkdir("dir", nil),
 				mkdir("dirx", nil),
 			}),
 			mkdir("randomx", nil),
 		}),
-		mkdir("some", []*DirectoryTree{
-			mkdir("directory", []*DirectoryTree{
-				mkdir("with", []*DirectoryTree{
+		mkdir("some", []*FolderItem{
+			mkdir("directory", []*FolderItem{
+				mkdir("with", []*FolderItem{
 					mkdir("a", nil),
 				}),
 			}),
@@ -1859,16 +1859,16 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "", 1, true)
-	expected = []*DirectoryTree{
-		mkdir("another", []*DirectoryTree{
+	expected = []*FolderItem{
+		mkdir("another", []*FolderItem{
 			mkdir("directory", nil),
 		}),
-		mkdir("other", []*DirectoryTree{
+		mkdir("other", []*FolderItem{
 			mkdir("rand", nil),
 			mkdir("random", nil),
 			mkdir("randomx", nil),
 		}),
-		mkdir("some", []*DirectoryTree{
+		mkdir("some", []*FolderItem{
 			mkdir("directory", nil),
 		}),
 	}
@@ -1878,7 +1878,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "another", 0, false)
-	expected = []*DirectoryTree{
+	expected = []*FolderItem{
 		mkdir("directory", nil),
 		mkfile("file"),
 	}
@@ -1888,15 +1888,15 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "some/directory", 0, false)
-	expected = []*DirectoryTree{mkdir("with", nil)}
+	expected = []*FolderItem{mkdir("with", nil)}
 
 	if mm(actual) != mm(expected) {
 		t.Errorf("Does not match:\n%s\n%s", mm(actual), mm(expected))
 	}
 
 	actual = m.GlobalDirectoryTree("default", "some/directory", 1, false)
-	expected = []*DirectoryTree{
-		mkdir("with", []*DirectoryTree{
+	expected = []*FolderItem{
+		mkdir("with", []*FolderItem{
 			mkdir("a", nil),
 		}),
 	}
@@ -1906,9 +1906,9 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "some/directory", 2, false)
-	expected = []*DirectoryTree{
-		mkdir("with", []*DirectoryTree{
-			mkdir("a", []*DirectoryTree{
+	expected = []*FolderItem{
+		mkdir("with", []*FolderItem{
+			mkdir("a", []*FolderItem{
 				mkfile("file"),
 			}),
 		}),
@@ -1919,9 +1919,9 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	actual = m.GlobalDirectoryTree("default", "another", -1, true)
-	expected = []*DirectoryTree{
-		mkdir("directory", []*DirectoryTree{
-			mkdir("with", []*DirectoryTree{
+	expected = []*FolderItem{
+		mkdir("directory", []*FolderItem{
+			mkdir("with", []*FolderItem{
 				mkdir("a", nil),
 			}),
 		}),
@@ -1933,7 +1933,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 
 	// No prefix matching!
 	actual = m.GlobalDirectoryTree("default", "som", -1, false)
-	expected = []*DirectoryTree{}
+	expected = []*FolderItem{}
 
 	if mm(actual) != mm(expected) {
 		t.Errorf("Does not match:\n%s\n%s", mm(actual), mm(expected))
@@ -1982,15 +1982,15 @@ func TestGlobalDirectorySelfFixing(t *testing.T) {
 		b(true, "xthis", "is", "a", "deep", "invalid", "file"),
 	}
 
-	mkdir := func(name string, children []*DirectoryTree) *DirectoryTree {
+	mkdir := func(name string, children []*FolderItem) *FolderItem {
 		if children == nil {
-			children = []*DirectoryTree{}
+			children = []*FolderItem{}
 		}
-		return &DirectoryTree{Name: name, IsDirectory: true, Children: children}
+		return &FolderItem{Name: name, FileType: 1, Children: children}
 	}
 
-	mkfile := func(name string) *DirectoryTree {
-		return &DirectoryTree{Name: name, IsDirectory: false, Children: []*DirectoryTree{}}
+	mkfile := func(name string) *FolderItem {
+		return &FolderItem{Name: name, FileType: 0, Children: []*FolderItem{}}
 	}
 
 	mm := func(data interface{}) string {
@@ -2004,50 +2004,50 @@ func TestGlobalDirectorySelfFixing(t *testing.T) {
 	m.Index(device1, "default", testdata)
 
 	actual := m.GlobalDirectoryTree("default", "", -1, false)
-	expected := []*DirectoryTree{
-		mkdir("another", []*DirectoryTree{
-			mkdir("directory", []*DirectoryTree{
+	expected := []*FolderItem{
+		mkdir("another", []*FolderItem{
+			mkdir("directory", []*FolderItem{
 				mkfile("afile"),
-				mkdir("with", []*DirectoryTree{
-					mkdir("a", []*DirectoryTree{
+				mkdir("with", []*FolderItem{
+					mkdir("a", []*FolderItem{
 						mkfile("file"),
 					}),
 					mkfile("file"),
 				}),
 			}),
 		}),
-		mkdir("other", []*DirectoryTree{
-			mkdir("random", []*DirectoryTree{
+		mkdir("other", []*FolderItem{
+			mkdir("random", []*FolderItem{
 				mkdir("dirx", nil),
 			}),
 			mkdir("randomx", nil),
 		}),
-		mkdir("some", []*DirectoryTree{
-			mkdir("directory", []*DirectoryTree{
-				mkdir("with", []*DirectoryTree{
-					mkdir("a", []*DirectoryTree{
+		mkdir("some", []*FolderItem{
+			mkdir("directory", []*FolderItem{
+				mkdir("with", []*FolderItem{
+					mkdir("a", []*FolderItem{
 						mkfile("file"),
 					}),
 					mkdir("x", nil),
 				}),
 			}),
 		}),
-		mkdir("this", []*DirectoryTree{
-			mkdir("is", []*DirectoryTree{
-				mkdir("a", []*DirectoryTree{
-					mkdir("deep", []*DirectoryTree{
-						mkdir("invalid", []*DirectoryTree{
+		mkdir("this", []*FolderItem{
+			mkdir("is", []*FolderItem{
+				mkdir("a", []*FolderItem{
+					mkdir("deep", []*FolderItem{
+						mkdir("invalid", []*FolderItem{
 							mkdir("directory", nil),
 						}),
 					}),
 				}),
 			}),
 		}),
-		mkdir("xthis", []*DirectoryTree{
-			mkdir("is", []*DirectoryTree{
-				mkdir("a", []*DirectoryTree{
-					mkdir("deep", []*DirectoryTree{
-						mkdir("invalid", []*DirectoryTree{
+		mkdir("xthis", []*FolderItem{
+			mkdir("is", []*FolderItem{
+				mkdir("a", []*FolderItem{
+					mkdir("deep", []*FolderItem{
+						mkdir("invalid", []*FolderItem{
 							mkfile("file"),
 						}),
 					}),

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1964,7 +1964,7 @@ func TestGlobalDirectorySelfFixing(t *testing.T) {
 		}
 	}
 
-	//filedata := []interface{}{time.Unix(0x666, 0).Format(time.RFC3339), 0xa}
+	filedata := []interface{}{time.Unix(0x666, 0).Format(time.RFC3339), 0xa}
 
 	testdata := []protocol.FileInfo{
 		b(true, "another", "directory", "afile"),
@@ -2060,34 +2060,34 @@ func TestGlobalDirectorySelfFixing(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(actual), mm(expected))
 	}
 
-	//result = m.GlobalDirectoryTree("default", "xthis/is/a/deep", -1, false)
-	//currentResult := map[string]interface{}{
-	//	"invalid": map[string]interface{}{
-	//		"file": filedata,
-	//	},
-	//}
-	//
-	//if mm(result) != mm(currentResult) {
-	//	t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
-	//}
-	//
-	//result = m.GlobalDirectoryTree("default", "xthis/is/a/deep", -1, true)
-	//currentResult = map[string]interface{}{
-	//	"invalid": map[string]interface{}{},
-	//}
-	//
-	//if mm(result) != mm(currentResult) {
-	//	t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
-	//}
-	//
-	//// !!! This is actually BAD, because we don't have enough level allowance
-	//// to accept this file, hence the tree is left unbuilt !!!
-	//result = m.GlobalDirectoryTree("default", "xthis", 1, false)
-	//currentResult = map[string]interface{}{}
-	//
-	//if mm(result) != mm(currentResult) {
-	//	t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
-	//}
+	result := m.GlobalDirectoryTree("default", "xthis/is/a/deep", -1, false)
+	currentResult := map[string]interface{}{
+		"invalid": map[string]interface{}{
+			"file": filedata,
+		},
+	}
+
+	if mm(result) != mm(currentResult) {
+		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
+	}
+
+	result = m.GlobalDirectoryTree("default", "xthis/is/a/deep", -1, true)
+	currentResult = map[string]interface{}{
+		"invalid": map[string]interface{}{},
+	}
+
+	if mm(result) != mm(currentResult) {
+		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
+	}
+
+	// !!! This is actually BAD, because we don't have enough level allowance
+	// to accept this file, hence the tree is left unbuilt !!!
+	result = m.GlobalDirectoryTree("default", "xthis", 1, false)
+	currentResult = map[string]interface{}{}
+
+	if mm(result) != mm(currentResult) {
+		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
+	}
 }
 
 func genDeepFiles(n, d int) []protocol.FileInfo {


### PR DESCRIPTION
After a long semester, I finally found some time to finish the code, whether you decide to merge it or not.

Reference to #6108  and issue https://github.com/syncthing/syncthing/issues/4729 .

@AudriusButkevicius 
I reprogrammed the route to return the array-like structure as you suggested in the mentioned PR. I also did the AngularJS part. However, I simplified it a little bit so I don't spend a lifetime programming it.
It looks like this now:

<img width="563" alt="Screen Shot 2020-01-22 at 16 05 05" src="https://user-images.githubusercontent.com/14272775/72905574-0a140f00-3d31-11ea-83cb-7da702d760ff.png">
<img width="903" alt="Screen Shot 2020-01-22 at 16 05 16" src="https://user-images.githubusercontent.com/14272775/72905581-0bddd280-3d31-11ea-99ca-d66fa713f96d.png">
The blue directories are clickable. "Back" is not present in root directory.
<img width="902" alt="Screen Shot 2020-01-22 at 16 05 25" src="https://user-images.githubusercontent.com/14272775/72905585-0da79600-3d31-11ea-9b74-52ce7818208f.png">
You can go back to root directory by clicking on "Back".


Currently the route returns this kind of result:

```
[
  {
    "name": ".DS_Store",
    "isDirectory": false,
    "children": []
  },
  {
    "name": "file-0",
    "isDirectory": false,
    "children": []
  },
  {
    "name": "file-1",
    "isDirectory": false,
    "children": []
  },
  {
    "name": "file-2",
    "isDirectory": false,
    "children": []
  },
  {
    "name": "file-3",
    "isDirectory": false,
    "children": []
  },
  {
    "name": "file-4",
    "isDirectory": false,
    "children": []
  },
  {
    "name": "file-5",
    "isDirectory": false,
    "children": []
  },
  {
    "name": "neh",
    "isDirectory": true,
    "children": []
  },
  {
    "name": "neh2",
    "isDirectory": true,
    "children": []
  },
  {
    "name": "neh3",
    "isDirectory": true,
    "children": []
  },
  {
    "name": "turaa.jpg",
    "isDirectory": false,
    "children": []
  }
]
```

There are still things I would like to ask about before I decide to finish them somehow.

1. There is a test suite in lib/model/model_test.go which says, that route "some/directory" doesn't have to come at all, but "some/directory/file" comes.
https://github.com/nitrajka/syncthing/blob/view-included-files/lib/model/model_test.go#L1943
 In this case, I have to create the whole path from one route. I didn't know that when programming the back end. Should I fix it?

2. If you would consider merging it, I should add the documentation. That is the purpose of syncthing/docs repository, right? So, what do you think?

3. As I am creating the route when nesting in the newly programmed file browser, I use the linux-based path delimeter: 

https://github.com/nitrajka/syncthing/blob/view-included-files/gui/default/syncthing/folder/folderFilesModalView.html#L9

That may be a problem for windows based file systems. Do you have any hint on how should I fix it?

4. Should I add translations on https://www.transifex.com/projects/p/syncthing/ ?

5. The original route returned a structure where a file had some metadata. My version doesn't have any metadata. Is that a problem?

6. Every time I run compiled syncthing I use "STNOUPGRADE=1" flag. But we want the upgraded version to have file browser as well. Do we?

