### PR TITLE
lib/scanner: Fix Validate docs

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -108,9 +108,9 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 	return blocks, nil
 }
 
-// Validate quickly validates buf against the cryptohash hash (if len(hash)>0)
-// and the 32-bit hash weakHash (if not zero). It is satisfied if either hash
-// matches, or neither is given.
+// Validate quickly validates buf against the 32-bit weakHash, if not zero,
+// else against the cryptohash hash, if len(hash)>0.
+// It is satisfied if neither hash is given.
 func Validate(buf, hash []byte, weakHash uint32) bool {
 	if weakHash != 0 {
 		return adler32.Checksum(buf) == weakHash


### PR DESCRIPTION
As spotted by @crzbear in a comment on 9c0825c0d99e4b13d965f721a3592e8bdff45a97, the description of blocks.Validate is incorrect. If a weak hash is given, only that is checked.