### PR TITLE
lib/db: Configurable block GC time

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -119,6 +119,10 @@ are mostly useful for developers. Use with care.
                    "h", "m" and "s" abbreviations for hours minutes and seconds.
                    Valid values are like "720h", "30s", etc.
 
+ STGCBLOCKSEVERY   Set to a time interval to override the default database
+                   block GC interval of 13 hours. Same format as the
+                   STRECHECKDBEVERY variable.
+
  GOMAXPROCS        Set the maximum number of CPU cores to use. Defaults to all
                    available CPU cores.
 

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -506,7 +506,6 @@ func (db *Lowlevel) timeUntil(key string, every time.Duration) time.Duration {
 	if sleepTime < 0 {
 		sleepTime = 0
 	}
-	l.Infoln("sleep time is", sleepTime)
 	return sleepTime
 }
 

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -27,6 +27,7 @@ const (
 	blockGCBloomCapacity          = 100000
 	blockGCBloomFalsePositiveRate = 0.01 // 1%
 	blockGCDefaultInterval        = 13 * time.Hour
+	blockGCTimeKey                = "lastGCTime"
 )
 
 var blockGCInterval = blockGCDefaultInterval
@@ -472,8 +473,7 @@ func (db *Lowlevel) dropPrefix(prefix []byte) error {
 }
 
 func (db *Lowlevel) gcRunner() {
-	const gcTimeKey = "lastGCTime"
-	t := time.NewTimer(db.timeUntil(gcTimeKey, blockGCInterval))
+	t := time.NewTimer(db.timeUntil(blockGCTimeKey, blockGCInterval))
 	defer t.Stop()
 	for {
 		select {
@@ -483,8 +483,8 @@ func (db *Lowlevel) gcRunner() {
 			if err := db.gcBlocks(); err != nil {
 				l.Warnln("Database block GC failed:", err)
 			}
-			db.recordTime(gcTimeKey)
-			t.Reset(db.timeUntil(gcTimeKey, blockGCInterval))
+			db.recordTime(blockGCTimeKey)
+			t.Reset(db.timeUntil(blockGCTimeKey, blockGCInterval))
 		}
 	}
 }

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -451,5 +451,7 @@ func (db *schemaUpdater) updateSchema7to8(_ int) error {
 		return err
 	}
 
+	db.recordTime(blockGCTimeKey)
+
 	return t.commit()
 }


### PR DESCRIPTION
Also retain the interval over restarts by storing last GC time in the
database. This to make sure that GC eventually happens even if the
interval is configured to a long time (say, a month).
