### PR TITLE
gui: Prevent text overflow in file lists (fixes #6268)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -136,6 +136,11 @@ table.table-auto td {
     max-width: 0px;
 }
 
+/* Wrap long file paths to prevent text overflow. See issue #6268. */
+.file-path {
+    word-break: break-all;
+}
+
 .folder-advanced {
     padding: 1rem;
     margin-bottom: 15px;

--- a/gui/default/syncthing/device/globalChangesModalView.html
+++ b/gui/default/syncthing/device/globalChangesModalView.html
@@ -20,7 +20,7 @@
             <td>{{changeEvent.data.action}}</td>
             <td>{{changeEvent.data.type}}</td>
             <td class="no-overflow-ellipse">{{folderLabel(changeEvent.data.folder)}}</td>
-            <td class="no-overflow-ellipse">{{changeEvent.data.path}}</td>
+            <td class="file-path no-overflow-ellipse">{{changeEvent.data.path}}</td>
             <td class="no-overflow-ellipse">{{changeEvent.time | date:"yyyy-MM-dd HH:mm:ss"}}</td>
           </tr>
         </tbody>

--- a/gui/default/syncthing/transfer/localChangedFilesModalView.html
+++ b/gui/default/syncthing/transfer/localChangedFilesModalView.html
@@ -11,7 +11,7 @@
         </tr>
       </thead>
       <tr dir-paginate="file in localChanged.files | itemsPerPage: localChanged.perpage" current-page="localChanged.page" total-items="model[localChangedFolder].receiveOnlyTotalItems" pagination-id="localChanged">
-        <td>{{file.name}}</td>
+        <td class="file-path">{{file.name}}</td>
         <td><span ng-hide="file.type == 'DIRECTORY'">{{file.size | binary}}B</span></td>
       </tr>
     </table>

--- a/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
+++ b/gui/default/syncthing/transfer/remoteNeededFilesModalView.html
@@ -22,7 +22,7 @@
                 </tr>
               </thead>
               <tr dir-paginate="file in remoteNeed[folder].files | itemsPerPage: remoteNeed[folder].perpage" current-page="remoteNeed[folder].page" total-items="completion[remoteNeedDevice.deviceID][folder].needItems" pagination-id="'remoteNeed-' + folder">
-                <td>{{file.name}}</td>
+                <td class="file-path">{{file.name}}</td>
                 <td><span ng-hide="file.type == 'DIRECTORY'">{{file.size | binary}}B</span></td>
                 <td>{{file.modified | date:"yyyy-MM-dd HH:mm:ss"}}</td>
                 <td ng-if="file.modifiedBy">{{friendlyNameFromShort(file.modifiedBy)}}</td>


### PR DESCRIPTION
### Purpose

This change forces breakage of long file paths and names, so that the text does not overflow the available display area, which is the case in many places in the GUI right now, such as "Recent Changes" or "Out of Sync Items". See the commit for details.

### Testing

I have tested in Chromium 79.0.3945.130 and IE 11.973.17763.0, but the `word-break: break-all` CSS rule itself is supported in all browsers, starting from at least IE 6.

### Screenshots

Text cut and date not visible before:

![image](https://user-images.githubusercontent.com/5626656/73063782-f14b5b00-3ee2-11ea-9407-379543d29a0b.png)

Text wrapped and date visible after:

![image](https://user-images.githubusercontent.com/5626656/73063792-f90aff80-3ee2-11ea-8c35-2d97fa6a8102.png)
