### PR TITLE
lib/db: Don't get blocklists on drop and missing continue (ref #6457)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -406,6 +406,7 @@ func (db *Lowlevel) checkGlobals(folder []byte, meta *metadataTracker) error {
 			if err := t.Delete(dbi.Key()); err != nil {
 				return err
 			}
+			continue
 		}
 
 		// Check the global version list for consistency. An issue in previous

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -431,7 +431,7 @@ func (db *Lowlevel) checkGlobals(folder []byte, meta *metadataTracker) error {
 			newVL.Versions = append(newVL.Versions, version)
 
 			if i == 0 {
-				if fi, ok, err := t.getFileByKey(dk); err != nil {
+				if fi, ok, err := t.getFileTrunc(dk, true); err != nil {
 					return err
 				} else if ok {
 					meta.addFile(protocol.GlobalDeviceID, fi)

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -488,7 +488,7 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 
 	name := []byte(file.Name)
 
-	var global protocol.FileInfo
+	var global FileIntf
 	if insertedAt == 0 {
 		// Inserted a new newest version
 		global = file
@@ -497,7 +497,7 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 		if err != nil {
 			return nil, false, err
 		}
-		new, ok, err := t.getFileByKey(keyBuf)
+		new, ok, err := t.getFileTrunc(keyBuf, true)
 		if err != nil || !ok {
 			return keyBuf, false, err
 		}
@@ -530,7 +530,7 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 	if err != nil {
 		return nil, false, err
 	}
-	oldFile, ok, err := t.getFileByKey(keyBuf)
+	oldFile, ok, err := t.getFileTrunc(keyBuf, true)
 	if err != nil {
 		return nil, false, err
 	}

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -554,7 +554,7 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 // updateLocalNeed checks whether the given file is still needed on the local
 // device according to the version list and global FileInfo given and updates
 // the db accordingly.
-func (t readWriteTransaction) updateLocalNeed(keyBuf, folder, name []byte, fl VersionList, global protocol.FileInfo) ([]byte, error) {
+func (t readWriteTransaction) updateLocalNeed(keyBuf, folder, name []byte, fl VersionList, global FileIntf) ([]byte, error) {
 	var err error
 	keyBuf, err = t.keyer.GenerateNeedFileKey(keyBuf, folder, name)
 	if err != nil {
@@ -657,7 +657,7 @@ func (t readWriteTransaction) removeFromGlobal(gk, keyBuf, folder, device []byte
 		if err != nil {
 			return nil, err
 		}
-		global, ok, err := t.getFileByKey(keyBuf)
+		global, ok, err := t.getFileTrunc(keyBuf, true)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -631,7 +631,7 @@ func (t readWriteTransaction) removeFromGlobal(gk, keyBuf, folder, device []byte
 		if err != nil {
 			return nil, err
 		}
-		if f, ok, err := t.getFileByKey(keyBuf); err != nil {
+		if f, ok, err := t.getFileTrunc(keyBuf, true); err != nil {
 			return nil, err
 		} else if ok {
 			meta.removeFile(protocol.GlobalDeviceID, f)


### PR DESCRIPTION
This fixes the panic in #6457, however not the underlying problem.  
After quite extensive debugging with @eiszfuchs (thanks) the problem there became clear: While the check on upgrade makes sure there is a file info for ever global list entry, it does not unmarshal that file info. On dropping a file we do, and as part of unmarshalling we also look for the block list. That lookup then failed and caused the file not found error (which mislead me for a long time, as the file itself is there, just not the blocks).

Now we only get the truncated file info when dropping a file, which is enough and thus avoids the panic. The file info is still without a block list, so a problem will likely come up at some other point. And I have no clue what might cause it in the first place. In the debugged instance no RCs prior to 1.4.1-rc.3 were ever installed (and known bugs causing missing blocklists were only present in RCs).

The missing (now added) continue was luckily harmless: Without it the key was deleted twice, which has no consequence.