### PR TITLE
Add tree view showing what files are ignored

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -146,6 +146,12 @@
           <p translate>Enter ignore patterns, one per line.</p>
           <textarea class="form-control" rows="5"></textarea>
           <hr />
+          <p translate>View which files get ignored.</p>
+          <div id="folder-ignores-tree">
+          </div>
+          <div id="folder-ignores-nodestatus">
+          </div>
+          <hr />
           <p class="small"><span translate>Quick guide to supported patterns</span> (<a href="https://docs.syncthing.net/users/ignoring.html" target="_blank" translate>full documentation</a>):</p>
           <dl class="dl-horizontal dl-narrow small">
             <dt><code>(?d)</code></dt>


### PR DESCRIPTION
### Prelude

This PR is a second stab at #2491, after the failure of #5132. This PR is not ready to be merged yet but it should be close to providing a useful feature that can be merged even though it doesn't fulfill all requirements in the issue. Think of it as a way to slowly chip away at #2491. The requirements I tried to fulfill here are:

* Must be understandable by someone who understands the interface in use by DropBox, OneDrive, etc.
* Must be a simple tree view with checkboxes
  * Root of tree (=folder root) checked by default
* Power user access to flexible, underlying patterns

Feel free to give your opinion on this, even if it means changing a bunch of stuff or simply refusing to merge. I don't mind at all as that would mean we're progressing on this issue by knowing what we _don't_ want.

### Purpose

This PR introduces a tree view in the edit folder modal in the ignores tab. The tree view shows the whole global directory, not only what's local to the device/folder. Each node of the tree has a checkbox that is checked unless that file or directory is ignored. The sync is one way: updating the patterns changing what checkbox is checked but changing a checkbox has no effect. Doing this I was able to keep the PR concise.

![1582567599](https://user-images.githubusercontent.com/1044950/75178736-85306280-56ed-11ea-8ba4-7f9f59475405.png)

The corresponding folder state shows that indeed, some files are ignored:

![1582533805](https://user-images.githubusercontent.com/1044950/75179082-2c14fe80-56ee-11ea-913a-498cd3ad31e3.png)

When updating the ignored patterns and clicking Save, the modal is not closed but instead the nodes in the tree view are refreshed. The goal is to see relatively quickly the impact of changing the ignore rules. It's kind of like having a REPL loop. I modified the behavior of the Save button to _not_ close the modal, otherwise refreshing the tree doesn't even make sense. I don't really like modifying the Save button behavior but I don't know what would be better.

Here is for example what happens if I modify the pattern match `documents` above and click on save:

![1582566838](https://user-images.githubusercontent.com/1044950/75178753-8c577080-56ed-11ea-80c6-eba552028d85.png)

When clicking on a node, the bottom text is updated with information pertaining to that node. It's very crude and probably useless for now but I wanted to show this is possible.

`documents` is selected:
![1582567640](https://user-images.githubusercontent.com/1044950/75178781-99745f80-56ed-11ea-86fa-d8b1870892ce.png)

`pictures` is selected:
![1582567645](https://user-images.githubusercontent.com/1044950/75178790-9e391380-56ed-11ea-8707-4653d3c9ef52.png)

Changing the checkbox state on a node has no effect at all. This is most certainly bad UX and I'm happy to change that to something that makes more sense.

The tree is lazy loaded using fancytree's lazyLoad feature. I added a new api endpoint that merges the `db/browse` and `db/file` while only keeping a few fields in the returned json. I felt it made more sense to do that in go than in javascript. Note that #5930 talks about removing the `db/browse` api endpoint and this PR goes a bit against the claim that Syncthing is not a file browser.

### Testing

Manual. I set up two Syncthing instances and shared a folder between them:
```
STNOUPGRADE=true STGUIASSETS=~/src/syncthing/gui ./bin/syncthing -no-browser
STNOUPGRADE=true STGUIASSETS=~/src/syncthing/gui ./bin/syncthing -no-browser -home ~/.config/syncthing2 -gui-address "http://127.0.0.1:8385"
```

I then made some updates to the ignored patterns.

### Documentation

I was waiting a consensus on this first.
