### PR TITLE
cmd/strelaypoolsrv: Fix race condition in caching

### DIFF
--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -115,10 +115,10 @@ var (
 	proto           string
 	statsRefresh    = time.Minute / 2
 
-	getMut      = sync.NewRWMutex()
+	getMut      = sync.NewMutex()
 	getLRUCache *lru.Cache
 
-	postMut      = sync.NewRWMutex()
+	postMut      = sync.NewMutex()
 	postLRUCache *lru.Cache
 
 	requests = make(chan request, 10)
@@ -573,22 +573,21 @@ func evict(relay *relay) func() {
 	}
 }
 
-func limit(addr string, cache *lru.Cache, lock sync.RWMutex, intv time.Duration, burst int) bool {
+func limit(addr string, cache *lru.Cache, lock sync.Mutex, intv time.Duration, burst int) bool {
 	if host, _, err := net.SplitHostPort(addr); err == nil {
 		addr = host
 	}
 
-	lock.RLock()
+	lock.Lock()
 	bkt, ok := cache.Get(addr)
-	lock.RUnlock()
 	if ok {
+		lock.Unlock()
 		bkt := bkt.(*rate.Limiter)
 		if !bkt.Allow() {
 			// Rate limit
 			return true
 		}
 	} else {
-		lock.Lock()
 		cache.Add(addr, rate.NewLimiter(rate.Every(intv), burst))
 		lock.Unlock()
 	}


### PR DESCRIPTION
Successful LRU cache lookups modify the cache's recency list, so RWMutex.RLock isn't enough protection.

Secondarily, multiple concurrent lookups with the same key should not lead to multiple rate limiters being created, so release the lock only when presence of the key has been ascertained.