### PR TITLE
build, lib/build: Build faster, auto detect program name

### DIFF
--- a/cmd/stdiscosrv/main.go
+++ b/cmd/stdiscosrv/main.go
@@ -92,7 +92,7 @@ func main() {
 	showVersion := flag.Bool("version", false, "Show version")
 	flag.Parse()
 
-	log.Println(build.LongVersion)
+	log.Println(build.LongVersionFor("stdiscosrv"))
 	if *showVersion {
 		return
 	}

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -102,8 +102,9 @@ func main() {
 	showVersion := flag.Bool("version", false, "Show version")
 	flag.Parse()
 
+	longVer := build.LongVersionFor("strelaysrv")
 	if *showVersion {
-		fmt.Println(build.LongVersion)
+		fmt.Println(longVer)
 		return
 	}
 
@@ -135,7 +136,7 @@ func main() {
 		}
 	}
 
-	log.Println(build.LongVersion)
+	log.Println(longVer)
 
 	maxDescriptors, err := osutil.MaximizeOpenFileLimit()
 	if maxDescriptors > 0 {

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -9,6 +9,8 @@ package build
 import (
 	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -72,6 +74,10 @@ func setBuildData() {
 
 	stamp, _ := strconv.Atoi(Stamp)
 	Date = time.Unix(int64(stamp), 0)
+
+	if exe, err := os.Executable(); err == nil {
+		Program = strings.TrimSuffix(strings.ToLower(filepath.Base(exe)), ".exe")
+	}
 
 	date := Date.UTC().Format("2006-01-02 15:04:05 MST")
 	LongVersion = fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, Program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -9,8 +9,6 @@ package build
 import (
 	"fmt"
 	"log"
-	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -20,7 +18,6 @@ import (
 
 var (
 	// Injected by build script
-	Program = "syncthing"
 	Version = "unknown-dev"
 	Host    = "unknown"
 	User    = "unknown"
@@ -74,15 +71,16 @@ func setBuildData() {
 
 	stamp, _ := strconv.Atoi(Stamp)
 	Date = time.Unix(int64(stamp), 0)
+	LongVersion = LongVersionFor("syncthing")
+}
 
-	if exe, err := os.Executable(); err == nil {
-		Program = strings.TrimSuffix(strings.ToLower(filepath.Base(exe)), ".exe")
-	}
-
+// LongVersionFor returns the long version string for the given program name.
+func LongVersionFor(program string) string {
+	// This string and date format is essentially part of our external API. Never change it.
 	date := Date.UTC().Format("2006-01-02 15:04:05 MST")
-	LongVersion = fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, Program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
-
+	v := fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
 	if len(Tags) > 0 {
-		LongVersion = fmt.Sprintf("%s [%s]", LongVersion, strings.Join(Tags, ", "))
+		v = fmt.Sprintf("%s [%s]", v, strings.Join(Tags, ", "))
 	}
+	return v
 }


### PR DESCRIPTION
This changes the build script to build all the things in one go
invocation, instead of one invocation per cmd. This is a lot faster
because it means more things get compiled concurrently. It's especially
a lot faster when things *don't* need to be rebuilt, possibly because it
only needs to build the dependency map and such once instead of once per
binary.

In order for this to work we need to be able to pass the same ldflags to
all the binaries. This means we can't set the program name with an
ldflag; instead I made it auto detect using os.Executable().

When it needs to rebuild everything (go clean -cache):

    ( ./old-build -gocmd go1.14.2 build all 2> /dev/null; )  65.82s user 11.28s system 574% cpu 13.409 total
    ( ./new-build -gocmd go1.14.2 build all 2> /dev/null; )  63.26s user 7.12s system 1220% cpu 5.766 total

On a subsequent run (nothing to build, just link the binaries):

    ( ./old-build -gocmd go1.14.2 build all 2> /dev/null; )  26.58s user 7.53s system 582% cpu 5.853 total
    ( ./new-build -gocmd go1.14.2 build all 2> /dev/null; )  18.66s user 2.45s system 1090% cpu 1.935 total

