### PR TITLE
lib/ignore: Only skip for toplevel includes (fixes #6487)

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -67,16 +67,11 @@ func (p Pattern) allowsSkippingIgnoredDirs() bool {
 	if p.pattern[0] != '/' {
 		return false
 	}
-	// Double asterisk everywhere in the path except at the end is bad
-	if strings.Contains(strings.TrimSuffix(p.pattern, "**"), "**") {
+	if strings.Contains(p.pattern[1:], "/") {
 		return false
 	}
-	// Any wildcards anywhere except for the last path component are bad
-	lastSep := strings.LastIndex(p.pattern, "/")
-	if lastSep == -1 {
-		return true
-	}
-	return p.pattern[:lastSep] == glob.QuoteMeta(p.pattern[:lastSep])
+	// Double asterisk everywhere in the path except at the end is bad
+	return !strings.Contains(strings.TrimSuffix(p.pattern, "**"), "**")
 }
 
 type Result uint8

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1110,10 +1110,10 @@ func TestSkipIgnoredDirs(t *testing.T) {
 		{`!/t*t`, true},
 		{`!/t?t`, true},
 		{`!/**`, true},
-		{`!/parent/test`, true},
-		{`!/parent/t[eih]t`, true},
-		{`!/parent/t*t`, true},
-		{`!/parent/t?t`, true},
+		{`!/parent/test`, false},
+		{`!/parent/t[eih]t`, false},
+		{`!/parent/t*t`, false},
+		{`!/parent/t?t`, false},
 		{`!/**.mp3`, false},
 		{`!/pa*nt/test`, false},
 		{`!/pa[sdf]nt/t[eih]t`, false},
@@ -1149,6 +1149,17 @@ func TestSkipIgnoredDirs(t *testing.T) {
 	}
 	if !pats.SkipIgnoredDirs() {
 		t.Error("SkipIgnoredDirs should be true")
+	}
+
+	stignore = `
+	!/foo/ign*
+	*
+	`
+	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
+		t.Fatal(err)
+	}
+	if pats.SkipIgnoredDirs() {
+		t.Error("SkipIgnoredDirs should be false")
 	}
 }
 

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -809,7 +809,7 @@ func TestSkipIgnoredDirs(t *testing.T) {
 func TestIncludedSubdir(t *testing.T) {
 	fss := fs.NewFilesystem(fs.FilesystemTypeFake, "")
 
-	name := "foo/bar/included"
+	name := filepath.Clean("foo/bar/included")
 	err := fss.MkdirAll(name, 0777)
 	if err != nil {
 		t.Fatal(err)

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -767,16 +767,10 @@ func TestNotExistingError(t *testing.T) {
 }
 
 func TestSkipIgnoredDirs(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmp)
-
-	fss := fs.NewFilesystem(fs.FilesystemTypeBasic, tmp)
+	fss := fs.NewFilesystem(fs.FilesystemTypeFake, "")
 
 	name := "foo/ignored"
-	err = fss.MkdirAll(name, 0777)
+	err := fss.MkdirAll(name, 0777)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -808,6 +802,50 @@ func TestSkipIgnoredDirs(t *testing.T) {
 
 	if err := fn(name, stat, nil); err != fs.SkipDir {
 		t.Errorf("Expected %v, got %v", fs.SkipDir, err)
+	}
+}
+
+// https://github.com/syncthing/syncthing/issues/6487
+func TestIncludedSubdir(t *testing.T) {
+	fss := fs.NewFilesystem(fs.FilesystemTypeFake, "")
+
+	name := "foo/bar/included"
+	err := fss.MkdirAll(name, 0777)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pats := ignore.New(fss, ignore.WithCache(true))
+
+	stignore := `
+	!/foo/bar
+	*
+	`
+	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
+		t.Fatal(err)
+	}
+
+	fchan := Walk(context.TODO(), Config{
+		CurrentFiler: make(fakeCurrentFiler),
+		Filesystem:   fss,
+		Matcher:      pats,
+	})
+
+	found := false
+	for f := range fchan {
+		if f.Err != nil {
+			t.Fatalf("Error while scanning %v: %v", f.Err, f.Path)
+		}
+		if f.File.IsIgnored() {
+			t.Error("File is ignored:", f.File.Name)
+		}
+		if f.File.Name == name {
+			found = true
+		}
+	}
+
+	if !found {
+		t.Errorf("File not present in scan results")
 	}
 }
 


### PR DESCRIPTION
### Purpose

The assumption when "optimizing" includes in https://github.com/syncthing/syncthing/pull/6151, that all rooted patterns without wildcards do not require scanning the entire tree is just not correct - at least not without additional smarts. We'd have to make sure that all the parent path components are also included. That's definitely doable, but not something I am interested in right now. So I just dumbed the logic down to just optimize includes in the root, nowhere else.

### Testing

I needed to adjust the unit testing in lib/ignore, but the relevant test reproducing #6151 is in lib/scanner.