### PR TITLE
lib/model: Consider weak hash on recheckFile

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3174,9 +3174,9 @@ func TestIssue5002(t *testing.T) {
 	}
 	blockSize := int32(file.BlockSize())
 
-	m.recheckFile(protocol.LocalDeviceID, "default", "foo", file.Size-int64(blockSize), []byte{1, 2, 3, 4})
-	m.recheckFile(protocol.LocalDeviceID, "default", "foo", file.Size, []byte{1, 2, 3, 4}) // panic
-	m.recheckFile(protocol.LocalDeviceID, "default", "foo", file.Size+int64(blockSize), []byte{1, 2, 3, 4})
+	m.recheckFile(protocol.LocalDeviceID, "default", "foo", file.Size-int64(blockSize), []byte{1, 2, 3, 4}, 0)
+	m.recheckFile(protocol.LocalDeviceID, "default", "foo", file.Size, []byte{1, 2, 3, 4}, 0) // panic
+	m.recheckFile(protocol.LocalDeviceID, "default", "foo", file.Size+int64(blockSize), []byte{1, 2, 3, 4}, 0)
 }
 
 func TestParentOfUnignored(t *testing.T) {


### PR DESCRIPTION
Still discovered an issue while "cleaning up" pre-adler weak hashes: I saw almost no progress and lots of hashing, leading to this pattern on the new/pulling side:

```
$ journalctl -u syncthing@simon.service | grep "Brittannia-1-NE.pdf"
[...]
Jun 25 14:51:53 simon-t450s-deb syncthing[28769]: [GQ5Y5] INFO: Puller (folder "Dokumente" (Dokumente), item "Bergsteiginfos/Kartenausschnitte/Brittannia-1-NE.pdf"): no connected device has the required version of this file
Jun 25 14:57:07 simon-t450s-deb syncthing[28769]: [GQ5Y5] INFO: Puller (folder "Dokumente" (Dokumente), item "Bergsteiginfos/Kartenausschnitte/Brittannia-1-NE.pdf"): pull: no such file
Jun 25 15:02:31 simon-t450s-deb syncthing[28769]: [GQ5Y5] INFO: Puller (folder "Dokumente" (Dokumente), item "Bergsteiginfos/Kartenausschnitte/Brittannia-1-NE.pdf"): no connected device has the required version of this file
Jun 25 15:05:47 simon-t450s-deb syncthing[28769]: [GQ5Y5] INFO: Puller (folder "Dokumente" (Dokumente), item "Bergsteiginfos/Kartenausschnitte/Brittannia-1-NE.pdf"): pull: no such file
[...]
```

What's happening is the file is rehashed on the sending side due to having a pre-adler weak hash. Then the first puller iteration is over, and it requests tries the file again, with the old (wrong) weak hash. Thus validation on the sending side fails, and because we don't consider the weak hash when invalidating the file for rehashing, it gets rehashed again. Rinse and repeat.