### PR TITLE
cmd/syncthing: Add indication that reset db happened

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -374,6 +374,7 @@ func main() {
 			l.Warnln("Resetting database:", err)
 			os.Exit(syncthing.ExitError.AsInt())
 		}
+		l.Infoln("Successfully reset database - it will be rebuilt after next start.")
 		return
 	}
 


### PR DESCRIPTION
There's not indication that something happened when running with `-reset-database`, which can cause confusion (see https://forum.syncthing.net/t/database-to-upgrade-to-v1-4-0-rc-7/14563).