### PR TITLE
Custom login fix

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -68,7 +68,6 @@
           </a>
           <ul class="dropdown-menu">
             <li><a href="" ng-click="showSettings()"><span class="fas fa-fw fa-cog"></span>&nbsp;<span translate>Settings</span></a></li>
-            <li><a href="" ng-click="logout()"><span class="fas fa-fw fa-sign-out"></span>&nbsp;<span translate>Logout</span></a></li>
             <li><a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()"><span class="fas fa-fw fa-qrcode"></span>&nbsp;<span translate>Show ID</span></a></li>
             <li class="divider" aria-hidden="true"></li>
             <li><a href="" ng-click="shutdown()"><span class="fas fa-fw fa-power-off"></span>&nbsp;<span translate>Shutdown</span></a></li>
@@ -83,6 +82,7 @@
             <li class="divider" aria-hidden="true"></li>
             <li><a href="" ng-click="advanced()"><span class="fas fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
             <li><a href="" ng-click="logging.show()"><span class="far fa-fw fa-file-alt"></span>&nbsp;<span translate>Logs</span></a></li>
+            <li id="logout"></li>
             <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
             <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
           </ul>
@@ -850,6 +850,7 @@
   <!-- vendor scripts -->
   <script type="text/javascript" src="vendor/jquery/jquery-2.2.2.js"></script>
   <script type="text/javascript" src="vendor/angular/angular.js"></script>
+  <script type="text/javascript" src="vendor/angular/angular-cookies.js"></script>
   <script type="text/javascript" src="vendor/angular/angular-sanitize.js"></script>
   <script type="text/javascript" src="vendor/angular/angular-translate.js"></script>
   <script type="text/javascript" src="vendor/angular/angular-translate-loader-static-files.js"></script>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -68,6 +68,7 @@
           </a>
           <ul class="dropdown-menu">
             <li><a href="" ng-click="showSettings()"><span class="fas fa-fw fa-cog"></span>&nbsp;<span translate>Settings</span></a></li>
+            <li><a href="" ng-click="showLogin()"><span class="fas fa-fw fa-user"></span>&nbsp;<span translate>Login</span></a></li>
             <li><a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()"><span class="fas fa-fw fa-qrcode"></span>&nbsp;<span translate>Show ID</span></a></li>
             <li class="divider" aria-hidden="true"></li>
             <li><a href="" ng-click="shutdown()"><span class="fas fa-fw fa-power-off"></span>&nbsp;<span translate>Shutdown</span></a></li>
@@ -816,7 +817,8 @@
       </ul>
     </div>
   </nav>
-
+  
+  <ng-include src="'syncthing/login/loginModalView.html'"></ng-include>
   <ng-include src="'syncthing/core/networkErrorDialogView.html'"></ng-include>
   <ng-include src="'syncthing/core/httpErrorDialogView.html'"></ng-include>
   <ng-include src="'syncthing/core/restartingDialogView.html'"></ng-include>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -68,7 +68,7 @@
           </a>
           <ul class="dropdown-menu">
             <li><a href="" ng-click="showSettings()"><span class="fas fa-fw fa-cog"></span>&nbsp;<span translate>Settings</span></a></li>
-            <li><a href="" ng-click="showLogin()"><span class="fas fa-fw fa-user"></span>&nbsp;<span translate>Login</span></a></li>
+            <li><a href="" ng-click="logout()"><span class="fas fa-fw fa-sign-out"></span>&nbsp;<span translate>Logout</span></a></li>
             <li><a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()"><span class="fas fa-fw fa-qrcode"></span>&nbsp;<span translate>Show ID</span></a></li>
             <li class="divider" aria-hidden="true"></li>
             <li><a href="" ng-click="shutdown()"><span class="fas fa-fw fa-power-off"></span>&nbsp;<span translate>Shutdown</span></a></li>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -56,12 +56,11 @@ angular.module('syncthing.core')
           // logout function
         $scope.logout = function () {
             // here we'll place the logout code
-            // $http.get(urlbase+"/logout").success(checkLoginAndStart).error(function(){
-                $http.post(urlbase+"/logout").success(
-                    function(){
-                       checkLoginAndStart();
-                    })
-            // })
+            $http.get(urlbase+"/logout").success(
+                function(){
+                    checkLoginAndStart();
+                }
+            )
         };
 
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -43,13 +43,26 @@ angular.module('syncthing.core')
             var username = $scope.currentFolder.username
             var password = $scope.currentFolder.password
 
