### PR TITLE
lib/db: Don't call backend.Commit twice (ref #6337)

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -755,10 +755,7 @@ func (t *readWriteTransaction) withAllFolderTruncated(folder []byte, fn func(dev
 			return nil
 		}
 	}
-	if err := dbi.Error(); err != nil {
-		return err
-	}
-	return t.Commit()
+	return dbi.Error()
 }
 
 type marshaller interface {


### PR DESCRIPTION
In `recalcMeta` we first call `t.withAllFolderTruncated` and then `t.Commit`, while it isn't allowed to call anything except `Release` after `Commit`. For some reasons that doesn't blow up in tests. It did in a very weird way (segfault deep in leveldb) in a local feature branch, took me a while to find the cause (leveldb should return an error, not segfault, but that's hardly worth spending effort on).

Also from a conceptual standpoint I believe it's wrong to call `t.Commit` or `t.Release` anywhere else than the place where the transaction was created.