### PR TITLE
lib/upnp: Exit quicker

### DIFF
--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -175,9 +175,10 @@ USER-AGENT: syncthing/1.0
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// Listen for responses until a timeout is reached
-loop:
+	// Listen for responses until a timeout is reached or the context is
+	// cancelled
 	resp := make([]byte, 65536)
+loop:
 	for {
 		if err := socket.SetDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
 			l.Infoln("UPnP socket:", err)

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -160,12 +160,6 @@ USER-AGENT: syncthing/1.0
 	}
 	defer socket.Close() // Make sure our socket gets closed
 
-	err = socket.SetDeadline(time.Now().Add(timeout))
-	if err != nil {
-		l.Debugln("UPnP discovery: setting socket deadline:", err)
-		return
-	}
-
 	l.Debugln("Sending search request for device type", deviceType, "on", intf.Name)
 
 	_, err = socket.WriteTo(search, ssdp)
@@ -178,15 +172,29 @@ USER-AGENT: syncthing/1.0
 
 	l.Debugln("Listening for UPnP response for device type", deviceType, "on", intf.Name)
 
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	// Listen for responses until a timeout is reached
+loop:
 	for {
 		resp := make([]byte, 65536)
+		if err := socket.SetDeadline(time.Now().Add(time.Second)); err != nil {
+			l.Infoln("UPnP socket:", err)
+			break
+		}
 		n, _, err := socket.ReadFrom(resp)
 		if err != nil {
+			select {
+			case <-ctx.Done():
+				break loop
+			default:
+			}
 			if e, ok := err.(net.Error); !ok || !e.Timeout() {
 				l.Infoln("UPnP read:", err) //legitimate error, not a timeout.
+				break
 			}
-			break
+			continue // continue reading
 		}
 		igds, err := parseResponse(ctx, deviceType, resp[:n])
 		if err != nil {

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -179,7 +179,7 @@ USER-AGENT: syncthing/1.0
 loop:
 	for {
 		resp := make([]byte, 65536)
-		if err := socket.SetDeadline(time.Now().Add(time.Second)); err != nil {
+		if err := socket.SetDeadline(time.Now().Add(250 * time.Millisecond)); err != nil {
 			l.Infoln("UPnP socket:", err)
 			break
 		}


### PR DESCRIPTION
During NAT discovery we block for 10s (NatTimeoutS) before returning.
This is mostly noticeable when Ctrl-C:ing a Syncthing directly after
startup as we wait for those ten seconds before shutting down. This
makes it check the context a little bit more frequently.
