### PR TITLE
lib/config: Apply defaults to folders/devices on config load (ref #6748)

### DIFF
--- a/lib/config/deviceconfiguration.go
+++ b/lib/config/deviceconfiguration.go
@@ -7,6 +7,8 @@
 package config
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"sort"
 
 	"github.com/syncthing/syncthing/lib/protocol"
@@ -55,6 +57,20 @@ func (cfg DeviceConfiguration) Copy() DeviceConfiguration {
 	c.PendingFolders = make([]ObservedFolder, len(cfg.PendingFolders))
 	copy(c.PendingFolders, cfg.PendingFolders)
 	return c
+}
+
+func (cfg *DeviceConfiguration) UnmarshalJSON(data []byte) error {
+	util.SetDefaults(cfg)
+	type noCustomUnmarshal DeviceConfiguration
+	ptr := (*noCustomUnmarshal)(cfg)
+	return json.Unmarshal(data, ptr)
+}
+
+func (cfg *DeviceConfiguration) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	util.SetDefaults(cfg)
+	type noCustomUnmarshal DeviceConfiguration
+	ptr := (*noCustomUnmarshal)(cfg)
+	return d.DecodeElement(ptr, &start)
 }
 
 func (cfg *DeviceConfiguration) prepare(sharedFolders []string) {

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -7,6 +7,8 @@
 package config
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"runtime"
@@ -95,6 +97,20 @@ func (f FolderConfiguration) Copy() FolderConfiguration {
 	copy(c.Devices, f.Devices)
 	c.Versioning = f.Versioning.Copy()
 	return c
+}
+
+func (cfg *FolderConfiguration) UnmarshalJSON(data []byte) error {
+	util.SetDefaults(cfg)
+	type noCustomUnmarshal FolderConfiguration
+	ptr := (*noCustomUnmarshal)(cfg)
+	return json.Unmarshal(data, ptr)
+}
+
+func (cfg *FolderConfiguration) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	util.SetDefaults(cfg)
+	type noCustomUnmarshal FolderConfiguration
+	ptr := (*noCustomUnmarshal)(cfg)
+	return d.DecodeElement(ptr, &start)
 }
 
 func (f FolderConfiguration) Filesystem() fs.Filesystem {

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -7,10 +7,14 @@
 package config
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"net/url"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 type GUIConfiguration struct {
@@ -144,4 +148,18 @@ func (c GUIConfiguration) IsValidAPIKey(apiKey string) bool {
 
 func (c GUIConfiguration) Copy() GUIConfiguration {
 	return c
+}
+
+func (c *GUIConfiguration) UnmarshalJSON(data []byte) error {
+	util.SetDefaults(c)
+	type noCustomUnmarshal GUIConfiguration
+	ptr := (*noCustomUnmarshal)(c)
+	return json.Unmarshal(data, ptr)
+}
+
+func (c *GUIConfiguration) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	util.SetDefaults(c)
+	type noCustomUnmarshal GUIConfiguration
+	ptr := (*noCustomUnmarshal)(c)
+	return d.DecodeElement(ptr, &start)
 }

--- a/lib/config/ldapconfiguration.go
+++ b/lib/config/ldapconfiguration.go
@@ -6,6 +6,13 @@
 
 package config
 
+import (
+	"encoding/json"
+	"encoding/xml"
+
+	"github.com/syncthing/syncthing/lib/util"
+)
+
 type LDAPConfiguration struct {
 	Address            string        `xml:"address,omitempty" json:"address"`
 	BindDN             string        `xml:"bindDN,omitempty" json:"bindDN"`
@@ -17,4 +24,18 @@ type LDAPConfiguration struct {
 
 func (c LDAPConfiguration) Copy() LDAPConfiguration {
 	return c
+}
+
+func (c *LDAPConfiguration) UnmarshalJSON(data []byte) error {
+	util.SetDefaults(c)
+	type noCustomUnmarshal LDAPConfiguration
+	ptr := (*noCustomUnmarshal)(c)
+	return json.Unmarshal(data, ptr)
+}
+
+func (c *LDAPConfiguration) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	util.SetDefaults(c)
+	type noCustomUnmarshal LDAPConfiguration
+	ptr := (*noCustomUnmarshal)(c)
+	return d.DecodeElement(ptr, &start)
 }

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -7,6 +7,8 @@
 package config
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"runtime"
 
@@ -203,4 +205,18 @@ func (opts OptionsConfiguration) MaxConcurrentIncomingRequestKiB() int {
 
 func (opts OptionsConfiguration) ShouldAutoUpgrade() bool {
 	return opts.AutoUpgradeIntervalH > 0
+}
+
+func (opts *OptionsConfiguration) UnmarshalJSON(data []byte) error {
+	util.SetDefaults(opts)
+	type noCustomUnmarshal OptionsConfiguration
+	ptr := (*noCustomUnmarshal)(opts)
+	return json.Unmarshal(data, ptr)
+}
+
+func (opts *OptionsConfiguration) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	util.SetDefaults(opts)
+	type noCustomUnmarshal OptionsConfiguration
+	ptr := (*noCustomUnmarshal)(opts)
+	return d.DecodeElement(ptr, &start)
 }


### PR DESCRIPTION
This makes it so that `default:"..."` struct tags on devices and folders actually take effect during JSON/XML loading, like it does for general and GUI options.

This means we can add a field to a device/folder and have it take its default value on config load without writing a config migration. (I suspect we've missed this in the past because the current
behavior is unintuitive...)
