### PR TITLE
lib/syncthing: Save version to db after upgrade ops are done (ref #6457)

### DIFF
--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -236,9 +236,6 @@ func (a *App) startup() error {
 		// Drop delta indexes in case we've changed random stuff we
 		// shouldn't have. We will resend our index on next connect.
 		db.DropDeltaIndexIDs(a.ll)
-
-		// Remember the new version.
-		miscDB.PutString("prevVersion", build.Version)
 	}
 
 	// Check and repair metadata and sequences on every upgrade including RCs.
@@ -247,6 +244,11 @@ func (a *App) startup() error {
 	if rel := upgrade.CompareVersions(prevParts[0], curParts[0]); rel != upgrade.Equal {
 		l.Infoln("Checking db due to upgrade - this may take a while...")
 		a.ll.CheckRepair()
+	}
+
+	if build.Version != prevVersion {
+		// Remember the new version.
+		miscDB.PutString("prevVersion", build.Version)
 	}
 
 	m := model.NewModel(a.cfg, a.myID, "syncthing", build.Version, a.ll, protectedFiles, a.evLogger)


### PR DESCRIPTION
We currently save the version to db before repairing the db. Thus if repairing results in a panic, it won't be retried on a successive start. That in itself isn't that bad, as it probably anyway doesn't succeed, but we also have no way of knowing if the repairing ever happened. Thus lets just store the new version in db after all the operations triggered by an update went through.