### PR TITLE
lib/api: Add LDAP search filters (fixes #5376)

### DIFF
--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -172,7 +172,7 @@ func authLDAP(username string, password string, cfg config.LDAPConfiguration) bo
 	}
 
 	if cfg.SearchFilter == "" || cfg.SearchBaseDN == "" {
-		l.Warnln("LDAP Configuration: both searchFilter and searchBaseDN must be set, or neither.")
+		l.Warnln("LDAP configuration: both searchFilter and searchBaseDN must be set, or neither.")
 		return false
 	}
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -171,13 +171,14 @@ func authLDAP(username string, password string, cfg config.LDAPConfiguration) bo
 		return true
 	}
 
+	if cfg.SearchFilter == "" || cfg.SearchBaseDN == "" {
+		l.Warnln("LDAP Configuration: both searchFilter and searchBaseDN must be set, or neither.")
+		return false
+	}
+
 	// If a search filter or search base is set we do an LDAP search for the
 	// user. If this matches precisely one user then we are good to go. The
-	// search filter uses the same %s interpolation as the bind DN. In
-	// practice it is required to set both the search base DN and the
-	// filter, but we run this code as soon as either is set in order to
-	// minimize false positives (i.e., a filter being configured so it looks
-	// active, but actually isn't used at all).
+	// search filter uses the same %s interpolation as the bind DN.
 
 	searchString := fmt.Sprintf(cfg.SearchFilter, username)
 	const sizeLimit = 2  // we search for up to two users -- we only want to match one, so getting any number >1 is a failure.

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -177,7 +177,7 @@ func authLDAP(username string, password string, cfg config.LDAPConfiguration) bo
 	// practice it is required to set both the search base DN and the
 	// filter, but we run this code as soon as either is set in order to
 	// minimize false positives (i.e., a filter being configured so it looks
-	// active, but actually in use).
+	// active, but actually isn't used at all).
 
 	searchString := fmt.Sprintf(cfg.SearchFilter, username)
 	const sizeLimit = 2  // we search for up to two users -- we only want to match one, so getting any number >1 is a failure.

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -176,9 +176,9 @@ func authLDAP(username string, password string, cfg config.LDAPConfiguration) bo
 		return false
 	}
 
-	// If a search filter or search base is set we do an LDAP search for the
-	// user. If this matches precisely one user then we are good to go. The
-	// search filter uses the same %s interpolation as the bind DN.
+	// If a search filter and search base is set we do an LDAP search for
+	// the user. If this matches precisely one user then we are good to go.
+	// The search filter uses the same %s interpolation as the bind DN.
 
 	searchString := fmt.Sprintf(cfg.SearchFilter, username)
 	const sizeLimit = 2  // we search for up to two users -- we only want to match one, so getting any number >1 is a failure.

--- a/lib/config/ldapconfiguration.go
+++ b/lib/config/ldapconfiguration.go
@@ -11,6 +11,8 @@ type LDAPConfiguration struct {
 	BindDN             string        `xml:"bindDN,omitempty" json:"bindDN"`
 	Transport          LDAPTransport `xml:"transport,omitempty" json:"transport"`
 	InsecureSkipVerify bool          `xml:"insecureSkipVerify,omitempty" json:"insecureSkipVerify" default:"false"`
+	SearchBaseDN       string        `xml:"searchBaseDN,omitempty" json:"searchBaseDN"`
+	SearchFilter       string        `xml:"searchFilter,omitempty" json:"searchFilter"`
 }
 
 func (c LDAPConfiguration) Copy() LDAPConfiguration {


### PR DESCRIPTION
## Purpose

This adds the functionality to run a user search with a filter for LDAP
authentication. The search is done after successful bind, as the binding
user. The typical use case is to limit authentication to users who are
member of a group or under a certain OU. For example, to only match
users in the "Syncthing" group in otherwise default Active Directory
set up for example.com:

    <searchBaseDN>CN=Users,DC=example,DC=com</searchBaseDN>
    <searchFilter>(&amp;(sAMAccountName=%s)(memberOf=CN=Syncthing,CN=Users,DC=example,DC=com))</searchFilter>

The search filter is an "and" of two criteria (with the ampersand being
XML quoted),

- "(sAMAccountName=%s)" matches the user logging in
- "(memberOf=CN=Syncthing,CN=Users,DC=example,DC=com)" matches members
  of the group in question.

Authentication will only proceed if the search filter matches precisely
one user.

## Testing

WFM