### PR TITLE
lib/model: Do Revert/Override synchronously

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -50,14 +50,14 @@ type folder struct {
 
 	scanInterval        time.Duration
 	scanTimer           *time.Timer
-	scanNow             chan rescanRequest
 	scanDelay           chan time.Duration
 	initialScanFinished chan struct{}
 	scanErrors          []FileError
 	scanErrorsMut       sync.Mutex
 
 	pullScheduled chan struct{}
-	syncChan      chan chan struct{}
+
+	doInSyncChan chan syncRequest
 
 	watchCancel      context.CancelFunc
 	watchChan        chan []string
@@ -68,9 +68,9 @@ type folder struct {
 	puller puller
 }
 
-type rescanRequest struct {
-	subdirs []string
-	err     chan error
+type syncRequest struct {
+	fn  func() error
+	err chan error
 }
 
 type puller interface {
@@ -91,13 +91,13 @@ func newFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, cfg conf
 
 		scanInterval:        time.Duration(cfg.RescanIntervalS) * time.Second,
 		scanTimer:           time.NewTimer(time.Millisecond), // The first scan should be done immediately.
-		scanNow:             make(chan rescanRequest),
 		scanDelay:           make(chan time.Duration),
 		initialScanFinished: make(chan struct{}),
 		scanErrorsMut:       sync.NewMutex(),
 
 		pullScheduled: make(chan struct{}, 1), // This needs to be 1-buffered so that we queue a pull if we're busy when it comes.
-		syncChan:      make(chan chan struct{}),
+
+		doInSyncChan: make(chan syncRequest),
 
 		watchCancel:      func() {},
 		restartWatchChan: make(chan struct{}, 1),
@@ -147,13 +147,6 @@ func (f *folder) serve(ctx context.Context) {
 	}
 
 	for {
-		// Do Revert/Override with priority
-		select {
-		case done := <-f.syncChan:
-			<-done
-		default:
-		}
-
 		select {
 		case <-f.ctx.Done():
 			return
@@ -181,9 +174,9 @@ func (f *folder) serve(ctx context.Context) {
 			l.Debugln(f, "Scanning due to timer")
 			f.scanTimerFired()
 
-		case req := <-f.scanNow:
-			l.Debugln(f, "Scanning due to request")
-			req.err <- f.scanSubdirs(req.subdirs)
+		case req := <-f.doInSyncChan:
+			l.Debugln(f, "Running something due to request")
+			req.err <- req.fn()
 
 		case next := <-f.scanDelay:
 			l.Debugln(f, "Delaying scan")
@@ -196,10 +189,6 @@ func (f *folder) serve(ctx context.Context) {
 		case <-f.restartWatchChan:
 			l.Debugln(f, "Restart watcher")
 			f.restartWatch()
-
-		// Revert/Override
-		case done := <-f.syncChan:
-			<-done
 		}
 	}
 }
@@ -237,13 +226,19 @@ func (f *folder) Jobs(_, _ int) ([]string, []string, int) {
 
 func (f *folder) Scan(subdirs []string) error {
 	<-f.initialScanFinished
-	req := rescanRequest{
-		subdirs: subdirs,
-		err:     make(chan error),
+	return f.doInSync(func() error { return f.scanSubdirs(subdirs) })
+}
+
+// doInSync allows to run functions synchronously in folder.serve from exported,
+// asynchronously called methods.
+func (f *folder) doInSync(fn func() error) error {
+	req := syncRequest{
+		fn:  fn,
+		err: make(chan error),
 	}
 
 	select {
-	case f.scanNow <- req:
+	case f.doInSyncChan <- req:
 		return <-req.err
 	case <-f.ctx.Done():
 		return f.ctx.Err()

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -234,7 +234,7 @@ func (f *folder) Scan(subdirs []string) error {
 func (f *folder) doInSync(fn func() error) error {
 	req := syncRequest{
 		fn:  fn,
-		err: make(chan error),
+		err: make(chan error, 1),
 	}
 
 	select {

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -64,14 +64,10 @@ func newReceiveOnlyFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 }
 
 func (f *receiveOnlyFolder) Revert() {
-	done := make(chan struct{})
-	select {
-	case f.syncChan <- done:
-		defer close(done)
-	case <-f.ctx.Done():
-		return
-	}
+	f.doInSync(func() error { f.revert(); return nil })
+}
 
+func (f *receiveOnlyFolder) revert() {
 	l.Infof("Reverting folder %v", f.Description)
 
 	f.setState(FolderScanning)

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -64,6 +64,14 @@ func newReceiveOnlyFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 }
 
 func (f *receiveOnlyFolder) Revert() {
+	done := make(chan struct{})
+	select {
+	case f.syncChan <- done:
+		defer close(done)
+	case <-f.ctx.Done():
+		return
+	}
+
 	l.Infof("Reverting folder %v", f.Description)
 
 	f.setState(FolderScanning)

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -97,17 +97,15 @@ func (f *sendOnlyFolder) pull() bool {
 }
 
 func (f *sendOnlyFolder) Override() {
-	done := make(chan struct{})
-	select {
-	case f.syncChan <- done:
-		defer close(done)
-	case <-f.ctx.Done():
-		return
-	}
+	f.doInSync(func() error { f.override(); return nil })
+}
 
+func (f *sendOnlyFolder) override() {
 	l.Infof("Overriding global state on folder %v", f.Description)
 
 	f.setState(FolderScanning)
+	defer f.setState(FolderIdle)
+
 	batch := make([]protocol.FileInfo, 0, maxBatchSizeFiles)
 	batchSizeBytes := 0
 	snap := f.fset.Snapshot()
@@ -142,5 +140,4 @@ func (f *sendOnlyFolder) Override() {
 	if len(batch) > 0 {
 		f.updateLocalsFromScanning(batch)
 	}
-	f.setState(FolderIdle)
 }

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -97,6 +97,14 @@ func (f *sendOnlyFolder) pull() bool {
 }
 
 func (f *sendOnlyFolder) Override() {
+	done := make(chan struct{})
+	select {
+	case f.syncChan <- done:
+		defer close(done)
+	case <-f.ctx.Done():
+		return
+	}
+
 	l.Infof("Overriding global state on folder %v", f.Description)
 
 	f.setState(FolderScanning)


### PR DESCRIPTION
Writing a test for https://github.com/syncthing/syncthing/pull/6433 I realised `Override` and `Revert` happen asynchronously, i.e. you can't depend on any order of folder operations in conjunction with those. In addition they both set folder state and update the db, so as far as I see they mustn't run asynchronously.

I added a general purpose `syncChan` - I could also add two special purpose chans for overriding and reverting instead if this is "too magic".