### PR TITLE
lib/model: Adjust remote-rename-test to timer-based versions (fixes #6625)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -471,7 +471,7 @@ nextFile:
 			// map.
 			desired := fileDeletions[candidate.Name]
 			if err := f.renameFile(candidate, desired, fi, snap, dbUpdateChan, scanChan); err != nil {
-				l.Debugln("rename shortcut for %s failed: %S", fi.Name, err.Error())
+				l.Debugf("rename shortcut for %s failed: %S", fi.Name, err.Error())
 				// Failed to rename, try next one.
 				continue
 			}

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -471,7 +471,7 @@ nextFile:
 			// map.
 			desired := fileDeletions[candidate.Name]
 			if err := f.renameFile(candidate, desired, fi, snap, dbUpdateChan, scanChan); err != nil {
-				l.Debugf("rename shortcut for %s failed: %S", fi.Name, err.Error())
+				l.Debugf("rename shortcut for %s failed: %s", fi.Name, err.Error())
 				// Failed to rename, try next one.
 				continue
 			}


### PR DESCRIPTION
There likely more tests that check for a specific, expected version vector. And that's now a race by definition, which probably isn't triggered often as it has seconds perecision and most tests take much less than a second.