### PR TITLE
lib/versioner: Fix "30 days" interval (fixes #6410)

### DIFF
--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -60,10 +60,10 @@ func newStaggered(folderFs fs.Filesystem, params map[string]string) Versioner {
 		folderFs:      folderFs,
 		versionsFs:    versionsFs,
 		interval: [4]interval{
-			{30, 60*60},       // first hour -> 30 sec between versions
-			{60*60, 24*60*60},    // next day -> 1 h between versions
-			{24*60*60, 30*24*60*60},  // next 30 days -> 1 day between versions
-			{7*24*60*60, maxAge}, // next year -> 1 week between versions
+			{30, 60 * 60},                     // first hour -> 30 sec between versions
+			{60 * 60, 24 * 60 * 60},           // next day -> 1 h between versions
+			{24 * 60 * 60, 30 * 24 * 60 * 60}, // next 30 days -> 1 day between versions
+			{7 * 24 * 60 * 60, maxAge},        // next year -> 1 week between versions
 		},
 		mutex: sync.NewMutex(),
 	}

--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -60,10 +60,10 @@ func newStaggered(folderFs fs.Filesystem, params map[string]string) Versioner {
 		folderFs:      folderFs,
 		versionsFs:    versionsFs,
 		interval: [4]interval{
-			{30, 3600},       // first hour -> 30 sec between versions
-			{3600, 86400},    // next day -> 1 h between versions
-			{86400, 592000},  // next 30 days -> 1 day between versions
-			{604800, maxAge}, // next year -> 1 week between versions
+			{30, 60*60},       // first hour -> 30 sec between versions
+			{60*60, 24*60*60},    // next day -> 1 h between versions
+			{24*60*60, 30*24*60*60},  // next 30 days -> 1 day between versions
+			{7*24*60*60, maxAge}, // next year -> 1 week between versions
 		},
 		mutex: sync.NewMutex(),
 	}


### PR DESCRIPTION


### Purpose

Make intervals more readable, which also address the "30 day" interval having the wrong value. Fixes #6410.

### Testing

Describe what testing has been done, and how the reviewer can test the change
if new tests are not included.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

