### PR TITLE
lib/db: Filter repeat files in one update (ref #6650)

### DIFF
--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -568,14 +568,16 @@ func TestDropDuplicates(t *testing.T) {
 		{[]int{0, 1, 1, 1, 1}, []int{0, 1}},
 		{[]int{0, 0, 0, 1}, []int{0, 1}},
 		{[]int{0, 1, 2, 3}, []int{0, 1, 2, 3}},
-		{[]int{0, 1, 2, 3, 0, 1, 2, 3}, []int{0, 1, 2, 3}},
+		{[]int{3, 2, 1, 0, 0, 1, 2, 3}, []int{0, 1, 2, 3}},
 		{[]int{0, 1, 1, 3, 0, 1, 0, 1, 2, 3}, []int{0, 1, 2, 3}},
 	}
 
 	for tci, tc := range tcs {
 		inp := make([]protocol.FileInfo, len(tc.in))
+		expSeq := make(map[string]int)
 		for i, j := range tc.in {
-			inp[i] = protocol.FileInfo{Name: names[j]}
+			inp[i] = protocol.FileInfo{Name: names[j], Sequence: int64(i)}
+			expSeq[names[j]] = i
 		}
 		outp := normalizeFilenamesAndDropDuplicates(inp)
 		if len(outp) != len(tc.out) {
@@ -585,6 +587,9 @@ func TestDropDuplicates(t *testing.T) {
 		for i, f := range outp {
 			if exp := names[tc.out[i]]; exp != f.Name {
 				t.Errorf("tc %v: Got file %v at pos %v, expected %v", tci, f.Name, i, exp)
+			}
+			if exp := int64(expSeq[outp[i].Name]); exp != f.Sequence {
+				t.Errorf("tc %v: Got sequence %v at pos %v, expected %v", tci, f.Sequence, i, exp)
 			}
 		}
 	}

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -553,3 +553,39 @@ func TestUpdateTo10(t *testing.T) {
 		t.Error("vl.Versions[1] not deleted for c")
 	}
 }
+
+func TestDropDuplicates(t *testing.T) {
+	names := []string{
+		"foo",
+		"bar",
+		"dcxvoijnds",
+		"3d/dsfase/4/ss2",
+	}
+	tcs := []struct{ in, out []int }{
+		{[]int{0}, []int{0}},
+		{[]int{0, 1}, []int{0, 1}},
+		{[]int{0, 1, 0, 1}, []int{0, 1}},
+		{[]int{0, 1, 1, 1, 1}, []int{0, 1}},
+		{[]int{0, 0, 0, 1}, []int{0, 1}},
+		{[]int{0, 1, 2, 3}, []int{0, 1, 2, 3}},
+		{[]int{0, 1, 2, 3, 0, 1, 2, 3}, []int{0, 1, 2, 3}},
+		{[]int{0, 1, 1, 3, 0, 1, 0, 1, 2, 3}, []int{0, 1, 3, 2}},
+	}
+
+	for _, tc := range tcs {
+		inp := make([]protocol.FileInfo, len(tc.in))
+		for i, j := range tc.in {
+			inp[i] = protocol.FileInfo{Name: names[j]}
+		}
+		outp := normalizeFilenamesAndDropDuplicates(inp)
+		if len(outp) != len(tc.out) {
+			t.Errorf("Expected %v entries, got %v", len(tc.out), len(outp))
+			continue
+		}
+		for i, f := range outp {
+			if exp := names[tc.out[i]]; exp != f.Name {
+				t.Errorf("Got file %v at pos %v, expected %v", f.Name, i, exp)
+			}
+		}
+	}
+}

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -569,22 +569,22 @@ func TestDropDuplicates(t *testing.T) {
 		{[]int{0, 0, 0, 1}, []int{0, 1}},
 		{[]int{0, 1, 2, 3}, []int{0, 1, 2, 3}},
 		{[]int{0, 1, 2, 3, 0, 1, 2, 3}, []int{0, 1, 2, 3}},
-		{[]int{0, 1, 1, 3, 0, 1, 0, 1, 2, 3}, []int{0, 1, 3, 2}},
+		{[]int{0, 1, 1, 3, 0, 1, 0, 1, 2, 3}, []int{0, 1, 2, 3}},
 	}
 
-	for _, tc := range tcs {
+	for tci, tc := range tcs {
 		inp := make([]protocol.FileInfo, len(tc.in))
 		for i, j := range tc.in {
 			inp[i] = protocol.FileInfo{Name: names[j]}
 		}
 		outp := normalizeFilenamesAndDropDuplicates(inp)
 		if len(outp) != len(tc.out) {
-			t.Errorf("Expected %v entries, got %v", len(tc.out), len(outp))
+			t.Errorf("tc %v: Expected %v entries, got %v", tci, len(tc.out), len(outp))
 			continue
 		}
 		for i, f := range outp {
 			if exp := names[tc.out[i]]; exp != f.Name {
-				t.Errorf("Got file %v at pos %v, expected %v", f.Name, i, exp)
+				t.Errorf("tc %v: Got file %v at pos %v, expected %v", tci, f.Name, i, exp)
 			}
 		}
 	}

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -478,17 +478,21 @@ func DropDeltaIndexIDs(db *Lowlevel) {
 
 func normalizeFilenamesAndDropDuplicates(fs []protocol.FileInfo) []protocol.FileInfo {
 	positions := make(map[string]int, len(fs))
-	duplicates := make([]int, 0, len(fs))
+	sentinel := protocol.FileInfo{Name: "/"} // Not a valid filename
 	for i, f := range fs {
 		norm := osutil.NormalizedFilename(f.Name)
 		if pos, ok := positions[norm]; ok {
-			duplicates = append(duplicates, pos)
+			fs[pos] = sentinel
 		}
 		positions[norm] = i
 		fs[i].Name = norm
 	}
-	for _, pos := range duplicates {
-		fs = append(fs[:pos], fs[pos+1:]...)
+	for i := 0; i < len(fs); {
+		if fs[i].Name == sentinel.Name {
+			fs = append(fs[:i], fs[i+1:]...)
+			continue
+		}
+		i++
 	}
 	return fs
 }

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -478,17 +478,19 @@ func DropDeltaIndexIDs(db *Lowlevel) {
 
 func normalizeFilenamesAndDropDuplicates(fs []protocol.FileInfo) []protocol.FileInfo {
 	positions := make(map[string]int, len(fs))
-	newFs := fs[:0]
-	for _, f := range fs {
+	duplicates := make([]int, 0, len(fs))
+	for i, f := range fs {
 		norm := osutil.NormalizedFilename(f.Name)
-		if i, ok := positions[norm]; ok {
-			newFs = append(newFs[:i], newFs[i+1:]...)
+		if pos, ok := positions[norm]; ok {
+			duplicates = append(duplicates, pos)
 		}
-		positions[norm] = len(newFs)
-		f.Name = norm
-		newFs = append(newFs, f)
+		positions[norm] = i
+		fs[i].Name = norm
 	}
-	return newFs
+	for _, pos := range duplicates {
+		fs = append(fs[:pos], fs[pos+1:]...)
+	}
+	return fs
 }
 
 func nativeFileIterator(fn Iterator) Iterator {

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -478,17 +478,16 @@ func DropDeltaIndexIDs(db *Lowlevel) {
 
 func normalizeFilenamesAndDropDuplicates(fs []protocol.FileInfo) []protocol.FileInfo {
 	positions := make(map[string]int, len(fs))
-	sentinel := protocol.FileInfo{Name: "/"} // Not a valid filename
 	for i, f := range fs {
 		norm := osutil.NormalizedFilename(f.Name)
 		if pos, ok := positions[norm]; ok {
-			fs[pos] = sentinel
+			fs[pos] = protocol.FileInfo{}
 		}
 		positions[norm] = i
 		fs[i].Name = norm
 	}
 	for i := 0; i < len(fs); {
-		if fs[i].Name == sentinel.Name {
+		if fs[i].Name == "" {
 			fs = append(fs[:i], fs[i+1:]...)
 			continue
 		}

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -124,7 +124,13 @@ func (s *FileSet) Update(device protocol.DeviceID, fs []protocol.FileInfo) {
 	// do not modify fs in place, it is still used in outer scope
 	fs = append([]protocol.FileInfo(nil), fs...)
 
-	normalizeFilenames(fs)
+	// If one file info is present multiple times, only keep the last.
+	// Updating the same file multiple times is problematic, because the
+	// previous updates won't yet be represented in the db when we update it
+	// again. Additionally even if that problem was taken care of, it would
+	// be pointless because we remove the previously added file info again
+	// right away.
+	fs = normalizeFilenamesAndDropDuplicates(fs)
 
 	s.updateMutex.Lock()
 	defer s.updateMutex.Unlock()
@@ -470,10 +476,19 @@ func DropDeltaIndexIDs(db *Lowlevel) {
 	}
 }
 
-func normalizeFilenames(fs []protocol.FileInfo) {
-	for i := range fs {
-		fs[i].Name = osutil.NormalizedFilename(fs[i].Name)
+func normalizeFilenamesAndDropDuplicates(fs []protocol.FileInfo) []protocol.FileInfo {
+	positions := make(map[string]int, len(fs))
+	newFs := fs[:0]
+	for _, f := range fs {
+		norm := osutil.NormalizedFilename(f.Name)
+		if i, ok := positions[norm]; ok {
+			newFs = append(newFs[:i], newFs[i+1:]...)
+		}
+		positions[norm] = len(newFs)
+		f.Name = norm
+		newFs = append(newFs, f)
 	}
+	return newFs
 }
 
 func nativeFileIterator(fn Iterator) Iterator {


### PR DESCRIPTION
### Purpose

From the code:
```
	// If one file info is present multiple times, only keep the last.
	// Updating the same file multiple times is problematic, because the
	// previous updates won't yet be represented in the db when we update it
	// again. Additionally even if that problem was taken care of, it would
	// be pointless because we remove the previously added file info again
	// right away.
```

### Testing

Added a unit test updating the same file twice in one update, then checking that it's not present twice in the sequence bucket afterwards (it is now).