### PR TITLE
lib/osutil: Use filepath.Join in tests

### DIFF
--- a/lib/osutil/osutil_test.go
+++ b/lib/osutil/osutil_test.go
@@ -26,25 +26,25 @@ func TestIsDeleted(t *testing.T) {
 	cases := []tc{
 		{"del", true},
 		{"del.file", false},
-		{"del/del", true},
+		{filepath.Join("del", "del"), true},
 		{"file", false},
 		{"linkToFile", false},
 		{"linkToDel", false},
 		{"linkToDir", false},
-		{"linkToDir/file", true},
-		{"file/behindFile", true},
+		{filepath.Join("linkToDir", "file"), true},
+		{filepath.Join("file", "behindFile"), true},
 		{"dir", false},
 		{"dir.file", false},
-		{"dir/file", false},
-		{"dir/del", true},
-		{"dir/del/del", true},
-		{"del/del/del", true},
+		{filepath.Join("dir", "file"), false},
+		{filepath.Join("dir", "del"), true},
+		{filepath.Join("dir", "del", "del"), true},
+		{filepath.Join("del", "del", "del"), true},
 	}
 
 	testFs := fs.NewFilesystem(fs.FilesystemTypeBasic, "testdata")
 
 	testFs.MkdirAll("dir", 0777)
-	for _, f := range []string{"file", "del.file", "dir.file", "dir/file"} {
+	for _, f := range []string{"file", "del.file", "dir.file", filepath.Join("dir", "file")} {
 		fd, err := testFs.Create(f)
 		if err != nil {
 			t.Fatal(err)
@@ -55,9 +55,9 @@ func TestIsDeleted(t *testing.T) {
 		// Can't create unreadable dir on windows
 		testFs.MkdirAll("inacc", 0777)
 		if err := testFs.Chmod("inacc", 0000); err == nil {
-			if _, err := testFs.Lstat("inacc/file"); fs.IsPermission(err) {
+			if _, err := testFs.Lstat(filepath.Join("inacc", "file")); fs.IsPermission(err) {
 				// May fail e.g. if tests are run as root -> just skip
-				cases = append(cases, tc{"inacc", false}, tc{"inacc/file", false})
+				cases = append(cases, tc{"inacc", false}, tc{filepath.Join("inacc", "file"), false})
 			}
 		}
 	}


### PR DESCRIPTION
Un-slashify test paths.