### PR TITLE
lib/model: Handle concurrently removed device in ClusterConfig

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -956,7 +956,11 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	}
 
 	changed := false
-	deviceCfg := m.cfg.Devices()[deviceID]
+	deviceCfg, ok := m.cfg.Devices()[deviceID]
+	if !ok {
+		l.Debugln("Device disappeared from config while processing cluster-config")
+		return errDeviceUnknown
+	}
 
 	// Needs to happen outside of the fmut, as can cause CommitConfiguration
 	if deviceCfg.AutoAcceptFolders {


### PR DESCRIPTION
I am not aware of any problems caused by this, but it's clearly not useful to go ahead creating a cluster config when the device it is created for doesn't exist. As to why a device can disappear while the connection is still there: The usual config racyness. Returning an error here causes the device the connection to be closed, which is fine given we don't know the device.