### PR TITLE
lib/db: Don't panic on incorrect BlocksHash (fixes #6353)

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -469,8 +469,8 @@ func (t readWriteTransaction) putFile(key []byte, fi protocol.FileInfo) error {
 			return err
 		}
 	} else if fi.BlocksHash != nil {
-		l.Warnln("Blocks is nil, but BlocksHash is not for file", fi)
-		panic("Blocks is nil, but BlocksHash is not")
+		l.Debugln("Blocks is nil, but BlocksHash is not for file", fi)
+		fi.BlocksHash = nil
 	}
 
 	fi.Blocks = nil


### PR DESCRIPTION
Minimal variant to get rid of #6353 (as opposed to https://github.com/syncthing/syncthing/pull/6354).