### PR TITLE
lib/connections: Correctly fixup port in IPv6 listen URLs

### DIFF
--- a/lib/connections/connections_test.go
+++ b/lib/connections/connections_test.go
@@ -21,10 +21,21 @@ func TestFixupPort(t *testing.T) {
 		{"tcp://1.2.3.4:5", "tcp://1.2.3.4:5"},
 		{"tcp://1.2.3.4:", "tcp://1.2.3.4:22000"},
 		{"tcp://1.2.3.4", "tcp://1.2.3.4:22000"},
+		{"tcp://[fe80::1]", "tcp://[fe80::1]:22000"},
+		{"tcp://[fe80::1]:", "tcp://[fe80::1]:22000"},
+		{"tcp://[fe80::1]:22000", "tcp://[fe80::1]:22000"},
+		{"tcp://[fe80::1]:22000", "tcp://[fe80::1]:22000"},
+		{"tcp://[fe80::1%25abc]", "tcp://[fe80::1%25abc]:22000"},
+		{"tcp://[fe80::1%25abc]:", "tcp://[fe80::1%25abc]:22000"},
+		{"tcp://[fe80::1%25abc]:22000", "tcp://[fe80::1%25abc]:22000"},
+		{"tcp://[fe80::1%25abc]:22000", "tcp://[fe80::1%25abc]:22000"},
 	}
 
 	for _, tc := range cases {
-		u0, _ := url.Parse(tc[0])
+		u0, err := url.Parse(tc[0])
+		if err != nil {
+			t.Fatal(err)
+		}
 		u1 := fixupPort(u0, 22000).String()
 		if u1 != tc[1] {
 			t.Errorf("fixupPort(%q, 22000) => %q, expected %q", tc[0], u1, tc[1])

--- a/lib/connections/util.go
+++ b/lib/connections/util.go
@@ -18,10 +18,15 @@ func fixupPort(uri *url.URL, defaultPort int) *url.URL {
 
 	host, port, err := net.SplitHostPort(uri.Host)
 	if err != nil && strings.Contains(err.Error(), "missing port") {
-		// addr is on the form "1.2.3.4"
-		copyURI.Host = net.JoinHostPort(uri.Host, strconv.Itoa(defaultPort))
+		// addr is on the form "1.2.3.4" or "[fe80::1]"
+		host = uri.Host
+		if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+			// net.JoinHostPort will add the brackets again
+			host = host[1 : len(host)-1]
+		}
+		copyURI.Host = net.JoinHostPort(host, strconv.Itoa(defaultPort))
 	} else if err == nil && port == "" {
-		// addr is on the form "1.2.3.4:"
+		// addr is on the form "1.2.3.4:" or "[fe80::1]:"
 		copyURI.Host = net.JoinHostPort(host, strconv.Itoa(defaultPort))
 	}
 


### PR DESCRIPTION
Previously tcp://[fe80::1] would get "fixed" to tcp://[[fe80::1]]:22000
which is not great.
