### PR TITLE
lib/config: Add missing quic address in case of non-default port (fixes #6679)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -133,7 +133,7 @@ func NewWithFreePorts(myID protocol.DeviceID) (Configuration, error) {
 		cfg.Options.RawListenAddresses = []string{"default"}
 	} else {
 		cfg.Options.RawListenAddresses = []string{
-			fmt.Sprintf("tcp://%s", net.JoinHostPort("0.0.0.0", strconv.Itoa(port))),
+			util.Address("tcp", net.JoinHostPort("0.0.0.0", strconv.Itoa(port))),
 			"dynamic+https://relays.syncthing.net/endpoint",
 			util.Address("quic", net.JoinHostPort("0.0.0.0", strconv.Itoa(port))),
 		}

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -135,6 +135,7 @@ func NewWithFreePorts(myID protocol.DeviceID) (Configuration, error) {
 		cfg.Options.RawListenAddresses = []string{
 			fmt.Sprintf("tcp://%s", net.JoinHostPort("0.0.0.0", strconv.Itoa(port))),
 			"dynamic+https://relays.syncthing.net/endpoint",
+			util.Address("quic", net.JoinHostPort("0.0.0.0", strconv.Itoa(port))),
 		}
 	}
 


### PR DESCRIPTION
This fix adds missing quic listener on same port as TCP incase of default port being blocked

fixes #6679 

