### PR TITLE
lib/util: Fix potential data race

### DIFF
--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -255,8 +255,12 @@ func (s *service) Stop() {
 	default:
 		s.cancel()
 	}
+
+	// Cache s.stopped in a variable while we hold the mutex
+	// to prevent a data race with Serve's resetting it.
+	stopped := s.stopped
 	s.mut.Unlock()
-	<-s.stopped
+	<-stopped
 }
 
 func (s *service) Error() error {


### PR DESCRIPTION
This fixes a potential data race in lib/util.service. That type's Serve method sets a field, stopped, while holding a lock. Its Stop method, however, gets the field's value without synchronizing. The solution is to get the variable while holding the lock but only use it after unlocking.