### PR TITLE
lib/db: Don't panic on seq. coruption when debugging

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -272,8 +272,7 @@ func (t *readOnlyTransaction) withHaveSequence(folder []byte, startSeq int64, fn
 
 		if shouldDebug() {
 			if seq := t.keyer.SequenceFromSequenceKey(dbi.Key()); f.Sequence != seq {
-				l.Warnf("Sequence index corruption (folder %v, file %v): sequence %d != expected %d", string(folder), f.Name, f.Sequence, seq)
-				panic("sequence index corruption")
+				l.Debugf("Sequence index corruption (folder %v, file %v): sequence %d != expected %d", string(folder), f.Name, f.Sequence, seq)
 			}
 		}
 		if !fn(f) {


### PR DESCRIPTION
That's an oversight from #6367: If db debug logging is activated, we still panic on corrupt sequences, even though we now handle that (and warn). Happened when trying to debug a db problem: https://forum.syncthing.net/t/unable-to-solve-non-increasing-sequence-detected-error/15019  
I just relegated it to a debug log instead of removing entirely, as it might still be useful if that function is ever called in a different context than from model.