### PR TITLE
lib/connections: React to listeners going up and down faster

### DIFF
--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -102,7 +102,9 @@ func (t *quicListener) serve(ctx context.Context) error {
 		l.Infoln("Listen (BEP/quic):", err)
 		return err
 	}
+	t.notifyAddressesChanged(t)
 	defer listener.Close()
+	defer t.clearAddresses(t.uri)
 
 	l.Infof("QUIC listener (%v) starting", packetConn.LocalAddr())
 	defer l.Infof("QUIC listener (%v) shutting down", packetConn.LocalAddr())

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -104,7 +104,7 @@ func (t *quicListener) serve(ctx context.Context) error {
 	}
 	t.notifyAddressesChanged(t)
 	defer listener.Close()
-	defer t.clearAddresses(t.uri)
+	defer t.clearAddresses(t)
 
 	l.Infof("QUIC listener (%v) starting", packetConn.LocalAddr())
 	defer l.Infof("QUIC listener (%v) shutting down", packetConn.LocalAddr())

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -62,7 +62,7 @@ func (t *relayListener) serve(ctx context.Context) error {
 
 	l.Infof("Relay listener (%v) starting", t)
 	defer l.Infof("Relay listener (%v) shutting down", t)
-	defer t.clearAddresses(t.uri)
+	defer t.clearAddresses(t)
 
 	for {
 		select {

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -57,10 +57,12 @@ func (t *relayListener) serve(ctx context.Context) error {
 	defer clnt.Stop()
 	t.mut.Unlock()
 
-	oldURI := clnt.URI()
+	// Start with nil, so that we send a addresses changed notification as soon as we connect somewhere.
+	var oldURI *url.URL
 
 	l.Infof("Relay listener (%v) starting", t)
 	defer l.Infof("Relay listener (%v) shutting down", t)
+	defer t.clearAddresses(t.uri)
 
 	for {
 		select {

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -565,11 +565,11 @@ func (s *service) createListener(factory listenerFactory, uri *url.URL) bool {
 	return true
 }
 
-func (s *service) logListenAddressesChangedEvent(l genericListener) {
+func (s *service) logListenAddressesChangedEvent(l ListenerAddresses) {
 	s.evLogger.Log(events.ListenAddressesChanged, map[string]interface{}{
-		"address": l.URI(),
-		"lan":     l.LANAddresses(),
-		"wan":     l.WANAddresses(),
+		"address": l.URI,
+		"lan":     l.LANAddresses,
+		"wan":     l.WANAddresses,
 	})
 }
 

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -224,9 +224,9 @@ func (o *onAddressesChangedNotifier) notifyAddressesChanged(l genericListener) {
 	})
 }
 
-func (o *onAddressesChangedNotifier) clearAddresses(uri *url.URL) {
+func (o *onAddressesChangedNotifier) clearAddresses(l genericListener) {
 	o.notifyAddresses(ListenerAddresses{
-		URI: uri,
+		URI: l.URI(),
 	})
 }
 

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -55,7 +55,9 @@ func (t *tcpListener) serve(ctx context.Context) error {
 		l.Infoln("Listen (BEP/tcp):", err)
 		return err
 	}
+	t.notifyAddressesChanged(t)
 	defer listener.Close()
+	defer t.clearAddresses(t.uri)
 
 	l.Infof("TCP listener (%v) starting", listener.Addr())
 	defer l.Infof("TCP listener (%v) shutting down", listener.Addr())

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -57,7 +57,7 @@ func (t *tcpListener) serve(ctx context.Context) error {
 	}
 	t.notifyAddressesChanged(t)
 	defer listener.Close()
-	defer t.clearAddresses(t.uri)
+	defer t.clearAddresses(t)
 
 	l.Infof("TCP listener (%v) starting", listener.Addr())
 	defer l.Infof("TCP listener (%v) shutting down", listener.Addr())

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -197,7 +197,7 @@ func (c *globalClient) serve(ctx context.Context) {
 		return
 	}
 
-	timer := time.NewTimer(0)
+	timer := time.NewTimer(5 * time.Second)
 	defer timer.Stop()
 
 	eventSub := c.evLogger.Subscribe(events.ListenAddressesChanged)

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -213,9 +213,9 @@ func (c *globalClient) serve(ctx context.Context) {
 				// Defer announcement by 2 seconds, essentially debouncing
 				// if we have a stream of events incoming in quick succession.
 				timer.Reset(2 * time.Second)
-			} else if timerResetCount == 10 {
-				// Yet only do it if we haven't had to reset 10 times in a row, so if
-				// something is flip-flopping within 2 seconds, we don't end up in a permanent reset loop.
+			} else if timerResetCount == maxAddressChangesBetweenAnnouncements {
+				// Yet only do it if we haven't had to reset maxAddressChangesBetweenAnnouncements times in a row,
+				// so if something is flip-flopping within 2 seconds, we don't end up in a permanent reset loop.
 				l.Warnf("Detected a flip-flopping listener")
 				c.setError(errors.New("flip flopping listener"))
 				// Incrementing the count above 10 will prevent us from warning or setting the error again

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -46,9 +46,10 @@ type httpClient interface {
 }
 
 const (
-	defaultReannounceInterval  = 30 * time.Minute
-	announceErrorRetryInterval = 5 * time.Minute
-	requestTimeout             = 5 * time.Second
+	defaultReannounceInterval             = 30 * time.Minute
+	announceErrorRetryInterval            = 5 * time.Minute
+	requestTimeout                        = 5 * time.Second
+	maxAddressChangesBetweenAnnouncements = 10
 )
 
 type announcement struct {
@@ -208,7 +209,7 @@ func (c *globalClient) serve(ctx context.Context) {
 	for {
 		select {
 		case <-eventSub.C():
-			if timerResetCount < 10 {
+			if timerResetCount < maxAddressChangesBetweenAnnouncements {
 				// Defer announcement by 2 seconds, essentially debouncing
 				// if we have a stream of events incoming in quick succession.
 				timer.Reset(2 * time.Second)

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -30,14 +30,13 @@ import (
 
 type globalClient struct {
 	suture.Service
-	server           string
-	addrList         AddressLister
-	announceClient   httpClient
-	queryClient      httpClient
-	noAnnounce       bool
-	noLookup         bool
-	evLogger         events.Logger
-	nextAnnouncement time.Time
+	server         string
+	addrList       AddressLister
+	announceClient httpClient
+	queryClient    httpClient
+	noAnnounce     bool
+	noLookup       bool
+	evLogger       events.Logger
 	errorHolder
 }
 
@@ -122,14 +121,13 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 	}
 
 	cl := &globalClient{
-		server:           server,
-		addrList:         addrList,
-		announceClient:   announceClient,
-		queryClient:      queryClient,
-		noAnnounce:       opts.noAnnounce,
-		noLookup:         opts.noLookup,
-		evLogger:         evLogger,
-		nextAnnouncement: time.Now(),
+		server:         server,
+		addrList:       addrList,
+		announceClient: announceClient,
+		queryClient:    queryClient,
+		noAnnounce:     opts.noAnnounce,
+		noLookup:       opts.noLookup,
+		evLogger:       evLogger,
 	}
 	cl.Service = util.AsService(cl.serve, cl.String())
 	if !opts.noAnnounce {
@@ -213,9 +211,7 @@ func (c *globalClient) serve(ctx context.Context) {
 			timer.Reset(2 * time.Second)
 
 		case <-timer.C:
-			if c.nextAnnouncement.Before(time.Now()) {
-				c.sendAnnouncement(ctx, timer)
-			}
+			c.sendAnnouncement(ctx, timer)
 
 		case <-ctx.Done():
 			return
@@ -261,10 +257,8 @@ func (c *globalClient) sendAnnouncement(ctx context.Context, timer *time.Timer) 
 			// The server has a recommendation on when we should
 			// retry. Follow it.
 			if secs, err := strconv.Atoi(h); err == nil && secs > 0 {
-				delay := time.Duration(secs) * time.Second
-				l.Debugln("announce Retry-After:", delay, err)
-				c.nextAnnouncement = time.Now().Add(delay)
-				timer.Reset(delay)
+				l.Debugln("announce Retry-After:", secs, err)
+				timer.Reset(time.Duration(secs) * time.Second)
 				return
 			}
 		}
@@ -279,10 +273,8 @@ func (c *globalClient) sendAnnouncement(ctx context.Context, timer *time.Timer) 
 		// The server has a recommendation on when we should
 		// reannounce. Follow it.
 		if secs, err := strconv.Atoi(h); err == nil && secs > 0 {
-			delay := time.Duration(secs) * time.Second
-			l.Debugln("announce Reannounce-After:", delay, err)
-			c.nextAnnouncement = time.Now().Add(delay)
-			timer.Reset(delay)
+			l.Debugln("announce Reannounce-After:", secs, err)
+			timer.Reset(time.Duration(secs) * time.Second)
 			return
 		}
 	}

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -237,7 +237,7 @@ func (c *globalClient) sendAnnouncement(ctx context.Context, timer *time.Timer) 
 	// The marshal doesn't fail, I promise.
 	postData, _ := json.Marshal(ann)
 
-	l.Debugf("Announcement: %s", postData)
+	l.Debugf("Announcement: %v", ann)
 
 	resp, err := c.announceClient.Post(ctx, c.server, "application/json", bytes.NewReader(postData))
 	if err != nil {


### PR DESCRIPTION
So the first problem is that there is a race between the listeners starting and the global announce starting.

It seems global announce tries to send a notification straight away, at which point none of the listeners might be up yet, so it sends nothing, and backs off for 5 mins.

Second problem is that listeners starting/stopping do not actually notify of the addresses changing, which means the announcer does not know it needs to do something and, and we end up waiting the whole announceErrorRetryInterval (5mins) after startup before sending the first real announcement.
