### PR TITLE
lib/model: Check dir before deletion when pulling

### DIFF
--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -163,8 +163,14 @@ var SkipDir = filepath.SkipDir
 // IsExist is the equivalent of os.IsExist
 var IsExist = os.IsExist
 
+// IsExist is the equivalent of os.ErrExist
+var ErrExist = os.ErrExist
+
 // IsNotExist is the equivalent of os.IsNotExist
 var IsNotExist = os.IsNotExist
+
+// ErrNotExist is the equivalent of os.ErrNotExist
+var ErrNotExist = os.ErrNotExist
 
 // IsPermission is the equivalent of os.IsPermission
 var IsPermission = os.IsPermission

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -674,6 +674,8 @@ func TestIssue3164(t *testing.T) {
 		Name: "issue3164",
 	}
 
+	must(t, f.scanSubdirs(nil))
+
 	matcher := ignore.New(ffs)
 	must(t, matcher.Parse(bytes.NewBufferString("(?d)oktodelete"), ""))
 	f.ignores = matcher
@@ -767,9 +769,10 @@ func TestDeleteIgnorePerms(t *testing.T) {
 	must(t, err)
 	ffs.Chmod(name, 0600)
 	scanChan := make(chan string)
+	dbUpdateChan := make(chan dbUpdateJob)
 	finished := make(chan struct{})
 	go func() {
-		err = f.checkToBeDeleted(fi, scanChan)
+		err = f.checkToBeDeleted(fi, fi, true, dbUpdateDeleteFile, dbUpdateChan, scanChan)
 		close(finished)
 	}()
 	select {


### PR DESCRIPTION
### Purpose

The main fix in this PR is that an unscanned directory was deleted when pulling a deletion for said path. That likely didn't cause much real-world problems, as it would later fail if there's any content in the directory. Nevertheless it's wrong.

Another discovered issue: `scanIfItemChanged` scheduled a scan for an empty string whenever there wasn't anything in the db yet, but something on disk. That's because if the the db fileinfo `cur` is empty, `cur.Name` is empty too naturally. Again, that "just" meant needless scanning, the outcome was still correct.

### Testing

One new unit test for deleting an unscanned directory (which also fails on the empty string to be scanned).

One existing unit test failed due to that change, thus needed a scan before the scenario to make sure the scenario in said test is represented in the db.