### PR TITLE
lib/scanner: Less strict validation (fixes #6827)

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -109,11 +109,11 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 }
 
 // Validate quickly validates buf against the 32-bit weakHash, if not zero,
-// else against the cryptohash hash, if len(hash)>0.
-// It is satisfied if neither hash is given.
+// else against the cryptohash hash, if len(hash)>0. It is satisfied if
+// either hash matches or neither hash is given.
 func Validate(buf, hash []byte, weakHash uint32) bool {
-	if weakHash != 0 {
-		return adler32.Checksum(buf) == weakHash
+	if weakHash != 0 && adler32.Checksum(buf) == weakHash {
+		return true
 	}
 
 	if len(hash) > 0 {


### PR DESCRIPTION
This fixes the change in #6674 where the weak hash became a deciding
factor. Now we again just use it to accept a block, but don't take a
negative as meaning the block is bad.

