### PR TITLE
lib/db: Allow put partial FileInfo without blocks (ref #6353)

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -468,9 +468,6 @@ func (t readWriteTransaction) putFile(key []byte, fi protocol.FileInfo) error {
 		} else if err != nil {
 			return err
 		}
-	} else if fi.BlocksHash != nil {
-		l.Debugln("Blocks is nil, but BlocksHash is not for file", fi)
-		fi.BlocksHash = nil
 	}
 
 	fi.Blocks = nil


### PR DESCRIPTION
### Purpose

Act like a normal FileInfo-marshal-and-save again when there are no blocks.

This seems like the simplest fix for the current debacle and also somewhat resistant to future mistakes.