### PR TITLE
lib/fs: Pass inf. rec. err on instead of warning

### DIFF
--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -11,8 +11,11 @@
 package fs
 
 import (
+	"errors"
 	"path/filepath"
 )
+
+var ErrInfiniteRecursion = errors.New("infinite filesystem recursion detected")
 
 type ancestorDirList struct {
 	list []FileInfo
@@ -90,8 +93,7 @@ func (f *walkFilesystem) walk(path string, info FileInfo, walkFn WalkFunc, ances
 		ancestors.Push(info)
 		defer ancestors.Pop()
 	} else {
-		l.Warnf("Infinite filesystem recursion detected on path '%s', not walking further down", path)
-		return nil
+		return walkFn(path, info, ErrInfiniteRecursion)
 	}
 
 	names, err := f.DirNames(path)

--- a/lib/fs/walkfs_test.go
+++ b/lib/fs/walkfs_test.go
@@ -101,8 +101,7 @@ func testWalkInfiniteRecursion(t *testing.T, fsType FilesystemType, uri string) 
 	if err := createDirJunct(filepath.Join(uri, "target"), filepath.Join(uri, "towalk/dirjunct")); err != nil {
 		t.Fatal(err)
 	}
-	badJunction := "target/foo/recurse"
-	if err := createDirJunct(filepath.Join(uri, "towalk"), filepath.Join(uri, badJunction)); err != nil {
+	if err := createDirJunct(filepath.Join(uri, "towalk"), filepath.Join(uri, "target/foo/recurse")); err != nil {
 		t.Fatal(err)
 	}
 	dirjunctCnt := 0
@@ -110,7 +109,10 @@ func testWalkInfiniteRecursion(t *testing.T, fsType FilesystemType, uri string) 
 	found := false
 	if err := fs.Walk("towalk", func(path string, info FileInfo, err error) error {
 		if err != nil {
-			if path == badJunction && errors.Is(err, ErrInfiniteRecursion) {
+			if errors.Is(err, ErrInfiniteRecursion) {
+				if found {
+					t.Fatal("second infinite recursion detected at", path)
+				}
 				found = true
 				return nil
 			}


### PR DESCRIPTION
Prompted by https://forum.syncthing.net/t/infinite-filesystem-recursion-detected/15285. In my opinion the filesystem shouldn't throw warnings but pass on errors for the caller to decide what's to be happening with it. Right now in this PR an infinite recursion is a normal scan error, i.e. folder is in failed state and displays failed items, but no warning. I think that's appropriate but if deemed appropriate an additional warning can be thrown in the scanner.
