### PR TITLE
lib/model: Handle deleted items on RO for remove remotes (fixes #6432)

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -333,9 +333,7 @@ func (s *Snapshot) NeedSize() Counts {
 	return result
 }
 
-// LocalChangedFiles returns a paginated list of currently needed files in
-// progress, queued, and to be queued on next puller iteration, as well as the
-// total number of files currently needed.
+// LocalChangedFiles returns a paginated list of files that were changed locally.
 func (s *Snapshot) LocalChangedFiles(page, perpage int) []FileInfoTruncated {
 	if s.ReceiveOnlyChangedSize().TotalItems() == 0 {
 		return nil

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -140,6 +140,14 @@ func (f FileInfoTruncated) ConvertToDeletedFileInfo(by protocol.ShortID) protoco
 	return file
 }
 
+// ConvertDeletedToFileInfo converts a deleted truncated file info to a regular file info
+func (f FileInfoTruncated) ConvertDeletedToFileInfo() protocol.FileInfo {
+	if !f.Deleted {
+		panic("ConvertDeletedToFileInfo must only be called on deleted items")
+	}
+	return f.copyToFileInfo()
+}
+
 // copyToFileInfo just copies all members of FileInfoTruncated to protocol.FileInfo
 func (f FileInfoTruncated) copyToFileInfo() protocol.FileInfo {
 	return protocol.FileInfo{

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -548,6 +548,20 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 				batch.append(nf)
 				changes++
 			}
+
+			// Check for deleted, locally changed items that noone else has.
+			if f.localFlags&protocol.FlagLocalReceiveOnly == 0 {
+				return true
+			}
+			if !fi.IsDeleted() || !fi.IsReceiveOnlyChanged() || len(snap.Availability(fi.FileName())) > 0 {
+				return true
+			}
+			nf := fi.(db.FileInfoTruncated).ConvertDeletedToFileInfo()
+			nf.LocalFlags = 0
+			nf.Version = protocol.Vector{}
+			batch.append(nf)
+			changes++
+
 			return true
 		})
 


### PR DESCRIPTION
### Purpose

Scenario here is that a file is deleted locally on a receive-only folder, but exists on a remote. That remote is then removed. Currently that deleted file will show up as locally changed. When we delete something, we do pick this up in the scanner and mark it as not locally changed if noone else has the file. However in this scenario there is no change for the scanner to notice, as it is already deleted.

### Testing

Unit test for the scenario described above. 
