### PR TITLE
lib: Walk fs and db simultaneously on scan

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -187,6 +187,13 @@ func (s *Snapshot) WithPrefixedHaveTruncated(device protocol.DeviceID, prefix st
 	}
 }
 
+func (s *Snapshot) WithPrefixedHave(device protocol.DeviceID, prefix string, fn Iterator) {
+	l.Debugf("%s WithPrefixedHave(%v)", s.folder, device)
+	if err := s.t.withHave([]byte(s.folder), device[:], []byte(osutil.NormalizedFilename(prefix)), false, nativeFileIterator(fn)); err != nil && !backend.IsClosed(err) {
+		panic(err)
+	}
+}
+
 func (s *Snapshot) WithGlobal(fn Iterator) {
 	l.Debugf("%s WithGlobal()", s.folder)
 	if err := s.t.withGlobal([]byte(s.folder), nil, false, nativeFileIterator(fn)); err != nil && !backend.IsClosed(err) {

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -163,8 +163,14 @@ var SkipDir = filepath.SkipDir
 // IsExist is the equivalent of os.IsExist
 var IsExist = os.IsExist
 
+// IsExist is the equivalent of os.ErrExist
+var ErrExist = os.ErrExist
+
 // IsNotExist is the equivalent of os.IsNotExist
 var IsNotExist = os.IsNotExist
+
+// IsNotExist is the equivalent of os.ErrNotExist
+var ErrNotExist = os.ErrNotExist
 
 // IsPermission is the equivalent of os.IsPermission
 var IsPermission = os.IsPermission

--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -12,6 +12,7 @@ package fs
 
 import (
 	"path/filepath"
+	"sort"
 )
 
 type ancestorDirList struct {
@@ -98,6 +99,7 @@ func (f *walkFilesystem) walk(path string, info FileInfo, walkFn WalkFunc, ances
 	if err != nil {
 		return walkFn(path, info, err)
 	}
+	sort.Strings(names)
 
 	for _, name := range names {
 		filename := filepath.Join(path, name)

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -404,7 +405,8 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 		Subs:                  subDirs,
 		Matcher:               f.ignores,
 		TempLifetime:          time.Duration(f.model.cfg.Options().KeepTemporariesH) * time.Hour,
-		CurrentFiler:          cFiler{snap},
+		Have:                  haveWalker{snap},
+		Global:                globaler{snap},
 		Filesystem:            mtimefs,
 		IgnorePerms:           f.IgnorePerms,
 		AutoNormalize:         f.AutoNormalize,
@@ -460,6 +462,7 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 
 	f.clearScanErrors(subDirs)
 	alreadyUsed := make(map[string]struct{})
+	var delDirStack []protocol.FileInfo
 	for res := range fchan {
 		if res.Err != nil {
 			f.newScanError(res.Path, res.Err)
@@ -470,154 +473,48 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 			return err
 		}
 
-		batch.append(res.File)
+		// Append deleted dirs from stack if the current file isn't a child,
+		// which means all children were already processed.
+		for len(delDirStack) != 0 && !strings.HasPrefix(res.New.Name, delDirStack[len(delDirStack)-1].Name+string(fs.PathSeparator)) {
+			lastDelDir := delDirStack[len(delDirStack)-1]
+			batch.append(lastDelDir)
+			changes++
+			if nf, ok := f.findRename(snap, mtimefs, res.New, alreadyUsed); ok {
+				batch.append(nf)
+				changes++
+			}
+			if err := batch.flushIfFull(); err != nil {
+				return err
+			}
+			delDirStack = delDirStack[:len(delDirStack)-1]
+		}
+
+		// Delay appending deleted dirs until all its children are processed
+		if res.Old.IsDirectory() && (res.New.Deleted || !res.New.IsDirectory()) {
+			delDirStack = append(delDirStack, res.New)
+			continue
+		}
+
+		batch.append(res.New)
 		changes++
 
-		if f.localFlags&protocol.FlagLocalReceiveOnly == 0 {
-			if nf, ok := f.findRename(snap, mtimefs, res.File, alreadyUsed); ok {
-				batch.append(nf)
-				changes++
-			}
-		}
-	}
-
-	if err := batch.flush(); err != nil {
-		return err
-	}
-
-	if len(subDirs) == 0 {
-		// If we have no specific subdirectories to traverse, set it to one
-		// empty prefix so we traverse the entire folder contents once.
-		subDirs = []string{""}
-	}
-
-	// Do a scan of the database for each prefix, to check for deleted and
-	// ignored files.
-	var toIgnore []db.FileInfoTruncated
-	ignoredParent := ""
-
-	snap.Release()
-	snap = f.fset.Snapshot()
-	defer snap.Release()
-
-	for _, sub := range subDirs {
-		var iterError error
-
-		snap.WithPrefixedHaveTruncated(protocol.LocalDeviceID, sub, func(fi protocol.FileIntf) bool {
-			select {
-			case <-f.ctx.Done():
-				return false
-			default:
-			}
-
-			file := fi.(db.FileInfoTruncated)
-
-			if err := batch.flushIfFull(); err != nil {
-				iterError = err
-				return false
-			}
-
-			if ignoredParent != "" && !fs.IsParent(file.Name, ignoredParent) {
-				for _, file := range toIgnore {
-					l.Debugln("marking file as ignored", file)
-					nf := file.ConvertToIgnoredFileInfo(f.shortID)
-					batch.append(nf)
-					changes++
-					if err := batch.flushIfFull(); err != nil {
-						iterError = err
-						return false
-					}
-				}
-				toIgnore = toIgnore[:0]
-				ignoredParent = ""
-			}
-
-			switch ignored := f.ignores.Match(file.Name).IsIgnored(); {
-			case !file.IsIgnored() && ignored:
-				// File was not ignored at last pass but has been ignored.
-				if file.IsDirectory() {
-					// Delay ignoring as a child might be unignored.
-					toIgnore = append(toIgnore, file)
-					if ignoredParent == "" {
-						// If the parent wasn't ignored already, set
-						// this path as the "highest" ignored parent
-						ignoredParent = file.Name
-					}
-					return true
-				}
-
-				l.Debugln("marking file as ignored", file)
-				nf := file.ConvertToIgnoredFileInfo(f.shortID)
-				batch.append(nf)
-				changes++
-
-			case file.IsIgnored() && !ignored:
-				// Successfully scanned items are already un-ignored during
-				// the scan, so check whether it is deleted.
-				fallthrough
-			case !file.IsIgnored() && !file.IsDeleted() && !file.IsUnsupported():
-				// The file is not ignored, deleted or unsupported. Lets check if
-				// it's still here. Simply stat:ing it wont do as there are
-				// tons of corner cases (e.g. parent dir->symlink, missing
-				// permissions)
-				if !osutil.IsDeleted(mtimefs, file.Name) {
-					if ignoredParent != "" {
-						// Don't ignore parents of this not ignored item
-						toIgnore = toIgnore[:0]
-						ignoredParent = ""
-					}
-					return true
-				}
-				nf := file.ConvertToDeletedFileInfo(f.shortID)
-				nf.LocalFlags = f.localFlags
-				if file.ShouldConflict() {
-					// We do not want to override the global version with
-					// the deleted file. Setting to an empty version makes
-					// sure the file gets in sync on the following pull.
-					nf.Version = protocol.Vector{}
-				}
-
-				batch.append(nf)
-				changes++
-			}
-
-			// Check for deleted, locally changed items that noone else has.
-			if f.localFlags&protocol.FlagLocalReceiveOnly == 0 {
-				return true
-			}
-			if !fi.IsDeleted() || !fi.IsReceiveOnlyChanged() || len(snap.Availability(fi.FileName())) > 0 {
-				return true
-			}
-			nf := fi.(db.FileInfoTruncated).ConvertDeletedToFileInfo()
-			nf.LocalFlags = 0
-			nf.Version = protocol.Vector{}
+		if nf, ok := f.findRename(snap, mtimefs, res.New, alreadyUsed); ok {
 			batch.append(nf)
 			changes++
-
-			return true
-		})
-
-		select {
-		case <-f.ctx.Done():
-			return f.ctx.Err()
-		default:
 		}
 
-		if iterError == nil && len(toIgnore) > 0 {
-			for _, file := range toIgnore {
-				l.Debugln("marking file as ignored", f)
-				nf := file.ConvertToIgnoredFileInfo(f.shortID)
-				batch.append(nf)
-				changes++
-				if iterError = batch.flushIfFull(); iterError != nil {
-					break
-				}
-			}
-			toIgnore = toIgnore[:0]
-		}
+	}
 
-		if iterError != nil {
-			return iterError
+	// Append remaining deleted dirs.
+	for i := len(delDirStack) - 1; i >= 0; i-- {
+		if err := batch.flushIfFull(); err != nil {
+			return err
+		}
+		batch.append(delDirStack[i])
+		changes++
+		if nf, ok := f.findRename(snap, mtimefs, delDirStack[i], alreadyUsed); ok {
+			batch.append(nf)
+			changes++
 		}
 	}
 
@@ -632,6 +529,10 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 
 func (f *folder) findRename(snap *db.Snapshot, mtimefs fs.Filesystem, file protocol.FileInfo, alreadyUsed map[string]struct{}) (protocol.FileInfo, bool) {
 	if len(file.Blocks) == 0 || file.Size == 0 {
+		return protocol.FileInfo{}, false
+	}
+
+	if f.localFlags&protocol.FlagLocalReceiveOnly == 0 {
 		return protocol.FileInfo{}, false
 	}
 
@@ -1063,11 +964,28 @@ func unifySubs(dirs []string, exists func(dir string) bool) []string {
 	return dirs
 }
 
-type cFiler struct {
+// Implements scanner.TruncatedGlobaler
+type globaler struct {
 	*db.Snapshot
 }
 
 // Implements scanner.CurrentFiler
-func (cf cFiler) CurrentFile(file string) (protocol.FileInfo, bool) {
-	return cf.Get(protocol.LocalDeviceID, file)
+func (g globaler) GlobalTruncated(file string) (protocol.FileIntf, bool) {
+	return g.GetGlobalTruncated(file)
+}
+
+type haveWalker struct {
+	*db.Snapshot
+}
+
+func (h haveWalker) Walk(prefix string, ctx context.Context, out chan<- protocol.FileInfo) {
+	h.WithPrefixedHave(protocol.LocalDeviceID, prefix, func(fi protocol.FileIntf) bool {
+		f := fi.(protocol.FileInfo)
+		select {
+		case out <- f:
+		case <-ctx.Done():
+			return false
+		}
+		return true
+	})
 }

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -394,8 +394,12 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 
 	f.setState(FolderScanning)
 
+	// If we return early e.g. due to a folder health error, the scan needs
+	// to be cancelled.
+	scanCtx, scanCancel := context.WithCancel(f.ctx)
+	defer scanCancel()
 	mtimefs := f.fset.MtimeFS()
-	fchan := scanner.Walk(f.ctx, scanner.Config{
+	fchan := scanner.Walk(scanCtx, scanner.Config{
 		Folder:                f.ID,
 		Subs:                  subDirs,
 		Matcher:               f.ignores,
@@ -885,6 +889,7 @@ func (f *folder) String() string {
 
 func (f *folder) newScanError(path string, err error) {
 	f.scanErrorsMut.Lock()
+	l.Infof("Scanner (folder %s, item %q): %v", f.Description(), path, err)
 	f.scanErrors = append(f.scanErrors, FileError{
 		Err:  err.Error(),
 		Path: path,

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -334,6 +334,18 @@ func (f *FileInfo) setNoContent() {
 	f.Size = 0
 }
 
+func (f *FileInfo) IgnoredCopy(invalidatedBy ShortID) FileInfo {
+	copy := *f
+	copy.SetIgnored(invalidatedBy)
+	return copy
+}
+
+func (f *FileInfo) DeletedCopy(deletedBy ShortID) FileInfo {
+	copy := *f
+	copy.SetDeleted(deletedBy)
+	return copy
+}
+
 func (b BlockInfo) String() string {
 	return fmt.Sprintf("Block{%d/%d/%d/%x}", b.Offset, b.Size, b.WeakHash, b.Hash)
 }

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -923,3 +923,30 @@ func TestIndexIDString(t *testing.T) {
 		t.Error(i.String())
 	}
 }
+
+func TestCopyFileInfo(t *testing.T) {
+	f := FileInfo{
+		Name:        "aName",
+		Type:        FileInfoTypeFile,
+		Size:        1234,
+		Permissions: 0666,
+		ModifiedS:   time.Now().Unix(),
+		Version:     Vector{Counters: []Counter{{ID: 1 << 60, Value: 1}, {ID: 2 << 60, Value: 1}}},
+	}
+
+	del := f.DeletedCopy(LocalDeviceID.Short())
+	if f.Deleted {
+		t.Errorf("Source file info was deleted on copy")
+	}
+	if !del.Deleted {
+		t.Errorf("Returned file info was not deleted on copy")
+	}
+
+	inv := f.IgnoredCopy(LocalDeviceID.Short())
+	if f.IsIgnored() {
+		t.Errorf("Source file info was invalid on copy")
+	}
+	if !inv.IsIgnored() {
+		t.Errorf("Returned file info was not invalid on copy")
+	}
+}

--- a/lib/scanner/blockqueue.go
+++ b/lib/scanner/blockqueue.go
@@ -65,13 +65,13 @@ type parallelHasher struct {
 	fs      fs.Filesystem
 	workers int
 	outbox  chan<- ScanResult
-	inbox   <-chan protocol.FileInfo
+	inbox   <-chan ScanResult
 	counter Counter
 	done    chan<- struct{}
 	wg      sync.WaitGroup
 }
 
-func newParallelHasher(ctx context.Context, fs fs.Filesystem, workers int, outbox chan<- ScanResult, inbox <-chan protocol.FileInfo, counter Counter, done chan<- struct{}) {
+func newParallelHasher(ctx context.Context, fs fs.Filesystem, workers int, outbox chan<- ScanResult, inbox <-chan ScanResult, counter Counter, done chan<- struct{}) {
 	ph := &parallelHasher{
 		fs:      fs,
 		workers: workers,
@@ -100,30 +100,30 @@ func (ph *parallelHasher) hashFiles(ctx context.Context) {
 				return
 			}
 
-			if f.IsDirectory() || f.IsDeleted() {
+			if f.New.IsDirectory() || f.New.IsDeleted() {
 				panic("Bug. Asked to hash a directory or a deleted file.")
 			}
 
-			blocks, err := HashFile(ctx, ph.fs, f.Name, f.BlockSize(), ph.counter, true)
+			blocks, err := HashFile(ctx, ph.fs, f.New.Name, f.New.BlockSize(), ph.counter, true)
 			if err != nil {
-				l.Debugln("hash error:", f.Name, err)
+				l.Debugln("hash error:", f.New.Name, err)
 				continue
 			}
 
-			f.Blocks = blocks
-			f.BlocksHash = protocol.BlocksHash(blocks)
+			f.New.Blocks = blocks
+			f.New.BlocksHash = protocol.BlocksHash(blocks)
 
 			// The size we saw when initially deciding to hash the file
 			// might not have been the size it actually had when we hashed
 			// it. Update the size from the block list.
 
-			f.Size = 0
+			f.New.Size = 0
 			for _, b := range blocks {
-				f.Size += int64(b.Size)
+				f.New.Size += int64(b.Size)
 			}
 
 			select {
-			case ph.outbox <- ScanResult{File: f}:
+			case ph.outbox <- f:
 			case <-ctx.Done():
 				return
 			}

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -531,7 +531,6 @@ func (w *walker) handleError(ctx context.Context, context, path string, err erro
 	if fs.IsNotExist(err) {
 		return
 	}
-	l.Infof("Scanner (folder %s, item %q): %s: %v", w.Folder, path, context, err)
 	select {
 	case finishedChan <- ScanResult{
 		Err:  fmt.Errorf("%s: %w", context, err),

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -35,8 +35,10 @@ type Config struct {
 	Matcher *ignore.Matcher
 	// Number of hours to keep temporary files for
 	TempLifetime time.Duration
-	// If CurrentFiler is not nil, it is queried for the current file before rescanning.
-	CurrentFiler CurrentFiler
+	// Walks over file infos as present in the db before the scan alphabetically.
+	Have HaveWalker
+	// Returns the currently global item truncated
+	Global TruncatedGlobaler
 	// The Filesystem provides an abstraction on top of the actual filesystem.
 	Filesystem fs.Filesystem
 	// If IgnorePerms is true, changes to permission bits will not be
@@ -61,22 +63,35 @@ type Config struct {
 	EventLogger events.Logger
 }
 
-type CurrentFiler interface {
-	// CurrentFile returns the file as seen at last scan.
-	CurrentFile(name string) (protocol.FileInfo, bool)
+type HaveWalker interface {
+	// Walk passes all local file infos from the db which start with prefix
+	// to out and aborts early if ctx is cancelled.
+	Walk(prefix string, ctx context.Context, out chan<- protocol.FileInfo)
+}
+
+type TruncatedGlobaler interface {
+	GlobalTruncated(name string) (protocol.FileIntf, bool)
+}
+
+type fsWalkResult struct {
+	path string
+	info fs.FileInfo
+	err  error
 }
 
 type ScanResult struct {
-	File protocol.FileInfo
-	Err  error
-	Path string // to be set in case Err != nil and File == nil
+	New    protocol.FileInfo
+	Old    protocol.FileInfo
+	HasOld bool
+	Err    error
+	Path   string // to be set in case Err != nil
 }
 
 func Walk(ctx context.Context, cfg Config) chan ScanResult {
 	w := walker{cfg}
 
-	if w.CurrentFiler == nil {
-		w.CurrentFiler = noCurrentFiler{}
+	if w.Have == nil {
+		w.Have = noHaveWalker{}
 	}
 	if w.Filesystem == nil {
 		panic("no filesystem specified")
@@ -101,28 +116,18 @@ type walker struct {
 // Walk returns the list of files found in the local folder by scanning the
 // file system. Files are blockwise hashed.
 func (w *walker) walk(ctx context.Context) chan ScanResult {
-	l.Debugln("Walk", w.Subs, w.Matcher)
+	l.Debugln(w, "Walk", w.Subs, w.Matcher)
 
-	toHashChan := make(chan protocol.FileInfo)
+	haveChan := make(chan protocol.FileInfo)
+	haveCtx, haveCancel := context.WithCancel(ctx)
+	go w.dbWalkerRoutine(haveCtx, haveChan)
+
+	fsChan := make(chan fsWalkResult)
+	go w.fsWalkerRoutine(ctx, fsChan, haveCancel)
+
+	toHashChan := make(chan ScanResult)
 	finishedChan := make(chan ScanResult)
-
-	// A routine which walks the filesystem tree, and sends files which have
-	// been modified to the counter routine.
-	go func() {
-		hashFiles := w.walkAndHashFiles(ctx, toHashChan, finishedChan)
-		if len(w.Subs) == 0 {
-			w.Filesystem.Walk(".", hashFiles)
-		} else {
-			for _, sub := range w.Subs {
-				if err := osutil.TraversesSymlink(w.Filesystem, filepath.Dir(sub)); err != nil {
-					l.Debugf("Skip walking %v as it is below a symlink", sub)
-					continue
-				}
-				w.Filesystem.Walk(sub, hashFiles)
-			}
-		}
-		close(toHashChan)
-	}()
+	go w.processWalkResults(ctx, fsChan, haveChan, toHashChan, finishedChan)
 
 	// We're not required to emit scan progress events, just kick off hashers,
 	// and feed inputs directly from the walker.
@@ -146,15 +151,15 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 	// Parallel hasher is stopped by this routine when we close the channel over
 	// which it receives the files we ask it to hash.
 	go func() {
-		var filesToHash []protocol.FileInfo
+		var filesToHash []ScanResult
 		var total int64 = 1
 
 		for file := range toHashChan {
 			filesToHash = append(filesToHash, file)
-			total += file.Size
+			total += file.New.Size
 		}
 
-		realToHashChan := make(chan protocol.FileInfo)
+		realToHashChan := make(chan ScanResult)
 		done := make(chan struct{})
 		progress := newByteCounter()
 
@@ -168,13 +173,13 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 			for {
 				select {
 				case <-done:
-					l.Debugln("Walk progress done", w.Folder, w.Subs, w.Matcher)
+					l.Debugln(w, "Walk progress done", w.Folder, w.Subs, w.Matcher)
 					ticker.Stop()
 					return
 				case <-ticker.C:
 					current := progress.Total()
 					rate := progress.Rate()
-					l.Debugf("Walk %s %s current progress %d/%d at %.01f MiB/s (%d%%)", w.Folder, w.Subs, current, total, rate/1024/1024, current*100/total)
+					l.Debugf("%s Walk %s s current progress %d/%d at %.01f MiB/s (%d%%)", w, w.Subs, current, total, rate/1024/1024, current*100/total)
 					w.EventLogger.Log(events.FolderScanProgress, map[string]interface{}{
 						"folder":  w.Folder,
 						"current": current,
@@ -190,7 +195,7 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 
 	loop:
 		for _, file := range filesToHash {
-			l.Debugln("real to hash:", file.Name)
+			l.Debugln(w, "real to hash:", file.New.Name)
 			select {
 			case realToHashChan <- file:
 			case <-ctx.Done():
@@ -203,17 +208,58 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 	return finishedChan
 }
 
-func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protocol.FileInfo, finishedChan chan<- ScanResult) fs.WalkFunc {
+// dbWalkerRoutine walks the db and sends back file infos to be compared to scan results.
+func (w *walker) dbWalkerRoutine(ctx context.Context, haveChan chan<- protocol.FileInfo) {
+	defer close(haveChan)
+
+	if len(w.Subs) == 0 {
+		w.Have.Walk("", ctx, haveChan)
+		return
+	}
+
+	for _, sub := range w.Subs {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if sub == "." {
+			sub = ""
+		}
+		w.Have.Walk(sub, ctx, haveChan)
+	}
+}
+
+// fsWalkerRoutine walks the filesystem tree and sends back file infos and potential
+// errors at paths that need to be processed.
+func (w *walker) fsWalkerRoutine(ctx context.Context, fsChan chan<- fsWalkResult, haveCancel context.CancelFunc) {
+	defer close(fsChan)
+
+	walkFn := w.createFSWalkFn(ctx, fsChan)
+	if len(w.Subs) == 0 {
+		if err := w.Filesystem.Walk(".", walkFn); err != nil {
+			haveCancel()
+		}
+		return
+	}
+
+	for _, sub := range w.Subs {
+		if err := osutil.TraversesSymlink(w.Filesystem, filepath.Dir(sub)); err != nil {
+			l.Debugf("%s Skip walking %v as it is below a symlink", w, sub)
+			continue
+		}
+		if err := w.Filesystem.Walk(sub, walkFn); err != nil {
+			haveCancel()
+			break
+		}
+	}
+}
+
+func (w *walker) createFSWalkFn(ctx context.Context, fsChan chan<- fsWalkResult) fs.WalkFunc {
 	now := time.Now()
 	ignoredParent := ""
 
 	return func(path string, info fs.FileInfo, err error) error {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
 		// Return value used when we are returning early and don't want to
 		// process the item. For directories, this means do-not-descend.
 		var skip error // nil
@@ -223,26 +269,26 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 		}
 
 		if !utf8.ValidString(path) {
-			w.handleError(ctx, "scan", path, errUTF8Invalid, finishedChan)
+			fsWalkError(ctx, fsChan, path, errUTF8Invalid)
 			return skip
 		}
 
 		if fs.IsTemporary(path) {
-			l.Debugln("temporary:", path, "err:", err)
+			l.Debugln(w, "temporary:", path, "err:", err)
 			if err == nil && info.IsRegular() && info.ModTime().Add(w.TempLifetime).Before(now) {
 				w.Filesystem.Remove(path)
-				l.Debugln("removing temporary:", path, info.ModTime())
+				l.Debugln(w, "removing temporary:", path, info.ModTime())
 			}
 			return nil
 		}
 
 		if fs.IsInternal(path) {
-			l.Debugln("ignored (internal):", path)
+			l.Debugln(w, "skip walking (internal):", path)
 			return skip
 		}
 
 		if w.Matcher.Match(path).IsIgnored() {
-			l.Debugln("ignored (patterns):", path)
+			l.Debugln(w, "ignored (patterns):", path)
 			// Only descend if matcher says so and the current file is not a symlink.
 			if err != nil || w.Matcher.SkipIgnoredDirs() || info.IsSymlink() {
 				return skip
@@ -255,7 +301,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 		}
 
 		if err != nil {
-			w.handleError(ctx, "scan", path, err, finishedChan)
+			fsWalkError(ctx, fsChan, path, err)
 			return skip
 		}
 
@@ -265,7 +311,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 
 		if ignoredParent == "" {
 			// parent isn't ignored, nothing special
-			return w.handleItem(ctx, path, info, toHashChan, finishedChan, skip)
+			return w.fsWalkSend(ctx, fsChan, path, info, skip)
 		}
 
 		// Part of current path below the ignored (potential) parent
@@ -274,7 +320,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 		// ignored path isn't actually a parent of the current path
 		if rel == path {
 			ignoredParent = ""
-			return w.handleItem(ctx, path, info, toHashChan, finishedChan, skip)
+			return w.fsWalkSend(ctx, fsChan, path, info, skip)
 		}
 
 		// The previously ignored parent directories of the current, not
@@ -286,10 +332,10 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 			info, err = w.Filesystem.Lstat(ignoredParent)
 			// An error here would be weird as we've already gotten to this point, but act on it nonetheless
 			if err != nil {
-				w.handleError(ctx, "scan", ignoredParent, err, finishedChan)
+				fsWalkError(ctx, fsChan, ignoredParent, err)
 				return skip
 			}
-			if err = w.handleItem(ctx, ignoredParent, info, toHashChan, finishedChan, skip); err != nil {
+			if err = w.fsWalkSend(ctx, fsChan, ignoredParent, info, skip); err != nil {
 				return err
 			}
 		}
@@ -299,38 +345,189 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 	}
 }
 
-func (w *walker) handleItem(ctx context.Context, path string, info fs.FileInfo, toHashChan chan<- protocol.FileInfo, finishedChan chan<- ScanResult, skip error) error {
+func (w *walker) fsWalkSend(ctx context.Context, fsChan chan<- fsWalkResult, path string, info fs.FileInfo, skip error) error {
 	oldPath := path
 	path, err := w.normalizePath(path, info)
 	if err != nil {
-		w.handleError(ctx, "normalizing path", oldPath, err, finishedChan)
+		err = fmt.Errorf("normalizing path: %w", err)
+		path = oldPath
+	}
+
+	select {
+	case fsChan <- fsWalkResult{
+		path: path,
+		info: info,
+		err:  err,
+	}:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	// under no circumstances shall we descend into a symlink
+	if info.IsSymlink() && info.IsDir() {
+		l.Debugln(w, "skip walking (symlinked directory):", path)
 		return skip
 	}
-
-	switch {
-	case info.IsSymlink():
-		if err := w.walkSymlink(ctx, path, info, finishedChan); err != nil {
-			return err
-		}
-		if info.IsDir() {
-			// under no circumstances shall we descend into a symlink
-			return fs.SkipDir
-		}
-		return nil
-
-	case info.IsDir():
-		err = w.walkDir(ctx, path, info, finishedChan)
-
-	case info.IsRegular():
-		err = w.walkRegular(ctx, path, info, toHashChan)
-	}
-
-	return err
+	return nil
 }
 
-func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileInfo, toHashChan chan<- protocol.FileInfo) error {
-	curFile, hasCurFile := w.CurrentFiler.CurrentFile(relPath)
+func fsWalkError(ctx context.Context, fsChan chan<- fsWalkResult, path string, err error) {
+	select {
+	case fsChan <- fsWalkResult{
+		path: path,
+		info: nil,
+		err:  fmt.Errorf("scan: %w", err),
+	}:
+	case <-ctx.Done():
+	}
+}
 
+func (w *walker) processWalkResults(ctx context.Context, fsChan <-chan fsWalkResult, haveChan <-chan protocol.FileInfo, toHashChan, finishedChan chan<- ScanResult) {
+	ctxChan := ctx.Done()
+	fsRes, fsChanOpen := <-fsChan
+	currDBFile, haveChanOpen := <-haveChan
+	for fsChanOpen {
+		if haveChanOpen {
+			// File infos below an error walking the filesystem tree
+			// may be marked as ignored but should not be deleted.
+			if fsRes.err != nil && (strings.HasPrefix(currDBFile.Name, fsRes.path+string(fs.PathSeparator)) || fsRes.path == ".") {
+				l.Debugln(w, "error in filesystem on parent of existing item", currDBFile.Name)
+				w.checkAndSetIgnored(currDBFile, finishedChan, ctxChan)
+				currDBFile, haveChanOpen = <-haveChan
+				continue
+			}
+			// Delete file infos that were not encountered when
+			// walking the filesystem tree, except on error (see
+			// above) or if they are ignored.
+			if currDBFile.Name < fsRes.path {
+				l.Debugln(w, "detected deleted", currDBFile.Name)
+				w.checkIgnoredAndDelete(currDBFile, finishedChan, ctxChan)
+				currDBFile, haveChanOpen = <-haveChan
+				continue
+			}
+		}
+
+		var oldFile protocol.FileInfo
+		var hasOldFile bool
+		if haveChanOpen && currDBFile.Name == fsRes.path {
+			oldFile = currDBFile
+			hasOldFile = true
+			currDBFile, haveChanOpen = <-haveChan
+		}
+
+		if fsRes.err != nil {
+			if errors.Is(fsRes.err, fs.ErrNotExist) && !oldFile.IsEmpty() && !oldFile.Deleted {
+				nf := oldFile.DeletedCopy(w.ShortID)
+				nf.LocalFlags = w.LocalFlags
+				select {
+				case finishedChan <- ScanResult{
+					New: nf,
+					Old: oldFile,
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			if !errors.Is(fsRes.err, fs.ErrNotExist) {
+				select {
+				case finishedChan <- ScanResult{
+					Err:  fsRes.err,
+					Path: fsRes.path,
+				}:
+				case <-ctx.Done():
+					return
+				}
+			}
+			fsRes, fsChanOpen = <-fsChan
+			continue
+		}
+
+		switch {
+		case fsRes.info.IsDir():
+			w.walkDir(ctx, fsRes.path, fsRes.info, oldFile, hasOldFile, finishedChan)
+
+		case fsRes.info.IsSymlink():
+			w.walkSymlink(ctx, fsRes.path, fsRes.info, oldFile, hasOldFile, finishedChan)
+
+		case fsRes.info.IsRegular():
+			w.walkRegular(ctx, fsRes.path, fsRes.info, oldFile, hasOldFile, toHashChan)
+		}
+
+		fsRes, fsChanOpen = <-fsChan
+	}
+
+	// Filesystem tree walking finished, if there is anything left in the
+	// db, mark it as deleted, except when it's ignored.
+	if haveChanOpen {
+		w.checkIgnoredAndDelete(currDBFile, finishedChan, ctxChan)
+		for currDBFile = range haveChan {
+			w.checkIgnoredAndDelete(currDBFile, finishedChan, ctxChan)
+		}
+	}
+
+	close(toHashChan)
+}
+
+func (w *walker) checkIgnoredAndDelete(f protocol.FileInfo, finishedChan chan<- ScanResult, done <-chan struct{}) {
+	if w.checkAndSetIgnored(f, finishedChan, done) {
+		return
+	}
+
+	// Check if global is deleted too and if yes, drop local flag.
+	if f.Deleted && f.IsReceiveOnlyChanged() {
+		if global, _ := w.Global.GlobalTruncated(f.Name); !global.IsDeleted() {
+			return
+		}
+		nf := f.DeletedCopy(w.ShortID) // Is already deleted, still want to copy
+		nf.Version = protocol.Vector{}
+		nf.LocalFlags = 0
+		select {
+		case finishedChan <- ScanResult{
+			New: nf,
+			Old: f,
+		}:
+		case <-done:
+		}
+		return
+	}
+
+	if f.Deleted || f.IsUnsupported() {
+		return
+	}
+
+	nf := f.DeletedCopy(w.ShortID)
+	nf.LocalFlags = w.LocalFlags
+	if f.ShouldConflict() {
+		nf.Version = protocol.Vector{}
+	}
+	select {
+	case finishedChan <- ScanResult{
+		New: nf,
+		Old: f,
+	}:
+	case <-done:
+	}
+}
+
+func (w *walker) checkAndSetIgnored(f protocol.FileInfo, finishedChan chan<- ScanResult, done <-chan struct{}) bool {
+	if !w.Matcher.Match(f.Name).IsIgnored() {
+		return false
+	}
+
+	if !f.IsIgnored() {
+		select {
+		case finishedChan <- ScanResult{
+			New: f.IgnoredCopy(w.ShortID),
+			Old: f,
+		}:
+		case <-done:
+		}
+	}
+
+	return true
+}
+
+func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileInfo, curFile protocol.FileInfo, hasCurFile bool, toHashChan chan<- ScanResult) {
 	blockSize := protocol.BlockSize(info.Size())
 
 	if hasCurFile {
@@ -354,7 +551,7 @@ func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileIn
 
 	if hasCurFile {
 		if curFile.IsEquivalentOptional(f, w.ModTimeWindow, w.IgnorePerms, true, w.LocalFlags) {
-			return nil
+			return
 		}
 		if curFile.ShouldConflict() {
 			// The old file was invalid for whatever reason and probably not
@@ -364,30 +561,29 @@ func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileIn
 			// conflict.
 			f.Version = f.Version.DropOthers(w.ShortID)
 		}
-		l.Debugln("rescan:", curFile, info.ModTime().Unix(), info.Mode()&fs.ModePerm)
+		l.Debugln(w, "rescan:", curFile, info.ModTime().Unix(), info.Mode()&fs.ModePerm)
 	}
 
-	l.Debugln("to hash:", relPath, f)
+	l.Debugln(w, "to hash:", relPath, f)
 
 	select {
-	case toHashChan <- f:
+	case toHashChan <- ScanResult{
+		New:    f,
+		Old:    curFile,
+		HasOld: hasCurFile,
+	}:
 	case <-ctx.Done():
-		return ctx.Err()
 	}
-
-	return nil
 }
 
-func (w *walker) walkDir(ctx context.Context, relPath string, info fs.FileInfo, finishedChan chan<- ScanResult) error {
-	curFile, hasCurFile := w.CurrentFiler.CurrentFile(relPath)
-
+func (w *walker) walkDir(ctx context.Context, relPath string, info fs.FileInfo, curFile protocol.FileInfo, hasCurFile bool, finishedChan chan<- ScanResult) {
 	f, _ := CreateFileInfo(info, relPath, nil)
 	f = w.updateFileInfo(f, curFile)
 	f.NoPermissions = w.IgnorePerms
 
 	if hasCurFile {
 		if curFile.IsEquivalentOptional(f, w.ModTimeWindow, w.IgnorePerms, true, w.LocalFlags) {
-			return nil
+			return
 		}
 		if curFile.ShouldConflict() {
 			// The old file was invalid for whatever reason and probably not
@@ -399,39 +595,45 @@ func (w *walker) walkDir(ctx context.Context, relPath string, info fs.FileInfo, 
 		}
 	}
 
-	l.Debugln("dir:", relPath, f)
+	l.Debugln(w, "dir:", relPath, f)
 
 	select {
-	case finishedChan <- ScanResult{File: f}:
+	case finishedChan <- ScanResult{
+		New:    f,
+		Old:    curFile,
+		HasOld: hasCurFile,
+	}:
 	case <-ctx.Done():
-		return ctx.Err()
 	}
-
-	return nil
 }
 
 // walkSymlink returns nil or an error, if the error is of the nature that
 // it should stop the entire walk.
-func (w *walker) walkSymlink(ctx context.Context, relPath string, info fs.FileInfo, finishedChan chan<- ScanResult) error {
+func (w *walker) walkSymlink(ctx context.Context, relPath string, info fs.FileInfo, curFile protocol.FileInfo, hasCurFile bool, finishedChan chan<- ScanResult) {
 	// Symlinks are not supported on Windows. We ignore instead of returning
 	// an error.
 	if runtime.GOOS == "windows" {
-		return nil
+		return
 	}
 
 	f, err := CreateFileInfo(info, relPath, w.Filesystem)
 	if err != nil {
-		w.handleError(ctx, "reading link:", relPath, err, finishedChan)
-		return nil
+		select {
+		case finishedChan <- ScanResult{
+			Err:  fmt.Errorf("reading link: %w", err),
+			Path: relPath,
+		}:
+		case <-ctx.Done():
+			return
+		}
+		return
 	}
-
-	curFile, hasCurFile := w.CurrentFiler.CurrentFile(relPath)
 
 	f = w.updateFileInfo(f, curFile)
 
 	if hasCurFile {
 		if curFile.IsEquivalentOptional(f, w.ModTimeWindow, w.IgnorePerms, true, w.LocalFlags) {
-			return nil
+			return
 		}
 		if curFile.ShouldConflict() {
 			// The old file was invalid for whatever reason and probably not
@@ -443,15 +645,16 @@ func (w *walker) walkSymlink(ctx context.Context, relPath string, info fs.FileIn
 		}
 	}
 
-	l.Debugln("symlink changedb:", relPath, f)
+	l.Debugln(w, "symlink changedb:", relPath, f)
 
 	select {
-	case finishedChan <- ScanResult{File: f}:
+	case finishedChan <- ScanResult{
+		New:    f,
+		Old:    curFile,
+		HasOld: hasCurFile,
+	}:
 	case <-ctx.Done():
-		return ctx.Err()
 	}
-
-	return nil
 }
 
 // normalizePath returns the normalized relative path (possibly after fixing
@@ -526,18 +729,8 @@ func (w *walker) updateFileInfo(file, curFile protocol.FileInfo) protocol.FileIn
 	return file
 }
 
-func (w *walker) handleError(ctx context.Context, context, path string, err error, finishedChan chan<- ScanResult) {
-	// Ignore missing items, as deletions are not handled by the scanner.
-	if fs.IsNotExist(err) {
-		return
-	}
-	select {
-	case finishedChan <- ScanResult{
-		Err:  fmt.Errorf("%s: %w", context, err),
-		Path: path,
-	}:
-	case <-ctx.Done():
-	}
+func (w *walker) String() string {
+	return fmt.Sprintf("walker/%s@%p", w.Folder, w)
 }
 
 // A byteCounter gets bytes added to it via Update() and then provides the
@@ -585,13 +778,9 @@ func (c *byteCounter) Close() {
 	close(c.stop)
 }
 
-// A no-op CurrentFiler
+type noHaveWalker struct{}
 
-type noCurrentFiler struct{}
-
-func (noCurrentFiler) CurrentFile(name string) (protocol.FileInfo, bool) {
-	return protocol.FileInfo{}, false
-}
+func (noHaveWalker) Walk(prefix string, ctx context.Context, out chan<- protocol.FileInfo) {}
 
 func CreateFileInfo(fi fs.FileInfo, name string, filesystem fs.Filesystem) (protocol.FileInfo, error) {
 	f := protocol.FileInfo{Name: name}


### PR DESCRIPTION
In the end I still want to do https://github.com/syncthing/syncthing/pull/6735, just a bit differently (shouldn't reason about and close PRs late at night xD ):   

This still walks the filesystem and db at the same time, however still does two passes. In the first detecting changes to items existing in the filesystem, and in the second detecting deletions (and deleted files being ignored). The difference is that due to walking the fs instead of stating this does correctly detect case renames on case-insensitive systems. And it's probably a bit more efficient as well, as it's now a single listdir call per directory instead of stating every single file and instead of individual db lookups for every item in the fs, it walks over keys in db.

The rename detection in the folder still relies on stating to detect deletions, i.e. will not work in case of case conflicts on case-insensitive systems. However that's just an optimisation that fails and will be solved once the "super-cow-stat" is in place.

The first commit is https://github.com/syncthing/syncthing/pull/6736, the latter two are just historical, no need to look at them separately.