### PR TITLE
gui: Fix regression on refreshNeed (fixes #6560, ref #6452)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -298,12 +298,12 @@ angular.module('syncthing.core')
             for (var folder in $scope.progress) {
                 if (!(folder in progress)) {
                     if ($scope.neededFolder === folder) {
-                        refreshNeed($scope.needed.page, $scope.needed.perpage);
+                        $scope.refreshNeed($scope.needed.page, $scope.needed.perpage);
                     }
                 } else if ($scope.neededFolder === folder) {
                     for (file in $scope.progress[folder]) {
                         if (!(file in progress[folder])) {
-                            refreshNeed($scope.needed.page, $scope.needed.perpage);
+                            $scope.refreshNeed($scope.needed.page, $scope.needed.perpage);
                             break;
                         }
                     }


### PR DESCRIPTION
Just got a JS error using 1.5.0-rc.1 and the cause is obviously #6452 - apparently there was no download progress going on when I "manually tested" that. Thus it is RC material.