### PR TITLE
lib/db: Improve error message on meta inconsistency

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -811,7 +811,12 @@ func (db *Lowlevel) getMetaAndCheck(folder string) *metadataTracker {
 func (db *Lowlevel) loadMetadataTracker(folder string) *metadataTracker {
 	meta := newMetadataTracker()
 	if err := meta.fromDB(db, []byte(folder)); err != nil {
-		l.Infof("No stored folder metadata for %q; recalculating", folder)
+		if err == errMetaInconsistent {
+			l.Infof("Stored folder metadata for %q is inconsistent; recalculating", folder)
+		} else {
+			l.Infof("No stored folder metadata for %q; recalculating", folder)
+
+		}
 		return db.getMetaAndCheck(folder)
 	}
 


### PR DESCRIPTION
Not a functional change, just don't be actively confusing towards users:

> 2020-06-16 03:10:04 Stored folder metadata for "y9qce-uafde" is 442306h10m4.252789s old; recalculating
> 
> I don’t know if the ‘old’ time is a red herring, but I restarted this instance yesterday whilst looking at this issue; it certainly wasn’t 50 years ago…
