### PR TITLE
lib/connections: Actually record connection errors

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -713,7 +713,7 @@ func (s *service) ConnectionStatus() map[string]ConnectionStatusEntry {
 }
 
 func (s *service) setConnectionStatus(address string, err error) {
-	if errors.Cause(err) != context.Canceled {
+	if errors.Cause(err) == context.Canceled {
 		return
 	}
 


### PR DESCRIPTION
### Purpose

Connection errors weren't getting populated in the GUI.