### PR TITLE
lib/db: Garbage collect deleted items

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -521,7 +521,7 @@ func (db *Lowlevel) gcRunner() {
 				l.Warnln("Deleted file GC failed:", err)
 			}
 			db.recordTime(deletedGCTimeKey)
-			blocksTimer.Reset(db.timeUntil(deletedGCTimeKey, deletedGCInterval))
+			deletedTimer.Reset(db.timeUntil(deletedGCTimeKey, deletedGCInterval))
 		}
 	}
 }

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -661,6 +661,7 @@ func (db *Lowlevel) gcDeleted() error {
 	if err != nil {
 		return err
 	}
+	defer it.Release()
 	for it.Next() {
 		// Load our version of the file. See if it's an old deleted one.
 


### PR DESCRIPTION
### Purpose

This is in relation #6284 in order to clean out old deleted files. It's not beautiful in any way whatsoever, and there may be things I didn't consider, so consider this a suggestion/wip.

This new GC step simply iterates and deleted items that are 1) deleted 2) not in the need list 3) older than a threshold. We drop our file entry, every one elses file entries, and the global entry. Poof, gone! If the other side runs with the same set up then they'll do the same and that's the end of it. If they don't, the  entry will get reintroduced next time we do a full index transfer and the cycle repeats... 

One thing not handled: metadata accounting adjustment. Maybe we need to, maybe we don't (deleted files don't play too large a role there), I haven't considered it closely.

As for why bother, the linked issue shows a database where deleted items are the vast majority of items. I don't have any reason to believe this is atypical for how it looks after being up and running for a while.