### PR TITLE
cmd/syncthing, lib/db: Store upgrade info to throttle queries (fixes #6513)

### DIFF
--- a/lib/db/namespaced.go
+++ b/lib/db/namespaced.go
@@ -16,13 +16,13 @@ import (
 // NamespacedKV is a simple key-value store using a specific namespace within
 // a leveldb.
 type NamespacedKV struct {
-	db     *Lowlevel
+	db     backend.Backend
 	prefix string
 }
 
 // NewNamespacedKV returns a new NamespacedKV that lives in the namespace
 // specified by the prefix.
-func NewNamespacedKV(db *Lowlevel, prefix string) *NamespacedKV {
+func NewNamespacedKV(db backend.Backend, prefix string) *NamespacedKV {
 	return &NamespacedKV{
 		db:     db,
 		prefix: prefix,
@@ -133,18 +133,18 @@ func (n NamespacedKV) prefixedKey(key string) []byte {
 
 // NewDeviceStatisticsNamespace creates a KV namespace for device statistics
 // for the given device.
-func NewDeviceStatisticsNamespace(db *Lowlevel, device string) *NamespacedKV {
+func NewDeviceStatisticsNamespace(db backend.Backend, device string) *NamespacedKV {
 	return NewNamespacedKV(db, string(KeyTypeDeviceStatistic)+device)
 }
 
 // NewFolderStatisticsNamespace creates a KV namespace for folder statistics
 // for the given folder.
-func NewFolderStatisticsNamespace(db *Lowlevel, folder string) *NamespacedKV {
+func NewFolderStatisticsNamespace(db backend.Backend, folder string) *NamespacedKV {
 	return NewNamespacedKV(db, string(KeyTypeFolderStatistic)+folder)
 }
 
 // NewMiscDateNamespace creates a KV namespace for miscellaneous metadata.
-func NewMiscDataNamespace(db *Lowlevel) *NamespacedKV {
+func NewMiscDataNamespace(db backend.Backend) *NamespacedKV {
 	return NewNamespacedKV(db, string(KeyTypeMiscData))
 }
 


### PR DESCRIPTION
### Purpose

Make sure we check for updates max once per minute, and attempt upgrades to the same version max once per hour. For that we store the last times we checked for and attempted an upgrade plus which version we attempted to upgrade to. The reason for the distinction is that we want to reasonably quickly pick up new releases (e.g. if we push a quick followup-release to something broken),  put not attempt repeatedly to check for upgrades or to try to upgrade to the same version.

In cmd/syncthing, we handle a db backend, not a lowlevel. However that's actually enough for `db.NamespacedKV`, I just needed to replace lowlevel with backend there.

### Testing

Manually tested that upgrading still works. Then put garbage into the release url and the first time an error was printed, the second time not (check was skipped as I started within a minute).
