### PR TITLE
build: Pass -64 to goversioninfo on amd64

### DIFF
--- a/build.go
+++ b/build.go
@@ -684,7 +684,11 @@ func shouldBuildSyso(dir string) (string, error) {
 
 	sysoPath := filepath.Join(dir, "cmd", "syncthing", "resource.syso")
 
-	if _, err := runError("goversioninfo", "-o", sysoPath); err != nil {
+	args := []string{"-o", sysoPath}
+	if goarch == "amd64" {
+		args = append(args, "-64")
+	}
+	if _, err := runError("goversioninfo", args...); err != nil {
 		return "", errors.New("failed to create " + sysoPath + ": " + err.Error())
 	}
 


### PR DESCRIPTION
Trying to build syncthing on windows with mingw-w64 I got the following error:

```
 // c:\go\pkg\tool\windows_amd64\link.exe: running gcc failed: exit status 1
// C:/Program Files/mingw-w64/x86_64-8.1.0-posix-seh-rt_v6-rev0/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/8.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: i386 architecture of input file `C:\Users\2007p\AppData\Local\Temp\go-link-332898159\000000.o' is incompatible with i386:x86-64 output
// collect2.exe: error: ld returned 1 exit status
```

Passing `-w64` to `goversioninfo` fixed that. However I am not sure which arch setting is relevant here: The host system (probably not), the c++ compiler binary or go target architecture. I would expect the latter (and proposed the change like that), however CI right now is building both 32 and 64 bit binaries for windows and it works, without the `-64` flag.