### PR TITLE
lib/ignore: Don't crash on empty patterns (fixes #6300)

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -422,6 +422,10 @@ func parseLine(line string) ([]Pattern, error) {
 		}
 	}
 
+	if line == "" {
+		return nil, errors.New("missing pattern")
+	}
+
 	if pattern.result.IsCaseFolded() {
 		line = strings.ToLower(line)
 	}

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -1148,5 +1149,22 @@ func TestSkipIgnoredDirs(t *testing.T) {
 	}
 	if !pats.SkipIgnoredDirs() {
 		t.Error("SkipIgnoredDirs should be true")
+	}
+}
+
+func TestEmptyPatterns(t *testing.T) {
+	// These patterns are all invalid and should be rejected as such (without panicking...)
+	tcs := []string{
+		"!",
+		"(?d)",
+		"(?i)",
+	}
+
+	for _, tc := range tcs {
+		m := New(fs.NewFilesystem(fs.FilesystemTypeFake, ""))
+		err := m.Parse(strings.NewReader(tc), ".stignore")
+		if err == nil {
+			t.Error("Should reject invalid pattern", tc)
+		}
 	}
 }


### PR DESCRIPTION
Instead of panicking when we try to look closer at the empty pattern,
return something like `invalid pattern "(?d)" in ignore file: missing
pattern`.
