### PR TITLE
lib/model: Don't increase pull pause on triggered pull

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -295,8 +295,7 @@ func (f *folder) pull() (success bool) {
 
 	defer func() {
 		if success {
-			// We're good. Don't schedule another pull and reset
-			// the pause interval.
+			// We're good, reset the pause interval.
 			f.pullPause = f.pullBasePause()
 		}
 	}()


### PR DESCRIPTION
The pull fail pause is increased on every failed pause, even if the pull was triggered and thus happened way ahead of that pause:

```
May 28 20:27:07 [...] isn't making sync progress - retrying in 16m8.081801858s.
May 28 20:26:59 [...] isn't making sync progress - retrying in 8m5.21589791s.
May 28 20:26:53 [...] isn't making sync progress - retrying in 4m4.313521634s.
May 28 20:26:49 [...] isn't making sync progress - retrying in 2m2.50329418s.
May 28 20:26:47 [...] isn't making sync progress - retrying in 1m1.771580476s.
```

While not particularly harmful, it looks weird and definitely isn't the intention. Thus the last time a pull happened is now tracked and the puller pause is not increased if the time since the last pull is smaller than the current pause.

And the precision to which go prints the duration is completely nuts - truncate to 1s.