### PR TITLE
build: Update .gitignores for new asset locs (ref #6624)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,5 @@ coverage.xml
 syncthing.sig
 RELEASE
 deb
-lib/auto/gui.files.go
 *.bz2
 /repos

--- a/lib/api/auto/.gitignore
+++ b/lib/api/auto/.gitignore
@@ -1,0 +1,1 @@
+gui.files.go


### PR DESCRIPTION
Asset location changed: Use the same local .gitignore that's already in `cmd/strelaypoolsrv/auto`.