### PR TITLE
lib/scanner, lib/model: Improve error handling when scanning

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -394,8 +394,12 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 
 	f.setState(FolderScanning)
 
+	// If we return early e.g. due to a folder health error, the scan needs
+	// to be cancelled.
+	scanCtx, scanCancel := context.WithCancel(f.ctx)
+	defer scanCancel()
 	mtimefs := f.fset.MtimeFS()
-	fchan := scanner.Walk(f.ctx, scanner.Config{
+	fchan := scanner.Walk(scanCtx, scanner.Config{
 		Folder:                f.ID,
 		Subs:                  subDirs,
 		Matcher:               f.ignores,
@@ -885,6 +889,7 @@ func (f *folder) String() string {
 
 func (f *folder) newScanError(path string, err error) {
 	f.scanErrorsMut.Lock()
+	l.Infof("Scanner (folder %s, item %q): %v", f.Description(), path, err)
 	f.scanErrors = append(f.scanErrors, FileError{
 		Err:  err.Error(),
 		Path: path,

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -531,7 +531,6 @@ func (w *walker) handleError(ctx context.Context, context, path string, err erro
 	if fs.IsNotExist(err) {
 		return
 	}
-	l.Infof("Scanner (folder %s, item %q): %s: %v", w.Folder, path, context, err)
 	select {
 	case finishedChan <- ScanResult{
 		Err:  fmt.Errorf("%s: %w", context, err),


### PR DESCRIPTION
Two small improvements around scanning:

When we encounter a folder error while scanning, we return early without telling the scanner about that. Now there's a derived context passed to the scanner, that is defer-cancelled.

Currently we log scan errors on the scanner side, but also pass the error on to the model, which takes further action on the error. The logging is now done by the model.