### PR TITLE
lib/model: Don't mark deleted local only as locally changed (fixes #6432)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -675,7 +675,7 @@ func (db *Lowlevel) repairSequenceGCLocked(folderStr string, meta *metadataTrack
 			if err := t.Put(sk, it.Key()); err != nil {
 				return 0, err
 			}
-			if err := t.putFile(it.Key(), fi.CopyToFileInfo()); err != nil {
+			if err := t.putFile(it.Key(), fi.copyToFileInfo()); err != nil {
 				return 0, err
 			}
 		}

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -675,7 +675,7 @@ func (db *Lowlevel) repairSequenceGCLocked(folderStr string, meta *metadataTrack
 			if err := t.Put(sk, it.Key()); err != nil {
 				return 0, err
 			}
-			if err := t.putFile(it.Key(), fi.copyToFileInfo()); err != nil {
+			if err := t.putFile(it.Key(), fi.CopyToFileInfo()); err != nil {
 				return 0, err
 			}
 		}

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -443,9 +443,7 @@ func (s *Snapshot) NeedSize() Counts {
 	return result
 }
 
-// LocalChangedFiles returns a paginated list of currently needed files in
-// progress, queued, and to be queued on next puller iteration, as well as the
-// total number of files currently needed.
+// LocalChangedFiles returns a paginated list of files that were changed locally.
 func (s *Snapshot) LocalChangedFiles(page, perpage int) []FileInfoTruncated {
 	if s.ReceiveOnlyChangedSize().TotalItems() == 0 {
 		return nil

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -129,19 +129,27 @@ func (f FileInfoTruncated) FileModifiedBy() protocol.ShortID {
 }
 
 func (f FileInfoTruncated) ConvertToIgnoredFileInfo(by protocol.ShortID) protocol.FileInfo {
-	file := f.CopyToFileInfo()
+	file := f.copyToFileInfo()
 	file.SetIgnored(by)
 	return file
 }
 
 func (f FileInfoTruncated) ConvertToDeletedFileInfo(by protocol.ShortID) protocol.FileInfo {
-	file := f.CopyToFileInfo()
+	file := f.copyToFileInfo()
 	file.SetDeleted(by)
 	return file
 }
 
+// ConvertDeletedToFileInfo converts a deleted truncated file info to a regular file info
+func (f FileInfoTruncated) ConvertDeletedToFileInfo() protocol.FileInfo {
+	if !f.Deleted {
+		panic("ConvertDeletedToFileInfo must only be called on deleted items")
+	}
+	return f.copyToFileInfo()
+}
+
 // copyToFileInfo just copies all members of FileInfoTruncated to protocol.FileInfo
-func (f FileInfoTruncated) CopyToFileInfo() protocol.FileInfo {
+func (f FileInfoTruncated) copyToFileInfo() protocol.FileInfo {
 	return protocol.FileInfo{
 		Name:          f.Name,
 		Size:          f.Size,

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -129,19 +129,19 @@ func (f FileInfoTruncated) FileModifiedBy() protocol.ShortID {
 }
 
 func (f FileInfoTruncated) ConvertToIgnoredFileInfo(by protocol.ShortID) protocol.FileInfo {
-	file := f.copyToFileInfo()
+	file := f.CopyToFileInfo()
 	file.SetIgnored(by)
 	return file
 }
 
 func (f FileInfoTruncated) ConvertToDeletedFileInfo(by protocol.ShortID) protocol.FileInfo {
-	file := f.copyToFileInfo()
+	file := f.CopyToFileInfo()
 	file.SetDeleted(by)
 	return file
 }
 
 // copyToFileInfo just copies all members of FileInfoTruncated to protocol.FileInfo
-func (f FileInfoTruncated) copyToFileInfo() protocol.FileInfo {
+func (f FileInfoTruncated) CopyToFileInfo() protocol.FileInfo {
 	return protocol.FileInfo{
 		Name:          f.Name,
 		Size:          f.Size,

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -172,8 +172,9 @@ func (f *receiveOnlyFolder) pull() {
 		if !fi.IsDeleted() || !fi.IsReceiveOnlyChanged() || len(snap.Availability(fi.FileName())) > 0 {
 			return true
 		}
-		file := fi.(db.FileInfoTruncated).CopyToFileInfo()
+		file := fi.(db.FileInfoTruncated).ConvertDeletedToFileInfo()
 		file.LocalFlags = 0
+		file.Version = protocol.Vector{}
 		batch = append(batch, file)
 		batchSizeBytes += file.ProtoSize()
 		if len(batch) == maxBatchSizeFiles || batchSizeBytes > maxBatchSizeBytes {


### PR DESCRIPTION
> A file that only ever existed locally, but is now deleted, keeps showing up as a locally changed item. That has no value, as for all practical intents and purposes it does not exist.

Like with similar special conditions on send only folder, this adds a stage to pulling that checks for this situation and fixes it by removing the local flag.