### PR TITLE
lib/protocol: Include WeakHash in BlocksHash

### DIFF
--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -745,6 +745,11 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 		}
 	}
 
+	dbi.Release()
+	if err != dbi.Error() {
+		return err
+	}
+
 	return t.Commit()
 }
 

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -27,10 +27,9 @@ import (
 //   8-9: v1.4.0
 //   10-11: v1.6.0
 //   12-13: v1.7.0
-//   14: v1.8.0
 const (
-	dbVersion             = 14
-	dbMinSyncthingVersion = "v1.8.0"
+	dbVersion             = 13
+	dbMinSyncthingVersion = "v1.7.0"
 )
 
 var errFolderMissing = errors.New("folder present in global list but missing in keyer index")
@@ -96,7 +95,6 @@ func (db *schemaUpdater) updateSchema() error {
 		{10, db.updateSchemaTo10},
 		{11, db.updateSchemaTo11},
 		{13, db.updateSchemaTo13},
-		{14, db.updateSchemaTo14},
 	}
 
 	for _, m := range migrations {
@@ -679,84 +677,6 @@ func (db *schemaUpdater) updateSchemaTo13(prev int) error {
 	}
 
 	if err := db.rewriteGlobals(t); err != nil {
-		return err
-	}
-
-	return t.Commit()
-}
-
-func (db *schemaUpdater) updateSchemaTo14(_ int) error {
-	t, err := db.newReadWriteTransaction()
-	if err != nil {
-		return err
-	}
-	defer t.close()
-
-	dbi, err := t.NewPrefixIterator([]byte{KeyTypeDevice})
-	if err != nil {
-		return err
-	}
-	defer dbi.Release()
-
-	var key, folder, name []byte
-	var ok bool
-	for dbi.Next() {
-		fi, err := t.unmarshalTrunc(dbi.Value(), false)
-		if err != nil {
-			if backend.IsNotFound(err) {
-				if err = t.Delete(dbi.Key()); err != nil && !backend.IsNotFound(err) {
-					return err
-				}
-				continue
-			}
-			return err
-		}
-		f := fi.(protocol.FileInfo)
-		if len(f.Blocks) == 0 {
-			continue
-		}
-
-		newBlocksHash := protocol.BlocksHash(f.Blocks)
-		if bytes.Equal(newBlocksHash, f.BlocksHash) {
-			continue
-		}
-
-		// Remove old BlockList and BlockListMap
-		key = t.keyer.GenerateBlockListKey(key, f.BlocksHash)
-		if err = t.Delete(key); err != nil && !backend.IsNotFound(err) {
-			return err
-		}
-		folder, ok = t.keyer.FolderFromDeviceFileKey(dbi.Key())
-		if !ok {
-			if err = t.Delete(dbi.Key()); err != nil && !backend.IsNotFound(err) {
-				return err
-			}
-			continue
-		}
-		name = t.keyer.NameFromDeviceFileKey(dbi.Key())
-		key, err = db.keyer.GenerateBlockListMapKey(key, folder, f.BlocksHash, name)
-		if err != nil {
-			return err
-		}
-		if err = t.Delete(key); err != nil && !backend.IsNotFound(err) {
-			return err
-		}
-
-		// Insert new file (takes care of BlockList too) and BlockListMap
-		key, err = db.keyer.GenerateBlockListMapKey(key, folder, newBlocksHash, name)
-		if err != nil {
-			return err
-		}
-		if err = t.Put(key, nil); err != nil {
-			return err
-		}
-		if err = t.putFile(dbi.Key(), f, false); err != nil {
-			return err
-		}
-	}
-
-	dbi.Release()
-	if err != dbi.Error() {
 		return err
 	}
 

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -716,6 +716,11 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 			continue
 		}
 
+		newBlocksHash := protocol.BlocksHash(f.Blocks)
+		if bytes.Equal(newBlocksHash, f.BlocksHash) {
+			continue
+		}
+
 		// Remove old BlockList and BlockListMap
 		key = t.keyer.GenerateBlockListKey(key, f.BlocksHash)
 		if err = t.Delete(key); err != nil && !backend.IsNotFound(err) {
@@ -738,7 +743,7 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 		}
 
 		// Insert new file (takes care of BlockList too) and BlockListMap
-		key, err = db.keyer.GenerateBlockListMapKey(key, folder, protocol.BlocksHash(f.Blocks), name)
+		key, err = db.keyer.GenerateBlockListMapKey(key, folder, newBlocksHash, name)
 		if err != nil {
 			return err
 		}

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -729,7 +729,7 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 			continue
 		}
 		name = t.keyer.NameFromDeviceFileKey(dbi.Key())
