### PR TITLE
lib/api, lib/model: Improve folder completion API (fixes #6075)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -673,7 +673,7 @@ func (s *service) getDBBrowse(w http.ResponseWriter, r *http.Request) {
 
 func (s *service) getDBCompletion(w http.ResponseWriter, r *http.Request) {
 	var qs = r.URL.Query()
-	var folder = qs.Get("folder")    // empty or missing means all folders
+	var folder = qs.Get("folder")    // empty means all folders
 	var deviceStr = qs.Get("device") // empty means local device ID
 
 	// We will check completion status for either the local device, or a
@@ -687,12 +687,6 @@ func (s *service) getDBCompletion(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-	}
-
-	// The user specifically asked for our own device ID. Internally that is
-	// known as protocol.LocalDeviceID so translate.
-	if device == s.id {
-		device = protocol.LocalDeviceID
 	}
 
 	sendJSON(w, s.model.Completion(device, folder).Map())

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -245,7 +245,7 @@ func (s *service) serve(ctx context.Context) {
 
 	// The GET handlers
 	getRestMux := http.NewServeMux()
-	getRestMux.HandleFunc("/rest/db/completion", s.getDBCompletion)              // device folder
+	getRestMux.HandleFunc("/rest/db/completion", s.getDBCompletion)              // [device] [folder]
 	getRestMux.HandleFunc("/rest/db/file", s.getDBFile)                          // folder file
 	getRestMux.HandleFunc("/rest/db/ignores", s.getDBIgnores)                    // folder
 	getRestMux.HandleFunc("/rest/db/need", s.getDBNeed)                          // folder [perpage] [page]

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -684,7 +684,7 @@ func (s *service) getDBCompletion(w http.ResponseWriter, r *http.Request) {
 		var err error
 		device, err = protocol.DeviceIDFromString(deviceStr)
 		if err != nil {
-			http.Error(w, err.Error(), 500)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 	}

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -673,8 +673,8 @@ func (s *service) getDBBrowse(w http.ResponseWriter, r *http.Request) {
 
 func (s *service) getDBCompletion(w http.ResponseWriter, r *http.Request) {
 	var qs = r.URL.Query()
-	var folder = qs.Get("folder")
-	var deviceStr = qs.Get("device")
+	var folder = qs.Get("folder")    // empty or missing means all folders
+	var deviceStr = qs.Get("device") // empty means local device ID
 
 	// We will check completion status for either the local device, or a
 	// specific given device ID.
@@ -695,20 +695,7 @@ func (s *service) getDBCompletion(w http.ResponseWriter, r *http.Request) {
 		device = protocol.LocalDeviceID
 	}
 
-	var comp model.FolderCompletion
-	if folder != "" {
-		// We want completion for a specific folder.
-		comp = s.model.Completion(device, folder)
-	} else {
-		// We want completion for all folders as an aggregate.
-		for _, fcfg := range s.cfg.FolderList() {
-			if device == protocol.LocalDeviceID || fcfg.SharedWith(device) {
-				comp.Add(s.model.Completion(device, fcfg.ID))
-			}
-		}
-	}
-
-	sendJSON(w, comp.Map())
+	sendJSON(w, s.model.Completion(device, folder).Map())
 }
 
 func (s *service) getDBStatus(w http.ResponseWriter, r *http.Request) {

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -700,9 +700,7 @@ func (s *service) getDBCompletion(w http.ResponseWriter, r *http.Request) {
 		// We want completion for a specific folder.
 		comp = s.model.Completion(device, folder)
 	} else {
-		// We want completion for all folders shared with the device, as an
-		// aggregate. Grab completion for all folders shared with the device
-		// and aggregate.
+		// We want completion for all folders as an aggregate.
 		for _, fcfg := range s.cfg.FolderList() {
 			if device == protocol.LocalDeviceID || fcfg.SharedWith(device) {
 				comp.Add(s.model.Completion(device, fcfg.ID))

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -780,6 +780,12 @@ func (comp FolderCompletion) Map() map[string]interface{} {
 // empty folder string means the aggregate of all folders shared with the
 // given device.
 func (m *model) Completion(device protocol.DeviceID, folder string) FolderCompletion {
+	// The user specifically asked for our own device ID. Internally that is
+	// known as protocol.LocalDeviceID so translate.
+	if device == m.id {
+		device = protocol.LocalDeviceID
+	}
+
 	if folder != "" {
 		// We want completion for a specific folder.
 		return m.folderCompletion(device, folder)

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -747,11 +747,10 @@ func (comp *FolderCompletion) add(other FolderCompletion) {
 func (comp *FolderCompletion) setComplectionPct() {
 	if comp.GlobalBytes == 0 {
 		comp.CompletionPct = 100
-		return
+	} else {
+		needRatio := float64(comp.NeedBytes) / float64(comp.GlobalBytes)
+		comp.CompletionPct = 100 * (1 - needRatio)
 	}
-
-	needRatio := float64(comp.NeedBytes) / float64(comp.GlobalBytes)
-	comp.CompletionPct = 100 * (1 - needRatio)
 
 	// If the completion is 100% but there are deletes we need to handle,
 	// drop it down a notch. Hack for consumers that look only at the

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -745,6 +745,11 @@ func (comp *FolderCompletion) Add(other FolderCompletion) {
 }
 
 func (comp *FolderCompletion) setComplectionPct() {
+	if comp.GlobalBytes == 0 {
+		comp.CompletionPct = 100
+		return
+	}
+
 	needRatio := float64(comp.NeedBytes) / float64(comp.GlobalBytes)
 	comp.CompletionPct = 100 * (1 - needRatio)
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3891,14 +3891,14 @@ func TestConnectionTerminationOnFolderUnpause(t *testing.T) {
 func TestAddFolderCompletion(t *testing.T) {
 	// Empty folders are always 100% complete.
 	comp := NewFolderCompletion(0, 0, 0, 0, 0)
-	comp.Add(NewFolderCompletion(0, 0, 0, 0, 0))
+	comp.add(NewFolderCompletion(0, 0, 0, 0, 0))
 	if comp.CompletionPct != 100 {
 		t.Error(comp.CompletionPct)
 	}
 
 	// Completion is of the whole
 	comp = NewFolderCompletion(100, 0, 0, 0, 0)     // 100% complete
-	comp.Add(NewFolderCompletion(400, 50, 0, 0, 0)) // 82.5% complete
+	comp.add(NewFolderCompletion(400, 50, 0, 0, 0)) // 82.5% complete
 	if comp.CompletionPct != 90 {                   // 100 * (1 - 50/500)
 		t.Error(comp.CompletionPct)
 	}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3888,6 +3888,22 @@ func TestConnectionTerminationOnFolderUnpause(t *testing.T) {
 	})
 }
 
+func TestAddFolderCompletion(t *testing.T) {
+	// Empty folders are always 100% complete.
+	comp := NewFolderCompletion(0, 0, 0, 0, 0)
+	comp.Add(NewFolderCompletion(0, 0, 0, 0, 0))
+	if comp.CompletionPct != 100 {
+		t.Error(comp.CompletionPct)
+	}
+
+	// Completion is of the whole
+	comp = NewFolderCompletion(100, 0, 0, 0, 0)     // 100% complete
+	comp.Add(NewFolderCompletion(400, 50, 0, 0, 0)) // 82.5% complete
+	if comp.CompletionPct != 90 {                   // 100 * (1 - 50/500)
+		t.Error(comp.CompletionPct)
+	}
+}
+
 func testConfigChangeClosesConnections(t *testing.T, expectFirstClosed, expectSecondClosed bool, pre func(config.Wrapper), fn func(config.Wrapper)) {
 	t.Helper()
 	wcfg, _ := tmpDefaultWrapper()

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3890,16 +3890,16 @@ func TestConnectionTerminationOnFolderUnpause(t *testing.T) {
 
 func TestAddFolderCompletion(t *testing.T) {
 	// Empty folders are always 100% complete.
-	comp := NewFolderCompletion(0, 0, 0, 0, 0)
-	comp.add(NewFolderCompletion(0, 0, 0, 0, 0))
+	comp := newFolderCompletion(db.Counts{}, db.Counts{})
+	comp.add(newFolderCompletion(db.Counts{}, db.Counts{}))
 	if comp.CompletionPct != 100 {
 		t.Error(comp.CompletionPct)
 	}
 
 	// Completion is of the whole
-	comp = NewFolderCompletion(100, 0, 0, 0, 0)     // 100% complete
-	comp.add(NewFolderCompletion(400, 50, 0, 0, 0)) // 82.5% complete
-	if comp.CompletionPct != 90 {                   // 100 * (1 - 50/500)
+	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{})             // 100% complete
+	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50})) // 82.5% complete
+	if comp.CompletionPct != 90 {                                              // 100 * (1 - 50/500)
 		t.Error(comp.CompletionPct)
 	}
 }

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -1,4 +1,4 @@
-<configuration version="29">
+<configuration version="31">
     <folder id="default" label="" path="s2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
@@ -24,6 +24,7 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
     </folder>
     <folder id="s23" label="" path="s23-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -49,6 +50,32 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+    </folder>
+    <folder id="zie6a-tezz4" label="" path="/Users/jb/tmp/zie6a-tezz4" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
+        <filesystemType>basic</filesystemType>
+        <device id="MRIW7OK-NETT3M4-N6SBWME-N25O76W-YJKVXPH-FUMQJ3S-P57B74J-GBITBAC" introducedBy=""></device>
+        <minDiskFree unit="%">1</minDiskFree>
+        <versioning></versioning>
+        <copiers>0</copiers>
+        <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
+        <hashers>0</hashers>
+        <order>random</order>
+        <ignoreDelete>false</ignoreDelete>
+        <scanProgressIntervalS>0</scanProgressIntervalS>
+        <pullerPauseS>0</pullerPauseS>
+        <maxConflicts>10</maxConflicts>
+        <disableSparseFiles>false</disableSparseFiles>
+        <disableTempIndexes>false</disableTempIndexes>
+        <paused>false</paused>
+        <weakHashThresholdPct>25</weakHashThresholdPct>
+        <markerName>.stfolder</markerName>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
+        <maxConcurrentWrites>0</maxConcurrentWrites>
+        <disableFsync>false</disableFsync>
+        <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
     </folder>
     <folder id="¯\_(ツ)_/¯ Räksmörgås 动作 Адрес" label="" path="s12-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -74,6 +101,7 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
     </folder>
     <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" name="s1" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22001</address>
@@ -140,6 +168,7 @@
         <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
         <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
         <tempIndexMinBlocks>10</tempIndexMinBlocks>
+        <unackedNotificationID>authenticationUserAndPassword</unackedNotificationID>
         <trafficClass>0</trafficClass>
         <defaultFolderPath>~</defaultFolderPath>
         <setLowPriority>true</setLowPriority>

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -1,4 +1,4 @@
-<configuration version="31">
+<configuration version="29">
     <folder id="default" label="" path="s2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
@@ -24,7 +24,6 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
-        <copyRangeMethod>standard</copyRangeMethod>
     </folder>
     <folder id="s23" label="" path="s23-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -50,32 +49,6 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
-        <copyRangeMethod>standard</copyRangeMethod>
-    </folder>
-    <folder id="zie6a-tezz4" label="" path="/Users/jb/tmp/zie6a-tezz4" type="sendreceive" rescanIntervalS="3600" fsWatcherEnabled="true" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
-        <filesystemType>basic</filesystemType>
-        <device id="MRIW7OK-NETT3M4-N6SBWME-N25O76W-YJKVXPH-FUMQJ3S-P57B74J-GBITBAC" introducedBy=""></device>
-        <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
-        <copiers>0</copiers>
-        <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
-        <hashers>0</hashers>
-        <order>random</order>
-        <ignoreDelete>false</ignoreDelete>
-        <scanProgressIntervalS>0</scanProgressIntervalS>
-        <pullerPauseS>0</pullerPauseS>
-        <maxConflicts>10</maxConflicts>
-        <disableSparseFiles>false</disableSparseFiles>
-        <disableTempIndexes>false</disableTempIndexes>
-        <paused>false</paused>
-        <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
-        <copyOwnershipFromParent>false</copyOwnershipFromParent>
-        <modTimeWindowS>0</modTimeWindowS>
-        <maxConcurrentWrites>0</maxConcurrentWrites>
-        <disableFsync>false</disableFsync>
-        <blockPullOrder>standard</blockPullOrder>
-        <copyRangeMethod>standard</copyRangeMethod>
     </folder>
     <folder id="¯\_(ツ)_/¯ Räksmörgås 动作 Адрес" label="" path="s12-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
@@ -101,7 +74,6 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
-        <copyRangeMethod>standard</copyRangeMethod>
     </folder>
     <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" name="s1" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22001</address>
@@ -168,7 +140,6 @@
         <releasesURL>https://upgrades.syncthing.net/meta.json</releasesURL>
         <overwriteRemoteDeviceNamesOnConnect>false</overwriteRemoteDeviceNamesOnConnect>
         <tempIndexMinBlocks>10</tempIndexMinBlocks>
-        <unackedNotificationID>authenticationUserAndPassword</unackedNotificationID>
         <trafficClass>0</trafficClass>
         <defaultFolderPath>~</defaultFolderPath>
         <setLowPriority>true</setLowPriority>


### PR DESCRIPTION
This makes the /rest/db/completion call more useful and user friendly.

Prior to this change the only supported use was with both "folder" and
"device" parameters, where the device is a remote device. This then
gives the completion status for specifically that folder on that device.

With this change we also allow the following:

- Omitting the "device" parameter, in which case it means the local
  device (and returns the local completion)

- Explicitly specifying the local device ID, which means the same thing.

- Omitting the "folder" parameter, in which case it means all folders.

- Omitting both, which logically then means the completion percentage
  for all folders as a whole on this device.

This should be closer to what people expect usage wise, while also now
giving a single place to check for a completion percentage for the local
device or any remote device as a whole.
