### PR TITLE
lib: Modify FileInfos consistently (ref #6321)

### DIFF
--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -129,27 +129,36 @@ func (f FileInfoTruncated) FileModifiedBy() protocol.ShortID {
 }
 
 func (f FileInfoTruncated) ConvertToIgnoredFileInfo(by protocol.ShortID) protocol.FileInfo {
-	return protocol.FileInfo{
-		Name:         f.Name,
-		Type:         f.Type,
-		ModifiedS:    f.ModifiedS,
-		ModifiedNs:   f.ModifiedNs,
-		ModifiedBy:   by,
-		Version:      f.Version,
-		RawBlockSize: f.RawBlockSize,
-		LocalFlags:   protocol.FlagLocalIgnored,
-	}
+	file := f.copyToFileInfo()
+	file.SetIgnored(by)
+	return file
 }
 
-func (f FileInfoTruncated) ConvertToDeletedFileInfo(by protocol.ShortID, localFlags uint32) protocol.FileInfo {
+func (f FileInfoTruncated) ConvertToDeletedFileInfo(by protocol.ShortID) protocol.FileInfo {
+	file := f.copyToFileInfo()
+	file.SetDeleted(by)
+	return file
+}
+
+// copyToFileInfo just copies all members of FileInfoTruncated to protocol.FileInfo
+func (f FileInfoTruncated) copyToFileInfo() protocol.FileInfo {
 	return protocol.FileInfo{
-		Name:       f.Name,
-		Type:       f.Type,
-		ModifiedS:  time.Now().Unix(),
-		ModifiedBy: by,
-		Deleted:    true,
-		Version:    f.Version.Update(by),
-		LocalFlags: localFlags,
+		Name:          f.Name,
+		Size:          f.Size,
+		ModifiedS:     f.ModifiedS,
+		ModifiedBy:    f.ModifiedBy,
+		Version:       f.Version,
+		Sequence:      f.Sequence,
+		SymlinkTarget: f.SymlinkTarget,
+		BlocksHash:    f.BlocksHash,
+		Type:          f.Type,
+		Permissions:   f.Permissions,
+		ModifiedNs:    f.ModifiedNs,
+		RawBlockSize:  f.RawBlockSize,
+		LocalFlags:    f.LocalFlags,
+		Deleted:       f.Deleted,
+		RawInvalid:    f.RawInvalid,
+		NoPermissions: f.NoPermissions,
 	}
 }
 

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -468,6 +468,9 @@ func (t readWriteTransaction) putFile(key []byte, fi protocol.FileInfo) error {
 		} else if err != nil {
 			return err
 		}
+	} else if fi.BlocksHash != nil {
+		l.Warnln("Blocks is nil, but BlocksHash is not for file", fi)
+		panic("Blocks is nil, but BlocksHash is not")
 	}
 
 	fi.Blocks = nil

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -532,7 +532,8 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 					}
 					return true
 				}
-				nf := file.ConvertToDeletedFileInfo(f.shortID, f.localFlags)
+				nf := file.ConvertToDeletedFileInfo(f.shortID)
+				nf.LocalFlags = f.localFlags
 				if file.ShouldConflict() {
 					// We do not want to override the global version with
 					// the deleted file. Setting to an empty version makes

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -104,14 +104,8 @@ func (f *receiveOnlyFolder) Revert() {
 				return true // continue
 			}
 
-			fi = protocol.FileInfo{
-				Name:       fi.Name,
-				Type:       fi.Type,
-				ModifiedS:  time.Now().Unix(),
-				ModifiedBy: f.shortID,
-				Deleted:    true,
-				Version:    protocol.Vector{}, // if this file ever resurfaces anywhere we want our delete to be strictly older
-			}
+			fi = fi.SetDeleted(f.shortID)
+			fi.Version = protocol.Vector{} // if this file ever resurfaces anywhere we want our delete to be strictly older
 		} else {
 			// Revert means to throw away our local changes. We reset the
 			// version to the empty vector, which is strictly older than any
@@ -155,7 +149,7 @@ func (f *receiveOnlyFolder) Revert() {
 		})
 	}
 	if len(batch) > 0 {
-		f.updateLocalsFromScanning(batch)
+		f.updateLoclsFromScanning(batch)
 	}
 
 	// We will likely have changed our local index, but that won't trigger a

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -104,7 +104,7 @@ func (f *receiveOnlyFolder) Revert() {
 				return true // continue
 			}
 
