### PR TITLE
lib/ur: use sysctl syscall to get RAM size on Mac

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/willf/bloom v2.0.3+incompatible
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
+	golang.org/x/sys v0.0.0-20191224085550-c709ea063b76
 	golang.org/x/text v0.3.2
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/lib/ur/memsize_darwin.go
+++ b/lib/ur/memsize_darwin.go
@@ -6,26 +6,9 @@
 
 package ur
 
-import (
-	"errors"
-	"os/exec"
-	"strconv"
-	"strings"
-)
+import "golang.org/x/sys/unix"
 
 func memorySize() (int64, error) {
-	cmd := exec.Command("sysctl", "hw.memsize")
-	out, err := cmd.Output()
-	if err != nil {
-		return 0, err
-	}
-	fs := strings.Fields(string(out))
-	if len(fs) != 2 {
-		return 0, errors.New("sysctl parse error")
-	}
-	bytes, err := strconv.ParseInt(fs[1], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return bytes, nil
+	mem, err := unix.SysctlUint64("hw.memsize")
+	return int64(mem), err
 }


### PR DESCRIPTION
### Purpose

syncthing currently spawns a process to get the memory size on Darwin. It can instead do a single system call to get this information.

The other BSDs could probably do this too, except that the "memsize" parameter name appears to be MacOS-specific.

### Testing

Trigger a usage report in the UI: Settings, Anonymous Usage Reporting, Preview.