### PR TITLE
lib/db, lib/model: Add FileSet.FolderIsNew

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -23,10 +23,11 @@ import (
 )
 
 type FileSet struct {
-	folder string
-	fs     fs.Filesystem
-	db     *Lowlevel
-	meta   *metadataTracker
+	folder      string
+	folderIsNew bool
+	fs          fs.Filesystem
+	db          *Lowlevel
+	meta        *metadataTracker
 
 	updateMutex sync.Mutex // protects database updates and the corresponding metadata changes
 }
@@ -64,11 +65,16 @@ type Iterator func(f FileIntf) bool
 func NewFileSet(folder string, fs fs.Filesystem, db *Lowlevel) *FileSet {
 	return &FileSet{
 		folder:      folder,
+		folderIsNew: !db.folderIdx.HasID([]byte(folder)),
 		fs:          fs,
 		db:          db,
 		meta:        db.loadMetadataTracker(folder),
 		updateMutex: sync.NewMutex(),
 	}
+}
+
+func (s *FileSet) FolderIsNew() bool {
+	return s.folderIsNew
 }
 
 func (s *FileSet) Drop(device protocol.DeviceID) {

--- a/lib/db/smallindex.go
+++ b/lib/db/smallindex.go
@@ -60,6 +60,13 @@ func (i *smallIndex) load() {
 	}
 }
 
+func (i *smallIndex) HasID(val []byte) bool {
+	i.mut.Lock()
+	_, ok := i.val2id[string(val)]
+	i.mut.Unlock()
+	return ok
+}
+
 // ID returns the index number for the given byte slice, allocating a new one
 // and persisting this to the database if necessary.
 func (i *smallIndex) ID(val []byte) (uint32, error) {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -314,10 +314,9 @@ func (m *model) addAndStartFolderLockedWithIgnores(cfg config.FolderConfiguratio
 		}
 	}
 
-	v, ok := fset.Sequence(protocol.LocalDeviceID), true
-	indexHasFiles := ok && v > 0
-	if !indexHasFiles {
-		// It's a blank folder, so this may the first time we're looking at
+	if fset.FolderIsNew() {
+		// There has been no account of this folder in the db before
+		// now, so this is likely the first time we're looking at
 		// it. Attempt to create and tag with our marker as appropriate. We
 		// don't really do anything with errors at this point except warn -
 		// if these things don't work, we still want to start the folder and

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1386,6 +1386,8 @@ func TestAutoAcceptPausedWhenFolderConfigNotChanged(t *testing.T) {
 }
 
 func changeIgnores(t *testing.T, m *model, expected []string) {
+	t.Helper()
+
 	arrEqual := func(a, b []string) bool {
 		if len(a) != len(b) {
 			return false
@@ -1401,7 +1403,7 @@ func changeIgnores(t *testing.T, m *model, expected []string) {
 
 	ignores, _, err := m.GetIgnores("default")
 	if err != nil {
-		t.Error(err)
+		t.Error("Failed getting ignores before changing:", err)
 	}
 
 	if !arrEqual(ignores, expected) {
@@ -1412,16 +1414,16 @@ func changeIgnores(t *testing.T, m *model, expected []string) {
 
 	err = m.SetIgnores("default", ignores)
 	if err != nil {
-		t.Error(err)
+		t.Error("Failed setting ignores on first change:", err)
 	}
 
 	ignores2, _, err := m.GetIgnores("default")
 	if err != nil {
-		t.Error(err)
+		t.Error("Failed getting ignores after first change:", err)
 	}
 
 	if !arrEqual(ignores, ignores2) {
-		t.Errorf("Incorrect ignores: %v != %v", ignores2, ignores)
+		t.Errorf("Incorrect ignores after first change: %v != %v", ignores2, ignores)
 	}
 
 	if runtime.GOOS == "darwin" {
@@ -1432,16 +1434,16 @@ func changeIgnores(t *testing.T, m *model, expected []string) {
 	}
 	err = m.SetIgnores("default", expected)
 	if err != nil {
-		t.Error(err)
+		t.Error("Failed setting ignores on second change:", err)
 	}
 
 	ignores, _, err = m.GetIgnores("default")
 	if err != nil {
-		t.Error(err)
+		t.Error("Failed getting ignores after second change:", err)
 	}
 
 	if !arrEqual(ignores, expected) {
-		t.Errorf("Incorrect ignores: %v != %v", ignores, expected)
+		t.Errorf("Incorrect ignores after second change: %v != %v", ignores, expected)
 	}
 }
 

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -56,7 +56,11 @@ func TestRequestSimple(t *testing.T) {
 	contents := []byte("test file contents\n")
 	fc.addFile("testfile", 0644, protocol.FileInfoTypeFile, contents)
 	fc.sendIndexUpdate()
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
 
 	// Verify the contents
 	if err := equalContents(filepath.Join(tfs.URI(), "testfile"), contents); err != nil {
@@ -98,7 +102,11 @@ func TestSymlinkTraversalRead(t *testing.T) {
 	contents := []byte("..")
 	fc.addFile("symlink", 0644, protocol.FileInfoTypeSymlink, contents)
 	fc.sendIndexUpdate()
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
 
 	// Request a file by traversing the symlink
 	res, err := m.Request(device1, "default", "symlink/requests_test.go", 10, 0, nil, 0, false)
@@ -148,7 +156,11 @@ func TestSymlinkTraversalWrite(t *testing.T) {
 	contents := []byte("..")
 	fc.addFile("symlink", 0644, protocol.FileInfoTypeSymlink, contents)
 	fc.sendIndexUpdate()
-	<-done
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
 
 	// Send an update for things behind the symlink, wait for requests for
 	// blocks for any of them to come back, or index entries. Hopefully none


### PR DESCRIPTION
Improves the "new folder detection"-heuristics by using the database's folder id index instead of looking for file entries.

This was prompted by https://forum.syncthing.net/t/stop-syncthing-from-auto-creating-syncd-folders-that-dont-exist/14920.