### PR TITLE
build: Add -trimpath compiler option

### DIFF
--- a/build.go
+++ b/build.go
@@ -410,7 +410,7 @@ func install(target target, tags []string) {
 	}
 
 	for _, pkg := range target.buildPkgs {
-		args := []string{"install", "-v"}
+		args := []string{"install", "-v", "-trimpath"}
 		args = appendParameters(args, tags, pkg)
 
 		runPrint(goCmd, args...)
@@ -443,7 +443,7 @@ func build(target target, tags []string) {
 	}
 
 	for _, pkg := range target.buildPkgs {
-		args := []string{"build", "-v"}
+		args := []string{"build", "-v", "-trimpath"}
 		args = appendParameters(args, tags, pkg)
 
 		runPrint(goCmd, args...)


### PR DESCRIPTION
Quoting the manual:

    -trimpath
      remove all file system paths from the resulting executable.
      Instead of absolute file system paths, the recorded file names
      will begin with either "go" (for the standard library),
      or a module path@version (when using modules),
      or a plain import path (when using GOPATH).

That is, when we panic, instead of:

    goroutine 1 [running]:
    main.main()
        /Users/jb/dev/syncthing/syncthing/cmd/syncthing/main.go:272 +0x116

we get:

    goroutine 1 [running]:
    main.main()
        github.com/syncthing/syncthing@/cmd/syncthing/main.go:272 +0x116

(Module path and file path within module.)
