### PR TITLE
lib/db: Rework flush hooks

### DIFF
--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -15,6 +15,8 @@ import (
 	"github.com/syncthing/syncthing/lib/locations"
 )
 
+type CommitHook func(WriteTransaction) error
+
 // The Reader interface specifies the read-only operations available on the
 // main database and on read-only transactions (snapshots). Note that when
 // called directly on the database handle these operations may take implicit
@@ -61,7 +63,7 @@ type ReadTransaction interface {
 type WriteTransaction interface {
 	ReadTransaction
 	Writer
-	Checkpoint(...func() error) error
+	Checkpoint() error
 	Commit() error
 }
 
@@ -108,7 +110,7 @@ type Backend interface {
 	Reader
 	Writer
 	NewReadTransaction() (ReadTransaction, error)
-	NewWriteTransaction() (WriteTransaction, error)
+	NewWriteTransaction(hooks ...CommitHook) (WriteTransaction, error)
 	Close() error
 	Compact() error
 }

--- a/lib/db/backend/leveldb_backend.go
+++ b/lib/db/backend/leveldb_backend.go
@@ -59,7 +59,7 @@ func (b *leveldbBackend) newSnapshot() (leveldbSnapshot, error) {
 	}, nil
 }
 
-func (b *leveldbBackend) NewWriteTransaction() (WriteTransaction, error) {
+func (b *leveldbBackend) NewWriteTransaction(hooks ...CommitHook) (WriteTransaction, error) {
 	rel, err := newReleaser(b.closeWG)
 	if err != nil {
 		return nil, err
@@ -74,6 +74,7 @@ func (b *leveldbBackend) NewWriteTransaction() (WriteTransaction, error) {
 		ldb:             b.ldb,
 		batch:           new(leveldb.Batch),
 		rel:             rel,
+		commitHooks:     hooks,
 	}, nil
 }
 
@@ -142,9 +143,10 @@ func (l leveldbSnapshot) Release() {
 // an actual leveldb transaction)
 type leveldbTransaction struct {
 	leveldbSnapshot
-	ldb   *leveldb.DB
-	batch *leveldb.Batch
-	rel   *releaser
+	ldb         *leveldb.DB
+	batch       *leveldb.Batch
+	rel         *releaser
+	commitHooks []CommitHook
 }
 
 func (t *leveldbTransaction) Delete(key []byte) error {
@@ -157,8 +159,8 @@ func (t *leveldbTransaction) Put(key, val []byte) error {
 	return t.checkFlush(dbFlushBatchMax)
 }
 
-func (t *leveldbTransaction) Checkpoint(preFlush ...func() error) error {
-	return t.checkFlush(dbFlushBatchMin, preFlush...)
+func (t *leveldbTransaction) Checkpoint() error {
+	return t.checkFlush(dbFlushBatchMin)
 }
 
 func (t *leveldbTransaction) Commit() error {
@@ -174,19 +176,19 @@ func (t *leveldbTransaction) Release() {
 }
 
 // checkFlush flushes and resets the batch if its size exceeds the given size.
-func (t *leveldbTransaction) checkFlush(size int, preFlush ...func() error) error {
+func (t *leveldbTransaction) checkFlush(size int) error {
 	if len(t.batch.Dump()) < size {
 		return nil
-	}
-	for _, hook := range preFlush {
-		if err := hook(); err != nil {
-			return err
-		}
 	}
 	return t.flush()
 }
 
 func (t *leveldbTransaction) flush() error {
+	for _, hook := range t.commitHooks {
+		if err := hook(t); err != nil {
+			return err
+		}
+	}
 	if t.batch.Len() == 0 {
 		return nil
 	}

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -640,7 +640,7 @@ func TestGCIndirect(t *testing.T) {
 
 	db := NewLowlevel(backend.OpenMemory())
 	defer db.Close()
-	meta := newMetadataTracker()
+	meta := newMetadataTracker(db.keyer)
 
 	// Add three files with different block lists
 

--- a/lib/db/meta_test.go
+++ b/lib/db/meta_test.go
@@ -52,7 +52,7 @@ func TestEachFlagBit(t *testing.T) {
 func TestMetaDevices(t *testing.T) {
 	d1 := protocol.DeviceID{1}
 	d2 := protocol.DeviceID{2}
-	meta := newMetadataTracker()
+	meta := newMetadataTracker(nil)
 
 	meta.addFile(d1, protocol.FileInfo{Sequence: 1})
 	meta.addFile(d1, protocol.FileInfo{Sequence: 2, LocalFlags: 1})
@@ -85,7 +85,7 @@ func TestMetaDevices(t *testing.T) {
 
 func TestMetaSequences(t *testing.T) {
 	d1 := protocol.DeviceID{1}
-	meta := newMetadataTracker()
+	meta := newMetadataTracker(nil)
 
 	meta.addFile(d1, protocol.FileInfo{Sequence: 1})
 	meta.addFile(d1, protocol.FileInfo{Sequence: 2, RawInvalid: true})

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -21,8 +21,6 @@ var (
 	errEmptyFileVersion       = errors.New("no devices in global file version")
 )
 
-type preFlushHook func() error
-
 // A readOnlyTransaction represents a database snapshot.
 type readOnlyTransaction struct {
 	backend.ReadTransaction

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -21,6 +21,8 @@ var (
 	errEmptyFileVersion       = errors.New("no devices in global file version")
 )
 
+type preFlushHook func() error
+
 // A readOnlyTransaction represents a database snapshot.
 type readOnlyTransaction struct {
 	backend.ReadTransaction
@@ -516,8 +518,8 @@ type readWriteTransaction struct {
 	readOnlyTransaction
 }
 
-func (db *Lowlevel) newReadWriteTransaction() (readWriteTransaction, error) {
-	tran, err := db.NewWriteTransaction()
+func (db *Lowlevel) newReadWriteTransaction(hooks ...backend.CommitHook) (readWriteTransaction, error) {
+	tran, err := db.NewWriteTransaction(hooks...)
 	if err != nil {
 		return readWriteTransaction{}, err
 	}


### PR DESCRIPTION
This moves the preFlush/commit hooks to be a property of the transaction.

I noticed that flushes might happen during Put's, which can happen when updating block map, or simply during t.updateGlobal while iterating over updateLocalFiles/updateRemoteFiles, which might flush out the transaction, but not run any hooks hence would not serialise the metadata.

In theory is should never happen as Checkpoint flushes over dbFlushBatchMin (64k), where as Put flushes over dbFlushBatchMax (1mb), so I think it's unlikely that in a tight loop where we call checkpoint after every file we go from less than dbFlushBatchMin in the previous iteration and suddenly to over dbFlushBatchMax in a single iteration, but regardless, this feels like a more robust way to do this.

I started looking at this effectively due to:
https://forum.syncthing.net/t/v1-6-1-local-and-global-state-swapped-between-two-nodes/15209/8

It seems that 2 devices are both missing the same index entries, making a small revelation that this index fudge problem is probably originating on the sending side and not the receiving side.

PS: Also, flush every 64k? Seems like tiny transaction size.
