### PR TITLE
lib/scanner: Fix HashFile benchmark

### DIFF
--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -554,7 +554,7 @@ func BenchmarkHashFile(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		if _, err := HashFile(context.TODO(), fs.NewFilesystem(fs.FilesystemTypeBasic, ""), testdataName, protocol.MinBlockSize, nil, true); err != nil {
+		if _, err := HashFile(context.TODO(), fs.NewFilesystem(fs.FilesystemTypeBasic, "."), testdataName, protocol.MinBlockSize, nil, true); err != nil {
 			b.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Prevents the following error when running the benchmark with plain go test -bench=.:

```
--- FAIL: BenchmarkHashFile
    walk_test.go:558: open /_random.data: no such file or directory
FAIL
exit status 1
FAIL	github.com/syncthing/syncthing/lib/scanner	0.115s
```