### PR TITLE
lib/model: Fix checking children when trying to delete a dir (fixes #6646)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -64,7 +64,7 @@ var (
 	activity                    = newDeviceActivity()
 	errNoDevice                 = errors.New("peers who had this file went away, or the file has changed while syncing. will retry later")
 	errDirPrefix                = "directory has been deleted on a remote device but "
-	errDirHasToBeScanned        = errors.New(errDirPrefix + "contains unexpected files, scheduling scan")
+	errDirHasToBeScanned        = errors.New(errDirPrefix + "contains changed files, scheduling scan")
 	errDirHasIgnored            = errors.New(errDirPrefix + "contains ignored files (see ignore documentation for (?d) prefix)")
 	errDirHasReceiveOnlyChanged = errors.New(errDirPrefix + "contains locally changed files")
 	errDirNotEmpty              = errors.New(errDirPrefix + "is not empty; the contents are probably ignored on that remote device, but not locally")
@@ -1819,24 +1819,48 @@ func (f *sendReceiveFolder) deleteDirOnDisk(dir string, snap *db.Snapshot, scanC
 
 	for _, dirFile := range files {
 		fullDirFile := filepath.Join(dir, dirFile)
-		if fs.IsTemporary(dirFile) || f.ignores.Match(fullDirFile).IsDeletable() {
+		switch {
+		case fs.IsTemporary(dirFile) || f.ignores.Match(fullDirFile).IsDeletable():
 			toBeDeleted = append(toBeDeleted, fullDirFile)
-		} else if f.ignores != nil && f.ignores.Match(fullDirFile).IsIgnored() {
+			continue
+		case f.ignores != nil && f.ignores.Match(fullDirFile).IsIgnored():
 			hasIgnored = true
-		} else if cf, ok := snap.Get(protocol.LocalDeviceID, fullDirFile); !ok || cf.IsDeleted() || cf.IsInvalid() {
-			if f.Type == config.FolderTypeReceiveOnly && cf.IsReceiveOnlyChanged() {
-				hasReceiveOnlyChanged = true
-			}
-			// Something appeared in the dir that we either are not aware of
-			// at all, that we think should be deleted or that is invalid,
-			// but not currently ignored -> schedule scan.
+			continue
+		}
+		cf, ok := snap.Get(protocol.LocalDeviceID, fullDirFile)
+		switch {
+		case !ok || cf.IsDeleted():
+			// Something appeared in the dir that we either are not
+			// aware of at all or that we think should be deleted
+			// -> schedule scan.
 			scanChan <- fullDirFile
 			hasToBeScanned = true
-		} else {
-			// Dir contains file that is valid according to db and
-			// not ignored -> something weird is going on
-			hasKnown = true
+			continue
+		case ok && f.Type == config.FolderTypeReceiveOnly && cf.IsReceiveOnlyChanged():
+			hasReceiveOnlyChanged = true
+			continue
 		}
+		info, err := f.fs.Lstat(fullDirFile)
+		var diskFile protocol.FileInfo
+		if err == nil {
+			diskFile, err = scanner.CreateFileInfo(info, fullDirFile, f.fs)
+		}
+		if err != nil {
+			// Lets just assume the file has changed.
+			scanChan <- fullDirFile
+			hasToBeScanned = true
+			continue
+		}
+		if !cf.IsEquivalentOptional(diskFile, f.ModTimeWindow(), f.IgnorePerms, true, protocol.LocalAllFlags) {
+			// File on disk changed compared to what we have in db
+			// -> schedule scan.
+			scanChan <- fullDirFile
+			hasToBeScanned = true
+			continue
+		}
+		// Dir contains file that is valid according to db and
+		// not ignored -> something weird is going on
+		hasKnown = true
 	}
 
 	if hasToBeScanned {


### PR DESCRIPTION
https://forum.syncthing.net/t/problems-when-syncing-from-windows-to-synology-nas/14996

When a directory deleted on a remote contains receive-only files, rescanning won't help and the current error message wont direct the user at the actual problem (locally changed files).

Also the scan chan cannot be nil, that might be true in tests, but not everywhere else (we send to it without checking for nil-ness in various other places). And if it is nil in tests, that should be changed instead of having weird code paths like this.