### PR TITLE
gui: Hide file pull order when folder is send only

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -207,7 +207,7 @@
                   <p ng-if="currentFolder.type == 'sendonly'" translate class="help-block">Files are protected from changes made on other devices, but changes made on this device will be sent to the rest of the cluster.</p>
                   <p ng-if="currentFolder.type == 'receiveonly'" translate class="help-block">Files are synchronized from the cluster, but any changes made locally will not be sent to other devices.</p>
                 </div>
-                <div class="col-md-6 form-group">
+                <div class="col-md-6 form-group" ng-show="currentFolder.type != 'sendonly'">
                   <label translate>File Pull Order</label>
                   <select class="form-control" ng-model="currentFolder.order">
                     <option value="random" translate>Random</option>


### PR DESCRIPTION
Fixes issue #6807 

### Testing

As stated by the below article, update default gui folder. Then run syncthing and setup new folder or edit existing folder, go to the Advanced tab and chage "Folder Type" to "Send Only" and observe "File Pull Order" is hidden.  
https://docs.syncthing.net/dev/web.html# 

NB: May need to force refresh to ensure html page isn't cached. 

### Screenshots

![image](https://user-images.githubusercontent.com/7538671/86540653-dbfd4280-befe-11ea-905c-45c8e861d41f.png)




