### PR TITLE
cmd/syncthing: Don't crash when failing to create default config (fixes #6655)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -527,7 +527,10 @@ func (e errNoUpgrade) Error() string {
 }
 
 func checkUpgrade() (upgrade.Release, error) {
-	cfg, _ := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	if err != nil {
+		return upgrade.Release{}, err
+	}
 	opts := cfg.Options()
 	release, err := upgrade.LatestRelease(opts.ReleasesURL, build.Version, opts.UpgradeToPreReleases)
 	if err != nil {


### PR DESCRIPTION
This is not an ignorable error, because it can happen if we fail to
allocate a free port for the GUI or sync port on first startup.
