### PR TITLE
lib/db: Handle missing block lists as missing file (ref #6321)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -550,7 +550,9 @@ func (db *Lowlevel) gcBlocks() error {
 		if err := bl.Unmarshal(it.Value()); err != nil {
 			return err
 		}
-		filter.Add(bl.BlocksHash)
+		if len(bl.BlocksHash) > 0 {
+			filter.Add(bl.BlocksHash)
+		}
 	}
 	it.Release()
 	if err := it.Error(); err != nil {

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -59,6 +59,9 @@ func (t readOnlyTransaction) getFileTrunc(key []byte, trunc bool) (FileIntf, boo
 		return nil, false, err
 	}
 	f, err := t.unmarshalTrunc(bs, trunc)
+	if backend.IsNotFound(err) {
+		return nil, false, nil
+	}
 	if err != nil {
 		return nil, false, err
 	}
@@ -86,7 +89,7 @@ func (t readOnlyTransaction) unmarshalTrunc(bs []byte, trunc bool) (FileIntf, er
 }
 
 func (t readOnlyTransaction) fillBlockList(fi *protocol.FileInfo) error {
-	if fi.BlocksHash == nil {
+	if len(fi.BlocksHash) == 0 {
 		return nil
 	}
 	blocksKey := t.keyer.GenerateBlockListKey(nil, fi.BlocksHash)


### PR DESCRIPTION
Bandage over the wound...

Also explicitly handle non-nil but empty block lists (if they should
ever pop up as an effect of unmarshalling changes or whatnot).

