### PR TITLE
lib/dialer: Preserve nilness in error handling (fixes #6368)

### DIFF
--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -76,10 +76,10 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 	if noFallback {
 		conn, err := dialer.DialContext(ctx, network, addr)
 		l.Debugf("Dialing no fallback result %s %s: %v %v", network, addr, conn, err)
-		conn = dialerConn{
-			conn, newDialerAddr(network, addr),
+		if err != nil {
+			return nil, err
 		}
-		return conn, err
+		return dialerConn{conn, newDialerAddr(network, addr)}, nil
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -91,8 +91,8 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 	go func() {
 		proxyConn, proxyErr = dialer.DialContext(ctx, network, addr)
 		l.Debugf("Dialing proxy result %s %s: %v %v", network, addr, proxyConn, proxyErr)
-		proxyConn = dialerConn{
-			proxyConn, newDialerAddr(network, addr),
+		if proxyErr != nil {
+			proxyConn = dialerConn{proxyConn, newDialerAddr(network, addr)}
 		}
 		close(proxyDone)
 	}()

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -91,7 +91,7 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 	go func() {
 		proxyConn, proxyErr = dialer.DialContext(ctx, network, addr)
 		l.Debugf("Dialing proxy result %s %s: %v %v", network, addr, proxyConn, proxyErr)
-		if proxyErr != nil {
+		if proxyErr == nil {
 			proxyConn = dialerConn{proxyConn, newDialerAddr(network, addr)}
 		}
 		close(proxyDone)

--- a/lib/osutil/ping.go
+++ b/lib/osutil/ping.go
@@ -22,7 +22,7 @@ func TCPPing(ctx context.Context, address string) (time.Duration, error) {
 	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 	conn, err := dialer.DialContext(ctx, "tcp", address)
-	if conn != nil {
+	if err == nil {
 		conn.Close()
 	}
 	return time.Since(start), err


### PR DESCRIPTION
Also the call site where it shouldn't anyway be looking at the conn when
the err is non-nil.
