### PR TITLE
lib/scanner: Test weak hash consistency (ref #5556)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1525,7 +1525,7 @@ func (m *model) Request(deviceID protocol.DeviceID, folder, name string, size in
 
 	if !scanner.Validate(res.data, hash, weakHash) {
 		m.recheckFile(deviceID, folder, name, offset, hash)
-		l.Debugf("%v REQ(in) failed validating data (%v): %s: %q / %q o=%d s=%d", m, err, deviceID, folder, name, offset, size)
+		l.Debugf("%v REQ(in) failed validating data: %s: %q / %q o=%d s=%d", m, deviceID, folder, name, offset, size)
 		return nil, protocol.ErrNoSuchFile
 	}
 


### PR DESCRIPTION
Relevant much earlier changes:
  9b1c592fb7e7ca86fec25545be742c13bdae25b9
  bd1c29ee323573bf66d01b9d2887e1e8cb70ab68

Make sure vanilla and rolling adler are consistent. And that they match
with scanner.Validate.

I just set up a new node and went down a little rabbit whole when I noticed tons of `no such file` sync errors and the remote doing tons of very short scans. I was worried the weak hashing is broken due to some mismatch between the standard and rolling implementation (see linked commits/PR), but it turned out this is "age-old data" (pre 2017) that was hashed with whatever we used before adler. All is good.

I added tests that ensure that both standard and rolling adler give the same results, as well as that `scanner.Validate` agrees with the hash too (which is somewhat redundant right now, but adds protection for future changes to `scanner.Validate`).

And then there's a minor log cleanup I discovered (err is always nil at that point).