### PR TITLE
lib/db: Dont add symlinks to blocks map (fixes #6637)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -201,7 +201,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		blocksHashSame := ok && bytes.Equal(ef.BlocksHash, f.BlocksHash)
 
 		if ok {
-			if !ef.IsDirectory() && !ef.IsDeleted() && !ef.IsInvalid() {
+			if len(ef.Blocks) != 0 {
 				for _, block := range ef.Blocks {
 					keyBuf, err = db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
 					if err != nil {
@@ -262,7 +262,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		}
 		l.Debugf("adding sequence; folder=%q sequence=%v %v", folder, f.Sequence, f.Name)
 
-		if !f.IsDirectory() && !f.IsDeleted() && !f.IsInvalid() {
+		if len(f.Blocks) != 0 {
 			for i, block := range f.Blocks {
 				binary.BigEndian.PutUint32(blockBuf, uint32(i))
 				keyBuf, err = db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -201,7 +201,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		blocksHashSame := ok && bytes.Equal(ef.BlocksHash, f.BlocksHash)
 
 		if ok {
-			if len(ef.Blocks) != 0 {
+			if len(ef.Blocks) != 0 && !ef.IsInvalid() {
 				for _, block := range ef.Blocks {
 					keyBuf, err = db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)
 					if err != nil {
@@ -262,7 +262,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		}
 		l.Debugf("adding sequence; folder=%q sequence=%v %v", folder, f.Sequence, f.Name)
 
-		if len(f.Blocks) != 0 {
+		if len(f.Blocks) != 0 && !f.IsInvalid() {
 			for i, block := range f.Blocks {
 				binary.BigEndian.PutUint32(blockBuf, uint32(i))
 				keyBuf, err = db.keyer.GenerateBlockMapKey(keyBuf, folder, block.Hash, name)

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -22,10 +22,10 @@ import (
 //   6: v0.14.50
 //   7: v0.14.53
 //   8-9: v1.4.0
-//   10-11: v1.6.0
-//   12: v1.7.0
+//   10-13: v1.6.0
+//   14: v1.7.0
 const (
-	dbVersion             = 12
+	dbVersion             = 14
 	dbMinSyncthingVersion = "v1.7.0"
 )
 
@@ -89,7 +89,8 @@ func (db *schemaUpdater) updateSchema() error {
 		{9, db.updateSchemaTo9},
 		{10, db.updateSchemaTo10},
 		{11, db.updateSchemaTo11},
-		{12, db.updateSchemaTo12},
+		{13, db.updateSchemaTo13},
+		{14, db.updateSchemaTo14},
 	}
 
 	for _, m := range migrations {
@@ -590,7 +591,7 @@ func (db *schemaUpdater) updateSchemaTo11(_ int) error {
 		var putErr error
 		err := t.withHave(folder, protocol.LocalDeviceID[:], nil, true, func(fi FileIntf) bool {
 			f := fi.(FileInfoTruncated)
-			if f.IsDirectory() || f.IsDeleted() || f.IsInvalid() || f.BlocksHash == nil {
+			if f.IsDirectory() || f.IsDeleted() || f.IsSymlink() || f.IsInvalid() || f.BlocksHash == nil {
 				return true
 			}
 
@@ -616,7 +617,61 @@ func (db *schemaUpdater) updateSchemaTo11(_ int) error {
 	return t.Commit()
 }
 
-func (db *schemaUpdater) updateSchemaTo12(_ int) error {
+// Skipping 12 because of master-release interactions
+
+func (db *schemaUpdater) updateSchemaTo13(prev int) error {
+	// Removes incorrect blocksmap entries for symlinks introduced in v1.6.0-rc.1
+	// https://github.com/syncthing/syncthing/issues/6637
+
+	if prev != 11 {
+		return nil
+	}
+
+	t, err := db.newReadWriteTransaction()
+	if err != nil {
+		return err
+	}
+	defer t.close()
+
+	var key []byte
+	for _, folderStr := range db.ListFolders() {
+		folder := []byte(folderStr)
+
+		key, err := t.keyer.GenerateBlockListMapKey(key, folder, nil, nil)
+		if err != nil {
+			return err
+		}
+		dbi, err := t.NewPrefixIterator(key.WithoutHashAndName())
+		if err != nil {
+			return err
+		}
+		defer dbi.Release()
+
+		for dbi.Next() {
+			file := t.keyer.NameFromBlockListMapKey(dbi.Key())
+			key, err := t.keyer.GenerateDeviceFileKey(key, folder, protocol.LocalDeviceID[:], file)
+			f, ok, err := t.getFileTrunc(key, true)
+			if err != nil {
+				return err
+			}
+			if !ok || f.IsSymlink() {
+				if err := t.Delete(dbi.Key()); err != nil {
+					return err
+				}
+			}
+		}
+		if err := dbi.Error(); err != nil {
+			return err
+		}
+		dbi.Release()
+		if err := t.Checkpoint(); err != nil {
+			return err
+		}
+	}
+	return t.Commit()
+}
+
+func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 	// Loads and rewrites all files, to deduplicate version vectors.
 
 	t, err := db.newReadWriteTransaction()

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -22,10 +22,10 @@ import (
 //   6: v0.14.50
 //   7: v0.14.53
 //   8-9: v1.4.0
-//   10-13: v1.6.0
-//   14: v1.7.0
+//   10-11: v1.6.0
+//   12: v1.7.0
 const (
-	dbVersion             = 14
+	dbVersion             = 12
 	dbMinSyncthingVersion = "v1.7.0"
 )
 
@@ -89,8 +89,7 @@ func (db *schemaUpdater) updateSchema() error {
 		{9, db.updateSchemaTo9},
 		{10, db.updateSchemaTo10},
 		{11, db.updateSchemaTo11},
-		{13, db.updateSchemaTo13},
-		{14, db.updateSchemaTo14},
+		{12, db.updateSchemaTo12},
 	}
 
 	for _, m := range migrations {
@@ -617,61 +616,7 @@ func (db *schemaUpdater) updateSchemaTo11(_ int) error {
 	return t.Commit()
 }
 
-// Skipping 12 because of master-release interactions
-
-func (db *schemaUpdater) updateSchemaTo13(prev int) error {
-	// Removes incorrect blocksmap entries for symlinks introduced in v1.6.0-rc.1
-	// https://github.com/syncthing/syncthing/issues/6637
-
-	if prev != 11 {
-		return nil
-	}
-
-	t, err := db.newReadWriteTransaction()
-	if err != nil {
-		return err
-	}
-	defer t.close()
-
-	var key []byte
-	for _, folderStr := range db.ListFolders() {
-		folder := []byte(folderStr)
-
-		key, err := t.keyer.GenerateBlockListMapKey(key, folder, nil, nil)
-		if err != nil {
-			return err
-		}
-		dbi, err := t.NewPrefixIterator(key.WithoutHashAndName())
-		if err != nil {
-			return err
-		}
-		defer dbi.Release()
-
-		for dbi.Next() {
-			file := t.keyer.NameFromBlockListMapKey(dbi.Key())
-			key, err := t.keyer.GenerateDeviceFileKey(key, folder, protocol.LocalDeviceID[:], file)
-			f, ok, err := t.getFileTrunc(key, true)
-			if err != nil {
-				return err
-			}
-			if !ok || f.IsSymlink() {
-				if err := t.Delete(dbi.Key()); err != nil {
-					return err
-				}
-			}
-		}
-		if err := dbi.Error(); err != nil {
-			return err
-		}
-		dbi.Release()
-		if err := t.Checkpoint(); err != nil {
-			return err
-		}
-	}
-	return t.Commit()
-}
-
-func (db *schemaUpdater) updateSchemaTo14(_ int) error {
+func (db *schemaUpdater) updateSchemaTo12(_ int) error {
 	// Loads and rewrites all files, to deduplicate version vectors.
 
 	t, err := db.newReadWriteTransaction()

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -623,6 +623,10 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 }
 
 func (f *folder) findRename(snap *db.Snapshot, mtimefs fs.Filesystem, file protocol.FileInfo) (protocol.FileInfo, bool) {
+	if len(file.Blocks) == 0 {
+		return protocol.FileInfo{}, false
+	}
+
 	found := false
 	nf := protocol.FileInfo{}
 


### PR DESCRIPTION
The source of the problem is in lowlevel.go

I also have a variant for the release branch - it's a bit annoying due to the db schema numbers.