### PR TITLE
lib/beacon: only send *cast to flagged interfaces

### DIFF
--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -67,6 +67,10 @@ func writeMulticasts(ctx context.Context, inbox <-chan []byte, addr string) erro
 
 		success := 0
 		for _, intf := range intfs {
+			if intf.Flags&net.FlagMulticast == 0 {
+				continue
+			}
+
 			wcm.IfIndex = intf.Index
 			pconn.SetWriteDeadline(time.Now().Add(time.Second))
 			_, err = pconn.WriteTo(bs, wcm, gaddr)


### PR DESCRIPTION
### Purpose

saves some traffic (potential mobile wakeups), may help with #5957.

### Testing

built and run on Linux, seems to work correctly (broadcasts still sent on Ethernet interfaces, not sent on WireGuard interfaces)

### Documentation

I don't think this change requires documentation beyond a changelog message.