### PR TITLE
lib/model: Progress emitter network operations dont need to be blocking

### DIFF
--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -149,7 +149,7 @@ func (t *ProgressEmitter) sendDownloadProgressMessagesLocked(ctx context.Context
 			updates := state.update(folder, activePullers)
 
 			if len(updates) > 0 {
-				conn.DownloadProgress(ctx, folder, updates)
+				go conn.DownloadProgress(ctx, folder, updates)
 			}
 		}
 	}

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -461,6 +461,10 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 
 func sendMsgs(p *ProgressEmitter) {
 	p.mut.Lock()
-	defer p.mut.Unlock()
-	p.sendDownloadProgressMessagesLocked(context.Background())
+	updates := p.computeProgressUpdates()
+	p.mut.Unlock()
+	ctx := context.Background()
+	for _, update := range updates {
+		update.send(ctx)
+	}
 }


### PR DESCRIPTION
If the network is slow, this could block while holding a lock, and block other components that use progress emitter (Completion for the UI for example)