### PR TITLE
lib/rand: Various fixes

### DIFF
--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -12,7 +12,6 @@ import (
 	"crypto/md5"
 	cryptoRand "crypto/rand"
 	"encoding/binary"
-	"io"
 	mathRand "math/rand"
 	"reflect"
 )
@@ -50,12 +49,7 @@ func Int63() int64 {
 
 // Int64 returns a strongly random int64.
 func Int64() int64 {
-	var bs [8]byte
-	_, err := io.ReadFull(cryptoRand.Reader, bs[:])
-	if err != nil {
-		panic("randomness failure: " + err.Error())
-	}
-	return int64(binary.BigEndian.Uint64(bs[:]))
+	return int64(defaultSecureSource.Uint64())
 }
 
 // Intn returns, as an int, a non-negative strongly random number in [0,n).

--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -20,16 +20,16 @@ import (
 // Reader is the standard crypto/rand.Reader, re-exported for convenience
 var Reader = cryptoRand.Reader
 
-// randomCharset contains the characters that can make up a randomString().
+// randomCharset contains the characters that can make up a rand.String().
 const randomCharset = "2345679abcdefghijkmnopqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ"
 
 var (
 	// defaultSecureSource is a concurrency safe math/rand.Source with a
 	// cryptographically sound base.
-	defaltSecureSource = newSecureSource()
+	defaultSecureSource = newSecureSource()
 
 	// defaultSecureRand is a math/rand.Rand based on the secure source.
-	defaultSecureRand = mathRand.New(defaltSecureSource)
+	defaultSecureRand = mathRand.New(defaultSecureSource)
 )
 
 // String returns a strongly random string of characters (taken from
@@ -43,12 +43,12 @@ func String(l int) string {
 	return string(bs)
 }
 
-// Int63 returns a strongly random int63
+// Int63 returns a strongly random int63.
 func Int63() int64 {
-	return defaltSecureSource.Int63()
+	return defaultSecureSource.Int63()
 }
 
-// Int64 returns a strongly random int64
+// Int64 returns a strongly random int64.
 func Int64() int64 {
 	var bs [8]byte
 	_, err := io.ReadFull(cryptoRand.Reader, bs[:])
@@ -75,7 +75,7 @@ func SeedFromBytes(bs []byte) int64 {
 	return int64(binary.BigEndian.Uint64(s[0:]) ^ binary.BigEndian.Uint64(s[8:]))
 }
 
-// Shuffle the order of elements
+// Shuffle the order of elements in slice.
 func Shuffle(slice interface{}) {
 	rv := reflect.ValueOf(slice)
 	swap := reflect.Swapper(slice)

--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -9,9 +9,7 @@
 package rand
 
 import (
-	"crypto/md5"
 	cryptoRand "crypto/rand"
-	"encoding/binary"
 	mathRand "math/rand"
 	"reflect"
 )
@@ -56,17 +54,6 @@ func Int64() int64 {
 // It panics if n <= 0.
 func Intn(n int) int {
 	return defaultSecureRand.Intn(n)
-}
-
-// SeedFromBytes calculates a weak 64 bit hash from the given byte slice,
-// suitable for use a predictable random seed.
-func SeedFromBytes(bs []byte) int64 {
-	h := md5.New()
-	h.Write(bs)
-	s := h.Sum(nil)
-	// The MD5 hash of the byte slice is 16 bytes long. We interpret it as two
-	// uint64s and XOR them together.
-	return int64(binary.BigEndian.Uint64(s[0:]) ^ binary.BigEndian.Uint64(s[8:]))
 }
 
 // Shuffle the order of elements in slice.

--- a/lib/rand/random_test.go
+++ b/lib/rand/random_test.go
@@ -8,23 +8,6 @@ package rand
 
 import "testing"
 
-func TestSeedFromBytes(t *testing.T) {
-	// should always return the same seed for the same bytes
-	tcs := []struct {
-		bs []byte
-		v  int64
-	}{
-		{[]byte("hello world"), -3639725434188061933},
-		{[]byte("hello worlx"), -2539100776074091088},
-	}
-
-	for _, tc := range tcs {
-		if v := SeedFromBytes(tc.bs); v != tc.v {
-			t.Errorf("Unexpected seed value %d != %d", v, tc.v)
-		}
-	}
-}
-
 func TestRandomString(t *testing.T) {
 	for _, l := range []int{0, 1, 2, 3, 4, 8, 42} {
 		s := String(l)

--- a/lib/rand/securesource.go
+++ b/lib/rand/securesource.go
@@ -37,6 +37,10 @@ func (s *secureSource) Seed(int64) {
 }
 
 func (s *secureSource) Int63() int64 {
+	return int64(s.Uint64() & (1<<63 - 1))
+}
+
+func (s *secureSource) Uint64() uint64 {
 	var buf [8]byte
 
 	// Read eight bytes of entropy from the buffered, secure random number
@@ -50,8 +54,5 @@ func (s *secureSource) Int63() int64 {
 	}
 
 	// Grab those bytes as an uint64
-	v := binary.BigEndian.Uint64(buf[:])
-
-	// Mask of the high bit and return the resulting int63
-	return int64(v & (1<<63 - 1))
+	return binary.BigEndian.Uint64(buf[:])
 }


### PR DESCRIPTION
### Purpose

Various small fixes to the lib/rand package. The potentially controversial one is aa86ab22f8592a4308efe6579a0cf826d9372231, which makes rand.Int64 use the synchronized interface to crypto/rand.Reader in the lib/rand package.