### PR TITLE
Fixed Docker health check for host networks (fixes #6604)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,8 @@ COPY --from=builder /src/script/docker-entrypoint.sh /bin/entrypoint.sh
 
 ENV PUID=1000 PGID=1000 HOME=/var/syncthing
 
+HEALTHCHECK --interval=1m --timeout=10s \
+  CMD nc -z 127.0.0.1 8384 || exit 1
+
 ENV STGUIADDRESS=0.0.0.0:8384
 ENTRYPOINT ["/bin/entrypoint.sh", "/bin/syncthing", "-home", "/var/syncthing/config"]


### PR DESCRIPTION
Fixed the health check instead of removing it for host networks as per @thedanbob's suggestions. Verified that the health check works for both host as well as non-host network configurations.