### PR TITLE
lib/config, gui: Set unix socket permissions for GUI listen address (fixes #5979)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2491,4 +2491,11 @@ angular.module('syncthing.core')
             $scope.config.options.crashReportingEnabled = enabled;
             $scope.saveConfig();
         };
+
+        $scope.isUnixAddress = function (address) {
+            return address != null &&
+                (address.startsWith('/') ||
+                    address.startsWith('unix://') ||
+                    address.startsWith('unixs://'));
+        }
     });

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -172,6 +172,8 @@
               </div>
             </div>
             <div class="col-md-6">
+              <label translate>UNIX Permissions</label>
+              <input id="UnixPerms" class="form-control" type="text" ng-model="tmpGUI.unixPerms" />
             </div>
           </div>
         </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -172,7 +172,7 @@
               </div>
             </div>
             <div class="col-md-6">
-              <div ng-if="tmpGUI.address.startsWith('/')" class="form-group" ng-class="{'has-error': settingsEditor.UnixSocketPermissions.$invalid && settingsEditor.UnixSocketPermissions.$dirty}">
+              <div ng-if="tmpGUI.address.startsWith('/') || tmpGUI.address.startsWith('unix://') || tmpGUI.address.startsWith('unixs://')" class="form-group" ng-class="{'has-error': settingsEditor.UnixSocketPermissions.$invalid && settingsEditor.UnixSocketPermissions.$dirty}">
                 <label translate>UNIX Permissions</label>
                 <input id="UnixSocketPermissions" name="UnixSocketPermissions" class="form-control" type="text" ng-model="tmpGUI.unixSocketPermissions" ng-pattern="/^0?[0-7]{0,3}$/" />
                 <p class="help-block" ng-show="settingsEditor.UnixSocketPermissions.$invalid" translate>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -172,8 +172,13 @@
               </div>
             </div>
             <div class="col-md-6">
-              <label translate>UNIX Permissions</label>
-              <input id="UnixPerms" class="form-control" type="text" ng-model="tmpGUI.unixPerms" />
+              <div class="form-group" ng-class="{'has-error': settingsEditor.UnixPerms.$invalid && settingsEditor.UnixPerms.$dirty}">
+                <label translate>UNIX Permissions</label>
+                <input id="UnixPerms" name="UnixPerms" class="form-control" type="text" ng-model="tmpGUI.unixPerms" ng-pattern="/^0?[0-7]{0,3}$/" />
+                <p class="help-block" ng-show="settingsEditor.UnixPerms.$invalid" translate>
+                  Enter up to three octal digits.
+                </p>
+              </div>
             </div>
           </div>
         </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -172,10 +172,10 @@
               </div>
             </div>
             <div class="col-md-6">
-              <div ng-if="tmpGUI.address.startsWith('/')" class="form-group" ng-class="{'has-error': settingsEditor.unixSocketPermissions.$invalid && settingsEditor.unixSocketPermissions.$dirty}">
+              <div ng-if="tmpGUI.address.startsWith('/')" class="form-group" ng-class="{'has-error': settingsEditor.UnixSocketPermissions.$invalid && settingsEditor.UnixSocketPermissions.$dirty}">
                 <label translate>UNIX Permissions</label>
-                <input id="unixSocketPermissions" name="unixSocketPermissions" class="form-control" type="text" ng-model="tmpGUI.unixSocketPermissions" ng-pattern="/^0?[0-7]{0,3}$/" />
-                <p class="help-block" ng-show="settingsEditor.unixSocketPermissions.$invalid" translate>
+                <input id="UnixSocketPermissions" name="UnixSocketPermissions" class="form-control" type="text" ng-model="tmpGUI.unixSocketPermissions" ng-pattern="/^0?[0-7]{0,3}$/" />
+                <p class="help-block" ng-show="settingsEditor.UnixSocketPermissions.$invalid" translate>
                   Enter up to three octal digits.
                 </p>
               </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -172,7 +172,7 @@
               </div>
             </div>
             <div class="col-md-6">
