### PR TITLE
lib/db: Keep metadata better in sync (ref #6335)

### DIFF
--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -48,10 +48,15 @@ type ReadTransaction interface {
 // purposes of saving memory when transactions are in-RAM. Note that
 // transactions may be checkpointed *anyway* even if this is not called, due to
 // resource constraints, but this gives you a chance to decide when.
+//
+// Functions can be passed to Checkpoint. These are run if and only if the
+// checkpoint will result in a flush, and will run before the flush. The
+// transaction can be accessed via a closure. If an error is returned from
+// these functions the flush will be aborted and the error bubbled.
 type WriteTransaction interface {
 	ReadTransaction
 	Writer
-	Checkpoint() error
+	Checkpoint(...func() error) error
 	Commit() error
 }
 

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -124,7 +124,9 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 			return err
 		}
 
-		if err := t.Checkpoint(); err != nil {
+		if err := t.Checkpoint(func() error {
+			return meta.toDB(t, folder)
+		}); err != nil {
 			return err
 		}
 	}
@@ -231,7 +233,9 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 			}
 		}
 
-		if err := t.Checkpoint(); err != nil {
+		if err := t.Checkpoint(func() error {
+			return meta.toDB(t, folder)
+		}); err != nil {
 			return err
 		}
 	}

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -124,6 +124,10 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 			return err
 		}
 
+		if err := meta.toDB(t, folder); err != nil {
+			return err
+		}
+
 		if err := t.Checkpoint(); err != nil {
 			return err
 		}
@@ -225,6 +229,10 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 					return err
 				}
 			}
+		}
+
+		if err := meta.toDB(t, folder); err != nil {
+			return err
 		}
 
 		if err := t.Checkpoint(); err != nil {

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -124,13 +124,13 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 			return err
 		}
 
-		if err := meta.toDB(t, folder); err != nil {
-			return err
-		}
-
 		if err := t.Checkpoint(); err != nil {
 			return err
 		}
+	}
+
+	if err := meta.toDB(t, folder); err != nil {
+		return err
 	}
 
 	return t.Commit()
@@ -231,13 +231,13 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 			}
 		}
 
-		if err := meta.toDB(t, folder); err != nil {
-			return err
-		}
-
 		if err := t.Checkpoint(); err != nil {
 			return err
 		}
+	}
+
+	if err := meta.toDB(t, folder); err != nil {
+		return err
 	}
 
 	return t.Commit()

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -62,8 +62,8 @@ func (m *metadataTracker) Marshal() ([]byte, error) {
 
 // toDB saves the marshalled metadataTracker to the given db, under the key
 // corresponding to the given folder
-func (m *metadataTracker) toDB(db *Lowlevel, folder []byte) error {
-	key, err := db.keyer.GenerateFolderMetaKey(nil, folder)
+func (m *metadataTracker) toDB(t readWriteTransaction, folder []byte) error {
+	key, err := t.keyer.GenerateFolderMetaKey(nil, folder)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func (m *metadataTracker) toDB(db *Lowlevel, folder []byte) error {
 	if err != nil {
 		return err
 	}
-	err = db.Put(key, bs)
+	err = t.Put(key, bs)
 	if err == nil {
 		m.dirty = false
 	}


### PR DESCRIPTION
This adds metadata updates to the same write batch as the underlying
file change. The odds of a metadata update going missing is greatly
reduced.

Bonus change: actually commit the transaction in recalcMeta.

This now makes the previous recovery thing not kick in during my stress testing...