### PR TITLE
lib/model: Partial revert of rename fix (fixes #6653)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -460,13 +460,8 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 			continue
 		}
 
-		if batch.full() {
-			if err := batch.flush(); err != nil {
-				return err
-			}
-			snap.Release()
-			snap = f.fset.Snapshot()
-			alreadyUsed = make(map[string]struct{})
+		if err := batch.flushIfFull(); err != nil {
+			return err
 		}
 
 		batch.append(res.File)


### PR DESCRIPTION
We can't just drop the snap because it's in use elsewhere. This should
be equally functional.
