### PR TITLE
lib/db: Use Commit() instead of commit()

### DIFF
--- a/lib/db/blockmap_test.go
+++ b/lib/db/blockmap_test.go
@@ -76,7 +76,7 @@ func addToBlockMap(db *Lowlevel, folder []byte, fs []protocol.FileInfo) error {
 			}
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 func discardFromBlockMap(db *Lowlevel, folder []byte, fs []protocol.FileInfo) error {
@@ -101,7 +101,7 @@ func discardFromBlockMap(db *Lowlevel, folder []byte, fs []protocol.FileInfo) er
 			}
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 func TestBlockMapAddUpdateWipe(t *testing.T) {

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -129,7 +129,7 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 		}
 	}
 
-	return t.commit()
+	return t.Commit()
 }
 
 // updateLocalFiles adds fileinfos to the db, and updates the global versionlist,
@@ -232,7 +232,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		}
 	}
 
-	return t.commit()
+	return t.Commit()
 }
 
 func (db *Lowlevel) dropFolder(folder []byte) error {
@@ -290,7 +290,7 @@ func (db *Lowlevel) dropFolder(folder []byte) error {
 		return err
 	}
 
-	return t.commit()
+	return t.Commit()
 }
 
 func (db *Lowlevel) dropDeviceFolder(device, folder []byte, meta *metadataTracker) error {
@@ -343,7 +343,7 @@ func (db *Lowlevel) dropDeviceFolder(device, folder []byte, meta *metadataTracke
 			return err
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 func (db *Lowlevel) checkGlobals(folder []byte, meta *metadataTracker) error {
@@ -411,7 +411,7 @@ func (db *Lowlevel) checkGlobals(folder []byte, meta *metadataTracker) error {
 	}
 
 	l.Debugf("db check completed for %q", folder)
-	return t.commit()
+	return t.Commit()
 }
 
 func (db *Lowlevel) getIndexID(device, folder []byte) (protocol.IndexID, error) {
@@ -469,7 +469,7 @@ func (db *Lowlevel) dropPrefix(prefix []byte) error {
 	if err := t.deleteKeyPrefix(prefix); err != nil {
 		return err
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 func (db *Lowlevel) gcRunner() {

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -204,7 +204,7 @@ func (db *schemaUpdater) updateSchema0to1(_ int) error {
 			return err
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 // updateSchema1to2 introduces a sequenceKey->deviceKey bucket for local items
@@ -240,7 +240,7 @@ func (db *schemaUpdater) updateSchema1to2(_ int) error {
 			return err
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 // updateSchema2to3 introduces a needKey->nil bucket for locally needed files.
@@ -288,7 +288,7 @@ func (db *schemaUpdater) updateSchema2to3(_ int) error {
 			return err
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 // updateSchemaTo5 resets the need bucket due to bugs existing in the v0.14.49
@@ -314,7 +314,7 @@ func (db *schemaUpdater) updateSchemaTo5(prevVersion int) error {
 			return err
 		}
 	}
-	if err := t.commit(); err != nil {
+	if err := t.Commit(); err != nil {
 		return err
 	}
 
@@ -361,7 +361,7 @@ func (db *schemaUpdater) updateSchema5to6(_ int) error {
 			return err
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 // updateSchema6to7 checks whether all currently locally needed files are really
@@ -418,7 +418,7 @@ func (db *schemaUpdater) updateSchema6to7(_ int) error {
 			return err
 		}
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 func (db *schemaUpdater) updateSchema7to8(_ int) error {
@@ -453,5 +453,5 @@ func (db *schemaUpdater) updateSchema7to8(_ int) error {
 
 	db.recordTime(blockGCTimeKey)
 
-	return t.commit()
+	return t.Commit()
 }

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -443,7 +443,7 @@ func (db *Lowlevel) newReadWriteTransaction() (readWriteTransaction, error) {
 	}, nil
 }
 
-func (t readWriteTransaction) commit() error {
+func (t readWriteTransaction) Commit() error {
 	t.readOnlyTransaction.close()
 	return t.WriteTransaction.Commit()
 }
@@ -758,7 +758,7 @@ func (t *readWriteTransaction) withAllFolderTruncated(folder []byte, fn func(dev
 	if err := dbi.Error(); err != nil {
 		return err
 	}
-	return t.commit()
+	return t.Commit()
 }
 
 type marshaller interface {


### PR DESCRIPTION
The readWriteTransaction offered both `commit()` (the one to use) and
`Commit()` (via embedding) where the latter didn't close the read
transaction. This removes the lower cased variant in order to prevent
the mistake.

The only place where the mistake was made was the new gc runner, where
it would leave a read snapshot open forever.
