### PR TITLE
Modified the Docker entrypoint so that the Syncthing Docker image can be started as a non-root user

### DIFF
--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -2,6 +2,10 @@
 
 set -eu
 
-chown "${PUID}:${PGID}" "${HOME}" \
-  && exec su-exec "${PUID}:${PGID}" \
-     env HOME="$HOME" "$@"
+if [ "$(id -u)" = '0' ]; then
+  chown "${PUID}:${PGID}" "${HOME}" \
+    && exec su-exec "${PUID}:${PGID}" \
+       env HOME="$HOME" "$@"
+else
+  exec "$@"
+fi


### PR DESCRIPTION
Modified the Docker entrypoint so that the Syncthing Docker image can be started as a non-root user

### Purpose

Allow running the Syncthing Docker image as a non-root user (fixes #6832)

### Testing

Before change:
<pre>
# This works
rm -rf data && mkdir data
docker run -p 8384:8384 -p 22000:22000 \
  -v "$(pwd)/data":/var/syncthing \
  syncthing/syncthing:latest

# This fails even when the user starting the Docker daemon has uid/gid 1000
rm -rf data && mkdir data
docker run -p 8384:8384 -p 22000:22000 \
  -v "$(pwd)/data":/var/syncthing \
  --user 1000:1000 \
  syncthing/syncthing:latest
</pre>

After change:
<pre>
# This still works
rm -rf data && mkdir data
docker run -p 8384:8384 -p 22000:22000 \
  -v "$(pwd)/data":/var/syncthing \
  syncthing:latest # Local syncthing Docker image

# This also works when the user starting the Docker daemon has uid/gid 1000
rm -rf data && mkdir data
docker run -p 8384:8384 -p 22000:22000 \
  -v "$(pwd)/data":/var/syncthing \
  --user 1000:1000 \
  syncthing:latest # Local syncthing Docker image
</pre>

### Documentation

Ask me if you would like me to add a line about running the Docker image as a non-root user.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

