### PR TITLE
build: Change version strings to not have plus in them (ref #6758)

### DIFF
--- a/lib/build/build_test.go
+++ b/lib/build/build_test.go
@@ -27,7 +27,6 @@ func TestAllowedVersions(t *testing.T) {
 		{"v0.13.0-some-weird-but-allowed-tag", true},
 		{"v0.13.0-allowed.to.do.this", true},
 		{"v0.13.0+not.allowed.to.do.this", false},
-		{"v1.6.1.1-dev.80.gf9ac3f503-dirty", true},
 	}
 
 	for i, c := range testcases {

--- a/lib/build/build_test.go
+++ b/lib/build/build_test.go
@@ -27,6 +27,7 @@ func TestAllowedVersions(t *testing.T) {
 		{"v0.13.0-some-weird-but-allowed-tag", true},
 		{"v0.13.0-allowed.to.do.this", true},
 		{"v0.13.0+not.allowed.to.do.this", false},
+		{"v1.6.1.1-dev.80.gf9ac3f503-dirty", true},
 	}
 
 	for i, c := range testcases {


### PR DESCRIPTION
Currently a random dev version has a version string like this:

	v1.7.0-rc.1+22-g946170f3f

That is, the tag name followed by a plus sign and the git describe
metadata (number of commits and hash) plus -dirty or -branchname in some
cases.

We introduced the plus sign in #473, where a dev version would
previously be called v0.9.0-42-gwhatever which is considered older than
v0.9.0 and hence caused a downgrade. The problem with the plus is that
per semver everything after the plus is ignored as build metadata, which
means we won't upgrade from v1.7.0-rc.1 to v1.7.0-rc.1+22-g946170f3f.

With this change the we use dots instead, and a "0-dev" marker, making
dev versions greater than the tag they come from but lesser than any
future real version:

	v1.7.0-rc.1.0-dev.22.g946170f3f

Or, after a release version:

	v1.7.0.0-dev.22.g946170f3f

The leading zero is to maintain semver-ish compliance in this case, as
we can't add non-numeric things before the dash, and we can't add a dash
directly after the tag version as v1.7.0-anything is older than v1.7.0
while we want to be newer...

With this we can still take any given released version and either bump
the last number or tack on a ".1" to become newer than the dev versions
in between.
