### PR TITLE
lib/fs: Basic with empty root shouldn't point at /

### DIFF
--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -30,6 +30,10 @@ type BasicFilesystem struct {
 }
 
 func newBasicFilesystem(root string) *BasicFilesystem {
+	if root == "" {
+		root = "." // Otherwise "" becomes "/" below
+	}
+
 	// The reason it's done like this:
 	// C:          ->  C:\            ->  C:\        (issue that this is trying to fix)
 	// C:\somedir  ->  C:\somedir\    ->  C:\somedir

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -514,6 +514,10 @@ func TestNewBasicFilesystem(t *testing.T) {
 		t.Skip("non-windows root paths")
 	}
 
+	currentDir, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
 	testCases := []struct {
 		input        string
 		expectedRoot string
@@ -521,7 +525,8 @@ func TestNewBasicFilesystem(t *testing.T) {
 	}{
 		{"/foo/bar/baz", "/foo/bar/baz", "/foo/bar/baz"},
 		{"/foo/bar/baz/", "/foo/bar/baz", "/foo/bar/baz"},
-		{"", "/", "/"},
+		{"", currentDir, currentDir},
+		{".", currentDir, currentDir},
 		{"/", "/", "/"},
 	}
 


### PR DESCRIPTION
This is a result of #6482, where the problem is that a basic fs with "" root points at "/". We actually have a test ensuring that behaviour:

https://github.com/syncthing/syncthing/blob/master/lib/fs/basicfs_test.go#L517

However that is in my opinion wrong in general and definitely inconsistent with golangs filepath package

>  If the result of this process is an empty string, Clean returns the string ".". 

and also our `fs.IsParent`, which treats "" the same as ".". Therefore I propose to change that behaviour.