### PR TITLE
lib/model: Stop summary sender faster (ref #6319)

### DIFF
--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -270,6 +270,11 @@ func (c *folderSummaryService) calculateSummaries(ctx context.Context) {
 		case <-pump.C:
 			t0 := time.Now()
 			for _, folder := range c.foldersToHandle() {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
 				c.sendSummary(folder)
 			}
 


### PR DESCRIPTION
One of the causes of "panic: database is closed" is that we try to send
summaries after it's been closed. Calculating summaries can take a long
time and if we have a lot of folders it's not unreasonable to think
that we might be stopped in this loop, so prepare to bail here.
