### PR TITLE
lib/db: Don't whack blocks when putting truncated file

### DIFF
--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -261,11 +261,11 @@ func TestRepairSequence(t *testing.T) {
 	short := protocol.LocalDeviceID.Short()
 
 	files := []protocol.FileInfo{
-		{Name: "fine"},
-		{Name: "duplicate"},
-		{Name: "missing"},
-		{Name: "overwriting"},
-		{Name: "inconsistent"},
+		{Name: "fine", Blocks: genBlocks(4)},
+		{Name: "duplicate", Blocks: genBlocks(4)},
+		{Name: "missing", Blocks: genBlocks(4)},
+		{Name: "overwriting", Blocks: genBlocks(4)},
+		{Name: "inconsistent", Blocks: genBlocks(4)},
 	}
 	for i, f := range files {
 		files[i].Version = f.Version.Update(short)
@@ -399,15 +399,19 @@ func TestRepairSequence(t *testing.T) {
 	}
 	defer it.Release()
 	for it.Next() {
-		fi, ok, err := ro.getFileTrunc(it.Value(), true)
+		intf, ok, err := ro.getFileTrunc(it.Value(), false)
 		if err != nil {
 			t.Fatal(err)
 		}
+		fi := intf.(protocol.FileInfo)
 		seq := ro.keyer.SequenceFromSequenceKey(it.Key())
 		if !ok {
 			t.Errorf("Sequence entry %v points at nothing", seq)
 		} else if fi.SequenceNo() != seq {
 			t.Errorf("Inconsistent sequence entry for %v: %v != %v", fi.FileName(), fi.SequenceNo(), seq)
+		}
+		if len(fi.Blocks) == 0 {
+			t.Error("Missing blocks in", fi.FileName())
 		}
 	}
 	if err := it.Error(); err != nil {

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -282,7 +282,7 @@ func TestRepairSequence(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := trans.putFile(dk, f); err != nil {
+		if err := trans.putFile(dk, f, false); err != nil {
 			t.Fatal(err)
 		}
 		sk, err := trans.keyer.GenerateSequenceKey(nil, folder, seq)

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -261,11 +261,11 @@ func TestRepairSequence(t *testing.T) {
 	short := protocol.LocalDeviceID.Short()
 
 	files := []protocol.FileInfo{
-		{Name: "fine", Blocks: genBlocks(4)},
-		{Name: "duplicate", Blocks: genBlocks(4)},
-		{Name: "missing", Blocks: genBlocks(4)},
+		{Name: "fine", Blocks: genBlocks(1)},
+		{Name: "duplicate", Blocks: genBlocks(2)},
+		{Name: "missing", Blocks: genBlocks(3)},
 		{Name: "overwriting", Blocks: genBlocks(4)},
-		{Name: "inconsistent", Blocks: genBlocks(4)},
+		{Name: "inconsistent", Blocks: genBlocks(5)},
 	}
 	for i, f := range files {
 		files[i].Version = f.Version.Update(short)

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -114,7 +114,7 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 		meta.addFile(devID, f)
 
 		l.Debugf("insert; folder=%q device=%v %v", folder, devID, f)
-		if err := t.putFile(dk, f); err != nil {
+		if err := t.putFile(dk, f, false); err != nil {
 			return err
 		}
 
@@ -201,7 +201,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		meta.addFile(protocol.LocalDeviceID, f)
 
 		l.Debugf("insert (local); folder=%q %v", folder, f)
-		if err := t.putFile(dk, f); err != nil {
+		if err := t.putFile(dk, f, false); err != nil {
 			return err
 		}
 
@@ -790,7 +790,7 @@ func (db *Lowlevel) repairSequenceGCLocked(folderStr string, meta *metadataTrack
 			if err := t.Put(sk, it.Key()); err != nil {
 				return 0, err
 			}
-			if err := t.putFile(it.Key(), fi.copyToFileInfo()); err != nil {
+			if err := t.putFile(it.Key(), fi.copyToFileInfo(), true); err != nil {
 				return 0, err
 			}
 		}

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -643,7 +643,7 @@ func (db *Lowlevel) getMetaAndCheck(folder string) *metadataTracker {
 		var fixed int
 		fixed, err = db.repairSequenceGCLocked(folder, meta)
 		if fixed != 0 {
-			l.Infoln("Repaired %v sequence entries in database", fixed)
+			l.Infof("Repaired %d sequence entries in database", fixed)
 		}
 	}
 

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -465,7 +465,7 @@ func (db *schemaUpdater) updateSchemato9(prev int) error {
 		if fi.Blocks == nil {
 			continue
 		}
-		if err := t.putFile(it.Key(), fi); err != nil {
+		if err := t.putFile(it.Key(), fi, false); err != nil {
 			return err
 		}
 		if err := t.Checkpoint(); err != nil {

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -435,11 +435,11 @@ func (t readWriteTransaction) close() {
 func (t readWriteTransaction) putFile(fkey []byte, fi protocol.FileInfo) error {
 	var bkey []byte
 
-	// Always set the blocks hash when there are blocks.
+	// Always set the blocks hash when there are blocks. Leave the blocks
+	// hash alone when there are no blocks, as we might be putting a
+	// "truncated" FileInfo (no blocks, but the hash reference in place.)
 	if len(fi.Blocks) > 0 {
 		fi.BlocksHash = protocol.BlocksHash(fi.Blocks)
-	} else {
-		fi.BlocksHash = nil
 	}
 
 	// Indirect the blocks if the block list is large enough.

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -440,8 +440,8 @@ func (t readWriteTransaction) putFile(fkey []byte, fi protocol.FileInfo, truncat
 	var bkey []byte
 
 	// Always set the blocks hash when there are blocks. Leave the blocks
-	// hash alone when there are no blocks, as we might be putting a
-	// "truncated" FileInfo (no blocks, but the hash reference in place.)
+	// hash alone when there are no blocks and we might be putting a
+	// "truncated" FileInfo (no blocks, but the hash reference is live).
 	if len(fi.Blocks) > 0 {
 		fi.BlocksHash = protocol.BlocksHash(fi.Blocks)
 	} else if !truncated {


### PR DESCRIPTION
As of the latest database checker we are again putting files without
blocks. I'm not 100% convinced that's a great idea, but we also do it
for ignored files apparently so it looks like we probably should support
it.
