### PR TITLE
cmd/syncthing, lib/locations: Separate data and config dirs (fixes #4924)

### DIFF
--- a/build.go
+++ b/build.go
@@ -364,12 +364,12 @@ func test(pkgs ...string) {
 
 	args := []string{"test", "-short", "-timeout", timeout, "-tags", "purego"}
 
-	if runtime.GOARCH == "amd64" {
-		switch runtime.GOOS {
-		case "darwin", "linux", "freebsd": // , "windows": # See https://github.com/golang/go/issues/27089
-			args = append(args, "-race")
-		}
-	}
+	// if runtime.GOARCH == "amd64" {
+	// 	switch runtime.GOOS {
+	// 	case "darwin", "linux", "freebsd": // , "windows": # See https://github.com/golang/go/issues/27089
+	// 		args = append(args, "-race")
+	// 	}
+	// }
 
 	if coverage {
 		args = append(args, "-covermode", "atomic", "-coverprofile", "coverage.txt", "-coverpkg", strings.Join(pkgs, ","))

--- a/build.go
+++ b/build.go
@@ -364,12 +364,12 @@ func test(pkgs ...string) {
 
 	args := []string{"test", "-short", "-timeout", timeout, "-tags", "purego"}
 
-	// if runtime.GOARCH == "amd64" {
-	// 	switch runtime.GOOS {
-	// 	case "darwin", "linux", "freebsd": // , "windows": # See https://github.com/golang/go/issues/27089
-	// 		args = append(args, "-race")
-	// 	}
-	// }
+	if runtime.GOARCH == "amd64" {
+		switch runtime.GOOS {
+		case "darwin", "linux", "freebsd": // , "windows": # See https://github.com/golang/go/issues/27089
+			args = append(args, "-race")
+		}
+	}
 
 	if coverage {
 		args = append(args, "-covermode", "atomic", "-coverprofile", "coverage.txt", "-coverpkg", strings.Join(pkgs, ","))

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -284,16 +284,24 @@ func main() {
 		osutil.HideConsole()
 	}
 
-	// Not set as default above because the string can be really long.
+	// Not set as default above because the strings can be really long.
 	var err error
-	if options.homeDir != "" {
+	homeSet := options.homeDir != ""
+	confSet := options.confDir != ""
+	dataSet := options.dataDir != ""
+	switch {
+	case dataSet != confSet:
+		err = errors.New("Either both or none of -conf and -data must be given, use -home to set both at once.")
+	case homeSet && dataSet:
+		err = errors.New("Option -home must not be used together with -conf and -data.")
+	case homeSet:
 		if err = setLocation(options.homeDir, locations.ConfigBaseDir); err == nil {
 			err = setLocation(options.homeDir, locations.DataBaseDir)
 		}
-	} else if options.confDir != "" {
-		err = setLocation(options.confDir, locations.ConfigBaseDir)
-	} else if options.dataDir != "" {
-		err = setLocation(options.dataDir, locations.DataBaseDir)
+	case dataSet:
+		if err = setLocation(options.confDir, locations.ConfigBaseDir); err == nil {
+			err = setLocation(options.dataDir, locations.DataBaseDir)
+		}
 	}
 	if err != nil {
 		l.Warnln(err)

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -291,9 +291,9 @@ func main() {
 	dataSet := options.dataDir != ""
 	switch {
 	case dataSet != confSet:
-		err = errors.New("Either both or none of -conf and -data must be given, use -home to set both at once.")
+		err = errors.New("either both or none of -conf and -data must be given, use -home to set both at once")
 	case homeSet && dataSet:
-		err = errors.New("Option -home must not be used together with -conf and -data.")
+		err = errors.New("-home must not be used together with -conf and -data")
 	case homeSet:
 		if err = setLocation(options.homeDir, locations.ConfigBaseDir); err == nil {
 			err = setLocation(options.homeDir, locations.DataBaseDir)
@@ -304,7 +304,7 @@ func main() {
 		}
 	}
 	if err != nil {
-		l.Warnln(err)
+		l.Warnln("Command line options:", err)
 		os.Exit(syncthing.ExitError.AsInt())
 	}
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -68,7 +68,7 @@ show time only (2).
 Logging always happens to the command line (stdout) and optionally to the
 file at the path specified by -logfile=path. In addition to an path, the special
 values "default" and "-" may be used. The former logs to DATADIR/syncthing.log
-(see -data-dir), which is the default on windows, and the latter only to stdout,
+(see -data-dir), which is the default on Windows, and the latter only to stdout,
 no file, which is the default anywhere else.
 
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -66,10 +66,10 @@ above). The value 0 is used to disable all of the above. The default is to
 show time only (2).
 
 Logging always happens to the command line (stdout) and optionally to the
-file at the path specified by -logfile=path. In addition to an explicity path,
-the special values "default" and "-" may be used. The former logs to
-DATADIR/syncthing.log (see -data-dir), which is the default on windows, and the
-latter only to stdout, no file, which is the default anywhere else.
+file at the path specified by -logfile=path. In addition to an path, the special
+values "default" and "-" may be used. The former logs to DATADIR/syncthing.log
+(see -data-dir), which is the default on windows, and the latter only to stdout,
+no file, which is the default anywhere else.
 
 
 Development Settings

--- a/etc/linux-desktop/syncthing-start.desktop
+++ b/etc/linux-desktop/syncthing-start.desktop
@@ -2,7 +2,7 @@
 Name=Start Syncthing
 GenericName=File synchronization
 Comment=Starts the main syncthing process in the background.
-Exec=/usr/bin/syncthing -no-browser -logfile=~/.config/syncthing/syncthing.log
+Exec=/usr/bin/syncthing -no-browser -logfile=""
 Icon=syncthing
 Terminal=false
 Type=Application

--- a/etc/linux-desktop/syncthing-start.desktop
+++ b/etc/linux-desktop/syncthing-start.desktop
@@ -2,7 +2,7 @@
 Name=Start Syncthing
 GenericName=File synchronization
 Comment=Starts the main syncthing process in the background.
-Exec=/usr/bin/syncthing -no-browser -logfile=""
+Exec=/usr/bin/syncthing -no-browser -logfile=default
 Icon=syncthing
 Terminal=false
 Type=Application

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -91,7 +91,7 @@ var locationTemplates = map[LocationEnum]string{
 	HTTPSKeyFile:  "${config}/https-key.pem",
 	Database:      "${data}/" + databaseDirname,
 	LogFile:       "${data}/syncthing.log", // -logfile on Windows
-	CsrfTokens:    "${config}/csrftokens.txt",
+	CsrfTokens:    "${data}/csrftokens.txt",
 	PanicLog:      "${data}/panic-${timestamp}.log",
 	AuditLog:      "${data}/audit-${timestamp}.log",
 	GUIAssets:     "${config}/gui",
@@ -155,13 +155,13 @@ func defaultDataDir(home, config string) string {
 		}
 		// Always use this env var, as it's explicitly set by the user
 		if xdgHome := os.Getenv("XDG_DATA_HOME"); xdgHome != "" {
-			return xdgHome
+			return filepath.Join(xdgHome, "syncthing")
 		}
 		// Only use the XDG default, if a syncthing specific dir already
 		// exists. Existence of ~/.local/share is not deemed enough, as
 		// it may also exist erroneously on non-XDG systems.
-		xdgDefault := filepath.Join(home, ".local/share")
-		if _, err := os.Lstat(filepath.Join(xdgDefault, "syncthing")); err == nil {
+		xdgDefault := filepath.Join(home, ".local/share/syncthing")
+		if _, err := os.Lstat(xdgDefault); err == nil {
 			return xdgDefault
 		}
 		// FYI: XDG_DATA_DIRS is not relevant, as it is for system-wide

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -43,7 +43,7 @@ const (
 	ConfigBaseDir BaseDirEnum = "config"
 	DataBaseDir   BaseDirEnum = "data"
 	// User's home directory, *not* -home flag
-	UserHomeBaseDir BaseDirEnum = "userhome"
+	UserHomeBaseDir BaseDirEnum = "userHome"
 )
 
 // Platform dependent directories


### PR DESCRIPTION
### Purpose

Doesn't change anything for existing users. Neither does it change anything for windows and mac users. For linux users, if there is no db at the "usual place" and there's a relevant xdg env var or the directory `~/.local/share/syncthing` in place, put db and logs there. Also there's two new flags `-config` and `-data` accompanying `-home` to set separate dirs for config/keys and db/logs.

### Testing

My test system picked the db up at a new location with command line flags.