### PR TITLE
lib/model: Consistent error return values for folder methods on model

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -48,7 +48,11 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 	m.Index(device1, "ro", knownFiles)
 	f.updateLocalsFromScanning(knownFiles)
 
-	size := globalSize(t, m, "ro")
+	m.fmut.RLock()
+	snap := m.folderFiles["ro"].Snapshot()
+	m.fmut.RUnlock()
+	size := snap.GlobalSize()
+	snap.Release()
 	if size.Files != 1 || size.Directories != 1 {
 		t.Fatalf("Global: expected 1 file and 1 directory: %+v", size)
 	}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -840,10 +840,11 @@ func (m *model) Completion(device protocol.DeviceID, folder string) FolderComple
 // DBSnapshot returns a snapshot of the database content relevant to the given folder.
 func (m *model) DBSnapshot(folder string) (*db.Snapshot, error) {
 	m.fmut.RLock()
-	rf, ok := m.folderFiles[folder]
+	err := m.checkFolderRunningLocked(folder)
+	rf := m.folderFiles[folder]
 	m.fmut.RUnlock()
-	if !ok {
-		return nil, errFolderMissing
+	if err != nil {
+		return nil, err
 	}
 	return rf.Snapshot(), nil
 }


### PR DESCRIPTION
~~#6272 makes sure not running folders don't result in a 404 on the rest api, however the method  `Model.DBSnapshot` introduced in #6239 doesn't look at why a folder isn't running, it just returns a folder missing error if it's not running. So Synctrayzor still presents an error message due to a 404: https://forum.syncthing.net/t/rest-db-status-returns-404-on-startup/14329/19~~  
Looks like #6239 isn't easily compatible with not returning a 404. At least it isn't doable with the fixes in this PR. The PR in itself is still useful.