### PR TITLE
lib/model: Refactor folder health/error handling (fixes #6557)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -54,7 +54,6 @@ type service interface {
 	Scan(subs []string) error
 	Serve()
 	Stop()
-	CheckHealth() error
 	Errors() []FileError
 	WatchError() error
 	ForceRescan(file protocol.FileInfo) error

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2294,8 +2294,8 @@ func TestIssue2782(t *testing.T) {
 	m.fmut.Lock()
 	runner := m.folderRunners["default"]
 	m.fmut.Unlock()
-	if err := runner.CheckHealth(); err != nil {
-		t.Error("health check error:", err)
+	if _, _, err := runner.getState(); err != nil {
+		t.Error("folder error:", err)
 	}
 }
 


### PR DESCRIPTION
See #6557 for infos on what this fixes.

The main fix is not using `CheckHealth` when pulling (and eradicating that function).

Folder error state includes ignores - any method that claims to check folder health but doesn't check ignores is misleading: `s/getHealthError/getHealthErrorWithoutIgnores/'. A function called `getHealthError` that also loads ignores is quite opaque: `s/getHealthError/getHealthErrorAndLoadIgnores/`. Those are quite a mouthful, suggestions for betting naming/handling of that are very welcome.