### PR TITLE
lib/rand: Various fixes

### DIFF
--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -367,7 +367,7 @@ func (i *IndexID) Unmarshal(bs []byte) error {
 }
 
 func NewIndexID() IndexID {
-	return IndexID(rand.Int64())
+	return IndexID(rand.Uint64())
 }
 
 func (f Folder) Description() string {

--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -45,9 +45,9 @@ func Int63() int64 {
 	return defaultSecureSource.Int63()
 }
 
-// Int64 returns a strongly random int64.
-func Int64() int64 {
-	return int64(defaultSecureSource.Uint64())
+// Uint64 returns a strongly random uint64.
+func Uint64() uint64 {
+	return defaultSecureSource.Uint64()
 }
 
 // Intn returns, as an int, a non-negative strongly random number in [0,n).

--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -21,17 +21,17 @@ var Reader = cryptoRand.Reader
 const randomCharset = "2345679abcdefghijkmnopqrstuvwxyzACDEFGHJKLMNPQRSTUVWXYZ"
 
 var (
-	// defaultSecureSource is a concurrency safe math/rand.Source with a
-	// cryptographically sound base.
+	// defaultSecureSource is a concurrency-safe, cryptographically secure
+	// math/rand.Source.
 	defaultSecureSource = newSecureSource()
 
 	// defaultSecureRand is a math/rand.Rand based on the secure source.
 	defaultSecureRand = mathRand.New(defaultSecureSource)
 )
 
-// String returns a strongly random string of characters (taken from
-// randomCharset) of the specified length. The returned string contains ~5.8
-// bits of entropy per character, due to the character set used.
+// String returns a cryptographically secure random string of characters
+// (taken from randomCharset) of the specified length. The returned string
+// contains ~5.8 bits of entropy per character, due to the character set used.
 func String(l int) string {
 	bs := make([]byte, l)
 	for i := range bs {
@@ -40,18 +40,18 @@ func String(l int) string {
 	return string(bs)
 }
 
-// Int63 returns a strongly random int63.
+// Int63 returns a cryptographically secure random int63.
 func Int63() int64 {
 	return defaultSecureSource.Int63()
 }
 
-// Uint64 returns a strongly random uint64.
+// Uint64 returns a cryptographically secure strongly random uint64.
 func Uint64() uint64 {
 	return defaultSecureSource.Uint64()
 }
 
-// Intn returns, as an int, a non-negative strongly random number in [0,n).
-// It panics if n <= 0.
+// Intn returns, as an int, a cryptographically secure non-negative
+// random number in [0,n). It panics if n <= 0.
 func Intn(n int) int {
 	return defaultSecureRand.Intn(n)
 }

--- a/lib/rand/random_test.go
+++ b/lib/rand/random_test.go
@@ -30,10 +30,10 @@ func TestRandomString(t *testing.T) {
 	}
 }
 
-func TestRandomInt64(t *testing.T) {
-	ints := make([]int64, 1000)
+func TestRandomUint64(t *testing.T) {
+	ints := make([]uint64, 1000)
 	for i := range ints {
-		ints[i] = Int64()
+		ints[i] = Uint64()
 		for j := range ints {
 			if i == j {
 				continue

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -102,7 +102,7 @@ func NewCertificate(certFile, keyFile, commonName string, lifetimeDays int) (tls
 	// NOTE: update checkExpiry() appropriately if you add or change attributes
 	// in here, especially DNSNames or IPAddresses.
 	template := x509.Certificate{
-		SerialNumber: new(big.Int).SetInt64(rand.Int63()),
+		SerialNumber: new(big.Int).SetUint64(rand.Uint64()),
 		Subject: pkix.Name{
 			CommonName: commonName,
 		},


### PR DESCRIPTION
Here's three patches to lib/rand and its use in Syncthing:

* The first removes a cast.
* The second adds one bit of randomness to TLS certificates' serial numbers. Since NewCertificate also generates a random key, this should not be crucial, but getting this extra bit doesn't hurt code complexity.
* The third clarifies the status of random functions wrt. cryptographic security. Strength of the RNG is too weak a property to rely on.