### PR TITLE
lib/model: Unset local flag on deleted files (fixes #6436)

### DIFF
--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -64,6 +64,8 @@ func newReceiveOnlyFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 }
 
 func (f *receiveOnlyFolder) Revert() {
+	l.Infof("Reverting folder %v", f.Description)
+
 	f.setState(FolderScanning)
 	defer f.setState(FolderIdle)
 
@@ -89,6 +91,7 @@ func (f *receiveOnlyFolder) Revert() {
 			return true
 		}
 
+		fi.LocalFlags &^= protocol.FlagLocalReceiveOnly
 		if len(fi.Version.Counters) == 1 && fi.Version.Counters[0].ID == f.shortID {
 			// We are the only device mentioned in the version vector so the
 			// file must originate here. A revert then means to delete it.
@@ -113,7 +116,6 @@ func (f *receiveOnlyFolder) Revert() {
 			// either, so we will not create a conflict copy of our local
 			// changes.
 			fi.Version = protocol.Vector{}
-			fi.LocalFlags &^= protocol.FlagLocalReceiveOnly
 		}
 
 		batch = append(batch, fi)

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -97,7 +97,7 @@ func (f *sendOnlyFolder) pull() bool {
 }
 
 func (f *sendOnlyFolder) Override() {
-	l.Infof("Overriding global stat on folder %v", f.Description)
+	l.Infof("Overriding global state on folder %v", f.Description)
 
 	f.setState(FolderScanning)
 	batch := make([]protocol.FileInfo, 0, maxBatchSizeFiles)

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -97,6 +97,8 @@ func (f *sendOnlyFolder) pull() bool {
 }
 
 func (f *sendOnlyFolder) Override() {
+	l.Infof("Overriding global stat on folder %v", f.Description)
+
 	f.setState(FolderScanning)
 	batch := make([]protocol.FileInfo, 0, maxBatchSizeFiles)
 	batchSizeBytes := 0


### PR DESCRIPTION
We previously didn't remove the local flag for files that only exist locally, resulting in those disappearing from local/global state, but still existing as locally changed items (thus override button and number of locally changed items remains in UI).

I also added two info log lines to the revert and override methods. Currently there's no clear indication of these operations happening in the logs. Given those are not regular operations, but ones triggered by the user, I believe that is appropriate verbosity.