### PR TITLE
Removed health check from Dockerfile (fixes #6604)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,5 @@ COPY --from=builder /src/script/docker-entrypoint.sh /bin/entrypoint.sh
 
 ENV PUID=1000 PGID=1000 HOME=/var/syncthing
 
-HEALTHCHECK --interval=1m --timeout=10s \
-  CMD nc -z localhost 8384 || exit 1
-
 ENV STGUIADDRESS=0.0.0.0:8384
 ENTRYPOINT ["/bin/entrypoint.sh", "/bin/syncthing", "-home", "/var/syncthing/config"]


### PR DESCRIPTION
### Purpose

When syncthing container is running in host network mode, the health check fails. However, the services work fine. On dashboard tools like Portainer, it gives a wrong impression that the services aren't responding.

### Testing

Validated that in host network mode the docker container functions properly.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

