### PR TITLE
cmd/stcrashreceiver: Enable (rough) affected users count

### DIFF
--- a/cmd/stcrashreceiver/sentry.go
+++ b/cmd/stcrashreceiver/sentry.go
@@ -31,11 +31,13 @@ var (
 	clientsMut sync.Mutex
 )
 
-func sendReport(dsn, path string, report []byte) error {
+func sendReport(dsn, path string, report []byte, userID string) error {
 	pkt, err := parseReport(path, report)
 	if err != nil {
 		return err
 	}
+
+	pkt.Interfaces = append(pkt.Interfaces, &raven.User{ID: userID})
 
 	clientsMut.Lock()
 	defer clientsMut.Unlock()


### PR DESCRIPTION
Seeing thousands of reports is no use when we don't know if they
represent one poor user or thousands.

I'm taking some effort to make the user ID meaningless and non-tracking.