### PR TITLE
lib/config: Correct spelling of address in LDAP config

### DIFF
--- a/lib/config/ldapconfiguration.go
+++ b/lib/config/ldapconfiguration.go
@@ -7,7 +7,7 @@
 package config
 
 type LDAPConfiguration struct {
-	Address            string        `xml:"address,omitempty" json:"addresd"`
+	Address            string        `xml:"address,omitempty" json:"address"`
 	BindDN             string        `xml:"bindDN,omitempty" json:"bindDN"`
 	Transport          LDAPTransport `xml:"transport,omitempty" json:"transport"`
 	InsecureSkipVerify bool          `xml:"insecureSkipVerify,omitempty" json:"insecureSkipVerify" default:"false"`


### PR DESCRIPTION
Literally noone uses this so I don't see a need to call this out or
trigger a 1.5 release for it.
