### PR TITLE
lib/protocol: Remove unused channel Connection.preventSends

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -165,7 +165,6 @@ type rawConnection struct {
 	closeBox              chan asyncMessage
 	clusterConfigBox      chan *ClusterConfig
 	dispatcherLoopStopped chan struct{}
-	preventSends          chan struct{}
 	closed                chan struct{}
 	closeOnce             sync.Once
 	sendCloseOnce         sync.Once
@@ -219,7 +218,6 @@ func NewConnection(deviceID DeviceID, reader io.Reader, writer io.Writer, receiv
 		closeBox:              make(chan asyncMessage),
 		clusterConfigBox:      make(chan *ClusterConfig),
 		dispatcherLoopStopped: make(chan struct{}),
-		preventSends:          make(chan struct{}),
 		closed:                make(chan struct{}),
 		compression:           compress,
 	}
@@ -656,7 +654,6 @@ func (c *rawConnection) send(ctx context.Context, msg message, done chan struct{
 	select {
 	case c.outbox <- asyncMessage{msg, done}:
 		return true
-	case <-c.preventSends:
 	case <-c.closed:
 	case <-ctx.Done():
 	}


### PR DESCRIPTION
### Purpose

Removes a channel from protocol.Connection to which no messages were ever sent.