### PR TITLE
lib: Add FolderPasswords to config.Wrapper

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,7 @@ github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/lib/api/mocked_config_test.go
+++ b/lib/api/mocked_config_test.go
@@ -106,6 +106,10 @@ func (c *mockedConfig) SetFolders(folders []config.FolderConfiguration) (config.
 	return noopWaiter{}, nil
 }
 
+func (c *mockedConfig) FolderPasswords(device protocol.DeviceID) map[string]string {
+	return nil
+}
+
 func (c *mockedConfig) Device(id protocol.DeviceID) (config.DeviceConfiguration, bool) {
 	return config.DeviceConfiguration{}, false
 }

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -74,6 +74,7 @@ type Wrapper interface {
 	FolderList() []FolderConfiguration
 	SetFolder(fld FolderConfiguration) (Waiter, error)
 	SetFolders(folders []FolderConfiguration) (Waiter, error)
+	FolderPasswords(device protocol.DeviceID) map[string]string
 
 	Device(id protocol.DeviceID) (DeviceConfiguration, bool)
 	Devices() map[protocol.DeviceID]DeviceConfiguration
@@ -330,6 +331,14 @@ func (w *wrapper) SetFolders(folders []FolderConfiguration) (Waiter, error) {
 	newCfg.Folders = append(newCfg.Folders, filtered...)
 
 	return w.replaceLocked(newCfg)
+}
+
+// FolderPasswords returns the folder passwords set for this device, for
+// folders that have an encryption password set.
+func (w *wrapper) FolderPasswords(device protocol.DeviceID) map[string]string {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+	return w.cfg.FolderPasswords(device)
 }
 
 // Options returns the current options configuration object.

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -321,7 +321,7 @@ func (s *service) handle(ctx context.Context) {
 		rd, wr := s.limiter.getLimiters(remoteID, c, isLAN)
 
 		var protoConn protocol.Connection
-		passwords := s.cfg.RawCopy().FolderPasswords(remoteID)
+		passwords := s.cfg.FolderPasswords(remoteID)
 		if len(passwords) > 0 {
 			protoConn = protocol.NewEncryptedConnection(passwords, remoteID, rd, wr, s.model, c.String(), deviceCfg.Compression)
 		} else {


### PR DESCRIPTION
This PR is for the encryption branch (https://github.com/syncthing/syncthing/tree/encryption).

Avoids copying the entire config on every handled connection.