### PR TITLE
lib/model: Don't force rescan already changed items

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -953,9 +953,13 @@ func (f *folder) updateLocals(fs []protocol.FileInfo) {
 	f.fset.Update(protocol.LocalDeviceID, fs)
 
 	filenames := make([]string, len(fs))
+	f.forcedRescanPathsMut.Lock()
 	for i, file := range fs {
 		filenames[i] = file.Name
+		// No need to rescan a file that was changed since anyway.
+		delete(f.forcedRescanPaths, file.Name)
 	}
+	f.forcedRescanPathsMut.Unlock()
 
 	f.evLogger.Log(events.LocalIndexUpdated, map[string]interface{}{
 		"folder":    f.ID,
@@ -1005,6 +1009,9 @@ func (f *folder) handleForcedRescans() {
 	}
 	f.forcedRescanPaths = make(map[string]struct{})
 	f.forcedRescanPathsMut.Unlock()
+	if len(paths) == 0 {
+		return
+	}
 
 	batch := newFileInfoBatch(func(fs []protocol.FileInfo) error {
 		f.fset.Update(protocol.LocalDeviceID, fs)


### PR DESCRIPTION
If we are waiting (iolimiter) for scanning/pulling and during that time force rescan requests come in, they will persist even if during that scan/pull the very file that's scheduled to be rehashed gets rehashed already. 