### PR TITLE
lib/model: Don't ignore stat failure in performFinish

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1540,6 +1540,8 @@ func (f *sendReceiveFolder) performFinish(file, curFile protocol.FileInfo, hasCu
 		if err != nil {
 			return err
 		}
+	} else if !fs.IsNotExist(err) {
+		return err
 	}
 
 	// Replace the original content with the new one. If it didn't work,


### PR DESCRIPTION
When stating in the last stage of the puller to compare what's on disk with what is in db we ignore an error from stat. Probably has no implications, as the ensuing operation will likely fail as well, nevertheless, it's wrong.