### PR TITLE
lib/db: Add closeWaitGroup to allow async operation

### DIFF
--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -7,9 +7,7 @@
 package backend
 
 import (
-	stdsync "sync"
-
-	"github.com/syncthing/syncthing/lib/sync"
+	"sync"
 )
 
 // The Reader interface specifies the read-only operations available on the
@@ -152,21 +150,17 @@ func IsNotFound(err error) bool {
 
 // releaser manages counting on top of a waitgroup
 type releaser struct {
-	wg   sync.CloseWaitGroup
-	once *stdsync.Once
+	wg   *closeWaitGroup
+	once *sync.Once
 }
 
-func newReleaser(wg sync.CloseWaitGroup) (*releaser, error) {
+func newReleaser(wg *closeWaitGroup) (*releaser, error) {
 	if err := wg.Add(1); err != nil {
-		// This should only return an error if wg was already closed
-		if err != sync.ErrClosed {
-			panic(err)
-		}
-		return nil, errClosed{}
+		return nil, err
 	}
 	return &releaser{
 		wg:   wg,
-		once: new(stdsync.Once),
+		once: new(sync.Once),
 	}, nil
 }
 
@@ -176,4 +170,30 @@ func (r releaser) Release() {
 	r.once.Do(func() {
 		r.wg.Done()
 	})
+}
+
+// closeWaitGroup behaves just like a sync.WaitGroup, but does not require
+// a single routine to do the Add and Wait calls. If Add is called after
+// CloseWait, it will return an error, and both are safe to be used concurrently.
+type closeWaitGroup struct {
+	sync.WaitGroup
+	closed   bool
+	closeMut sync.RWMutex
+}
+
+func (cg *closeWaitGroup) Add(i int) error {
+	cg.closeMut.RLock()
+	defer cg.closeMut.RUnlock()
+	if cg.closed {
+		return errClosed{}
+	}
+	cg.WaitGroup.Add(i)
+	return nil
+}
+
+func (cg *closeWaitGroup) CloseWait() {
+	cg.closeMut.Lock()
+	cg.closed = true
+	cg.closeMut.Unlock()
+	cg.WaitGroup.Wait()
 }

--- a/lib/db/backend/leveldb_open.go
+++ b/lib/db/backend/leveldb_open.go
@@ -42,7 +42,7 @@ func OpenLevelDB(location string, tuning Tuning) (Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &leveldbBackend{ldb: ldb}, nil
+	return newLeveldbBackend(ldb), nil
 }
 
 // OpenRO attempts to open the database at the given location, read only.
@@ -55,13 +55,13 @@ func OpenLevelDBRO(location string) (Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &leveldbBackend{ldb: ldb}, nil
+	return newLeveldbBackend(ldb), nil
 }
 
 // OpenMemory returns a new Backend referencing an in-memory database.
 func OpenLevelDBMemory() Backend {
 	ldb, _ := leveldb.Open(storage.NewMemStorage(), nil)
-	return &leveldbBackend{ldb: ldb}
+	return newLeveldbBackend(ldb)
 }
 
 // optsFor returns the database options to use when opening a database with

--- a/lib/db/blockmap_test.go
+++ b/lib/db/blockmap_test.go
@@ -106,6 +106,7 @@ func discardFromBlockMap(db *Lowlevel, folder []byte, fs []protocol.FileInfo) er
 
 func TestBlockMapAddUpdateWipe(t *testing.T) {
 	db, f := setup()
+	defer db.Close()
 
 	if !dbEmpty(db) {
 		t.Fatal("db not empty")
@@ -193,6 +194,7 @@ func TestBlockMapAddUpdateWipe(t *testing.T) {
 
 func TestBlockFinderLookup(t *testing.T) {
 	db, f := setup()
+	defer db.Close()
 
 	folder1 := []byte("folder1")
 	folder2 := []byte("folder2")

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -33,6 +33,7 @@ func TestIgnoredFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 	db := NewLowlevel(ldb)
+	defer db.Close()
 	if err := UpdateSchema(db); err != nil {
 		t.Fatal(err)
 	}
@@ -161,6 +162,7 @@ func TestUpdate0to3(t *testing.T) {
 	}
 
 	db := NewLowlevel(ldb)
+	defer db.Close()
 	updater := schemaUpdater{db}
 
 	folder := []byte(update0to3Folder)
@@ -173,6 +175,7 @@ func TestUpdate0to3(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer trans.Release()
 	if _, ok, err := trans.getFile(folder, protocol.LocalDeviceID[:], []byte(slashPrefixed)); err != nil {
 		t.Fatal(err)
 	} else if ok {
@@ -196,6 +199,7 @@ func TestUpdate0to3(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer trans.Release()
 	_ = trans.withHaveSequence(folder, 0, func(fi FileIntf) bool {
 		f := fi.(protocol.FileInfo)
 		l.Infoln(f)
@@ -227,6 +231,7 @@ func TestUpdate0to3(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer trans.Release()
 	_ = trans.withNeed(folder, protocol.LocalDeviceID[:], false, func(fi FileIntf) bool {
 		e, ok := need[fi.FileName()]
 		if !ok {
@@ -246,6 +251,7 @@ func TestUpdate0to3(t *testing.T) {
 
 func TestDowngrade(t *testing.T) {
 	db := NewLowlevel(backend.OpenMemory())
+	defer db.Close()
 	// sets the min version etc
 	if err := UpdateSchema(db); err != nil {
 		t.Fatal(err)

--- a/lib/db/keyer_test.go
+++ b/lib/db/keyer_test.go
@@ -19,6 +19,7 @@ func TestDeviceKey(t *testing.T) {
 	name := []byte("name")
 
 	db := NewLowlevel(backend.OpenMemory())
+	defer db.Close()
 
 	key, err := db.keyer.GenerateDeviceFileKey(nil, fld, dev, name)
 	if err != nil {
@@ -50,6 +51,7 @@ func TestGlobalKey(t *testing.T) {
 	name := []byte("name")
 
 	db := NewLowlevel(backend.OpenMemory())
+	defer db.Close()
 
 	key, err := db.keyer.GenerateGlobalVersionKey(nil, fld, name)
 	if err != nil {
@@ -78,6 +80,7 @@ func TestSequenceKey(t *testing.T) {
 	fld := []byte("folder6789012345678901234567890123456789012345678901234567890123")
 
 	db := NewLowlevel(backend.OpenMemory())
+	defer db.Close()
 
 	const seq = 1234567890
 	key, err := db.keyer.GenerateSequenceKey(nil, fld, seq)

--- a/lib/db/namespaced_test.go
+++ b/lib/db/namespaced_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestNamespacedInt(t *testing.T) {
 	ldb := NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	n1 := NewNamespacedKV(ldb, "foo")
 	n2 := NewNamespacedKV(ldb, "bar")
@@ -62,6 +63,7 @@ func TestNamespacedInt(t *testing.T) {
 
 func TestNamespacedTime(t *testing.T) {
 	ldb := NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	n1 := NewNamespacedKV(ldb, "foo")
 
@@ -85,6 +87,7 @@ func TestNamespacedTime(t *testing.T) {
 
 func TestNamespacedString(t *testing.T) {
 	ldb := NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	n1 := NewNamespacedKV(ldb, "foo")
 
@@ -107,6 +110,7 @@ func TestNamespacedString(t *testing.T) {
 
 func TestNamespacedReset(t *testing.T) {
 	ldb := NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	n1 := NewNamespacedKV(ldb, "foo")
 

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -129,6 +129,7 @@ func (l fileList) String() string {
 
 func TestGlobalSet(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	m := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -346,6 +347,7 @@ func TestGlobalSet(t *testing.T) {
 
 func TestNeedWithInvalid(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -383,6 +385,7 @@ func TestNeedWithInvalid(t *testing.T) {
 
 func TestUpdateToInvalid(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	s := db.NewFileSet(folder, fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
@@ -439,6 +442,7 @@ func TestUpdateToInvalid(t *testing.T) {
 
 func TestInvalidAvailability(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -480,6 +484,7 @@ func TestInvalidAvailability(t *testing.T) {
 
 func TestGlobalReset(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	m := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -518,6 +523,7 @@ func TestGlobalReset(t *testing.T) {
 
 func TestNeed(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	m := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -556,6 +562,7 @@ func TestNeed(t *testing.T) {
 
 func TestSequence(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	m := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -586,6 +593,7 @@ func TestSequence(t *testing.T) {
 
 func TestListDropFolder(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s0 := db.NewFileSet("test0", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 	local1 := []protocol.FileInfo{
@@ -636,6 +644,7 @@ func TestListDropFolder(t *testing.T) {
 
 func TestGlobalNeedWithInvalid(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s := db.NewFileSet("test1", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -677,6 +686,7 @@ func TestGlobalNeedWithInvalid(t *testing.T) {
 
 func TestLongPath(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -736,6 +746,7 @@ func BenchmarkUpdateOneFile(b *testing.B) {
 
 func TestIndexID(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -831,6 +842,7 @@ func TestDropFiles(t *testing.T) {
 
 func TestIssue4701(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -872,6 +884,7 @@ func TestIssue4701(t *testing.T) {
 
 func TestWithHaveSequence(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	s := db.NewFileSet(folder, fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
@@ -909,6 +922,7 @@ func TestStressWithHaveSequence(t *testing.T) {
 	}
 
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	s := db.NewFileSet(folder, fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
@@ -953,6 +967,7 @@ loop:
 
 func TestIssue4925(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	s := db.NewFileSet(folder, fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
@@ -979,6 +994,7 @@ func TestIssue4925(t *testing.T) {
 
 func TestMoveGlobalBack(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	file := "foo"
@@ -1043,6 +1059,7 @@ func TestMoveGlobalBack(t *testing.T) {
 // https://github.com/syncthing/syncthing/issues/5007
 func TestIssue5007(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	file := "foo"
@@ -1070,6 +1087,7 @@ func TestIssue5007(t *testing.T) {
 // when the global file is deleted.
 func TestNeedDeleted(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	file := "foo"
@@ -1104,6 +1122,7 @@ func TestNeedDeleted(t *testing.T) {
 
 func TestReceiveOnlyAccounting(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	s := db.NewFileSet(folder, fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
@@ -1208,6 +1227,7 @@ func TestReceiveOnlyAccounting(t *testing.T) {
 
 func TestNeedAfterUnignore(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	folder := "test"
 	file := "foo"
@@ -1240,6 +1260,7 @@ func TestRemoteInvalidNotAccounted(t *testing.T) {
 	// Remote files with the invalid bit should not count.
 
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
 	files := []protocol.FileInfo{
@@ -1259,6 +1280,7 @@ func TestRemoteInvalidNotAccounted(t *testing.T) {
 
 func TestNeedWithNewerInvalid(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	s := db.NewFileSet("default", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
@@ -1297,6 +1319,7 @@ func TestNeedWithNewerInvalid(t *testing.T) {
 
 func TestNeedAfterDeviceRemove(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	file := "foo"
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
@@ -1324,6 +1347,7 @@ func TestCaseSensitive(t *testing.T) {
 	// Normal case sensitive lookup should work
 
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
 	local := []protocol.FileInfo{
@@ -1361,6 +1385,7 @@ func TestSequenceIndex(t *testing.T) {
 	// Set up a db and a few files that we will manipulate.
 
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)
 
 	local := []protocol.FileInfo{
@@ -1454,6 +1479,7 @@ func TestSequenceIndex(t *testing.T) {
 
 func TestIgnoreAfterReceiveOnly(t *testing.T) {
 	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
 
 	file := "foo"
 	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeBasic, "."), ldb)

--- a/lib/sync/sync.go
+++ b/lib/sync/sync.go
@@ -42,17 +42,6 @@ type WaitGroup interface {
 	Wait()
 }
 
-var ErrClosed = fmt.Errorf("is closed")
-
-// CloseWaitGroup behaves just like a sync.WaitGroup, but does not require
-// a single routine to do the Add and Wait calls. If Add is called after
-// CloseWait, it will return an error, and both are safe to be used concurrently.
-type CloseWaitGroup interface {
-	Add(int) error
-	Done()
-	CloseWait()
-}
-
 func NewMutex() Mutex {
 	if useDeadlock {
 		return &deadlock.Mutex{}
@@ -222,33 +211,6 @@ func (wg *loggedWaitGroup) Wait() {
 	if duration >= threshold {
 		l.Debugf("WaitGroup took %v at %s", duration, getHolder())
 	}
-}
-
-type closeWaitGroup struct {
-	sync.WaitGroup
-	closed   bool
-	closeMut sync.RWMutex
-}
-
-func NewCloseWaitGroup() CloseWaitGroup {
-	return &closeWaitGroup{}
-}
-
-func (cg *closeWaitGroup) Add(i int) error {
-	cg.closeMut.RLock()
-	defer cg.closeMut.RUnlock()
-	if cg.closed {
-		return ErrClosed
-	}
-	cg.WaitGroup.Add(i)
-	return nil
-}
-
-func (cg *closeWaitGroup) CloseWait() {
-	cg.closeMut.Lock()
-	cg.closed = true
-	cg.closeMut.Unlock()
-	cg.WaitGroup.Wait()
 }
 
 func getHolder() holder {


### PR DESCRIPTION
Looking into https://forum.syncthing.net/t/test-panic-on-go1-14beta1/14462 (fruitlessly) I saw lots of gc runners in the backtrace. Turns out we never close databases in tests. Closing then turns up a race in goleveldb:

```
==================
WARNING: DATA RACE
Read at 0x00c00014a8b0 by goroutine 64:
  runtime.chansend()
      /media/ext4_data/Linux/source/go/src/runtime/chan.go:142 +0x0
  github.com/syndtr/goleveldb/leveldb.cAuto.ack()
      /media/ext4_data/Coding/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db_compaction.go:686 +0xab
  github.com/syndtr/goleveldb/leveldb.(*DB).mCompaction()
      /media/ext4_data/Coding/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db_compaction.go:778 +0xc9

Previous write at 0x00c00014a8b0 by goroutine 65:
  runtime.closechan()
      /media/ext4_data/Linux/source/go/src/runtime/chan.go:335 +0x0
  github.com/syndtr/goleveldb/leveldb.(*DB).compTriggerWait()
      /media/ext4_data/Coding/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db_compaction.go:730 +0x4eb
  github.com/syndtr/goleveldb/leveldb.(*DB).rotateMem()
      /media/ext4_data/Coding/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db_write.go:39 +0x7f
  github.com/syndtr/goleveldb/leveldb.(*DB).CompactRange()
      /media/ext4_data/Coding/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db_write.go:422 +0x415
  github.com/syncthing/syncthing/lib/db/backend.(*leveldbBackend).Compact()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/backend/leveldb_backend.go:107 +0xa8
  github.com/syncthing/syncthing/lib/db.(*Lowlevel).gcBlocks()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/lowlevel.go:590 +0x647
  github.com/syncthing/syncthing/lib/db.(*Lowlevel).gcRunner()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/lowlevel.go:483 +0x278

Goroutine 64 (running) created at:
  github.com/syndtr/goleveldb/leveldb.openDB()
      /media/ext4_data/Coding/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db.go:156 +0x971
  github.com/syndtr/goleveldb/leveldb.Open()
      /media/ext4_data/Coding/go/pkg/mod/github.com/syndtr/goleveldb@v1.0.1-0.20190923125748-758128399b1d/leveldb/db.go:203 +0x1e5
  github.com/syncthing/syncthing/lib/db/backend.OpenLevelDBMemory()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/backend/leveldb_open.go:63 +0xd7
  github.com/syncthing/syncthing/lib/db/backend.OpenMemory()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/backend/backend.go:122 +0x132
  github.com/syncthing/syncthing/lib/db.TestDeviceKey()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/keyer_test.go:21 +0x133
  testing.tRunner()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:993 +0x1eb

Goroutine 65 (running) created at:
  github.com/syncthing/syncthing/lib/db.NewLowlevel()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/lowlevel.go:65 +0x369
  github.com/syncthing/syncthing/lib/db.TestDeviceKey()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/keyer_test.go:21 +0x137
  testing.tRunner()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:993 +0x1eb
==================
```

Apparently it doesn't like when the db is closed while a compaction is ongoing. Easy, use the releaser in the compaction. That then more reliably brings up a race for `WaitGroup` (I have seen that before on TC very seldomly):

```
==================
WARNING: DATA RACE
Write at 0x00c000098550 by goroutine 85:
  internal/race.Write()
      /media/ext4_data/Linux/source/go/src/internal/race/race.go:41 +0x114
  sync.(*WaitGroup).Wait()
      /media/ext4_data/Linux/source/go/src/sync/waitgroup.go:128 +0x115
  github.com/syncthing/syncthing/lib/db/backend.(*leveldbBackend).Close()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/backend/leveldb_backend.go:59 +0x42
  github.com/syncthing/syncthing/lib/db.(*Lowlevel).Close()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/lowlevel.go:71 +0x78
  github.com/syncthing/syncthing/lib/db.TestNamespacedInt()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/namespaced_test.go:62 +0x6a2
  testing.tRunner()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:993 +0x1eb

Previous read at 0x00c000098550 by goroutine 92:
  internal/race.Read()
      /media/ext4_data/Linux/source/go/src/internal/race/race.go:37 +0x1e8
  sync.(*WaitGroup).Add()
      /media/ext4_data/Linux/source/go/src/sync/waitgroup.go:71 +0x1fb
  github.com/syncthing/syncthing/lib/db/backend.newReleaser()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/backend/backend.go:158 +0x1c0
  github.com/syncthing/syncthing/lib/db/backend.(*leveldbBackend).newSnapshot()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/backend/leveldb_backend.go:41 +0x1a1
  github.com/syncthing/syncthing/lib/db/backend.(*leveldbBackend).NewWriteTransaction()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/backend/leveldb_backend.go:46 +0x50
  github.com/syncthing/syncthing/lib/db.(*Lowlevel).newReadWriteTransaction()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/transactions.go:430 +0x6f
  github.com/syncthing/syncthing/lib/db.(*Lowlevel).gcBlocks()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/lowlevel.go:525 +0xf2
  github.com/syncthing/syncthing/lib/db.(*Lowlevel).gcRunner()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/lowlevel.go:483 +0x278

Goroutine 85 (running) created at:
  testing.(*T).Run()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:1044 +0x660
  testing.runTests.func1()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:1286 +0xa6
  testing.tRunner()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:993 +0x1eb
  testing.runTests()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:1284 +0x527
  testing.(*M).Run()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:1201 +0x2ff
  main.main()
      _testmain.go:156 +0x223

Goroutine 92 (running) created at:
  github.com/syncthing/syncthing/lib/db.NewLowlevel()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/lowlevel.go:65 +0x369
  github.com/syncthing/syncthing/lib/db.TestNamespacedInt()
      /media/ext4_data/Coding/go/src/github.com/syncthing/syncthing/lib/db/namespaced_test.go:17 +0x4c
  testing.tRunner()
      /media/ext4_data/Linux/source/go/src/testing/testing.go:993 +0x1eb
==================
```

That's because a waitgroup is not meant for async calls to `Add` and `Wait`. So I wrapped it in `lib/sync` as `CloseWaitGroup` which can be called async but can't be reuced (waiting "closes" the waitgroup).

That fixes all the races, however https://forum.syncthing.net/t/test-panic-on-go1-14beta1/14462 still occurs flakely.