### PR TITLE
lib/scanner: Simplify, optimize and document Validate (#6674)

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -108,10 +108,12 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 	return blocks, nil
 }
 
+// Validate quickly validates buf against the cryptohash hash (if len(hash)>0)
+// and the 32-bit hash weakHash (if not zero). It is satisfied if either hash
+// matches, or neither is given.
 func Validate(buf, hash []byte, weakHash uint32) bool {
-	if weakHash != 0 && adler32.Checksum(buf) == weakHash {
-		return true
-		// On mismatch, go to next algo.
+	if weakHash != 0 {
+		return adler32.Checksum(buf) == weakHash
 	}
 
 	if len(hash) > 0 {
@@ -119,7 +121,6 @@ func Validate(buf, hash []byte, weakHash uint32) bool {
 		return bytes.Equal(hbuf[:], hash)
 	}
 
-	// No hashes were specified. Assume it's all good.
 	return true
 }
 


### PR DESCRIPTION
This is fallout from the discussion over at  #6674. It turns out that the function scanner.Validate does benefit from Adler-32 hashes, after rewriting it.

The current function checks a block against an expected Adler-32 hash, then against a SHA-256 if it doesn't match. The rewritten version skips the latter check, since the SHA-256 won't match if the Adler-32 doesn't (by the assumption made in the rest of the code base, that sha256(x) = sha256(y) implies x = y). I've written some benchmarks to show what this buys:

```
name        old time/op    new time/op    delta
Validate-8    68.4ms ± 1%    10.5ms ± 0%   -84.64%  (p=0.000 n=10+10)

name        old alloc/op   new alloc/op   delta
Validate-8    26.4kB ± 0%     0.0kB       -100.00%  (p=0.000 n=9+10)

name        old allocs/op  new allocs/op  delta
Validate-8       600 ± 0%         0       -100.00%  (p=0.000 n=10+10)
```

The reduction of the number of allocations stems from using utility functions instead of Writer interfaces, which also reduces the code complexity.

I've also benchmarked against a version that only checks the SHA-256; it's significantly slower:

```
☑ bakkie:~/src/syncthing/lib/scanner (validate)$ benchstat old-validate no-weakhash 
name        old time/op    new time/op    delta
Validate-8    68.4ms ± 1%   115.9ms ± 1%   +69.45%  (p=0.000 n=10+10)

name        old alloc/op   new alloc/op   delta
Validate-8    26.4kB ± 0%     0.0kB       -100.00%  (p=0.000 n=9+9)

name        old allocs/op  new allocs/op  delta
Validate-8       600 ± 0%         0       -100.00%  (p=0.000 n=10+10)
```