### PR TITLE
gui, lib/model: Fix for folder stats with r-o and ignoreDel (fixes #6430)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -405,7 +405,7 @@
                     <tr ng-if="folder.type == 'receiveonly' && canRevert(folder.id)">
                       <th><span class="fas fa-fw fa-exclamation-circle"></span>&nbsp;<span translate>Locally Changed Items</span></th>
                       <td class="text-right">
-                        <a href="" ng-click="showLocalChanged(folder.id)">{{model[folder.id].receiveOnlyTotalItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{model[folder.id].receiveOnlyBytes | binary}}B</a>
+                        <a href="" ng-click="showLocalChanged(folder.id)">{{model[folder.id].receiveOnlyTotalItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{model[folder.id].receiveOnlyChangedBytes | binary}}B</a>
                       </td>
                     </tr>
                     <tr ng-if="folder.type != 'sendreceive'">

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -120,6 +120,7 @@ func (c *folderSummaryService) Summary(folder string) (map[string]interface{}, e
 	fcfg, ok := c.cfg.Folder(folder)
 
 	if ok && fcfg.IgnoreDelete {
+		res["needTotalItems"] -= res["needDeletes"]
 		res["needDeletes"] = 0
 	}
 

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -109,6 +109,12 @@ func (c *folderSummaryService) Summary(folder string) (map[string]interface{}, e
 
 	res["localFiles"], res["localDirectories"], res["localSymlinks"], res["localDeleted"], res["localBytes"], res["localTotalItems"] = local.Files, local.Directories, local.Symlinks, local.Deleted, local.Bytes, local.TotalItems()
 
+	fcfg, haveFcfg := c.cfg.Folder(folder)
+
+	if haveFcfg && fcfg.IgnoreDelete {
+		need.Deleted = 0
+	}
+
 	need.Bytes -= c.model.FolderProgressBytesCompleted(folder)
 	// This may happen if we are in progress of pulling files that were
 	// deleted globally after the pull started.
@@ -117,14 +123,7 @@ func (c *folderSummaryService) Summary(folder string) (map[string]interface{}, e
 	}
 	res["needFiles"], res["needDirectories"], res["needSymlinks"], res["needDeletes"], res["needBytes"], res["needTotalItems"] = need.Files, need.Directories, need.Symlinks, need.Deleted, need.Bytes, need.TotalItems()
 
-	fcfg, ok := c.cfg.Folder(folder)
-
-	if ok && fcfg.IgnoreDelete {
-		res["needTotalItems"] -= res["needDeletes"]
-		res["needDeletes"] = 0
-	}
-
-	if ok && fcfg.Type == config.FolderTypeReceiveOnly {
+	if haveFcfg && fcfg.Type == config.FolderTypeReceiveOnly {
 		// Add statistics for things that have changed locally in a receive
 		// only folder.
 		res["receiveOnlyChangedFiles"] = ro.Files


### PR DESCRIPTION
Correct an oversight (also adjust total needed items, not just deleted) and an incorrectly named variable - no testing done.