### PR TITLE
lib/db: Handle missed error variable in old schema upgrade

### DIFF
--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -423,6 +423,9 @@ func (db *schemaUpdater) updateSchema6to7(_ int) error {
 			}
 			return delErr == nil
 		})
+		if delErr != nil {
+			return delErr
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I just stumbled over this error `delErr` which is defined outside of the iterator scope but never checked. Fixing it has virtually no impact (only <0.14.50), but I'd still rather have it fixed for the sake of it.