### PR TITLE
cmd/syncthing: Do auto-upgrade before startup (fixes #6384)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -139,10 +139,12 @@ The following are valid values for the STTRACE variable:
 %s`
 )
 
-// Environment options
 var (
+	// Environment options
 	innerProcess    = os.Getenv("STNORESTART") != "" || os.Getenv("STMONITORED") != ""
 	noDefaultFolder = os.Getenv("STNODEFAULTFOLDER") != ""
+
+	errConcurrentUpgrade = errors.New("upgrade prevented by other running Syncthing instance")
 )
 
 type RuntimeOptions struct {
@@ -501,8 +503,6 @@ func checkUpgrade() (upgrade.Release, error) {
 	l.Infof("Upgrade available (current %q < latest %q)", build.Version, release.Tag)
 	return release, nil
 }
-
-var errConcurrentUpgrade = errors.New("upgrade prevented by other running Syncthing instance")
 
 func performUpgradeDirect(release upgrade.Release) error {
 	// Use leveldb database locks to protect against concurrent upgrades

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -613,10 +613,6 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 				os.Exit(syncthing.ExitUpgrade.AsInt())
 			}
 		}
-		// Disable auto-upgrades if unsupported
-		if err == upgrade.ErrUpgradeUnsupported {
-			shouldAutoUpgrade = false
-		}
 		// Log the error if relevant.
 		if err != nil {
 			if _, ok := err.(errNoUpgrade); !ok {
@@ -808,6 +804,9 @@ func standbyMonitor(app *syncthing.App) {
 }
 
 func shouldUpgrade(cfg config.Wrapper, runtimeOptions RuntimeOptions) bool {
+	if upgrade.DisabledByCompilation {
+		return false
+	}
 	if opts := cfg.Options(); opts.AutoUpgradeIntervalH < 0 {
 		return false
 	}


### PR DESCRIPTION
From https://github.com/syncthing/syncthing/issues/6384:

> This is usually fine, but sometimes we fuck up in release candidates and they crash. If that crash is early & persistent then the auto upgrade won't kick in and the user is stuck.
> 
> Maybe, potentially, we should consider doing the upgrade check early and before doing other stuff.

Of course it will never happen again that I produce a panic-inducing PR (ahem...), but nevertheless I believe that we definitely should do that.

I tested `-upgrade-check` `-upgrade` and with and without `STNOUPGRADE=1`: It all did the expected.

I made `checkUpgradeExitOnErr` a function variable instead of a global function, as I believe no functions except the `main...` ones should ever call `os.Exit`. If it is considered ugly, I'd rather go for the little bit of duplication of explicitly handling the errors in the two upgrade ifs below that.