### PR TITLE
lib/db: Fix updating/removing from global (ref #6413)

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -574,12 +574,10 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 	}
 	needNow := need(globalFV, true, fl.Versions[insertedAt].Version)
 	if needBefore {
-		if !gotOldGlobal {
-			if oldGlobal, err = t.updateGlobalGetOldGlobal(keyBuf, folder, name, oldGlobalFV); err != nil {
-				return nil, false, err
-			}
-			gotOldGlobal = true
+		if oldGlobal, err = t.updateGlobalGetOldGlobal(keyBuf, folder, name, oldGlobalFV); err != nil {
+			return nil, false, err
 		}
+		gotOldGlobal = true
 		meta.removeNeeded(deviceID, oldGlobal)
 		if !needNow && bytes.Equal(device, protocol.LocalDeviceID[:]) {
 			if keyBuf, err = t.updateLocalNeed(keyBuf, folder, name, false); err != nil {
@@ -588,12 +586,10 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 		}
 	}
 	if needNow {
-		if !gotGlobal {
-			if global, err = t.updateGlobalGetGlobal(keyBuf, folder, name, file, insertedAt, fl); err != nil {
-				return nil, false, err
-			}
-			gotGlobal = true
+		if global, err = t.updateGlobalGetGlobal(keyBuf, folder, name, file, insertedAt, fl); err != nil {
+			return nil, false, err
 		}
+		gotGlobal = true
 		meta.addNeeded(deviceID, global)
 		if !needBefore && bytes.Equal(device, protocol.LocalDeviceID[:]) {
 			if keyBuf, err = t.updateLocalNeed(keyBuf, folder, name, true); err != nil {
@@ -613,15 +609,19 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 		return keyBuf, true, nil
 	}
 
-	if global, err = t.updateGlobalGetGlobal(keyBuf, folder, name, file, insertedAt, fl); err != nil {
-		return nil, false, err
-	}
-	gotGlobal = true
-	if haveOldGlobal {
-		if oldGlobal, err = t.updateGlobalGetOldGlobal(keyBuf, folder, name, oldGlobalFV); err != nil {
+	if !gotGlobal {
+		if global, err = t.updateGlobalGetGlobal(keyBuf, folder, name, file, insertedAt, fl); err != nil {
 			return nil, false, err
 		}
-		gotOldGlobal = true
+		gotGlobal = true
+	}
+	if haveOldGlobal {
+		if !gotOldGlobal {
+			if oldGlobal, err = t.updateGlobalGetOldGlobal(keyBuf, folder, name, oldGlobalFV); err != nil {
+				return nil, false, err
+			}
+			gotOldGlobal = true
+		}
 		// Remove the old global from the global size counter
 		meta.removeFile(protocol.GlobalDeviceID, oldGlobal)
 	}

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -607,29 +607,27 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 	// even if both new and old are invalid, due to potential change in
 	// LocalFlags.
 
-	if !globalUnaffected {
-		if global, err = t.updateGlobalGetGlobal(keyBuf, folder, name, file, insertedAt, fl); err != nil {
-			return nil, false, err
-		}
-		gotGlobal = true
-		if haveOldGlobal {
-			if oldGlobal, err = t.updateGlobalGetOldGlobal(keyBuf, folder, name, oldGlobalFV); err != nil {
-				return nil, false, err
-			}
-			gotOldGlobal = true
-			// Remove the old global from the global size counter
-			meta.removeFile(protocol.GlobalDeviceID, oldGlobal)
-		}
-
-		// Add the new global to the global size counter
-		meta.addFile(protocol.GlobalDeviceID, global)
-	}
-
 	if globalUnaffected {
 		// Neither the global state nor the needs of any devices, except
 		// the one updated, changed.
 		return keyBuf, true, nil
 	}
+
+	if global, err = t.updateGlobalGetGlobal(keyBuf, folder, name, file, insertedAt, fl); err != nil {
+		return nil, false, err
+	}
+	gotGlobal = true
+	if haveOldGlobal {
+		if oldGlobal, err = t.updateGlobalGetOldGlobal(keyBuf, folder, name, oldGlobalFV); err != nil {
+			return nil, false, err
+		}
+		gotOldGlobal = true
+		// Remove the old global from the global size counter
+		meta.removeFile(protocol.GlobalDeviceID, oldGlobal)
+	}
+
+	// Add the new global to the global size counter
+	meta.addFile(protocol.GlobalDeviceID, global)
 
 	// If global changed, but both the new and old are invalid, noone needed
 	// the file before and now -> nothing to do.


### PR DESCRIPTION
This PR is a weird one: It corrects mistakes in #6413, but those mistakes are "benign". Meaning I only discovered them because I needed to change exactly that code for the global version list refactor and it looked off, however the both the old and corrected code do the same thing in the end. The corrected one is just less convoluted and/or actually takes the shortcuts intended (e.g. the return in line 809).

I suggest to look at it as separate commits: The complete diff is rather ugly, but the first four commits are straightforward (just moving stuff around). The last one isn't entirely straight forward, but it's still much clearer what's going on than in the full diff.

This is sort of a grey area in terms of RC: The PR only changes stuff that's RC specific, but there's also no real bug, in principle just "improvements".