-		key, err = db.keyer.GenerateBlockMapKey(key, folder, f.BlocksHash, name)
+		key, err = db.keyer.GenerateBlockListMapKey(key, folder, f.BlocksHash, name)
 		if err != nil {
 			return err
 		}
@@ -738,7 +738,7 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 		}
 
 		// Insert new file (takes care of BlockList too) and BlockListMap
-		key, err = db.keyer.GenerateBlockMapKey(key, folder, protocol.BlocksHash(f.Blocks), name)
+		key, err = db.keyer.GenerateBlockListMapKey(key, folder, protocol.BlocksHash(f.Blocks), name)
 		if err != nil {
 			return err
 		}

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -382,6 +382,7 @@ func BlocksHash(bs []BlockInfo) []byte {
 	h := sha256.New()
 	for _, b := range bs {
 		_, _ = h.Write(b.Hash)
+		_ = binary.Write(h, binary.BigEndian, b.WeakHash)
 	}
 	return h.Sum(nil)
 }

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -276,9 +276,11 @@ func PermsEqual(a, b uint32) bool {
 
 // BlocksEqual returns true when the two files have identical block lists.
 func (f FileInfo) BlocksEqual(other FileInfo) bool {
-	// If both sides have blocks hashes then we can just compare those.
-	if len(f.BlocksHash) > 0 && len(other.BlocksHash) > 0 {
-		return bytes.Equal(f.BlocksHash, other.BlocksHash)
+	// If both sides have blocks hashes and they match, we are good. If they
+	// don't match still check individual block hashes to catch differences
+	// in weak hashes only (e.g. after switching weak hash algo).
+	if len(f.BlocksHash) > 0 && len(other.BlocksHash) > 0 && bytes.Equal(f.BlocksHash, other.BlocksHash) {
+		return true
 	}
 
 	// Actually compare the block lists in full.

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -887,8 +887,8 @@ func TestBlocksEqual(t *testing.T) {
 		{blocksOne, nil, blocksOne, nil, true},          // blocks compared
 		{blocksOne, nil, blocksTwo, nil, false},         // blocks compared
 		{blocksOne, hashOne, blocksTwo, hashOne, true},  // hashes equal, blocks not looked at
-		{blocksOne, hashOne, blocksOne, hashTwo, true},  // hashes different, blocks ompared
-		{blocksOne, hashOne, blocksTwo, hashTwo, false}, // hashes different, blocks ompared
+		{blocksOne, hashOne, blocksOne, hashTwo, true},  // hashes different, blocks compared
+		{blocksOne, hashOne, blocksTwo, hashTwo, false}, // hashes different, blocks compared
 		{blocksOne, hashOne, nil, nil, false},           // blocks is different from no blocks
 		{blocksOne, nil, nil, nil, false},               // blocks is different from no blocks
 		{nil, hashOne, nil, nil, true},                  // nil blocks are equal, even of one side has a hash

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -887,7 +887,8 @@ func TestBlocksEqual(t *testing.T) {
 		{blocksOne, nil, blocksOne, nil, true},          // blocks compared
 		{blocksOne, nil, blocksTwo, nil, false},         // blocks compared
 		{blocksOne, hashOne, blocksTwo, hashOne, true},  // hashes equal, blocks not looked at
-		{blocksOne, hashOne, blocksOne, hashTwo, false}, // hashes different, blocks not looked at
+		{blocksOne, hashOne, blocksOne, hashTwo, true},  // hashes different, blocks ompared
+		{blocksOne, hashOne, blocksTwo, hashTwo, false}, // hashes different, blocks ompared
 		{blocksOne, hashOne, nil, nil, false},           // blocks is different from no blocks
 		{blocksOne, nil, nil, nil, false},               // blocks is different from no blocks
 		{nil, hashOne, nil, nil, true},                  // nil blocks are equal, even of one side has a hash


### PR DESCRIPTION
The resolution of way too much debugging is just a single line...

All my pre-adler weakhash files were being rehashed over and over again, even after applying the other two PR fixes from today. That's because on rehash the weak hashes changed, but the sha256 hashes didn't. And as the `BlocksHash` doesn't consider weak hashes, block deduplication kicked in and prevented the new block list from being saved. Thus when the file was requested again, the block hash still didn't match and it got scanned again.

This will prevent the scan rename detecting by blockhash map to kick in for new files, as existing files have the sha256-only bockshash, while new files include the weak hash. It's not critical, but also somewhat ugly - a migration won't hurt. I'll consider that tomorrow :)

Testing: I finally got my new node to sync up :)