### PR TITLE
lib/protocol, rc, utils: Add Unlock before panic

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -289,6 +289,7 @@ func (c *rawConnection) Request(ctx context.Context, folder string, name string,
 
 	c.awaitingMut.Lock()
 	if _, ok := c.awaiting[id]; ok {
+		c.awaitingMut.Unlock()
 		panic("id taken")
 	}
 	rc := make(chan asyncResult, 1)

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -547,6 +547,7 @@ func (p *Process) eventLoop() {
 				}
 				device := p.id.String()
 				if device == "" {
+					p.eventMut.Unlock()
 					panic("race, or startup not complete")
 				}
 				m[device] = version

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -251,6 +251,7 @@ func (s *service) Stop() {
 	s.mut.Lock()
 	select {
 	case <-s.ctx.Done():
+		s.mut.Unlock()
 		panic(fmt.Sprintf("Stop called more than once on %v", s))
 	default:
 		s.cancel()


### PR DESCRIPTION
### Purpose

Add Unlock before panic to avoid possible deadlock.

Three forgetting-unlock bugs are fixed in this PR:
1. In lib/protocol/protocol.go:
`func Request` forgets `c.awaitingMut.Unlock()` before panic
2. In lib/rc/rc.go:
`func eventLoop` forgets `p.eventMut.Unlock()` before panic
3. In lib/util/utils.go:
`func Stop` forgets `s.mut.Unlock()` before panic



