### PR TITLE
Add 'RestartSec=5' to Systemd service (user)

### DIFF
--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -5,6 +5,7 @@ Documentation=man:syncthing(1)
 [Service]
 ExecStart=/usr/bin/syncthing -no-browser -no-restart -logflags=0
 Restart=on-failure
+RestartSec=5
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 


### PR DESCRIPTION
### Purpose
Might help avoiding the 'Start request repeated too quickly.' error.

### Testing
Since the error doesn't happen very often, it's hard to test it (and I just applied it on my server anyways).
But it shouldn't be harmful, should it?

### Documentation
Maybe mention that it might take 5 seconds to restart if failed.