### PR TITLE
docker: Ensure correct ownership of Syncthing base and config directory

### DIFF
--- a/lib/fs/lstat_windows.go
+++ b/lib/fs/lstat_windows.go
@@ -57,7 +57,9 @@ type dirJunctFileInfo struct {
 }
 
 func (fi *dirJunctFileInfo) Mode() os.FileMode {
-	return fi.FileInfo.Mode() ^ os.ModeSymlink | os.ModeDir
+	// Simulate a directory and not a symlink; also set the execute
+	// bits so the directory can be traversed Unix-side.
+	return fi.FileInfo.Mode() ^ os.ModeSymlink | os.ModeDir | 0111
 }
 
 func (fi *dirJunctFileInfo) IsDir() bool {

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-chown "${PUID}:${PGID}" "${HOME}" \
+chown -R "${PUID}:${PGID}" "${HOME}" \
   && exec su-exec "${PUID}:${PGID}" \
      env HOME="$HOME" "$@"

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
-chown -R "${PUID}:${PGID}" "/var/syncthing/config" || true \
-   && exec su-exec "${PUID}:${PGID}" \
+mkdir -p "/var/syncthing/config" \
+  && chown "${PUID}:${PGID}" "/var/syncthing" \
+  && chown -R "${PUID}:${PGID}" "/var/syncthing/config" \
+  && exec su-exec "${PUID}:${PGID}" \
      env HOME="$HOME" "$@"

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-chown -R "${PUID}:${PGID}" "${HOME}" \
-  && exec su-exec "${PUID}:${PGID}" \
+chown -R "${PUID}:${PGID}" "/var/syncthing/config" || true \
+   && exec su-exec "${PUID}:${PGID}" \
      env HOME="$HOME" "$@"


### PR DESCRIPTION
This commit changes the docker entrypoint script to change the ownership
of the Syncthing home dir recursively. This allows e.g. the config dir
to be bind-mounted from docker host.

### Purpose
The purpose of the change is to allow the syncthing config dir (e.g. /var/syncthing/config) to be bind-mounted from the host. A scenario, I use at my company is to have /var/syncthing as a persistent named volume that contains the database and bind mount the config directory from the host. This allows e.g. to deploy the configuration with Ansible. However, to allow Syncthing to read, write and chmod the config files, the ownership change in the entrypoint script must be applied recursively to the syncthing home dir.

### Testing
Tested this with bind mount of host dir /etc/syncthing into /var/syncthing/config

