### PR TITLE
improve device status

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -928,6 +928,9 @@ angular.module('syncthing.core')
         $scope.deviceStatus = function (deviceCfg) {
             var status = '';
 
+            if( deviceCfg.deviceID === this.myID){
+                return '';
+            }
             if ($scope.deviceFolders(deviceCfg).length === 0) {
                 status = 'unused-';
             }
@@ -987,6 +990,9 @@ angular.module('syncthing.core')
                     case 'syncing':
                         syncCount++;
                         break;
+                    case 'paused':
+                        pauseCount++;
+                        break;
                     case 'stopped':
                     case 'unknown':
                     case 'outofsync':
@@ -1000,17 +1006,16 @@ angular.module('syncthing.core')
             var deviceCount = $scope.devices.length;
             var pendingFolders = 0;
             for (var i = 0; i < $scope.devices.length; i++) {
-                var status = $scope.deviceStatus({
-                    deviceID: $scope.devices[i].deviceID
-                });
+                var status = $scope.deviceStatus($scope.devices[i]);
                 switch (status) {
                     case 'unknown':
+                    case 'disconnected':
                         notifyCount++;
                         break;
                     case 'paused':
                         pauseCount++;
                         break;
-                    case 'unused':
+                    case 'unused-':
                         deviceCount--;
                         break;
                 }


### PR DESCRIPTION
The status icon was not being determined correctly. Here are my findings:

1. The current device was always being included and it status is "disconnected"
2. The syncthingStatus function was passing the device id instead of the device object like other places.
3. Device status for disconnected was not valid, might be because of #1 finding
4. Folders that had been paused where not included
5. device status of "unused" had a dash at the end, seems unusual

Changes
1. Added check for devices of the current device, so it would be ignored
2. Passed the device object to syncthingStatus
3. Added disconnected status for devices
4. Added paused status for folders
5. Changed the syncthingStatus for unused status to unused-, so there would be no impact on the rest of the system.

Testing-
I pause and disconnected both devices and folders. Also caused folders to error and caused normal syncing.

My first Syncthing change so thanks for your patience.  If there is any question or changes please let me know.