### PR TITLE
lib/db: Remove unused blockFinder global

### DIFF
--- a/lib/db/blockmap.go
+++ b/lib/db/blockmap.go
@@ -13,17 +13,11 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 )
 
-var blockFinder *BlockFinder
-
 type BlockFinder struct {
 	db *Lowlevel
 }
 
 func NewBlockFinder(db *Lowlevel) *BlockFinder {
-	if blockFinder != nil {
-		return blockFinder
-	}
-
 	return &BlockFinder{
 		db: db,
 	}


### PR DESCRIPTION
Removes an unused global variable in lib/db.