### PR TITLE
lib/connections, lib/nat: Correctly dis-/enable nat (fixes #6552)

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -123,7 +123,7 @@ type service struct {
 	tlsDefaultCommonName string
 	limiter              *limiter
 	natService           *nat.Service
-	natServiceToken      *suture.ServiceToken
+	natServiceEnabled    bool
 	evLogger             events.Logger
 
 	listenersMut       sync.RWMutex
@@ -652,14 +652,12 @@ func (s *service) CommitConfiguration(from, to config.Configuration) bool {
 	}
 	s.listenersMut.Unlock()
 
-	if to.Options.NATEnabled && s.natServiceToken == nil {
+	if to.Options.NATEnabled && !s.natServiceEnabled {
 		l.Debugln("Starting NAT service")
-		token := s.Add(s.natService)
-		s.natServiceToken = &token
-	} else if !to.Options.NATEnabled && s.natServiceToken != nil {
+		s.natServiceEnabled = true
+	} else if !to.Options.NATEnabled && s.natServiceEnabled {
 		l.Debugln("Stopping NAT service")
-		s.Remove(*s.natServiceToken)
-		s.natServiceToken = nil
+		s.natServiceEnabled = false
 	}
 
 	return true

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -187,6 +187,7 @@ func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *t
 	service.Add(util.AsService(service.connect, fmt.Sprintf("%s/connect", service)))
 	service.Add(util.AsService(service.handle, fmt.Sprintf("%s/handle", service)))
 	service.Add(service.listenerSupervisor)
+	service.Add(service.natService)
 
 	return service
 }

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -123,7 +123,6 @@ type service struct {
 	tlsDefaultCommonName string
 	limiter              *limiter
 	natService           *nat.Service
-	natServiceEnabled    bool
 	evLogger             events.Logger
 
 	listenersMut       sync.RWMutex
@@ -651,16 +650,6 @@ func (s *service) CommitConfiguration(from, to config.Configuration) bool {
 		}
 	}
 	s.listenersMut.Unlock()
-
-	if to.Options.NATEnabled && !s.natServiceEnabled {
-		l.Debugln("Starting NAT service")
-		s.natService.Enable()
-		s.natServiceEnabled = true
-	} else if !to.Options.NATEnabled && s.natServiceEnabled {
-		l.Debugln("Stopping NAT service")
-		s.natService.Disable()
-		s.natServiceEnabled = false
-	}
 
 	return true
 }

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -654,9 +654,11 @@ func (s *service) CommitConfiguration(from, to config.Configuration) bool {
 
 	if to.Options.NATEnabled && !s.natServiceEnabled {
 		l.Debugln("Starting NAT service")
+		s.natService.Enable()
 		s.natServiceEnabled = true
 	} else if !to.Options.NATEnabled && s.natServiceEnabled {
 		l.Debugln("Stopping NAT service")
+		s.natService.Disable()
 		s.natServiceEnabled = false
 	}
 

--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -48,6 +48,23 @@ func NewService(id protocol.DeviceID, cfg config.Wrapper) *Service {
 	return s
 }
 
+func (s *Service) Enable(ctx context.Context) {
+	s.mut.Lock()
+	if !s.timer.Stop() {
+		<-s.timer.C
+	}
+	s.timer.Reset(0)
+	s.mut.Unlock()
+}
+
+func (s *Service) Disable(ctx context.Context) {
+	s.mut.Lock()
+	if !s.timer.Stop() {
+		<-s.timer.C
+	}
+	s.mut.Unlock()
+}
+
 func (s *Service) serve(ctx context.Context) {
 	announce := stdsync.Once{}
 

--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -48,16 +48,13 @@ func NewService(id protocol.DeviceID, cfg config.Wrapper) *Service {
 	return s
 }
 
-func (s *Service) Enable(ctx context.Context) {
+func (s *Service) Enable() {
 	s.mut.Lock()
-	if !s.timer.Stop() {
-		<-s.timer.C
-	}
 	s.timer.Reset(0)
 	s.mut.Unlock()
 }
 
-func (s *Service) Disable(ctx context.Context) {
+func (s *Service) Disable() {
 	s.mut.Lock()
 	if !s.timer.Stop() {
 		<-s.timer.C

--- a/lib/nat/structs_test.go
+++ b/lib/nat/structs_test.go
@@ -7,9 +7,13 @@
 package nat
 
 import (
+	"io/ioutil"
 	"net"
+	"os"
 	"testing"
 
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
@@ -56,7 +60,15 @@ func TestMappingValidGateway(t *testing.T) {
 }
 
 func TestMappingClearAddresses(t *testing.T) {
-	natSvc := NewService(protocol.EmptyDeviceID, nil)
+	tmpFile, err := ioutil.TempFile("", "syncthing-testConfig-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := config.Wrap(tmpFile.Name(), config.Configuration{}, events.NoopLogger)
+	defer os.RemoveAll(tmpFile.Name())
+	tmpFile.Close()
+
+	natSvc := NewService(protocol.EmptyDeviceID, w)
 	// Mock a mapped port; avoids the need to actually map a port
 	ip := net.ParseIP("192.168.0.1")
 	m := natSvc.NewMapping(TCP, ip, 1024)


### PR DESCRIPTION
I added exported methods to control the nat service activity. The alternative would have been to subscribe the nat service to config changes, but this option felt a bit more straight forward/has less moving part.