### PR TITLE
lib/db: Recover sequence number and metadata on startup (fixes #6335)

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -146,6 +146,7 @@ func (s *FileSet) verifyLocalSequence() (ok bool) {
 
 	curSeq := s.meta.Sequence(protocol.LocalDeviceID)
 	snap := s.Snapshot()
+	ok = true
 	snap.WithHaveSequence(curSeq, func(fi FileIntf) bool {
 		if fi.SequenceNo() > curSeq {
 			// Out of sync, we will recalculate the folder.

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -148,7 +148,7 @@ func (s *FileSet) verifyLocalSequence() bool {
 
 	snap := s.Snapshot()
 	ok := true
-	snap.WithHaveSequence(curSeq, func(fi FileIntf) bool {
+	snap.WithHaveSequence(curSeq+1, func(fi FileIntf) bool {
 		ok = false // we got something, which we should not have
 		return false
 	})

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -146,14 +146,6 @@ func (s *FileSet) verifyLocalSequence() bool {
 
 	curSeq := s.meta.Sequence(protocol.LocalDeviceID)
 
-	first, err := s.db.keyer.GenerateSequenceKey(nil, folder, curSeq)
-	it, err := s.db.NewRangeIterator(first, nil)
-	if err != nil {
-		return false
-	}
-	defer it.Release()
-	return !it.Next()
-
 	snap := s.Snapshot()
 	ok := true
 	snap.WithHaveSequence(curSeq, func(fi FileIntf) bool {

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -71,7 +71,7 @@ func init() {
 }
 
 func NewFileSet(folder string, fs fs.Filesystem, db *Lowlevel) *FileSet {
-	var s = FileSet{
+	var s = &FileSet{
 		folder:      folder,
 		fs:          fs,
 		db:          db,
@@ -85,7 +85,7 @@ func NewFileSet(folder string, fs fs.Filesystem, db *Lowlevel) *FileSet {
 		} else if err != nil {
 			panic(err)
 		}
-		return &s
+		return s
 	}
 
 	if err := s.meta.fromDB(db, []byte(folder)); err != nil {
@@ -103,7 +103,7 @@ func NewFileSet(folder string, fs fs.Filesystem, db *Lowlevel) *FileSet {
 		return recalc()
 	}
 
-	return &s
+	return s
 }
 
 func (s *FileSet) recalcMeta() error {


### PR DESCRIPTION
### Purpose

If we crashed after writing new file entries but before updating metadata in the database the sequence number and metadata will be wrong. This fixes that.

### Testing

I have an elegant stress test for this, but it's too large to fit in the margins of this PR. I'm going to improve that a bit more (still bug hunting) and then commit it separately.

Testing it separately is annoying as we need to reach in and mess up the metadata which is tricky. :/
