### PR TITLE
lib/model: Check folder error before sync-waiting (fixes #6793)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -166,20 +166,6 @@ func newSendReceiveFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 // pull returns true if it manages to get all needed items from peers, i.e. get
 // the device in sync with the global state.
 func (f *sendReceiveFolder) pull() bool {
-	// Check if the ignore patterns changed.
-	oldHash := f.ignores.Hash()
-	defer func() {
-		if f.ignores.Hash() != oldHash {
-			f.ignoresUpdated()
-		}
-	}()
-	err := f.getHealthErrorAndLoadIgnores()
-	f.setError(err)
-	if err != nil {
-		l.Debugln("Skipping pull of", f.Description(), "due to folder error:", err)
-		return false
-	}
-
 	l.Debugf("%v pulling", f)
 
 	scanChan := make(chan string)


### PR DESCRIPTION
There's two related elements here: 1. `folder.pull` should not `defer f.setState(FolderIdle)`. The actual underlying pull already takes care of folder state (either error or idle). 2. For scanning and (real) pulling we always check folder health/error before setting status. We don't do the same for sync-waiting. This means an existing error gets "half-cleared": State changes to sync-waiting, but error remains (as errors are only touched by `setError`). Thus when the actual puller calls `setError`, it sees the same error before and after and thus returns early without setting the folder state back to error. Regardless of this issue I believe it makes sense to check folder health before acquiring the iolimiter token to get the error notification to the user faster.

I don't entirely get the separation of `setState` and `setError` though. Given `setError` is called with `nil`, it seems like one shouldn't call `setState` when an error is set/"active", but that's not enforced. If that's not the case and `setState` is meant to override errors, it doesn't do that (no `s.err = nil`). To me it would feel simpler and more robust if `setState` did clear previous error states. Does anyone have any insights into why things work as they do at the moment?