### PR TITLE
cmd/stcrashreceiver: Pick up extra build tags and send to Sentry

### DIFF
--- a/cmd/stcrashreceiver/sentry.go
+++ b/cmd/stcrashreceiver/sentry.go
@@ -149,7 +149,7 @@ func parseReport(path string, report []byte) (*raven.Packet, error) {
 		pkt.Tags = append(pkt.Tags, raven.Tag{Key: "commit", Value: version.commit})
 	}
 	for _, tag := range version.extra {
-		pkt.Tags = append(pkt.Tags, raven.Tag{Key: "extra", Value: tag})
+		pkt.Tags = append(pkt.Tags, raven.Tag{Key: tag, Value: "1"})
 	}
 
 	return pkt, nil

--- a/cmd/stcrashreceiver/sentry_test.go
+++ b/cmd/stcrashreceiver/sentry_test.go
@@ -30,16 +30,30 @@ func TestParseVersion(t *testing.T) {
 				builder:  "jb@kvin.kastelo.net",
 			},
 		},
+		{
+			longVersion: `syncthing v1.1.4-rc.1+30-g6aaae618-dirty-crashrep "Erbium Earthworm" (go1.12.5 darwin-amd64) jb@kvin.kastelo.net 2019-05-23 16:08:14 UTC [foo, bar]`,
+			parsed: version{
+				version:  "v1.1.4-rc.1+30-g6aaae618-dirty-crashrep",
+				tag:      "v1.1.4-rc.1",
+				commit:   "6aaae618",
+				codename: "Erbium Earthworm",
+				runtime:  "go1.12.5",
+				goos:     "darwin",
+				goarch:   "amd64",
+				builder:  "jb@kvin.kastelo.net",
+				extra:    []string{"foo", "bar"},
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		v, err := parseVersion(tc.longVersion)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("%s\nerror: %v\n", tc.longVersion, err)
 			continue
 		}
-		if v != tc.parsed {
-			t.Error(v)
+		if fmt.Sprint(v) != fmt.Sprint(tc.parsed) {
+			t.Errorf("%s\nA: %v\nE: %v\n", tc.longVersion, v, tc.parsed)
 		}
 	}
 }


### PR DESCRIPTION
This extracts the extra tags from any `[foo]` stuff at the end of the
version and sends them to Sentry for indexing.

If I need to modify that regexp again I'll probably write a from scratch
tokenizer and parser for our version string instead...
