### PR TITLE
all: Tweak error creation

### DIFF
--- a/cmd/stcli/client.go
+++ b/cmd/stcli/client.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -80,16 +81,16 @@ func (c *APIClient) Post(url, body string) (*http.Response, error) {
 
 func checkResponse(response *http.Response) error {
 	if response.StatusCode == 404 {
-		return fmt.Errorf("Invalid endpoint or API call")
+		return errors.New("invalid endpoint or API call")
 	} else if response.StatusCode == 403 {
-		return fmt.Errorf("Invalid API key")
+		return errors.New("invalid API key")
 	} else if response.StatusCode != 200 {
 		data, err := responseToBArray(response)
 		if err != nil {
 			return err
 		}
 		body := strings.TrimSpace(string(data))
-		return fmt.Errorf("Unexpected HTTP status returned: %s\n%s", response.Status, body)
+		return fmt.Errorf("unexpected HTTP status returned: %s\n%s", response.Status, body)
 	}
 	return nil
 }

--- a/cmd/stcli/errors.go
+++ b/cmd/stcli/errors.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -54,7 +55,7 @@ func errorsPush(c *cli.Context) error {
 		if body != "" {
 			errStr += "\nBody: " + body
 		}
-		return fmt.Errorf(errStr)
+		return errors.New(errStr)
 	}
 	return nil
 }

--- a/cmd/stcompdirs/main.go
+++ b/cmd/stcompdirs/main.go
@@ -60,7 +60,7 @@ func compareDirectories(dirs ...string) error {
 				} else if res[i].name > res[0].name {
 					return fmt.Errorf("%s missing %v (present in %s)", dirs[i], res[0], dirs[0])
 				}
-				return fmt.Errorf("Mismatch; %v (%s) != %v (%s)", res[i], dirs[i], res[0], dirs[0])
+				return fmt.Errorf("mismatch; %v (%s) != %v (%s)", res[i], dirs[i], res[0], dirs[0])
 			}
 		}
 

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -494,7 +495,7 @@ func handleRelayTest(request request) {
 		if debug {
 			log.Println("Test for relay", request.relay, "failed")
 		}
-		request.result <- result{fmt.Errorf("connection test failed"), 0}
+		request.result <- result{errors.New("connection test failed"), 0}
 		return
 	}
 

--- a/cmd/stvanity/main.go
+++ b/cmd/stvanity/main.go
@@ -14,6 +14,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"math/big"
@@ -191,7 +192,7 @@ func pemBlockForKey(priv interface{}) (*pem.Block, error) {
 		}
 		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}, nil
 	default:
-		return nil, fmt.Errorf("unknown key type")
+		return nil, errors.New("unknown key type")
 	}
 }
 