-              <div class="form-group" ng-class="{'has-error': settingsEditor.UnixPerms.$invalid && settingsEditor.UnixPerms.$dirty}">
+              <div ng-if="tmpGUI.address.startsWith('/')" class="form-group" ng-class="{'has-error': settingsEditor.UnixPerms.$invalid && settingsEditor.UnixPerms.$dirty}">
                 <label translate>UNIX Permissions</label>
                 <input id="UnixPerms" name="UnixPerms" class="form-control" type="text" ng-model="tmpGUI.unixPerms" ng-pattern="/^0?[0-7]{0,3}$/" />
                 <p class="help-block" ng-show="settingsEditor.UnixPerms.$invalid" translate>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -172,10 +172,10 @@
               </div>
             </div>
             <div class="col-md-6">
-              <div ng-if="tmpGUI.address.startsWith('/')" class="form-group" ng-class="{'has-error': settingsEditor.UnixPerms.$invalid && settingsEditor.UnixPerms.$dirty}">
+              <div ng-if="tmpGUI.address.startsWith('/')" class="form-group" ng-class="{'has-error': settingsEditor.unixSocketPermissions.$invalid && settingsEditor.unixSocketPermissions.$dirty}">
                 <label translate>UNIX Permissions</label>
-                <input id="UnixPerms" name="UnixPerms" class="form-control" type="text" ng-model="tmpGUI.unixPerms" ng-pattern="/^0?[0-7]{0,3}$/" />
-                <p class="help-block" ng-show="settingsEditor.UnixPerms.$invalid" translate>
+                <input id="unixSocketPermissions" name="unixSocketPermissions" class="form-control" type="text" ng-model="tmpGUI.unixSocketPermissions" ng-pattern="/^0?[0-7]{0,3}$/" />
+                <p class="help-block" ng-show="settingsEditor.unixSocketPermissions.$invalid" translate>
                   Enter up to three octal digits.
                 </p>
               </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -172,7 +172,7 @@
               </div>
             </div>
             <div class="col-md-6">
-              <div ng-if="tmpGUI.address.startsWith('/') || tmpGUI.address.startsWith('unix://') || tmpGUI.address.startsWith('unixs://')" class="form-group" ng-class="{'has-error': settingsEditor.UnixSocketPermissions.$invalid && settingsEditor.UnixSocketPermissions.$dirty}">
+              <div ng-if="isUnixAddress(tmpGUI.address)" class="form-group" ng-class="{'has-error': settingsEditor.UnixSocketPermissions.$invalid && settingsEditor.UnixSocketPermissions.$dirty}">
                 <label translate>UNIX Permissions</label>
                 <input id="UnixSocketPermissions" name="UnixSocketPermissions" class="form-control" type="text" ng-model="tmpGUI.unixSocketPermissions" ng-pattern="/^0?[0-7]{0,3}$/" />
                 <p class="help-block" ng-show="settingsEditor.UnixSocketPermissions.$invalid" translate>

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -187,11 +187,11 @@ func (s *service) getListener(guiCfg config.GUIConfiguration) (net.Listener, err
 		return nil, err
 	}
 
