### PR TITLE
cmd/syncthing: Do not truncate/rotate logs at start

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -230,7 +230,7 @@ func parseCommandLineOptions() RuntimeOptions {
 	flag.BoolVar(&options.Verbose, "verbose", false, "Print verbose log output")
 	flag.BoolVar(&options.paused, "paused", false, "Start with all devices and folders paused")
 	flag.BoolVar(&options.unpaused, "unpaused", false, "Start with all devices and folders unpaused")
-	flag.StringVar(&options.logFile, "logfile", options.logFile, "Log file name (still always logs to stdout).")
+	flag.StringVar(&options.logFile, "logfile", options.logFile, "Log file name (still always logs to stdout). This is best effort, i.e. Syncthing will keep running if encountering errors writing to this file.")
 	flag.IntVar(&options.logMaxSize, "log-max-size", options.logMaxSize, "Maximum size of any file (zero to disable log rotation).")
 	flag.IntVar(&options.logMaxFiles, "log-max-old-files", options.logMaxFiles, "Number of old files to keep (zero to keep only current).")
 	flag.StringVar(&options.auditFile, "auditfile", options.auditFile, "Specify audit file (use \"-\" for stdout, \"--\" for stderr)")

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -230,7 +230,7 @@ func parseCommandLineOptions() RuntimeOptions {
 	flag.BoolVar(&options.Verbose, "verbose", false, "Print verbose log output")
 	flag.BoolVar(&options.paused, "paused", false, "Start with all devices and folders paused")
 	flag.BoolVar(&options.unpaused, "unpaused", false, "Start with all devices and folders unpaused")
-	flag.StringVar(&options.logFile, "logfile", options.logFile, "Log file name (still always logs to stdout). This is best effort, i.e. Syncthing will keep running if encountering errors writing to this file.")
+	flag.StringVar(&options.logFile, "logfile", options.logFile, "Log file name (still always logs to stdout).")
 	flag.IntVar(&options.logMaxSize, "log-max-size", options.logMaxSize, "Maximum size of any file (zero to disable log rotation).")
 	flag.IntVar(&options.logMaxFiles, "log-max-old-files", options.logMaxFiles, "Number of old files to keep (zero to keep only current).")
 	flag.StringVar(&options.auditFile, "auditfile", options.auditFile, "Specify audit file (use \"-\" for stdout, \"--\" for stderr)")

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -65,7 +65,7 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 			fileDst, err = open(logFile)
 		}
 		if err != nil {
-			l.Infoln(`Failed to setup logging to file "%s", proceeding with logging to stdout only: %v`, logFile, err)
+			l.Warnln("Failed to setup logging to file, proceeding with logging to stdout only:", err)
 		} else {
 			if runtime.GOOS == "windows" {
 				// Translate line breaks to Windows standard

--- a/cmd/syncthing/monitor_test.go
+++ b/cmd/syncthing/monitor_test.go
@@ -24,13 +24,8 @@ func TestRotatedFile(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	open := func(name string) io.WriteCloser {
-		t.Helper()
-		fd, err := os.Create(name)
-		if err != nil {
-			t.Error(err)
-		}
-		return fd
+	open := func(name string) (io.WriteCloser, error) {
+		return os.Create(name)
 	}
 
 	logName := filepath.Join(dir, "log.txt")
@@ -148,7 +143,10 @@ func TestAutoClosedFile(t *testing.T) {
 	data := []byte("hello, world\n")
 
 	// An autoclosed file that closes very quickly
-	ac := newAutoclosedFile(file, time.Millisecond, time.Millisecond)
+	ac, err := newAutoclosedFile(file, time.Millisecond, time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Write some data.
 	if _, err := ac.Write(data); err != nil {
@@ -190,7 +188,10 @@ func TestAutoClosedFile(t *testing.T) {
 	}
 
 	// Open the file again.
-	ac = newAutoclosedFile(file, time.Second, time.Second)
+	ac, err = newAutoclosedFile(file, time.Second, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Write something
 	if _, err := ac.Write(data); err != nil {


### PR DESCRIPTION
Currently we are truncating a file when opening it. And we aren't opening a file when creating a rotated logger, instead rotating and opening on first write. Now we don't truncate anymore and rotate only if the log exceeds the limit.

See also https://forum.syncthing.net/t/rotating-logfiles-on-every-start/14542