### PR TITLE
lib/db: Use SipHash to deal with hash collisions in GC

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/certifi/gocertifi v0.0.0-20190905060710-a5e0173ced67 // indirect
 	github.com/chmduquesne/rollinghash v0.0.0-20180912150627-a60f8e7142b5
 	github.com/d4l3k/messagediff v1.2.1
+	github.com/dchest/siphash v1.2.1
 	github.com/dgraph-io/badger/v2 v2.0.3
 	github.com/flynn-archive/go-shlex v0.0.0-20150515145356-3f9db97f8568
 	github.com/getsentry/raven-go v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,8 @@ github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkE
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/siphash v1.2.1 h1:4cLinnzVJDKxTCl9B01807Yiy+W7ZzVHj/KIroQRvT4=
+github.com/dchest/siphash v1.2.1/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
 github.com/dgraph-io/badger v1.6.1 h1:w9pSFNSdq/JPM1N12Fz/F/bzo993Is1W+Q7HjPzi7yg=
 github.com/dgraph-io/badger/v2 v2.0.3 h1:inzdf6VF/NZ+tJ8RwwYMjJMvsOALTHYdozn0qSl6XJI=
 github.com/dgraph-io/badger/v2 v2.0.3/go.mod h1:3KY8+bsP8wI0OEnQJAKpd4wIJW/Mm32yw2j/9FUVnIM=


### PR DESCRIPTION
This fixes the following GC issue. If the GC finds a key k that it wants to keep, it records that in a Bloom filter. If a key k' can be removed but its hash collides with k, it will be kept too. Since the current Bloom filter code is completely deterministic, the next run will encounter the same collision, assuming k must still be kept, so k' can be kept indefinitely.

Randomizing the hash function and using all the SHA-256 bits solves this problem: the second run has a non-zero probability of removing k', as long as the Bloom filter is not completely full. (It's full at 268M entries with the current max. memory use.)

I considered three options for hash randomization:

* [hash/maphash](https://golang.org/pkg/hash/maphash) is fast at ~1GiB/s (older amd64), but requires Go 1.14.
* [dchest/siphash](/dchest/siphash) is about as fast in its pure Go implementation, and 10% faster than maphash when using the assembler version.
* [minio/highwayhash](/minio/highwayhash) is probably very fast on AVX2-supporting amd64, but slow everywhere else: 700MiB/s on older amd64.