-	if guiCfg.Network() == "unix" && guiCfg.Permissions() != 0 {
+	if guiCfg.Network() == "unix" && guiCfg.SocketPermissions() != 0 {
 		// We should error if this fails under the assumption that these permissions are
 		// required for operation. If the configuration option isn't correctly formatted,
 		// then we will ignore it.
-		err = os.Chmod(guiCfg.Address(), guiCfg.Permissions())
+		err = os.Chmod(guiCfg.Address(), guiCfg.SocketPermissions())
 		if err != nil {
 			return nil, err
 		}

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -189,8 +189,7 @@ func (s *service) getListener(guiCfg config.GUIConfiguration) (net.Listener, err
 
 	if guiCfg.Network() == "unix" && guiCfg.SocketPermissions() != 0 {
 		// We should error if this fails under the assumption that these permissions are
-		// required for operation. If the configuration option isn't correctly formatted,
-		// then we will ignore it.
+		// required for operation.
 		err = os.Chmod(guiCfg.Address(), guiCfg.SocketPermissions())
 		if err != nil {
 			return nil, err

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -187,10 +187,10 @@ func (s *service) getListener(guiCfg config.GUIConfiguration) (net.Listener, err
 		return nil, err
 	}
 
-	if guiCfg.Network() == "unix" && guiCfg.SocketPermissions() != 0 {
+	if guiCfg.Network() == "unix" && guiCfg.UnixSocketPermissions() != 0 {
 		// We should error if this fails under the assumption that these permissions are
 		// required for operation.
-		err = os.Chmod(guiCfg.Address(), guiCfg.SocketPermissions())
+		err = os.Chmod(guiCfg.Address(), guiCfg.UnixSocketPermissions())
 		if err != nil {
 			return nil, err
 		}

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -187,9 +187,11 @@ func (s *service) getListener(guiCfg config.GUIConfiguration) (net.Listener, err
 		return nil, err
 	}
 
-	if guiCfg.Network() == "unix" {
-		// We should error if this fails
-		err = os.Chmod(guiCfg.Address(), 0777)
+	if guiCfg.Network() == "unix" && guiCfg.Permissions() != 0 {
+		// We should error if this fails under the assumption that these permissions are
+		// required for operation. If the configuration option isn't correctly formatted,
+		// then we will ignore it.
+		err = os.Chmod(guiCfg.Address(), guiCfg.Permissions())
 		if err != nil {
 			return nil, err
 		}

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -187,6 +187,14 @@ func (s *service) getListener(guiCfg config.GUIConfiguration) (net.Listener, err
 		return nil, err
 	}
 
+	if guiCfg.Network() == "unix" {
+		// We should error if this fails
+		err = os.Chmod(guiCfg.Address(), 0777)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	listener := &tlsutil.DowngradingListener{
 		Listener:  rawListener,
 		TLSConfig: tlsCfg,

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -62,7 +62,7 @@ func (c GUIConfiguration) Address() string {
 }
 
 func (c GUIConfiguration) Permissions() os.FileMode {
-	perm, err := strconv.ParseUint(c.UnixPermissions, 0, 32)
+	perm, err := strconv.ParseUint(c.UnixPermissions, 8, 32)
 	if err != nil {
 		return 0
 	}

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -64,6 +64,7 @@ func (c GUIConfiguration) Address() string {
 func (c GUIConfiguration) SocketPermissions() os.FileMode {
 	perm, err := strconv.ParseUint(c.UnixSocketPermissions, 8, 32)
 	if err != nil {
+		// ignore incorrectly formatted permissions
 		return 0
 	}
 	return os.FileMode(perm) & os.ModePerm

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -16,7 +16,7 @@ import (
 type GUIConfiguration struct {
 	Enabled                   bool     `xml:"enabled,attr" json:"enabled" default:"true"`
 	RawAddress                string   `xml:"address" json:"address" default:"127.0.0.1:8384"`
-	UnixSocketPermissions     string   `xml:"unixSocketPermissions,omitempty" json:"unixSocketPermissions"`
+	RawUnixSocketPermissions  string   `xml:"unixSocketPermissions,omitempty" json:"unixSocketPermissions"`
 	User                      string   `xml:"user,omitempty" json:"user"`
 	Password                  string   `xml:"password,omitempty" json:"password"`
 	AuthMode                  AuthMode `xml:"authMode,omitempty" json:"authMode"`
@@ -61,8 +61,8 @@ func (c GUIConfiguration) Address() string {
 	return c.RawAddress
 }
 
-func (c GUIConfiguration) SocketPermissions() os.FileMode {
-	perm, err := strconv.ParseUint(c.UnixSocketPermissions, 8, 32)
+func (c GUIConfiguration) UnixSocketPermissions() os.FileMode {
+	perm, err := strconv.ParseUint(c.RawUnixSocketPermissions, 8, 32)
 	if err != nil {
 		// ignore incorrectly formatted permissions
 		return 0

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -9,12 +9,14 @@ package config
 import (
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 )
 
 type GUIConfiguration struct {
 	Enabled                   bool     `xml:"enabled,attr" json:"enabled" default:"true"`
 	RawAddress                string   `xml:"address" json:"address" default:"127.0.0.1:8384"`
+	UnixPermissions           string   `xml:"unixPerms,omitempty" json:"unixPerms"`
 	User                      string   `xml:"user,omitempty" json:"user"`
 	Password                  string   `xml:"password,omitempty" json:"password"`
 	AuthMode                  AuthMode `xml:"authMode,omitempty" json:"authMode"`
@@ -57,6 +59,14 @@ func (c GUIConfiguration) Address() string {
 	}
 
 	return c.RawAddress
+}
+
+func (c GUIConfiguration) Permissions() os.FileMode {
+	perm, err := strconv.ParseUint(c.UnixPermissions, 0, 32)
+	if err != nil {
+		return 0
+	}
+	return os.FileMode(perm) & os.ModePerm
 }
 
 func (c GUIConfiguration) Network() string {

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -16,7 +16,7 @@ import (
 type GUIConfiguration struct {
 	Enabled                   bool     `xml:"enabled,attr" json:"enabled" default:"true"`
 	RawAddress                string   `xml:"address" json:"address" default:"127.0.0.1:8384"`
-	UnixPermissions           string   `xml:"unixPerms,omitempty" json:"unixPerms"`
+	UnixSocketPermissions     string   `xml:"unixSocketPermissions,omitempty" json:"unixSocketPermissions"`
 	User                      string   `xml:"user,omitempty" json:"user"`
 	Password                  string   `xml:"password,omitempty" json:"password"`
 	AuthMode                  AuthMode `xml:"authMode,omitempty" json:"authMode"`
@@ -61,8 +61,8 @@ func (c GUIConfiguration) Address() string {
 	return c.RawAddress
 }
 
-func (c GUIConfiguration) Permissions() os.FileMode {
-	perm, err := strconv.ParseUint(c.UnixPermissions, 8, 32)
+func (c GUIConfiguration) SocketPermissions() os.FileMode {
+	perm, err := strconv.ParseUint(c.UnixSocketPermissions, 8, 32)
 	if err != nil {
 		return 0
 	}

--- a/man/syncthing-config.5
+++ b/man/syncthing-config.5
@@ -607,10 +607,6 @@ If the address is an absolute path it is interpreted as the path to a UNIX socke
 (Added in v0.14.52.)
 .UNINDENT
 .TP
-.B unixSocketPermissions
-In the case that a UNIX socket location is used for \fBaddress\fP,
-set this to an octal to override the default permissions of the socket.
-.TP
 .B user
 Set to require authentication.
 .TP

--- a/man/syncthing-config.5
+++ b/man/syncthing-config.5
@@ -607,7 +607,7 @@ If the address is an absolute path it is interpreted as the path to a UNIX socke
 (Added in v0.14.52.)
 .UNINDENT
 .TP
-.B unixPerms
+.B unixSocketPermissions
 In the case that a UNIX socket location is used for \fBaddress\fP,
 set this to an octal to override the default permissions of the socket.
 .TP

--- a/man/syncthing-config.5
+++ b/man/syncthing-config.5
@@ -607,6 +607,10 @@ If the address is an absolute path it is interpreted as the path to a UNIX socke
 (Added in v0.14.52.)
 .UNINDENT
 .TP
+.B unixPerms
+In the case that a \fBUNIX socket location\fP is used for \fBaddress\fP,
+set this to an octal to override the default permissions of the socket.
+.TP
 .B user
 Set to require authentication.
 .TP

--- a/man/syncthing-config.5
+++ b/man/syncthing-config.5
@@ -608,7 +608,7 @@ If the address is an absolute path it is interpreted as the path to a UNIX socke
 .UNINDENT
 .TP
 .B unixPerms
-In the case that a \fBUNIX socket location\fP is used for \fBaddress\fP,
+In the case that a UNIX socket location is used for \fBaddress\fP,
 set this to an octal to override the default permissions of the socket.
 .TP
 .B user


### PR DESCRIPTION
### Purpose

This pull request solves #5979.
The problem is that a user may wish a unix socket to have specific permissions.
We can solve this by adding a configuration option for unix socket permissions.

### Testing

Navigate under the web UI to Actions > Settings > GUI and change the GUI Listen Address line to a local file. That will be created as a web socket. Check the permissions of this file.

### Screenshots

![screen](https://user-images.githubusercontent.com/14015672/74387796-944b1280-4dc7-11ea-869f-b05721e8c96d.png)

### Documentation

https://github.com/syncthing/docs/pull/492

### Tasklist
- [X] Add basic implementation showcasing solution efficacy
- [x] Add configuration option
- [x] Add UI for configuration option
- [x] Use configuration option in code
- [x] Update man pages
- [X] Add documentation for new option
- [X] Finish PR information

<!--
## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.
-->
