### PR TITLE
cmd/strelaysrv: Fix JSON unmarshalling when joining a relay pool (fixes #6733)

### DIFF
--- a/cmd/strelaysrv/pool.go
+++ b/cmd/strelaysrv/pool.go
@@ -51,7 +51,7 @@ func poolHandler(pool string, uri *url.URL, mapping mapping) {
 			var x struct {
 				EvictionIn time.Duration `json:"evictionIn"`
 			}
-			if err := json.NewDecoder(resp.Body).Decode(&x); err == nil {
+			if err := json.Unmarshal(bs, &x); err == nil {
 				rejoin := x.EvictionIn - (x.EvictionIn / 5)
 				log.Printf("Joined pool %s, rejoining in %v", pool, rejoin)
 				time.Sleep(rejoin)


### PR DESCRIPTION
### Purpose

Fixes #6733

When joining a relay pool, the relay server always prints this line to logs:
`Joined pool https://relays.syncthing.net/endpoint, failed to deserialize response: http2: response body closed`

It happens because the response body is already read and closed a few lines above the response is being tried to deserialize. The PR fixes the deserialization of the response to print a proper log message and use a proper rejoin time

### Testing

Run the relay server, observe a proper joining message in logs:
`Joined pool https://relays.syncthing.net/endpoint, rejoining in 48m0s`

### Screenshots

Nothing here

### Documentation

Nothing here

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.
