### PR TITLE
lib/weakhash: Fix speed reporting in benchmark

### DIFF
--- a/lib/weakhash/benchmark_test.go
+++ b/lib/weakhash/benchmark_test.go
@@ -93,7 +93,7 @@ func BenchmarkBlock(b *testing.B) {
 						test.hash.Reset()
 					}
 
-					bbb.SetBytes(int64(len(buf)))
+					bbb.SetBytes(testSize)
 					bbb.ReportAllocs()
 				})
 


### PR DESCRIPTION
### Purpose

The block benchmark was using the wrong size in SetBytes, causing its
speeds to be off by a factor 100.

```
name                                  old speed      new speed      delta
Block/adler32-131072/#00-8             108GB/s ± 1%     1GB/s ± 1%  -99.23%  (p=0.008 n=5+5)
Block/bozo32-131072/#00-8             19.3GB/s ± 0%   0.1GB/s ± 1%  -99.23%  (p=0.008 n=5+5)
Block/buzhash32-131072/#00-8          26.8GB/s ± 0%   0.2GB/s ± 1%  -99.22%  (p=0.008 n=5+5)
Block/buzhash64-131072/#00-8          26.4GB/s ± 1%   0.2GB/s ± 0%  -99.23%  (p=0.008 n=5+5)
Block/vanilla-adler32-131072/#00-8     244GB/s ± 2%     2GB/s ± 3%  -99.23%  (p=0.008 n=5+5)
```