### PR TITLE
lib/db, lib/model: Code simplifications

### DIFF
--- a/lib/db/namespaced.go
+++ b/lib/db/namespaced.go
@@ -17,20 +17,15 @@ import (
 // a leveldb.
 type NamespacedKV struct {
 	db     *Lowlevel
-	prefix []byte
+	prefix string
 }
 
 // NewNamespacedKV returns a new NamespacedKV that lives in the namespace
 // specified by the prefix.
 func NewNamespacedKV(db *Lowlevel, prefix string) *NamespacedKV {
-	prefixBs := []byte(prefix)
-	// After the conversion from string the cap will be larger than the len (in Go 1.11.5,
-	// 32 bytes cap for small strings). We need to cut it down to ensure append() calls
-	// on the prefix make a new allocation.
-	prefixBs = prefixBs[:len(prefixBs):len(prefixBs)]
 	return &NamespacedKV{
 		db:     db,
-		prefix: prefixBs,
+		prefix: prefix,
 	}
 }
 
@@ -130,7 +125,7 @@ func (n NamespacedKV) Delete(key string) error {
 }
 
 func (n NamespacedKV) prefixedKey(key string) []byte {
-	return append(n.prefix, []byte(key)...)
+	return []byte(n.prefix + key)
 }
 
 // Well known namespaces that can be instantiated without knowing the key

--- a/lib/db/namespaced_test.go
+++ b/lib/db/namespaced_test.go
@@ -167,7 +167,7 @@ func reset(n *NamespacedKV) {
 	}
 	defer tr.Release()
 
-	it, err := tr.NewPrefixIterator(n.prefix)
+	it, err := tr.NewPrefixIterator([]byte(n.prefix))
 	if err != nil {
 		return
 	}

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1359,14 +1359,9 @@ func verifyBuffer(buf []byte, block protocol.BlockInfo) error {
 	if len(buf) != int(block.Size) {
 		return fmt.Errorf("length mismatch %d != %d", len(buf), block.Size)
 	}
-	hf := sha256.New()
-	_, err := hf.Write(buf)
-	if err != nil {
-		return err
-	}
-	hash := hf.Sum(nil)
 
-	if !bytes.Equal(hash, block.Hash) {
+	hash := sha256.Sum256(buf)
+	if !bytes.Equal(hash[:], block.Hash) {
 		return fmt.Errorf("hash mismatch %x != %x", hash, block.Hash)
 	}
 


### PR DESCRIPTION
Here are two unrelated patches that simplify the codebase. One replaces sha256.New + Write with the sha256.Sum utility function. The other replaces a []byte with a string to let the type system enforce immutability, instead of having to set the cap on the []byte.