### PR TITLE
cmd/syncthing: Correct auto upgrade criteria (fixes #6701)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -842,7 +842,7 @@ func shouldUpgrade(cfg config.Wrapper, runtimeOptions RuntimeOptions) bool {
 	if upgrade.DisabledByCompilation {
 		return false
 	}
-	if opts := cfg.Options(); opts.AutoUpgradeIntervalH < 0 {
+	if !cfg.Options().ShouldAutoUpgrade() {
 		return false
 	}
 	if runtimeOptions.NoUpgrade {

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -200,3 +200,7 @@ func (opts OptionsConfiguration) MaxConcurrentIncomingRequestKiB() int {
 	// Roll with it.
 	return opts.RawMaxCIRequestKiB
 }
+
+func (opts OptionsConfiguration) ShouldAutoUpgrade() bool {
+	return opts.AutoUpgradeIntervalH > 0
+}


### PR DESCRIPTION
We inadvertently moved the cutoff to the wrong side of zero. Adding a small convenience function.