### PR TITLE
lib/db: Remove emptied global list in checkGlobals (fixes #6425)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -417,7 +417,11 @@ func (db *Lowlevel) checkGlobals(folder []byte, meta *metadataTracker) error {
 			}
 		}
 
-		if len(newVL.Versions) != len(vl.Versions) {
+		if newLen := len(newVL.Versions); newLen == 0 {
+			if err := t.Delete(dbi.Key()); err != nil {
+				return err
+			}
+		} else if newLen != len(vl.Versions) {
 			if err := t.Put(dbi.Key(), mustMarshal(&newVL)); err != nil {
 				return err
 			}

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -257,14 +257,13 @@ func (vl VersionList) insertAt(i int, v FileVersion) VersionList {
 // as the removed FileVersion and the position, where that FileVersion was.
 // If there is no FileVersion for the given device, the position is -1.
 func (vl VersionList) pop(device []byte) (VersionList, FileVersion, int) {
-	removedAt := -1
 	for i, v := range vl.Versions {
 		if bytes.Equal(v.Device, device) {
 			vl.Versions = append(vl.Versions[:i], vl.Versions[i+1:]...)
 			return vl, v, i
 		}
 	}
-	return vl, FileVersion{}, removedAt
+	return vl, FileVersion{}, -1
 }
 
 func (vl VersionList) Get(device []byte) (FileVersion, bool) {

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -485,10 +485,6 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 	if err != nil {
 		return nil, false, err
 	}
-	if insertedAt == -1 {
-		l.Debugln("update global; same version, global unchanged")
-		return keyBuf, false, nil
-	}
 
 	name := []byte(file.Name)
 


### PR DESCRIPTION
If `checkGlobal` cleans out all entries in a global list entry (e.g. when it has only one entry pointing at nothing), it then commits that empty global list into the db. It's obviously not guaranteed to be the cause of #6425, but I can't find any way an empty list is committed in the other places we modify the global lists and adding check panics for empty global version lists and running integration tests didn't surface anything either - still no guarantee, but good enough imo.

~~Unfortunately I can't think of a good way to trigger `checkGlobals` on upgrade without a db schema upgrade, so the upgrade won't fix this immediately - ideas welcome.~~
See #6429 for a one-time check.

While checking everything I also found and removed two instances of useless code (`insertedAt` is never -1, we always insert the file).