### PR TITLE
lib/db: Use flags from arg not LocalFlags() updating meta

### DIFF
--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -197,7 +197,7 @@ func (m *metadataTracker) removeFile(dev protocol.DeviceID, f FileIntf) {
 }
 
 func (m *metadataTracker) removeFileLocked(dev protocol.DeviceID, flags uint32, f FileIntf) {
-	cp := m.countsPtr(dev, f.FileLocalFlags())
+	cp := m.countsPtr(dev, flags)
 
 	switch {
 	case f.IsDeleted():


### PR DESCRIPTION
We store metadata in single flag buckets. On adding files to meta we do it right and just use the flags passed as arguments, on removing we do however use the localflags from the file. That's what is fixed in the first commit (single line). The second commit renames `flags` to `flag` in places where it should by just a single bit and adds a check to `countsPtr` that it is indeed the case.

Unfortunately (or not) I think this has no real-world implications, as we only ever have one local flag set on a file. If I am wrong on that, this might actually fix inconsistent local states.