### PR TITLE
lib/model: Return empty summary on paused folders (ref #6272)

### DIFF
--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -90,6 +90,7 @@ func (c *folderSummaryService) Summary(folder string) (map[string]interface{}, e
 			ro = snap.ReceiveOnlyChangedSize()
 			ourSeq = snap.Sequence(protocol.LocalDeviceID)
 			remoteSeq = snap.Sequence(protocol.GlobalDeviceID)
+			snap.Release()
 		}
 	}
 	// For API backwards compatibility (SyncTrayzor needs it) an empty folder

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3479,3 +3479,16 @@ func TestNewLimitedRequestResponse(t *testing.T) {
 		t.Error("Bytes weren't returned in a timely fashion")
 	}
 }
+
+func TestSummaryPausedNoError(t *testing.T) {
+	wcfg, fcfg := tmpDefaultWrapper()
+	fcfg.Paused = true
+	wcfg.SetFolder(fcfg)
+	m := setupModel(wcfg)
+	defer cleanupModel(m)
+
+	fss := NewFolderSummaryService(wcfg, m, myID, events.NoopLogger)
+	if _, err := fss.Summary(fcfg.ID); err != nil {
+		t.Error("Expected no error getting a summary for a paused folder:", err)
+	}
+}


### PR DESCRIPTION
This now actually addresses the 404 on the rest api that makes trouble for SyncTrayzor (https://forum.syncthing.net/t/rest-db-status-returns-404-on-startup/14329). The behaviour is, that we return an empty folder summary in that case. I think that's not a good API and instead the folder summary service should have access to the db for paused folders as well (e.g. global and local state are still useful info then), but that's a much bigger change. This just makes sure the behaviour doesn't change.

I didn't add a rest api error, as it can't use the model package. However I added a test in the model that makes sure that no error is returned when getting a folder summary for a paused folder.