### PR TITLE
lib/build: Add some env vars as synthetic build tags

### DIFF
--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -89,7 +89,7 @@ func LongVersionFor(program string) string {
 	date := Date.UTC().Format("2006-01-02 15:04:05 MST")
 	v := fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
 	for _, envVar := range envTags {
-		if v := os.Getenv(envVar); v != "" {
+		if os.Getenv(envVar) != "" {
 			Tags = append(Tags, strings.ToLower(envVar))
 		}
 	}

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -9,6 +9,7 @@ package build
 import (
 	"fmt"
 	"log"
+	"os"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -37,6 +38,14 @@ var (
 	Tags []string
 
 	allowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-[^\s]+)?$`)
+
+	envTags = []string{
+		"STGUIASSETS",
+		"STHASHING",
+		"STNORESTART",
+		"STNOUPGRADE",
+		"USE_BADGER",
+	}
 )
 
 func init() {
@@ -79,6 +88,11 @@ func LongVersionFor(program string) string {
 	// This string and date format is essentially part of our external API. Never change it.
 	date := Date.UTC().Format("2006-01-02 15:04:05 MST")
 	v := fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
+	for _, envVar := range envTags {
+		if v := os.Getenv(envVar); v != "" {
+			Tags = append(Tags, strings.ToLower(envVar))
+		}
+	}
 	if len(Tags) > 0 {
 		v = fmt.Sprintf("%s [%s]", v, strings.Join(Tags, ", "))
 	}


### PR DESCRIPTION
This adds some env vars to the long version string as if they were build
tags. The purpose is to better understand what code was running or not
in the version output, usage reporting and crash reports. In order to
prevent possible privacy issues the actual value of the variable is not
reported, just the fact that it was set to something non-empty.

Example:

	% ./bin/syncthing --version
	syncthing v1.6.1+47-g1eb104f3-buildtags "Fermium Flea" (go1.14.3 darwin-amd64) jb@kvin.kastelo.net 2020-06-03 07:25:46 UTC [stnoupgrade, use_badger]
