### PR TITLE
cmd/stindex: Add missing KeyType values in stindex dump code

### DIFF
--- a/cmd/stindex/dump.go
+++ b/cmd/stindex/dump.go
@@ -105,6 +105,15 @@ func dump(ldb backend.Backend) {
 		case db.KeyTypeBlockList:
 			fmt.Printf("[blocklist] H:%x\n", key[1:])
 
+		case db.KeyTypeBlockListMap:
+			folder := binary.BigEndian.Uint32(key[1:])
+			hash := key[5:37]
+			fileName := string(key[37:])
+			fmt.Printf("[blocklistmap] F:%d H:%x N:%s\n", folder, hash, fileName)
+
+		case db.KeyTypeVersion:
+			fmt.Printf("[version] H:%x\n", key[1:])
+
 		default:
 			fmt.Printf("[??? %d]\n  %x\n  %x\n", key[0], key, it.Value())
 		}

--- a/cmd/stindex/dump.go
+++ b/cmd/stindex/dump.go
@@ -106,7 +106,7 @@ func dump(ldb backend.Backend) {
 			fmt.Printf("[blocklist] H:%x\n", key[1:])
 
 		default:
-			fmt.Printf("[???]\n  %x\n  %x\n", key, it.Value())
+			fmt.Printf("[??? %d]\n  %x\n  %x\n", key[0], key, it.Value())
 		}
 	}
 }

--- a/cmd/stindex/dump.go
+++ b/cmd/stindex/dump.go
@@ -52,10 +52,10 @@ func dump(ldb backend.Backend) {
 			fmt.Printf("[block] F:%d H:%x N:%q I:%d\n", folder, hash, name, binary.BigEndian.Uint32(it.Value()))
 
 		case db.KeyTypeDeviceStatistic:
-			fmt.Printf("[dstat] K:%x V:%x\n", it.Key(), it.Value())
+			fmt.Printf("[dstat] K:%x V:%x\n", key, it.Value())
 
 		case db.KeyTypeFolderStatistic:
-			fmt.Printf("[fstat] K:%x V:%x\n", it.Key(), it.Value())
+			fmt.Printf("[fstat] K:%x V:%x\n", key, it.Value())
 
 		case db.KeyTypeVirtualMtime:
 			folder := binary.BigEndian.Uint32(key[1:])
@@ -67,11 +67,11 @@ func dump(ldb backend.Backend) {
 			fmt.Printf("[mtime] F:%d N:%q R:%v V:%v\n", folder, name, real, virt)
 
 		case db.KeyTypeFolderIdx:
-			key := binary.BigEndian.Uint32(it.Key()[1:])
+			key := binary.BigEndian.Uint32(key[1:])
 			fmt.Printf("[folderidx] K:%d V:%q\n", key, it.Value())
 
 		case db.KeyTypeDeviceIdx:
-			key := binary.BigEndian.Uint32(it.Key()[1:])
+			key := binary.BigEndian.Uint32(key[1:])
 			val := it.Value()
 			if len(val) == 0 {
 				fmt.Printf("[deviceidx] K:%d V:<nil>\n", key)
@@ -81,32 +81,32 @@ func dump(ldb backend.Backend) {
 			}
 
 		case db.KeyTypeIndexID:
-			device := binary.BigEndian.Uint32(it.Key()[1:])
-			folder := binary.BigEndian.Uint32(it.Key()[5:])
+			device := binary.BigEndian.Uint32(key[1:])
+			folder := binary.BigEndian.Uint32(key[5:])
 			fmt.Printf("[indexid] D:%d F:%d I:%x\n", device, folder, it.Value())
 
 		case db.KeyTypeFolderMeta:
-			folder := binary.BigEndian.Uint32(it.Key()[1:])
+			folder := binary.BigEndian.Uint32(key[1:])
 			fmt.Printf("[foldermeta] F:%d V:%x\n", folder, it.Value())
 
 		case db.KeyTypeMiscData:
-			fmt.Printf("[miscdata] K:%q V:%q\n", it.Key()[1:], it.Value())
+			fmt.Printf("[miscdata] K:%q V:%q\n", key[1:], it.Value())
 
 		case db.KeyTypeSequence:
-			folder := binary.BigEndian.Uint32(it.Key()[1:])
-			seq := binary.BigEndian.Uint64(it.Key()[5:])
+			folder := binary.BigEndian.Uint32(key[1:])
+			seq := binary.BigEndian.Uint64(key[5:])
 			fmt.Printf("[sequence] F:%d S:%d V:%q\n", folder, seq, it.Value())
 
 		case db.KeyTypeNeed:
-			folder := binary.BigEndian.Uint32(it.Key()[1:])
-			file := string(it.Key()[5:])
+			folder := binary.BigEndian.Uint32(key[1:])
+			file := string(key[5:])
 			fmt.Printf("[need] F:%d V:%q\n", folder, file)
 
 		case db.KeyTypeBlockList:
-			fmt.Printf("[blocklist] H:%x\n", it.Key()[1:])
+			fmt.Printf("[blocklist] H:%x\n", key[1:])
 
 		default:
-			fmt.Printf("[???]\n  %x\n  %x\n", it.Key(), it.Value())
+			fmt.Printf("[???]\n  %x\n  %x\n", key, it.Value())
 		}
 	}
 }


### PR DESCRIPTION
### Purpose

Recently added DB key prefixes KeyTypeBlockListMap and KeyTypeVersion
were unknown to the stindex dumping tool.  Add basic parsing to dump
their key structure.  Clean up some surrounding code along the way.

### Testing

This is not tested, as I haven't seen any such DB entries in my database yet.  Just wanted to find out what KeyType was listed with "???" that was a remnant of previous tests in #6443.