-            $('#login').modal('hide');
             $http.post("rest/login?username="+username+"&password="+password).success(
                 function(){
-                    loginSuccessfull()
+                    
+                    $('#login').modal('hide');
+                $('#logout').html(` <a href="" ng-click="logout()" >
+                                        <span class="fas fa-fw fa-sign-out"></span>&nbsp;
+                                        <span translate>Logout</span>
+                                    </a>`)
+                    loginSuccessfull();
+
                 }).error(function(){
-                    alert('Error! your credentials are not correct!\n Retry please...')
-                    $('#login').modal('show');
+                    setTimeout(function(){
+                        $('#erreur').hide('slow');
+                    }, 5000);
+
+                    $('#erreur').html(`<div class="alert alert-danger" role="alert" id="erreur">
+                                            <p style="color: #fff">Error! your credentials are not correct!\n Retry please...</p>
+                                        </div>`);
+
+                    checkLoginAndStart();
                 })
         }
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -21,10 +21,7 @@ angular.module('syncthing.core')
             $http.get(urlbase + '/login').success(function() {
                 loginSuccessfull()
             }).error(function(){
-               
-                $http.post(urlbase + "/login?username=Mmg&password=123456").success(loginSuccessfull).error(function(){
-                    $('#login').modal('show');
-                })
+                $('#login').modal('show');
             })
         }
 
@@ -32,6 +29,24 @@ angular.module('syncthing.core')
             setInterval($scope.refresh, 10000);
             Events.start();
         }
+
+        $scope.login = function () {
+            var username = $scope.currentFolder.username
+            var password = $scope.currentFolder.password
+
+            $http.post(urlbase + "/login?usename="+username+"&password="+password).success(function(){
+                loginSuccessfull();
+                $('#login').modal('hide')
+            }).error(function(){
+                checkLoginAndStart()
+            })
+        }
+
+          // show login modal
+        $scope.showLogin = function () {
+            $('#login').modal('show');
+        };
+
 
         // public/scope definitions
 
@@ -172,6 +187,7 @@ angular.module('syncthing.core')
             $('#restarting').modal('hide');
             $('#shutdown').modal('hide');
         });
