### PR TITLE
etc: Use After=nework-online in systemd service

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Syncthing - Open Source Continuous File Synchronization for %I
 Documentation=man:syncthing(1)
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=%i


### PR DESCRIPTION
Also add "Wants=network-online.target"
https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/

### Purpose

Syncthing often fails to start on Ubuntu18.04 because the network is not really up.

### Testing

I have edited the service file like in the PR and it does start later, after the network is up.
