### PR TITLE
lib/db: Remove unused keyer methods

### DIFF
--- a/lib/db/keyer.go
+++ b/lib/db/keyer.go
@@ -80,7 +80,6 @@ type keyer interface {
 	// global version key stuff
 	GenerateGlobalVersionKey(key, folder, name []byte) (globalVersionKey, error)
 	NameFromGlobalVersionKey(key []byte) []byte
-	FolderFromGlobalVersionKey(key []byte) ([]byte, bool)
 
 	// block map key stuff (former BlockMap)
 	GenerateBlockMapKey(key, folder, hash, name []byte) (blockMapKey, error)
@@ -97,7 +96,6 @@ type keyer interface {
 
 	// index IDs
 	GenerateIndexIDKey(key, device, folder []byte) (indexIDKey, error)
-	DeviceFromIndexIDKey(key []byte) ([]byte, bool)
 
 	// Mtimes
 	GenerateMtimesKey(key, folder []byte) (mtimesKey, error)
@@ -185,10 +183,6 @@ func (k defaultKeyer) GenerateGlobalVersionKey(key, folder, name []byte) (global
 
 func (k defaultKeyer) NameFromGlobalVersionKey(key []byte) []byte {
 	return key[keyPrefixLen+keyFolderLen:]
-}
-
-func (k defaultKeyer) FolderFromGlobalVersionKey(key []byte) ([]byte, bool) {
-	return k.folderIdx.Val(binary.BigEndian.Uint32(key[keyPrefixLen:]))
 }
 
 type blockMapKey []byte
@@ -293,10 +287,6 @@ func (k defaultKeyer) GenerateIndexIDKey(key, device, folder []byte) (indexIDKey
 	binary.BigEndian.PutUint32(key[keyPrefixLen:], deviceID)
 	binary.BigEndian.PutUint32(key[keyPrefixLen+keyDeviceLen:], folderID)
 	return key, nil
-}
-
-func (k defaultKeyer) DeviceFromIndexIDKey(key []byte) ([]byte, bool) {
-	return k.deviceIdx.Val(binary.BigEndian.Uint32(key[keyPrefixLen:]))
 }
 
 type mtimesKey []byte

--- a/lib/db/keyer_test.go
+++ b/lib/db/keyer_test.go
@@ -58,21 +58,9 @@ func TestGlobalKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fld2, ok := db.keyer.FolderFromGlobalVersionKey(key)
-	if !ok {
-		t.Error("should have been found")
-	}
-	if !bytes.Equal(fld2, fld) {
-		t.Errorf("wrong folder %q != %q", fld2, fld)
-	}
 	name2 := db.keyer.NameFromGlobalVersionKey(key)
 	if !bytes.Equal(name2, name) {
 		t.Errorf("wrong name %q != %q", name2, name)
-	}
-
-	_, ok = db.keyer.FolderFromGlobalVersionKey([]byte{1, 2, 3, 4, 5})
-	if ok {
-		t.Error("should not have been found")
 	}
 }
 


### PR DESCRIPTION
This removes two unused methods.