### PR TITLE
lib/relays: Fix incorrect timeout, bring back logging (ref #6289)

### DIFF
--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -65,10 +65,14 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 		return nil, errUnexpectedInterfaceType
 	}
 	if dialer == proxy.Direct {
-		return fallback.DialContext(ctx, network, addr)
+		conn, err := fallback.DialContext(ctx, network, addr)
+		l.Debugf("Dialing direct result %s %s: %s %s", network, addr, conn, err)
+		return conn, err
 	}
 	if noFallback {
-		return dialer.DialContext(ctx, network, addr)
+		conn, err := dialer.DialContext(ctx, network, addr)
+		l.Debugf("Dialing no fallback result %s %s: %s %s", network, addr, conn, err)
+		return conn, err
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -79,10 +83,12 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 	fallbackDone := make(chan struct{})
 	go func() {
 		proxyConn, proxyErr = dialer.DialContext(ctx, network, addr)
+		l.Debugf("Dialing proxy result %s %s: %s %s", network, addr, proxyConn, proxyErr)
 		close(proxyDone)
 	}()
 	go func() {
 		fallbackConn, fallbackErr = fallback.DialContext(ctx, network, addr)
+		l.Debugf("Dialing fallback result %s %s: %s %s", network, addr, fallbackConn, fallbackErr)
 		close(fallbackDone)
 	}()
 	<-proxyDone

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -66,12 +66,12 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 	}
 	if dialer == proxy.Direct {
 		conn, err := fallback.DialContext(ctx, network, addr)
-		l.Debugf("Dialing direct result %s %s: %s %s", network, addr, conn, err)
+		l.Debugf("Dialing direct result %s %s: %v %v", network, addr, conn, err)
 		return conn, err
 	}
 	if noFallback {
 		conn, err := dialer.DialContext(ctx, network, addr)
-		l.Debugf("Dialing no fallback result %s %s: %s %s", network, addr, conn, err)
+		l.Debugf("Dialing no fallback result %s %s: %v %v", network, addr, conn, err)
 		return conn, err
 	}
 
@@ -83,12 +83,12 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 	fallbackDone := make(chan struct{})
 	go func() {
 		proxyConn, proxyErr = dialer.DialContext(ctx, network, addr)
-		l.Debugf("Dialing proxy result %s %s: %s %s", network, addr, proxyConn, proxyErr)
+		l.Debugf("Dialing proxy result %s %s: %v %v", network, addr, proxyConn, proxyErr)
 		close(proxyDone)
 	}()
 	go func() {
 		fallbackConn, fallbackErr = fallback.DialContext(ctx, network, addr)
-		l.Debugf("Dialing fallback result %s %s: %s %s", network, addr, fallbackConn, fallbackErr)
+		l.Debugf("Dialing fallback result %s %s: %v %v", network, addr, fallbackConn, fallbackErr)
 		close(fallbackDone)
 	}()
 	<-proxyDone

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -152,7 +152,7 @@ func (c *staticClient) connect(ctx context.Context) error {
 	}
 
 	t0 := time.Now()
-	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, c.connectTimeout)
 	defer cancel()
 	tcpConn, err := dialer.DialContext(timeoutCtx, "tcp", c.uri.Host)
 	if err != nil {


### PR DESCRIPTION
Seems to have slipped. Also adding logging back.

I don't think this is the root cause tho, as it should have been manifested as IO timeout.