### PR TITLE
lib/protocol: Avoid panic in DeviceIDFromBytes

### DIFF
--- a/cmd/stindex/dump.go
+++ b/cmd/stindex/dump.go
@@ -73,12 +73,16 @@ func dump(ldb backend.Backend) {
 		case db.KeyTypeDeviceIdx:
 			key := binary.BigEndian.Uint32(key[1:])
 			val := it.Value()
-			if len(val) == 0 {
-				fmt.Printf("[deviceidx] K:%d V:<nil>\n", key)
-			} else {
-				dev := protocol.DeviceIDFromBytes(val)
-				fmt.Printf("[deviceidx] K:%d V:%s\n", key, dev)
+			device := "<nil>"
+			if len(val) > 0 {
+				dev, err := protocol.DeviceIDFromBytes(val)
+				if err != nil {
+					device = fmt.Sprintf("<invalid %d bytes>", len(val))
+				} else {
+					device = dev.String()
+				}
 			}
+			fmt.Printf("[deviceidx] K:%d V:%s\n", key, device)
 
 		case db.KeyTypeIndexID:
 			device := binary.BigEndian.Uint32(key[1:])

--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -151,7 +151,11 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 			case protocol.ConnectRequest:
 				requestedPeer, err := syncthingprotocol.DeviceIDFromBytes(msg.ID)
 				if err != nil {
-					panic(err)
+					if debug {
+						log.Println(id, "is looking for an invalid peer ID")
+					}
+					conn.Close()
+					continue
 				}
 				outboxesMut.RLock()
 				peerOutbox, ok := outboxes[requestedPeer]

--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -149,7 +149,10 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 				protocol.WriteMessage(conn, protocol.ResponseSuccess)
 
 			case protocol.ConnectRequest:
-				requestedPeer := syncthingprotocol.DeviceIDFromBytes(msg.ID)
+				requestedPeer, err := syncthingprotocol.DeviceIDFromBytes(msg.ID)
+				if err != nil {
+					panic(err)
+				}
 				outboxesMut.RLock()
 				peerOutbox, ok := outboxes[requestedPeer]
 				outboxesMut.RUnlock()

--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -154,6 +154,7 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 					if debug {
 						log.Println(id, "is looking for an invalid peer ID")
 					}
+					protocol.WriteMessage(conn, protocol.ResponseNotFound)
 					conn.Close()
 					continue
 				}

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -264,7 +264,11 @@ func TestUpdate0to3(t *testing.T) {
 			t.Fatal(err)
 		}
 		if !ok {
-			t.Fatal("surprise missing global file", string(name), protocol.DeviceIDFromBytes(vl.Versions[0].Device))
+			device := "<invalid>"
+			if dev, err := protocol.DeviceIDFromBytes(vl.Versions[0].Device); err != nil {
+				device = dev.String()
+			}
+			t.Fatal("surprise missing global file", string(name), device)
 		}
 		e, ok := need[fi.FileName()]
 		if !ok {

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -121,7 +121,10 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 	defer t.close()
 
 	var dk, gk, keyBuf []byte
-	devID := protocol.DeviceIDFromBytes(device)
+	devID, err := protocol.DeviceIDFromBytes(device)
+	if err != nil {
+		return err
+	}
 	for _, f := range fs {
 		name := []byte(f.Name)
 		dk, err = db.keyer.GenerateDeviceFileKey(dk, folder, device, name)

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -52,7 +52,11 @@ func (m *metadataTracker) Unmarshal(bs []byte) error {
 
 	// Initialize the index map
 	for i, c := range m.counts.Counts {
-		m.indexes[metaKey{protocol.DeviceIDFromBytes(c.DeviceID), c.LocalFlags}] = i
+		dev, err := protocol.DeviceIDFromBytes(c.DeviceID)
+		if err != nil {
+			return err
+		}
+		m.indexes[metaKey{dev, c.LocalFlags}] = i
 	}
 	return nil
 }
@@ -392,7 +396,10 @@ func (m *countsMap) devices() []protocol.DeviceID {
 
 	for _, dev := range m.counts.Counts {
 		if dev.Sequence > 0 {
-			id := protocol.DeviceIDFromBytes(dev.DeviceID)
+			id, err := protocol.DeviceIDFromBytes(dev.DeviceID)
+			if err != nil {
+				panic(err)
+			}
 			if id == protocol.GlobalDeviceID || id == protocol.LocalDeviceID {
 				continue
 			}

--- a/lib/protocol/deviceid.go
+++ b/lib/protocol/deviceid.go
@@ -46,13 +46,13 @@ func DeviceIDFromString(s string) (DeviceID, error) {
 	return n, err
 }
 
-func DeviceIDFromBytes(bs []byte) DeviceID {
+func DeviceIDFromBytes(bs []byte) (DeviceID, error) {
 	var n DeviceID
 	if len(bs) != len(n) {
-		panic("incorrect length of byte slice representing device ID")
+		return n, fmt.Errorf("incorrect length of byte slice representing device ID")
 	}
 	copy(n[:], bs)
-	return n
+	return n, nil
 }
 
 // String returns the canonical string representation of the device ID

--- a/lib/protocol/deviceid_test.go
+++ b/lib/protocol/deviceid_test.go
@@ -99,8 +99,10 @@ func TestShortIDString(t *testing.T) {
 
 func TestDeviceIDFromBytes(t *testing.T) {
 	id0, _ := DeviceIDFromString(formatted)
-	id1 := DeviceIDFromBytes(id0[:])
-	if id1.String() != formatted {
+	id1, err := DeviceIDFromBytes(id0[:])
+	if err != nil {
+		t.Fatal(err)
+	} else if id1.String() != formatted {
 		t.Errorf("Wrong device ID, got %q, want %q", id1, formatted)
 	}
 }
@@ -150,7 +152,10 @@ func TestNewDeviceIDMarshalling(t *testing.T) {
 
 	// Verify it's the same
 
-	if DeviceIDFromBytes(msg2.Test) != id0 {
+	id1, err := DeviceIDFromBytes(msg2.Test)
+	if err != nil {
+		t.Fatal(err)
+	} else if id1 != id0 {
 		t.Error("Mismatch in old -> new direction")
 	}
 }

--- a/lib/relay/protocol/packets.go
+++ b/lib/relay/protocol/packets.go
@@ -56,11 +56,11 @@ type SessionInvitation struct {
 }
 
 func (i SessionInvitation) String() string {
-	address, err := syncthingprotocol.DeviceIDFromBytes(i.From)
-	if err != nil {
-		panic(err)
+	device := "<invalid>"
+	if address, err := syncthingprotocol.DeviceIDFromBytes(i.From); err == nil {
+		device = address.String()
 	}
-	return fmt.Sprintf("%s@%s", address, i.AddressString())
+	return fmt.Sprintf("%s@%s", device, i.AddressString())
 }
 
 func (i SessionInvitation) GoString() string {

--- a/lib/relay/protocol/packets.go
+++ b/lib/relay/protocol/packets.go
@@ -56,7 +56,11 @@ type SessionInvitation struct {
 }
 
 func (i SessionInvitation) String() string {
-	return fmt.Sprintf("%s@%s", syncthingprotocol.DeviceIDFromBytes(i.From), i.AddressString())
+	address, err := syncthingprotocol.DeviceIDFromBytes(i.From)
+	if err != nil {
+		panic(err)
+	}
+	return fmt.Sprintf("%s@%s", address, i.AddressString())
 }
 
 func (i SessionInvitation) GoString() string {


### PR DESCRIPTION
### Purpose

Return an error from DeviceIDFromBytes() if the length does not match,
instead of panicking.

Change all callers to handle the potential error value.  If possible,
pass it up or handle the condition gracefully, and panic immediately
after the function call in case there is no obvious better reaction.

Based on a related discussion in #6443.

### Testing

Test suite passes, no functional changes expected.
