### PR TITLE
all: Make all error implementations pointer types

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -522,7 +522,7 @@ type errNoUpgrade struct {
 	current, latest string
 }
 
-func (e errNoUpgrade) Error() string {
+func (e *errNoUpgrade) Error() string {
 	return fmt.Sprintf("no upgrade available (current %q >= latest %q).", e.current, e.latest)
 }
 
@@ -538,7 +538,7 @@ func checkUpgrade() (upgrade.Release, error) {
 	}
 
 	if upgrade.CompareVersions(release.Tag, build.Version) <= 0 {
-		return upgrade.Release{}, errNoUpgrade{build.Version, release.Tag}
+		return upgrade.Release{}, &errNoUpgrade{build.Version, release.Tag}
 	}
 
 	l.Infof("Upgrade available (current %q < latest %q)", build.Version, release.Tag)
@@ -646,7 +646,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 			err = upgrade.To(release)
 		}
 		if err != nil {
-			if _, ok := err.(errNoUpgrade); ok || err == errTooEarlyUpgradeCheck || err == errTooEarlyUpgrade {
+			if _, ok := err.(*errNoUpgrade); ok || err == errTooEarlyUpgradeCheck || err == errTooEarlyUpgrade {
 				l.Debugln("Initial automatic upgrade:", err)
 			} else {
 				l.Infoln("Initial automatic upgrade:", err)
@@ -996,7 +996,7 @@ func setPauseState(cfg config.Wrapper, paused bool) {
 }
 
 func exitCodeForUpgrade(err error) int {
-	if _, ok := err.(errNoUpgrade); ok {
+	if _, ok := err.(*errNoUpgrade); ok {
 		return syncthing.ExitNoUpgradeAvailable.AsInt()
 	}
 	return syncthing.ExitError.AsInt()

--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -146,30 +146,20 @@ func OpenMemory() Backend {
 
 type errClosed struct{}
 
-func (errClosed) Error() string { return "database is closed" }
+func (*errClosed) Error() string { return "database is closed" }
 
 type errNotFound struct{}
 
-func (errNotFound) Error() string { return "key not found" }
+func (*errNotFound) Error() string { return "key not found" }
 
 func IsClosed(err error) bool {
-	if _, ok := err.(errClosed); ok {
-		return true
-	}
-	if _, ok := err.(*errClosed); ok {
-		return true
-	}
-	return false
+	_, ok := err.(*errClosed)
+	return ok
 }
 
 func IsNotFound(err error) bool {
-	if _, ok := err.(errNotFound); ok {
-		return true
-	}
-	if _, ok := err.(*errNotFound); ok {
-		return true
-	}
-	return false
+	_, ok := err.(*errNotFound)
+	return ok
 }
 
 // releaser manages counting on top of a waitgroup
@@ -209,7 +199,7 @@ func (cg *closeWaitGroup) Add(i int) error {
 	cg.closeMut.RLock()
 	defer cg.closeMut.RUnlock()
 	if cg.closed {
-		return errClosed{}
+		return &errClosed{}
 	}
 	cg.WaitGroup.Add(i)
 	return nil

--- a/lib/db/backend/badger_backend.go
+++ b/lib/db/backend/badger_backend.go
@@ -402,10 +402,10 @@ func wrapBadgerErr(err error) error {
 		return nil
 	}
 	if err == badger.ErrDiscardedTxn {
-		return errClosed{}
+		return &errClosed{}
 	}
 	if err == badger.ErrKeyNotFound {
-		return errNotFound{}
+		return &errNotFound{}
 	}
 	return err
 }

--- a/lib/db/backend/leveldb_backend.go
+++ b/lib/db/backend/leveldb_backend.go
@@ -207,14 +207,11 @@ func (it *leveldbIterator) Error() error {
 
 // wrapLeveldbErr wraps errors so that the backend package can recognize them
 func wrapLeveldbErr(err error) error {
-	if err == nil {
-		return nil
-	}
 	if err == leveldb.ErrClosed {
-		return errClosed{}
+		return &errClosed{}
 	}
 	if err == leveldb.ErrNotFound {
-		return errNotFound{}
+		return &errNotFound{}
 	}
 	return err
 }

--- a/lib/db/backend/leveldb_open.go
+++ b/lib/db/backend/leveldb_open.go
@@ -149,12 +149,12 @@ func open(location string, opts *opt.Options) (*leveldb.DB, error) {
 		// the database and reindexing...
 		l.Infoln("Database corruption detected, unable to recover. Reinitializing...")
 		if err := os.RemoveAll(location); err != nil {
-			return nil, errorSuggestion{err, "failed to delete corrupted database"}
+			return nil, &errorSuggestion{err, "failed to delete corrupted database"}
 		}
 		db, err = leveldb.OpenFile(location, opts)
 	}
 	if err != nil {
-		return nil, errorSuggestion{err, "is another instance of Syncthing running?"}
+		return nil, &errorSuggestion{err, "is another instance of Syncthing running?"}
 	}
 
 	if debugEnvValue("CompactEverything", 0) != 0 {
@@ -227,6 +227,6 @@ type errorSuggestion struct {
 	suggestion string
 }
 
-func (e errorSuggestion) Error() string {
+func (e *errorSuggestion) Error() string {
 	return fmt.Sprintf("%s (%s)", e.inner.Error(), e.suggestion)
 }

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -477,7 +477,7 @@ func TestDowngrade(t *testing.T) {
 	// Pretend we just opened the DB and attempt to update it again
 	err := UpdateSchema(db)
 
-	if err, ok := err.(databaseDowngradeError); !ok {
+	if err, ok := err.(*databaseDowngradeError); !ok {
 		t.Fatal("Expected error due to database downgrade, got", err)
 	} else if err.minSyncthingVersion != dbMinSyncthingVersion {
 		t.Fatalf("Error has %v as min Syncthing version, expected %v", err.minSyncthingVersion, dbMinSyncthingVersion)

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -38,7 +38,7 @@ type databaseDowngradeError struct {
 	minSyncthingVersion string
 }
 
-func (e databaseDowngradeError) Error() string {
+func (e *databaseDowngradeError) Error() string {
 	if e.minSyncthingVersion == "" {
 		return "newer Syncthing required"
 	}
@@ -67,7 +67,7 @@ func (db *schemaUpdater) updateSchema() error {
 	}
 
 	if prevVersion > dbVersion {
-		err := databaseDowngradeError{}
+		err := &databaseDowngradeError{}
 		if minSyncthingVersion, ok, dbErr := miscDB.String("dbMinSyncthingVersion"); dbErr != nil {
 			return dbErr
 		} else if ok {

--- a/lib/osutil/traversessymlink.go
+++ b/lib/osutil/traversessymlink.go
@@ -19,7 +19,7 @@ type TraversesSymlinkError struct {
 	path string
 }
 
-func (e TraversesSymlinkError) Error() string {
+func (e *TraversesSymlinkError) Error() string {
 	return fmt.Sprintf("traverses symlink: %s", e.path)
 }
 
@@ -28,7 +28,7 @@ type NotADirectoryError struct {
 	path string
 }
 
-func (e NotADirectoryError) Error() string {
+func (e *NotADirectoryError) Error() string {
 	return fmt.Sprintf("not a directory: %s", e.path)
 }
 

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -201,7 +201,7 @@ func (c *staticClient) join() error {
 	switch msg := message.(type) {
 	case protocol.Response:
 		if msg.Code != 0 {
-			return incorrectResponseCodeErr{msg.Code, msg.Message}
+			return &incorrectResponseCodeErr{msg.Code, msg.Message}
 		}
 
 	case protocol.RelayFull:

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -79,7 +79,7 @@ type UnsupportedDeviceTypeError struct {
 	deviceType string
 }
 
-func (e UnsupportedDeviceTypeError) Error() string {
+func (e *UnsupportedDeviceTypeError) Error() string {
 	return fmt.Sprintf("Unsupported UPnP device of type %s", e.deviceType)
 }
 


### PR DESCRIPTION
This matches the convention of the stdlib ([json.MarshalerError](https://godoc.org/encoding/json#MarshalerError), [net.AddrError](https://godoc.org/net#AddrError), [os.PathError](https://godoc.org/os#PathError)) and avoids ambiguity: when customErr{} and &customErr{} both implement error, client code needs to check for both. The current lib/db/backend.{IsClosed,IsNotFound} do exactly that.

Memory use should remain the same, since storing a non-pointer type in an interface value still copies the value to the heap:

```
// foo.go
package foo

type customErr struct{}

func (customErr) Error() string { return "" }

func Foo() error { return customErr{} }
```

```
$ go build -gcflags=-m foo.go
# command-line-arguments
./foo.go:6:6: can inline customErr.Error
./foo.go:8:6: can inline Foo
./foo.go:8:36: customErr literal escapes to heap
<autogenerated>:1: inlining call to customErr.Error
<autogenerated>:1: .this does not escape
<autogenerated>:1: leaking param: .this
```