### PR TITLE
all: Update metadata modtime on delete (ref #6284)

### DIFF
--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -127,6 +127,7 @@ func (f FileInfoTruncated) FilePermissions() uint32 {
 func (f FileInfoTruncated) FileModifiedBy() protocol.ShortID {
 	return f.ModifiedBy
 }
+
 func (f FileInfoTruncated) ConvertToIgnoredFileInfo(by protocol.ShortID) protocol.FileInfo {
 	return protocol.FileInfo{
 		Name:         f.Name,
@@ -137,6 +138,18 @@ func (f FileInfoTruncated) ConvertToIgnoredFileInfo(by protocol.ShortID) protoco
 		Version:      f.Version,
 		RawBlockSize: f.RawBlockSize,
 		LocalFlags:   protocol.FlagLocalIgnored,
+	}
+}
+
+func (f FileInfoTruncated) ConvertToDeletedFileInfo(by protocol.ShortID, localFlags uint32) protocol.FileInfo {
+	return protocol.FileInfo{
+		Name:       f.Name,
+		Type:       f.Type,
+		ModifiedS:  time.Now().Unix(),
+		ModifiedBy: by,
+		Deleted:    true,
+		Version:    f.Version.Update(by),
+		LocalFlags: localFlags,
 	}
 }
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -532,22 +532,11 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 					}
 					return true
 				}
-				nf := protocol.FileInfo{
-					Name:       file.Name,
-					Type:       file.Type,
-					Size:       0,
-					ModifiedS:  file.ModifiedS,
-					ModifiedNs: file.ModifiedNs,
-					ModifiedBy: f.shortID,
-					Deleted:    true,
-					Version:    file.Version.Update(f.shortID),
-					LocalFlags: f.localFlags,
-				}
-				// We do not want to override the global version
-				// with the deleted file. Setting to an empty
-				// version makes sure the file gets in sync on
-				// the following pull.
+				nf := file.ConvertToDeletedFileInfo(f.shortID, f.localFlags)
 				if file.ShouldConflict() {
+					// We do not want to override the global version with
+					// the deleted file. Setting to an empty version makes
+					// sure the file gets in sync on the following pull.
 					nf.Version = protocol.Vector{}
 				}
 

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -107,8 +107,7 @@ func (f *receiveOnlyFolder) Revert() {
 			fi = protocol.FileInfo{
 				Name:       fi.Name,
 				Type:       fi.Type,
-				ModifiedS:  fi.ModifiedS,
-				ModifiedNs: fi.ModifiedNs,
+				ModifiedS:  time.Now().Unix(),
 				ModifiedBy: f.shortID,
 				Deleted:    true,
 				Version:    protocol.Vector{}, // if this file ever resurfaces anywhere we want our delete to be strictly older


### PR DESCRIPTION
This records the time a file was marked as deleted. It will, in the future, aid in garbage collecting old files.
