### PR TITLE
lib/db: Be more lenient during migration (fixes #6397)

### DIFF
--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -453,7 +453,16 @@ func (db *schemaUpdater) updateSchemato9(prev int) error {
 	metas := make(map[string]*metadataTracker)
 	for it.Next() {
 		intf, err := t.unmarshalTrunc(it.Value(), false)
-		if err != nil {
+		if backend.IsNotFound(err) {
+			// Unmarshal error due to missing parts (block list), probably
+			// due to a bad migration in a previous RC. Drop this key, as
+			// getFile would anyway return this as a "not found" in the
+			// normal flow of things.
+			if err := t.Delete(it.Key()); err != nil {
+				return err
+			}
+			continue
+		} else if err != nil {
 			return err
 		}
 		fi := intf.(protocol.FileInfo)


### PR DESCRIPTION
### Purpose

We might get a "not found" at one point in the migration, which should not abort the whole thing. We'll just retry it, and the same error during normal (non-migration) operations would simply result in the file being skipped, not a full database error.

### Testing

None so far... Hoping for testing from issue reporter