### PR TITLE
lib: Print nicely rounded durations

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -827,7 +827,7 @@ func (db *Lowlevel) loadMetadataTracker(folder string) *metadataTracker {
 	}
 
 	if age := time.Since(meta.Created()); age > db.recheckInterval {
-		l.Infof("Stored folder metadata for %q is %v old; recalculating", folder, age)
+		l.Infof("Stored folder metadata for %q is %v old; recalculating", folder, util.NiceDurationString(age))
 		return db.getMetaAndCheck(folder)
 	}
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -330,7 +330,7 @@ func (f *folder) pull() (success bool) {
 
 	// Pulling failed, try again later.
 	delay := f.pullPause + time.Since(startTime)
-	l.Infof("Folder %v isn't making sync progress - retrying in %v.", f.Description(), delay.Truncate(time.Second))
+	l.Infof("Folder %v isn't making sync progress - retrying in %v.", f.Description(), util.NiceDurationString(delay))
 	f.pullFailTimer.Reset(delay)
 	return false
 }

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -28,6 +28,7 @@ import (
 	"github.com/syncthing/syncthing/lib/scanner"
 	"github.com/syncthing/syncthing/lib/stats"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/util"
 	"github.com/syncthing/syncthing/lib/watchaggregator"
 
 	"github.com/thejerf/suture"

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -314,3 +314,19 @@ func CallWithContext(ctx context.Context, fn func() error) error {
 		return ctx.Err()
 	}
 }
+
+func NiceDurationString(d time.Duration) string {
+	switch {
+	case d > 24*time.Hour:
+		t = t.Round(time.Hour)
+	case d > time.Hour:
+		t = t.Round(time.Minute)
+	case d > time.Minute:
+		t = t.Round(time.Second)
+	case d > time.Second:
+		t = t.Round(time.Millisecond)
+	case d > time.Millisecond:
+		t = t.Round(time.Microsecond)
+	}
+	return t.String()
+}

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/syncthing/syncthing/lib/sync"
 
@@ -318,15 +319,15 @@ func CallWithContext(ctx context.Context, fn func() error) error {
 func NiceDurationString(d time.Duration) string {
 	switch {
 	case d > 24*time.Hour:
-		t = t.Round(time.Hour)
+		d = d.Round(time.Hour)
 	case d > time.Hour:
-		t = t.Round(time.Minute)
+		d = d.Round(time.Minute)
 	case d > time.Minute:
-		t = t.Round(time.Second)
+		d = d.Round(time.Second)
 	case d > time.Second:
-		t = t.Round(time.Millisecond)
+		d = d.Round(time.Millisecond)
 	case d > time.Millisecond:
-		t = t.Round(time.Microsecond)
+		d = d.Round(time.Microsecond)
 	}
-	return t.String()
+	return d.String()
 }


### PR DESCRIPTION
Forgot about @calmh's suggestion regarding rounding times in https://github.com/syncthing/syncthing/pull/6751, thus now in a followup. It's still not a particularly meaningful kind of rounding, but at least better than no rounding as in the default.