### PR TITLE
lib/db: Make database GC a service, stop on Stop()

### DIFF
--- a/lib/syncthing/debug.go
+++ b/lib/syncthing/debug.go
@@ -13,3 +13,7 @@ import (
 var (
 	l = logger.DefaultLogger.NewFacility("app", "Main run facility")
 )
+
+func shouldDebug() bool {
+	return l.ShouldDebug("app")
+}


### PR DESCRIPTION
This makes the GC runner a service that will stop fairly quickly when
told to.

As a bonus, STTRACE=app will print the service tree on the way out,
including any errors they've flagged.
