### PR TITLE
gui: sharpen device icons (fixes #5579)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -241,6 +241,7 @@ identicon {
 .identicon {
     width: 1em;
     height: 1em;
+    shape-rendering: crispEdges;
 }
 
 a.toggler {


### PR DESCRIPTION
### Purpose

This commit will add the rule [`shape-rendering: crispEdges`](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/shape-rendering) to the `.identicon` class to remove blurry grid lines within device icons.

This fixes #5579.

### Testing

No tests are included but can be added if necessary.

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/139387/87696581-00f38000-c75f-11ea-9f91-4bcf43e084e6.png)

#### After

![image](https://user-images.githubusercontent.com/139387/87696424-c4278900-c75e-11ea-9045-88d8dcd0ac0e.png)

### Documentation

No documentation changes are included but can be added if necessary.