+
 
         $scope.$on(Events.OFFLINE, function () {
             if (navigatingAway || !online) {
@@ -2310,11 +2326,6 @@ angular.module('syncthing.core')
         $scope.advanced = function () {
             $scope.advancedConfig = angular.copy($scope.config);
             $('#advanced').modal('show');
-        };
-
-         // show login modal
-         $scope.showLogin = function () {
-            $('#login').modal('show');
         };
 
         $scope.showReportPreview = function () {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -14,6 +14,21 @@ angular.module('syncthing.core')
 
         function initController() {
             LocaleService.autoConfigLocale();
+            checkLoginAndStart();
+        }
+
+        function checkLoginAndStart() {
+            $http.get(urlbase + '/login').success(function() {
+                loginSuccessfull()
+            }).error(function(){
+               
+                $http.post(urlbase + "/login?username=Mmg&password=123456").success(loginSuccessfull).error(function(){
+                    $('#login').modal('show');
+                })
+            })
+        }
+
+        function loginSuccessfull(){
             setInterval($scope.refresh, 10000);
             Events.start();
         }
@@ -53,6 +68,7 @@ angular.module('syncthing.core')
         $scope.metricRates = false;
         $scope.folderPathErrors = {};
         $scope.currentFolder = {};
+        // $scope.user = {}
         resetRemoteNeed();
 
         try {
@@ -1136,6 +1152,7 @@ angular.module('syncthing.core')
         $scope.showDiscoveryFailures = function () {
             $('#discovery-failures').modal();
         };
+
 
         $scope.logging = {
             facilities: {},
@@ -2293,6 +2310,11 @@ angular.module('syncthing.core')
         $scope.advanced = function () {
             $scope.advancedConfig = angular.copy($scope.config);
             $('#advanced').modal('show');
+        };
+
+         // show login modal
+         $scope.showLogin = function () {
+            $('#login').modal('show');
         };
 
         $scope.showReportPreview = function () {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -35,10 +35,8 @@ angular.module('syncthing.core')
             var password = $scope.currentFolder.password
 
             $('#login').modal('hide');
-            // alert("/"+urlbase + "/login?usename="+username+"&password="+password);
             $http.post(urlbase+"/login?usename="+username+"&password="+password).success(
                 function(){
-                    alert("c'est bon cette fois")
                     loginSuccessfull()
                 }).error(function(){
                     alert('Error!')

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -15,14 +15,23 @@ angular.module('syncthing.core')
         function initController() {
             LocaleService.autoConfigLocale();
             checkLoginAndStart();
+            // loginSuccessfull()
         }
 
         function checkLoginAndStart() {
             $http.get(urlbase + '/login').success(function() {
+                // We are logged in, or don't need to log in
                 loginSuccessfull()
             }).error(function(){
+                 // We must log in.
+                 // We Show the login prompt. Then try to log in:
                 $('#login').modal('show');
             })
+        }
+
+        function logoutSuccessfull(){
+            setInterval($scope.refresh, 10000);
+            Events.startOf;
         }
 
         function loginSuccessfull(){
@@ -35,11 +44,11 @@ angular.module('syncthing.core')
             var password = $scope.currentFolder.password
 
             $('#login').modal('hide');
-            $http.post(urlbase+"/login?usename="+username+"&password="+password).success(
+            $http.post("rest/login?username="+username+"&password="+password).success(
                 function(){
                     loginSuccessfull()
                 }).error(function(){
-                    alert('Error!')
+                    alert('Error! your credentials are not correct!\n Retry please...')
                     $('#login').modal('show');
                 })
         }
@@ -47,6 +56,12 @@ angular.module('syncthing.core')
           // logout function
         $scope.logout = function () {
             // here we'll place the logout code
+            // $http.get(urlbase+"/logout").success(checkLoginAndStart).error(function(){
+                $http.post(urlbase+"/logout").success(
+                    function(){
+                       checkLoginAndStart();
+                    })
+            // })
         };
 
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -34,17 +34,21 @@ angular.module('syncthing.core')
             var username = $scope.currentFolder.username
             var password = $scope.currentFolder.password
 
-            $http.post(urlbase + "/login?usename="+username+"&password="+password).success(function(){
-                loginSuccessfull();
-                $('#login').modal('hide')
-            }).error(function(){
-                checkLoginAndStart()
-            })
+            $('#login').modal('hide');
+            // alert("/"+urlbase + "/login?usename="+username+"&password="+password);
+            $http.post(urlbase+"/login?usename="+username+"&password="+password).success(
+                function(){
+                    alert("c'est bon cette fois")
+                    loginSuccessfull()
+                }).error(function(){
+                    alert('Error!')
+                    $('#login').modal('show');
+                })
         }
 
-          // show login modal
-        $scope.showLogin = function () {
-            $('#login').modal('show');
+          // logout function
+        $scope.logout = function () {
+            // here we'll place the logout code
         };
 
 

--- a/gui/default/syncthing/login/loginModalView.html
+++ b/gui/default/syncthing/login/loginModalView.html
@@ -1,0 +1,17 @@
+<modal id="login" status="default" icon="{{'fas fa-user'}}" heading="{{'Login' | translate}}" large="yes" closeable="yes">
+  <div class="modal-body">
+    <form role="form" action="/rest/login" method="POST">
+      <div class="form-group">
+          <label for="">Username</label>
+          <input class="form-control" type="text" name="username" id="">
+      </div>
+      <div class="form-group">
+          <label for="">Password</label>
+          <input class="form-control" type="password" name="password" id="">
+      </div>
+      
+      <input type="submit" class="btn btn-primary" value="Connexion">
+    </form>
+  </div>
+</modal>
+  

--- a/gui/default/syncthing/login/loginModalView.html
+++ b/gui/default/syncthing/login/loginModalView.html
@@ -1,16 +1,17 @@
 <modal id="login" status="default" icon="{{'fas fa-user'}}" heading="{{'Login' | translate}}" large="yes" closeable="yes">
   <div class="modal-body">
-    <form role="form" action="/rest/login" method="POST">
+    <form role="form" name="loginForm"  method="POST">
       <div class="form-group">
           <label for="">Username</label>
-          <input class="form-control" type="text" name="username" id="">
+          <input class="form-control" type="text" name="username" id="username" ng-model="currentFolder.username">
       </div>
       <div class="form-group">
           <label for="">Password</label>
-          <input class="form-control" type="password" name="password" id="">
+          <input class="form-control" type="password" name="password" id="password" ng-model="currentFolder.password">
       </div>
       
-      <input type="submit" class="btn btn-primary" value="Connexion">
+      <!-- <input class="btn btn-primary" ng-click="login()" value="Connexion"> -->
+      <button type="button" class="btn btn-primary" ng-click="login()">Connexion</button>
     </form>
   </div>
 </modal>

--- a/gui/default/syncthing/login/loginModalView.html
+++ b/gui/default/syncthing/login/loginModalView.html
@@ -1,6 +1,8 @@
 <modal id="login" status="default" icon="{{'fas fa-user'}}" heading="{{'Log in' | translate}}" large="yes" closeable="yes">
-  <div class="modal-body">
+  <div class="modal-body form-login">
     <form role="form" name="loginForm">
+      <p id="erreur"></p>
+
       <div class="form-group">
           <label for=""><span translate>GUI Authentication User</span></label>
           <input class="form-control" type="text" name="username" id="username" ng-model="currentFolder.username">

--- a/gui/default/syncthing/login/loginModalView.html
+++ b/gui/default/syncthing/login/loginModalView.html
@@ -1,17 +1,15 @@
-<modal id="login" status="default" icon="{{'fas fa-user'}}" heading="{{'Login' | translate}}" large="yes" closeable="yes">
+<modal id="login" status="default" icon="{{'fas fa-user'}}" heading="{{'Log in' | translate}}" large="yes" closeable="yes">
   <div class="modal-body">
-    <form role="form" name="loginForm"  method="POST">
+    <form role="form" name="loginForm">
       <div class="form-group">
-          <label for="">Username</label>
+          <label for=""><span translate>GUI Authentication User</span></label>
           <input class="form-control" type="text" name="username" id="username" ng-model="currentFolder.username">
       </div>
       <div class="form-group">
-          <label for="">Password</label>
+          <label for=""><span  translate>GUI Authentication Password</span></label>
           <input class="form-control" type="password" name="password" id="password" ng-model="currentFolder.password">
       </div>
-      
-      <!-- <input class="btn btn-primary" ng-click="login()" value="Connexion"> -->
-      <button type="button" class="btn btn-primary" ng-click="login()">Connexion</button>
+      <button type="button" class="btn btn-primary" ng-click="login()"><span translate>Log in</span></button>
     </form>
   </div>
 </modal>

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -244,7 +244,8 @@ func (s *service) serve(ctx context.Context) {
 
 	// The GET handlers
 	getRestMux := http.NewServeMux()
-	getRestMux.HandleFunc("/rest/db/completion", s.getDBCompletion)              // device folder
+	getRestMux.HandleFunc("/rest/db/completion", s.getDBCompletion) // device folder
+	getRestMux.HandleFunc("/rest/logout", s.restLogout)
 	getRestMux.HandleFunc("/rest/db/file", s.getDBFile)                          // folder file
 	getRestMux.HandleFunc("/rest/db/ignores", s.getDBIgnores)                    // folder
 	getRestMux.HandleFunc("/rest/db/need", s.getDBNeed)                          // folder [perpage] [page]
@@ -281,7 +282,7 @@ func (s *service) serve(ctx context.Context) {
 	postRestMux := http.NewServeMux()
 
 	postRestMux.HandleFunc("/rest/login", s.restLogin)
-	postRestMux.HandleFunc("/rest/logout", s.restLogout)
+	// postRestMux.HandleFunc("/rest/logout", s.restLogout)
 	postRestMux.HandleFunc("/rest/db/prio", s.postDBPrio)                          // folder file [perpage] [page]
 	postRestMux.HandleFunc("/rest/db/ignores", s.postDBIgnores)                    // folder
 	postRestMux.HandleFunc("/rest/db/override", s.postDBOverride)                  // folder
@@ -419,13 +420,11 @@ func (s *service) serve(ctx context.Context) {
 }
 
 func (s *service) restLogin(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("Nous sommes la")
 	w.Header().Set("location", "/")
 	w.WriteHeader(http.StatusTemporaryRedirect)
 }
 
 func (s *service) restLogout(w http.ResponseWriter, r *http.Request) {
-	fmt.Println("On est la")
 	mux := http.NewServeMux()
 	guiCfg := s.cfg.GUI()
 	auth := authAndSessionMiddleware{"sessionid-" + s.id.String()[:5], guiCfg, s.cfg.LDAP(), s.evLogger}
@@ -440,7 +439,6 @@ func (s *service) restLogout(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.SetCookie(w, c)
-	fmt.Println("Nous sommes la")
 	mux.HandleFunc("/rest/login", auth.loginHandler)
 }
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -116,6 +116,7 @@ func (mw authAndSessionMiddleware) loginHandler(w http.ResponseWriter, r *http.R
 		http.Error(w, "Not access authorized", http.StatusForbidden)
 	}
 
+	// Get the post values
 	username := r.FormValue("username")
 	password := r.FormValue("password")
 

--- a/lib/api/api_csrf.go
+++ b/lib/api/api_csrf.go
@@ -73,6 +73,11 @@ func (m *csrfManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.HasPrefix(r.URL.Path, "/rest/login") {
+		m.next.ServeHTTP(w, r)
+		return
+	}
+
 	// Allow requests for anything not under the protected path prefix,
 	// and set a CSRF cookie if there isn't already a valid one.
 	if !strings.HasPrefix(r.URL.Path, m.prefix) {

--- a/lib/api/api_csrf.go
+++ b/lib/api/api_csrf.go
@@ -73,10 +73,15 @@ func (m *csrfManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// if strings.HasPrefix(r.URL.Path, "/rest/login") {
-	// 	m.next.ServeHTTP(w, r)
-	// 	return
-	// }
+	if strings.HasPrefix(r.URL.Path, "/rest/login") {
+		m.next.ServeHTTP(w, r)
+		return
+	}
+
+	if strings.HasPrefix(r.URL.Path, "/rest/logout") {
+		m.next.ServeHTTP(w, r)
+		return
+	}
 
 	// Allow requests for anything not under the protected path prefix,
 	// and set a CSRF cookie if there isn't already a valid one.

--- a/lib/api/api_csrf.go
+++ b/lib/api/api_csrf.go
@@ -73,10 +73,10 @@ func (m *csrfManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if strings.HasPrefix(r.URL.Path, "/rest/login") {
-		m.next.ServeHTTP(w, r)
-		return
-	}
+	// if strings.HasPrefix(r.URL.Path, "/rest/login") {
+	// 	m.next.ServeHTTP(w, r)
+	// 	return
+	// }
 
 	// Allow requests for anything not under the protected path prefix,
 	// and set a CSRF cookie if there isn't already a valid one.


### PR DESCRIPTION
### Purpose

New HTML page with login form
New backend API request to process the login and hand out a cookie or  bearer token (see https://github.com/syncthing/syncthing/blob/master/lib/api/api_auth.go and the api code where that gets called)
Redirect unauthenticated requests to the login form (in the auth middleware probably)
We need a "logout" method to invalidate the session and send the user back to the login screen

### Testing

I tested the authentication with the new login interface.  To access the login form, click on action then login.

### Screenshots
![Capture d'écran Deepin_zone de sélection _20200404221341](https://user-images.githubusercontent.com/43537226/78509251-30bce000-778d-11ea-9e98-13181e4174e8.png)

## Authorship

Gael MUTANDA
mpoyigaelmmg@gmail.com