-			fi = fi.SetDeleted(f.shortID)
+			fi.SetDeleted(f.shortID)
 			fi.Version = protocol.Vector{} // if this file ever resurfaces anywhere we want our delete to be strictly older
 		} else {
 			// Revert means to throw away our local changes. We reset the
@@ -149,7 +149,7 @@ func (f *receiveOnlyFolder) Revert() {
 		})
 	}
 	if len(batch) > 0 {
-		f.updateLoclsFromScanning(batch)
+		f.updateLocalsFromScanning(batch)
 	}
 
 	// We will likely have changed our local index, but that won't trigger a

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -118,10 +118,7 @@ func (f *sendOnlyFolder) Override() {
 		}
 		if !ok || have.Name != need.Name {
 			// We are missing the file
-			need.Deleted = true
-			need.Blocks = nil
-			need.Version = need.Version.Update(f.shortID)
-			need.Size = 0
+			need.SetDeleted(f.shortID)
 		} else {
 			// We have the file, replace with our version
 			have.Version = have.Version.Merge(need.Version).Update(f.shortID)

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -289,7 +289,6 @@ func (f *FileInfo) setLocalFlags(by ShortID, flags uint32) {
 	f.RawInvalid = false
 	f.LocalFlags = flags
 	f.ModifiedBy = by
-	f.Sequence = 0
 	f.setNoContent()
 }
 

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -266,24 +266,37 @@ func BlocksEqual(a, b []BlockInfo) bool {
 }
 
 func (f *FileInfo) SetMustRescan(by ShortID) {
-	f.LocalFlags = FlagLocalMustRescan
-	f.ModifiedBy = by
-	f.Blocks = nil
-	f.Sequence = 0
+	f.setLocalFlags(by, FlagLocalMustRescan)
 }
 
 func (f *FileInfo) SetIgnored(by ShortID) {
-	f.LocalFlags = FlagLocalIgnored
-	f.ModifiedBy = by
-	f.Blocks = nil
-	f.Sequence = 0
+	f.setLocalFlags(by, FlagLocalIgnored)
 }
 
 func (f *FileInfo) SetUnsupported(by ShortID) {
-	f.LocalFlags = FlagLocalUnsupported
+	f.setLocalFlags(by, FlagLocalUnsupported)
+}
+
+func (f *FileInfo) SetDeleted(by ShortID) {
 	f.ModifiedBy = by
-	f.Blocks = nil
+	f.Deleted = true
+	f.Version = f.Version.Update(by)
+	f.ModifiedS = time.Now().Unix()
+	f.setNoContent()
+}
+
+func (f *FileInfo) setLocalFlags(by ShortID, flags uint32) {
+	f.RawInvalid = false
+	f.LocalFlags = flags
+	f.ModifiedBy = by
 	f.Sequence = 0
+	f.setNoContent()
+}
+
+func (f *FileInfo) setNoContent() {
+	f.Blocks = nil
+	f.BlocksHash = nil
+	f.Size = 0
 }
 
 func (b BlockInfo) String() string {


### PR DESCRIPTION
I unsuccessfully tried to reproduce the scenario https://github.com/syncthing/syncthing/issues/6321#issuecomment-587548420. That's due to the GC not kicking in, even if noone actually has the blocks. It's enough for an ignored file to have the `BlocksHash`.

Nevertheless I believe this is a good change: It firstly makes sure that whenever `Blocks` is set to nil, so is `BlocksHash`. That means blocks can get GCed when everyone has ignored files, while it can't at the moment. I also put in a check in the db that panics if this isn't true. That could be changed to just fix it on the fly, but I'd rather know about it when it happens and fix it. And while checking for other places where the same mistake might happen, I ensured that wherever file infos are modified, that's happening through the same functions (i.e. consistently).