### PR TITLE
lib: Use encoding.TextUnmarshaler for utils.SetDefaults

### DIFF
--- a/lib/config/size.go
+++ b/lib/config/size.go
@@ -72,8 +72,8 @@ func (s Size) String() string {
 	return fmt.Sprintf("%v %s", s.Value, s.Unit)
 }
 
-func (s *Size) ParseDefault(str string) error {
-	sz, err := ParseSize(str)
+func (s *Size) UnmarshalText(bs []byte) error {
+	sz, err := ParseSize(string(bs))
 	*s = sz
 	return err
 }

--- a/lib/fs/filesystem_copy_range_method.go
+++ b/lib/fs/filesystem_copy_range_method.go
@@ -59,7 +59,3 @@ func (o *CopyRangeMethod) UnmarshalText(bs []byte) error {
 	}
 	return nil
 }
-
-func (o *CopyRangeMethod) ParseDefault(str string) error {
-	return o.UnmarshalText([]byte(str))
-}

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -8,6 +8,7 @@ package util
 
 import (
 	"context"
+	"encoding"
 	"fmt"
 	"net"
 	"net/url"
@@ -21,10 +22,6 @@ import (
 	"github.com/thejerf/suture"
 )
 
-type defaultParser interface {
-	ParseDefault(string) error
-}
-
 // SetDefaults sets default values on a struct, based on the default annotation.
 func SetDefaults(data interface{}) {
 	s := reflect.ValueOf(data).Elem()
@@ -37,8 +34,8 @@ func SetDefaults(data interface{}) {
 		v := tag.Get("default")
 		if len(v) > 0 {
 			if f.CanInterface() {
-				if parser, ok := f.Interface().(defaultParser); ok {
-					if err := parser.ParseDefault(v); err != nil {
+				if unmarshaler, ok := f.Interface().(encoding.TextUnmarshaler); ok {
+					if err := unmarshaler.UnmarshalText([]byte(v)); err != nil {
 						panic(err)
 					}
 					continue
@@ -46,8 +43,8 @@ func SetDefaults(data interface{}) {
 			}
 
 			if f.CanAddr() && f.Addr().CanInterface() {
-				if parser, ok := f.Addr().Interface().(defaultParser); ok {
-					if err := parser.ParseDefault(v); err != nil {
+				if unmarshaler, ok := f.Addr().Interface().(encoding.TextUnmarshaler); ok {
+					if err := unmarshaler.UnmarshalText([]byte(v)); err != nil {
 						panic(err)
 					}
 					continue

--- a/lib/util/utils_test.go
+++ b/lib/util/utils_test.go
@@ -16,8 +16,8 @@ type Defaulter struct {
 	Value string
 }
 
-func (d *Defaulter) ParseDefault(v string) error {
-	*d = Defaulter{Value: v}
+func (d *Defaulter) UnmarshalText(bs []byte) error {
+	*d = Defaulter{Value: string(bs)}
 	return nil
 }
 


### PR DESCRIPTION
When adding a new default value for `fs.FilesystemType` for #6717 that the `defaultParser` interface duplicates `encoding.TextUnmarshaler` that config types already need to implement for xml/json encoding.