### PR TITLE
lib/model: Remove double error handling in performFinish

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1518,8 +1518,6 @@ func (f *sendReceiveFolder) performFinish(file, curFile protocol.FileInfo, hasCu
 		// handle that.
 
 		if err := f.scanIfItemChanged(file.Name, stat, curFile, hasCurFile, scanChan); err != nil {
-			err = errors.Wrap(err, "handling file")
-			f.newPullError(file.Name, err)
 			return err
 		}
 


### PR DESCRIPTION
Just doesn't belong there, the the caller of `performFinish` already passes any returned error to `newPullError`.