### PR TITLE
lib/model: Don't stay scanning forever on fail

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -360,6 +360,7 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 	}()
 
 	f.setState(FolderScanWaiting)
+	defer f.setState(FolderIdle)
 
 	if err := f.ioLimiter.takeWithContext(f.ctx, 1); err != nil {
 		return err
@@ -626,7 +627,6 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 	}
 
 	f.ScanCompleted()
-	f.setState(FolderIdle)
 	return nil
 }
 


### PR DESCRIPTION
Just stumbled across this by accident: Folder stays in scanning state forever if scan fails (if it's the first scan, because then nothing ever happens, otherwise forever=next triggered action).