### PR TITLE
lib/api, lib/model: Fixes around event request tracking

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1202,7 +1202,6 @@ func (s *service) postDBIgnores(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *service) getIndexEvents(w http.ResponseWriter, r *http.Request) {
-	s.fss.OnEventRequest()
 	mask := s.getEventMask(r.URL.Query().Get("events"))
 	sub := s.getEventSub(mask)
 	s.getEvents(w, r, sub)
@@ -1214,6 +1213,8 @@ func (s *service) getDiskEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *service) getEvents(w http.ResponseWriter, r *http.Request, eventSub events.BufferedSubscription) {
+	s.fss.OnEventRequest()
+
 	qs := r.URL.Query()
 	sinceStr := qs.Get("since")
 	limitStr := qs.Get("limit")

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1213,7 +1213,7 @@ func (s *service) getDiskEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *service) getEvents(w http.ResponseWriter, r *http.Request, eventSub events.BufferedSubscription) {
-	if eventSub.Mask()&events.FolderSummary != 0 {
+	if eventSub.Mask()&(events.FolderSummary|events.FolderCompletion) != 0 {
 		s.fss.OnEventRequest()
 	}
 

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1213,7 +1213,9 @@ func (s *service) getDiskEvents(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *service) getEvents(w http.ResponseWriter, r *http.Request, eventSub events.BufferedSubscription) {
-	s.fss.OnEventRequest()
+	if eventSub.Mask()&events.FolderSummary != 0 {
+		s.fss.OnEventRequest()
+	}
 
 	qs := r.URL.Query()
 	sinceStr := qs.Get("since")

--- a/lib/api/mocked_events_test.go
+++ b/lib/api/mocked_events_test.go
@@ -17,3 +17,5 @@ type mockedEventSub struct{}
 func (s *mockedEventSub) Since(id int, into []events.Event, timeout time.Duration) []events.Event {
 	select {}
 }
+
+func (s *mockedEventSub) Mask() events.EventType { return 0 }

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -22,7 +22,7 @@ import (
 	"github.com/syncthing/syncthing/lib/util"
 )
 
-const maxDurSinceLastEventReq = time.Minute
+const maxDurationSinceLastEventReq = time.Minute
 
 type FolderSummaryService interface {
 	suture.Service
@@ -303,7 +303,7 @@ func (c *folderSummaryService) foldersToHandle() []string {
 	c.lastEventReqMut.Lock()
 	last := c.lastEventReq
 	c.lastEventReqMut.Unlock()
-	if time.Since(last) > maxDurSinceLastEventReq {
+	if time.Since(last) > maxDurationSinceLastEventReq {
 		return nil
 	}
 

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -22,7 +22,7 @@ import (
 	"github.com/syncthing/syncthing/lib/util"
 )
 
-const minSummaryInterval = time.Minute
+const maxDurSinceLastEventReq = time.Minute
 
 type FolderSummaryService interface {
 	suture.Service
@@ -303,7 +303,7 @@ func (c *folderSummaryService) foldersToHandle() []string {
 	c.lastEventReqMut.Lock()
 	last := c.lastEventReq
 	c.lastEventReqMut.Unlock()
-	if time.Since(last) > minSummaryInterval {
+	if time.Since(last) > maxDurSinceLastEventReq {
 		return nil
 	}
 


### PR DESCRIPTION
Two small things:

1. When refactoring the api I clearly didn't grok the function of the "minute-variable" in the folder summary service. Luckily I only changed the name but not semantics, so nothing broke but the name was completely off.

2. We don't register all calls to the event endpoint, e.g. not those to the `event/disk` endpoint. I don't see why we'd do that, thus I moved the `OnEventSub` call to the generic `getEvents` function.