### PR TITLE
gui: Disable file pull order when for send-only (fixes #6807)

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -209,13 +209,16 @@
                 </div>
                 <div class="col-md-6 form-group">
                   <label translate>File Pull Order</label>
-                  <select class="form-control" ng-model="currentFolder.order">
+                  <select class="form-control" ng-model="currentFolder.order" ng-if="currentFolder.type != 'sendonly'">
                     <option value="random" translate>Random</option>
                     <option value="alphabetic" translate>Alphabetic</option>
                     <option value="smallestFirst" translate>Smallest First</option>
                     <option value="largestFirst" translate>Largest First</option>
                     <option value="oldestFirst" translate>Oldest First</option>
                     <option value="newestFirst" translate>Newest First</option>
+                  </select>
+                  <select class="form-control" ng-if="currentFolder.type == 'sendonly'" disabled>
+                    <option value="disabled" translate>Disabled</option>
                   </select>
                 </div>
               </div>


### PR DESCRIPTION
Fixes issue #6807

### Testing

As stated by the below article, update default gui folder. Then run syncthing and setup new folder or edit existing folder, go to the Advanced tab and chage "Folder Type" to "Send Only" and observe "File Pull Order" is set to disabled.  
https://docs.syncthing.net/dev/web.html# 

NB: May need to force refresh to ensure html page isn't cached. 

### Screenshots

![image](https://user-images.githubusercontent.com/7538671/86968739-92ae2c80-c164-11ea-80c7-bb276ca7df8b.png)