--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -266,10 +266,10 @@ type report struct {
 
 func (r *report) Validate() error {
 	if r.UniqueID == "" || r.Version == "" || r.Platform == "" {
-		return fmt.Errorf("missing required field")
+		return errors.New("missing required field")
 	}
 	if len(r.Date) != 8 {
-		return fmt.Errorf("date not initialized")
+		return errors.New("date not initialized")
 	}
 
 	// Some fields may not be null.

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -543,7 +543,7 @@ func startHTTP(cfg *mockedConfig) (string, *suture.Supervisor, error) {
 	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {
 		supervisor.Stop()
-		return "", nil, fmt.Errorf("Weird address from API service: %v", err)
+		return "", nil, fmt.Errorf("weird address from API service: %w", err)
 	}
 
 	host, _, _ := net.SplitHostPort(cfg.gui.RawAddress)

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -295,11 +295,11 @@ func (cfg *Configuration) clean() error {
 		}
 
 		if folder.Path == "" {
-			return fmt.Errorf("folder %q: %v", folder.ID, errFolderPathEmpty)
+			return fmt.Errorf("folder %q: %w", folder.ID, errFolderPathEmpty)
 		}
 
 		if _, ok := existingFolders[folder.ID]; ok {
-			return fmt.Errorf("folder %q: %v", folder.ID, errFolderIDDuplicate)
+			return fmt.Errorf("folder %q: %w", folder.ID, errFolderIDDuplicate)
 		}
 
 		existingFolders[folder.ID] = folder

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -941,7 +941,7 @@ func (s *service) validateIdentity(c internalConn, expectedID protocol.DeviceID)
 	if remoteID == s.myID {
 		l.Infof("Connected to myself (%s) at %s - should not happen", remoteID, c)
 		c.Close()
-		return fmt.Errorf("connected to self")
+		return errors.New("connected to self")
 	}
 
 	// We should see the expected device ID

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -8,6 +8,7 @@ package db
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -32,8 +33,8 @@ const (
 )
 
 var (
-	errFolderIdxMissing = fmt.Errorf("folder db index missing")
-	errDeviceIdxMissing = fmt.Errorf("device db index missing")
+	errFolderIdxMissing = errors.New("folder db index missing")
+	errDeviceIdxMissing = errors.New("device db index missing")
 )
 
 type databaseDowngradeError struct {

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -11,7 +11,6 @@ package fs
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"

--- a/lib/fs/basicfs_windows.go
+++ b/lib/fs/basicfs_windows.go
@@ -137,7 +137,7 @@ func (f *BasicFilesystem) Roots() ([]string, error) {
 
 	hr, _, _ := getLogicalDriveStringsHandle.Call(uintptr(unsafe.Pointer(&bufferSize)), uintptr(unsafe.Pointer(&buffer)))
 	if hr == 0 {
-		return nil, fmt.Errorf("Syscall failed")
+		return nil, errors.New("syscall failed")
 	}
 
 	var drives []string

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -508,13 +508,13 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 		case strings.HasPrefix(line, "#include"):
 			fields := strings.SplitN(line, " ", 2)
 			if len(fields) != 2 {
-				err = fmt.Errorf("failed to parse #include line: no file?")
+				err = errors.New("failed to parse #include line: no file?")
 				break
 			}
 
 			includeRel := strings.TrimSpace(fields[1])
 			if includeRel == "" {
-				err = fmt.Errorf("failed to parse #include line: no file?")
+				err = errors.New("failed to parse #include line: no file?")
 				break
 			}
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -345,7 +345,7 @@ func (m *model) startFolderLocked(cfg config.FolderConfiguration) {
 		var err error
 		ver, err = versioner.New(ffs, cfg.Versioning)
 		if err != nil {
-			panic(fmt.Errorf("creating versioner: %v", err))
+			panic(fmt.Errorf("creating versioner: %w", err))
 		}
 		if service, ok := ver.(suture.Service); ok {
 			// The versioner implements the suture.Service interface, so
@@ -1688,7 +1688,7 @@ func (m *model) GetIgnores(folder string) ([]string, []string, error) {
 	if !cfgOk {
 		cfg, cfgOk = m.cfg.Folders()[folder]
 		if !cfgOk {
-			return nil, nil, fmt.Errorf("Folder %s does not exist", folder)
+			return nil, nil, fmt.Errorf("folder %s does not exist", folder)
 		}
 	}
 

--- a/lib/protocol/hello.go
+++ b/lib/protocol/hello.go
@@ -5,7 +5,6 @@ package protocol
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"io"
 )
 
@@ -66,7 +65,7 @@ func readHello(c io.Reader) (HelloResult, error) {
 		}
 		msgSize := binary.BigEndian.Uint16(header[:2])
 		if msgSize > 32767 {
-			return HelloResult{}, fmt.Errorf("hello message too big")
+			return HelloResult{}, errors.New("hello message too big")
 		}
 		buf := make([]byte, msgSize)
 		if _, err := io.ReadFull(c, buf); err != nil {

--- a/lib/protocol/luhn.go
+++ b/lib/protocol/luhn.go
@@ -27,7 +27,7 @@ func (a luhnAlphabet) generate(s string) (rune, error) {
 	for i := range s {
 		codepoint := strings.IndexByte(string(a), s[i])
 		if codepoint == -1 {
-			return 0, fmt.Errorf("Digit %q not valid in alphabet %q", s[i], a)
+			return 0, fmt.Errorf("digit %q not valid in alphabet %q", s[i], a)
 		}
 		addend := factor * codepoint
 		if factor == 2 {

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -232,7 +232,7 @@ func (p *Process) Events(since int) ([]Event, error) {
 	dec.UseNumber()
 	err = dec.Decode(&evs)
 	if err != nil {
-		return nil, fmt.Errorf("events: %s in %q", err, bs)
+		return nil, fmt.Errorf("events: %w in %q", err, bs)
 	}
 	return evs, err
 }

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -232,7 +232,7 @@ func (p *Process) Events(since int) ([]Event, error) {
 	dec.UseNumber()
 	err = dec.Decode(&evs)
 	if err != nil {
-		return nil, fmt.Errorf("Events: %s in %q", err, bs)
+		return nil, fmt.Errorf("events: %s in %q", err, bs)
 	}
 	return evs, err
 }
@@ -398,7 +398,7 @@ func (p *Process) readResponse(resp *http.Response) ([]byte, error) {
 		return bs, err
 	}
 	if resp.StatusCode != 200 {
-		return bs, fmt.Errorf("%s", resp.Status)
+		return bs, errors.New(resp.Status)
 	}
 	return bs, nil
 }

--- a/lib/relay/client/client.go
+++ b/lib/relay/client/client.go
@@ -38,7 +38,7 @@ type RelayClient interface {
 func NewClient(uri *url.URL, certs []tls.Certificate, invitations chan protocol.SessionInvitation, timeout time.Duration) (RelayClient, error) {
 	factory, ok := supportedSchemes[uri.Scheme]
 	if !ok {
-		return nil, fmt.Errorf("Unsupported scheme: %s", uri.Scheme)
+		return nil, fmt.Errorf("unsupported scheme: %s", uri.Scheme)
 	}
 
 	return factory(uri, certs, invitations, timeout), nil

--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -100,7 +101,7 @@ func (c *dynamicClient) serve(ctx context.Context) error {
 		}
 	}
 	l.Debugln(c, "could not find a connectable relay")
-	return fmt.Errorf("could not find a connectable relay")
+	return errors.New("could not find a connectable relay")
 }
 
 func (c *dynamicClient) Stop() {

--- a/lib/relay/client/methods.go
+++ b/lib/relay/client/methods.go
@@ -19,7 +19,7 @@ import (
 
 func GetInvitationFromRelay(ctx context.Context, uri *url.URL, id syncthingprotocol.DeviceID, certs []tls.Certificate, timeout time.Duration) (protocol.SessionInvitation, error) {
 	if uri.Scheme != "relay" {
-		return protocol.SessionInvitation{}, fmt.Errorf("Unsupported relay scheme: %v", uri.Scheme)
+		return protocol.SessionInvitation{}, fmt.Errorf("unsupported relay scheme: %v", uri.Scheme)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -53,7 +53,7 @@ func GetInvitationFromRelay(ctx context.Context, uri *url.URL, id syncthingproto
 
 	switch msg := message.(type) {
 	case protocol.Response:
-		return protocol.SessionInvitation{}, fmt.Errorf("Incorrect response code %d: %s", msg.Code, msg.Message)
+		return protocol.SessionInvitation{}, fmt.Errorf("incorrect response code %d: %s", msg.Code, msg.Message)
 	case protocol.SessionInvitation:
 		l.Debugln("Received invitation", msg, "via", conn.LocalAddr())
 		ip := net.IP(msg.Address)
@@ -96,7 +96,7 @@ func JoinSession(ctx context.Context, invitation protocol.SessionInvitation) (ne
 	switch msg := message.(type) {
 	case protocol.Response:
 		if msg.Code != 0 {
-			return nil, fmt.Errorf("Incorrect response code %d: %s", msg.Code, msg.Message)
+			return nil, fmt.Errorf("incorrect response code %d: %s", msg.Code, msg.Message)
 		}
 		return conn, nil
 	default:

--- a/lib/relay/protocol/protocol.go
+++ b/lib/relay/protocol/protocol.go
@@ -3,7 +3,7 @@
 package protocol
 
 import (
-	"fmt"
+	"errors"
 	"io"
 )
 
@@ -53,7 +53,7 @@ func WriteMessage(w io.Writer, message interface{}) error {
 		payload, err = msg.MarshalXDR()
 		header.messageType = messageTypeRelayFull
 	default:
-		err = fmt.Errorf("Unknown message type")
+		err = errors.New("unknown message type")
 	}
 
 	if err != nil {
@@ -84,7 +84,7 @@ func ReadMessage(r io.Reader) (interface{}, error) {
 	}
 
 	if header.magic != magic {
-		return nil, fmt.Errorf("magic mismatch")
+		return nil, errors.New("magic mismatch")
 	}
 
 	buf = make([]byte, int(header.messageLength))
@@ -127,5 +127,5 @@ func ReadMessage(r io.Reader) (interface{}, error) {
 		return msg, err
 	}
 
-	return nil, fmt.Errorf("Unknown message type")
+	return nil, errors.New("unknown message type")
 }

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -536,7 +536,7 @@ func (w *walker) handleError(ctx context.Context, context, path string, err erro
 	l.Infof("Scanner (folder %s, item %q): %s: %v", w.Folder, path, context, err)
 	select {
 	case finishedChan <- ScanResult{
-		Err:  fmt.Errorf("%s: %s", context, err.Error()),
+		Err:  fmt.Errorf("%s: %w", context, err),
 		Path: path,
 	}:
 	case <-ctx.Done():

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -836,7 +837,7 @@ func verify(r io.Reader, blocksize int, blocks []protocol.BlockInfo) error {
 	bs := make([]byte, 1)
 	n, err := r.Read(bs)
 	if n != 0 || err != io.EOF {
-		return fmt.Errorf("file continues past end of blocks")
+		return errors.New("file continues past end of blocks")
 	}
 
 	return nil

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -14,7 +14,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"fmt"
 	"math/big"
 	"net"
 	"os"
@@ -26,7 +25,7 @@ import (
 )
 
 var (
-	ErrIdentificationFailed = fmt.Errorf("failed to identify socket type")
+	ErrIdentificationFailed = errors.New("failed to identify socket type")
 )
 
 var (
@@ -239,7 +238,7 @@ func pemBlockForKey(priv interface{}) (*pem.Block, error) {
 		}
 		return &pem.Block{Type: "EC PRIVATE KEY", Bytes: b}, nil
 	default:
-		return nil, fmt.Errorf("unknown key type")
+		return nil, errors.New("unknown key type")
 	}
 }
 

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -15,6 +15,7 @@ import (
 	"compress/gzip"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -366,10 +367,10 @@ func archiveFileVisitor(dir string, tempFile *string, signature *[]byte, archive
 
 func verifyUpgrade(archiveName, tempName string, sig []byte) error {
 	if tempName == "" {
-		return fmt.Errorf("no upgrade found")
+		return errors.New("no upgrade found")
 	}
 	if sig == nil {
-		return fmt.Errorf("no signature found")
+		return errors.New("no signature found")
 	}
 
 	l.Debugf("checking signature\n%s", sig)

--- a/lib/versioner/util.go
+++ b/lib/versioner/util.go
@@ -7,7 +7,6 @@
 package versioner
 
 import (
-	"fmt"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -20,9 +19,11 @@ import (
 	"github.com/syncthing/syncthing/lib/util"
 )
 
-var errDirectory = fmt.Errorf("cannot restore on top of a directory")
-var errNotFound = fmt.Errorf("version not found")
-var errFileAlreadyExists = fmt.Errorf("file already exists")
+var (
+	errDirectory         = errors.New("cannot restore on top of a directory")
+	errNotFound          = errors.New("version not found")
+	errFileAlreadyExists = errors.New("file already exists")
+)
 
 // TagFilename inserts ~tag just before the extension of the filename.
 func TagFilename(name, tag string) string {

--- a/lib/versioner/versioner.go
+++ b/lib/versioner/versioner.go
@@ -9,6 +9,7 @@
 package versioner
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -32,7 +33,7 @@ type factory func(filesystem fs.Filesystem, params map[string]string) Versioner
 
 var factories = make(map[string]factory)
 
-var ErrRestorationNotSupported = fmt.Errorf("version restoration not supported with the current versioner")
+var ErrRestorationNotSupported = errors.New("version restoration not supported with the current versioner")
 
 const (
 	TimeFormat = "20060102-150405"

--- a/meta/copyright_test.go
+++ b/meta/copyright_test.go
@@ -68,5 +68,5 @@ func checkCopyright(path string, info os.FileInfo, err error) error {
 		}
 	}
 
-	return fmt.Errorf("Missing copyright in %s?", path)
+	return fmt.Errorf("missing copyright in %s?", path)
 }

--- a/test/sync_test.go
+++ b/test/sync_test.go
@@ -265,7 +265,7 @@ func scSyncAndCompare(p []*rc.Process, expected [][]fileInfo) error {
 			return err
 		}
 		if err := compareDirectoryContents(actual, expected[0]); err != nil {
-			return fmt.Errorf("%s: %v", dir, err)
+			return fmt.Errorf("%s: %w", dir, err)
 		}
 	}
 
@@ -276,7 +276,7 @@ func scSyncAndCompare(p []*rc.Process, expected [][]fileInfo) error {
 				return err
 			}
 			if err := compareDirectoryContents(actual, expected[1]); err != nil {
-				return fmt.Errorf("%s: %v", dir, err)
+				return fmt.Errorf("%s: %w", dir, err)
 			}
 		}
 	}
@@ -288,7 +288,7 @@ func scSyncAndCompare(p []*rc.Process, expected [][]fileInfo) error {
 				return err
 			}
 			if err := compareDirectoryContents(actual, expected[2]); err != nil {
-				return fmt.Errorf("%s: %v", dir, err)
+				return fmt.Errorf("%s: %w", dir, err)
 			}
 		}
 	}

--- a/test/util.go
+++ b/test/util.go
@@ -330,7 +330,7 @@ func compareDirectories(dirs ...string) error {
 		for i := 1; i < len(res); i++ {
 			if res[i] != res[0] {
 				close(abort)
-				return fmt.Errorf("Mismatch; %#v (%s) != %#v (%s)", res[i], dirs[i], res[0], dirs[0])
+				return fmt.Errorf("mismatch; %#v (%s) != %#v (%s)", res[i], dirs[i], res[0], dirs[0])
 			}
 		}
 
@@ -381,7 +381,7 @@ func compareDirectoryContents(actual, expected []fileInfo) error {
 
 	for i := range actual {
 		if actual[i] != expected[i] {
-			return fmt.Errorf("Mismatch; actual %#v != expected %#v", actual[i], expected[i])
+			return fmt.Errorf("mismatch; actual %#v != expected %#v", actual[i], expected[i])
 		}
 	}
 	return nil


### PR DESCRIPTION
- In the few places where we wrap errors, use the new Go 1.13 "%w"
  construction instead of %s or %v.

- Where we create errors with constant strings, consistently use
  errors.New and not fmt.Errorf.

- Remove capitalization from errors in the few places where we had that.
