### PR TITLE
lib/db: Upgrade to Blobloom v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6
-	github.com/greatroar/blobloom v0.0.0-20200416084947-36d5bf1a4e53
+	github.com/greatroar/blobloom v0.1.1
 	github.com/jackpal/gateway v1.0.6
 	github.com/jackpal/go-nat-pmp v1.0.2
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/greatroar/blobloom v0.0.0-20200416084947-36d5bf1a4e53 h1:A6KOo8OOZb+mjFqwDhiUcNPxZVSsK3GGJtfZWh2SqJk=
-github.com/greatroar/blobloom v0.0.0-20200416084947-36d5bf1a4e53/go.mod h1:we9vO6GNYMmsNvCWINtZnQbcGEHUT6hGBAznNHd6RlE=
+github.com/greatroar/blobloom v0.1.1 h1:6sz3aX6Dk2NVvMV50a4G8EyN4UUs7+4wFcIvUpe1a+k=
+github.com/greatroar/blobloom v0.1.1/go.mod h1:we9vO6GNYMmsNvCWINtZnQbcGEHUT6hGBAznNHd6RlE=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/jackpal/gateway v1.0.6 h1:/MJORKvJEwNVldtGVJC2p2cwCnsSoLn3hl3zxmZT7tk=

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -597,9 +597,9 @@ func (db *Lowlevel) gcIndirect(ctx context.Context) error {
 		capacity = db.gcKeyCount
 	}
 	blockFilter := blobloom.NewOptimized(blobloom.Config{
-		FPRate:  indirectGCBloomFalsePositiveRate,
-		MaxBits: 8 * indirectGCBloomMaxBytes,
-		NKeys:   uint64(capacity),
+		Capacity: uint64(capacity),
+		FPRate:   indirectGCBloomFalsePositiveRate,
+		MaxBits:  8 * indirectGCBloomMaxBytes,
 	})
 
 	// Iterate the FileInfos, unmarshal the block and version hashes and
@@ -622,7 +622,7 @@ func (db *Lowlevel) gcIndirect(ctx context.Context) error {
 			return err
 		}
 		if len(bl.BlocksHash) > 0 {
-			blockFilter.Add64(bloomHash(bl.BlocksHash))
+			blockFilter.Add(bloomHash(bl.BlocksHash))
 		}
 	}
 	it.Release()
@@ -647,7 +647,7 @@ func (db *Lowlevel) gcIndirect(ctx context.Context) error {
 		}
 
 		key := blockListKey(it.Key())
-		if blockFilter.Has64(bloomHash(key)) {
+		if blockFilter.Has(bloomHash(key)) {
 			matchedBlocks++
 			continue
 		}


### PR DESCRIPTION
I was hoping you'd wait just an hour longer to merge #6537, because I just changed the Blobloom API (methods and Config fields renamed). Here's an update to v0.1.1, which is faster still and is now under the Apache 2.0 license instead of MPL.