### PR TITLE
lib/db: Hold the bloom filter the right way (fixes #6614)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -647,7 +647,7 @@ func (db *Lowlevel) gcIndirect(ctx context.Context) error {
 		}
 
 		key := blockListKey(it.Key())
-		if blockFilter.Has(bloomHash(key)) {
+		if blockFilter.Has(bloomHash(key.BlocksHash())) {
 			matchedBlocks++
 			continue
 		}
@@ -672,8 +672,8 @@ func (db *Lowlevel) gcIndirect(ctx context.Context) error {
 
 // Hash function for the bloomfilter: first eight bytes of the SHA-256.
 // Big or little-endian makes no difference, as long as we're consistent.
-func bloomHash(key blockListKey) uint64 {
-	return binary.BigEndian.Uint64(key.BlocksHash())
+func bloomHash(key []byte) uint64 {
+	return binary.BigEndian.Uint64(key)
 }
 
 // CheckRepair checks folder metadata and sequences for miscellaneous errors.


### PR DESCRIPTION
### Purpose

Not eat all the blocks

### Testing

It didn't eat all my blocks (yet)

---

The diff looks like a no-op, but there's another (first) call site for bloomHash() where we correctly give it just the hash in question. On the second call site we need to extract the hash from the database key (i.e., chop off the leading type byte) and we do that before, now...