### PR TITLE
change default marker folder name

### DIFF
--- a/cmd/stcompdirs/main.go
+++ b/cmd/stcompdirs/main.go
@@ -91,7 +91,7 @@ func startWalker(dir string, res chan<- fileInfo, abort <-chan struct{}) chan er
 		if rn == "." {
 			return nil
 		}
-		if rn == ".stversions" || rn == ".stfolder" {
+		if rn == ".stversions" || rn == ".syncthing" {
 			return filepath.SkipDir
 		}
 

--- a/lib/api/testdata/config/config.xml
+++ b/lib/api/testdata/config/config.xml
@@ -19,7 +19,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <useLargeBlocks>true</useLargeBlocks>
     </folder>
     <folder id="¯\_(ツ)_/¯ Räksmörgås 动作 Адрес" label="" path="s12-1/" type="sendreceive" rescanIntervalS="10" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -460,7 +460,7 @@ func TestFolderCheckPath(t *testing.T) {
 	}
 	testFs := fs.NewFilesystem(fs.FilesystemTypeBasic, n)
 
-	err = os.MkdirAll(filepath.Join(n, "dir", ".stfolder"), os.FileMode(0777))
+	err = os.MkdirAll(filepath.Join(n, "dir", ".syncthing"), os.FileMode(0777))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -26,7 +26,7 @@ var (
 	ErrMarkerMissing    = errors.New("folder marker missing (this indicates potential data loss, search docs/forum to get information about how to proceed)")
 )
 
-const DefaultMarkerName = ".stfolder"
+const DefaultMarkerName = ".syncthing"
 
 type FolderConfiguration struct {
 	ID                      string                      `xml:"id,attr" json:"id"`

--- a/lib/config/migrations.go
+++ b/lib/config/migrations.go
@@ -144,7 +144,7 @@ func migrateToConfigV23(cfg *Configuration) {
 		permBits = 0700
 	}
 
-	// Upgrade code remains hardcoded for .stfolder despite configurable
+	// Upgrade code remains hardcoded for .syncthing despite configurable
 	// marker name in later versions.
 
 	for i := range cfg.Folders {

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -132,7 +132,7 @@ func newFakeFilesystem(rootURI string) *fakefs {
 	}
 
 	// Also create a default folder marker for good measure
-	fs.Mkdir(".stfolder", 0700)
+	fs.Mkdir(".syncthing", 0700)
 
 	// We only set the latency after doing the operations required to create
 	// the filesystem initially.

--- a/lib/fs/fakefs_test.go
+++ b/lib/fs/fakefs_test.go
@@ -257,8 +257,8 @@ func createTestDir(t *testing.T) (string, bool) {
 		t.Fatalf("could not create temporary dir for testing: %s", err)
 	}
 
-	if fd, err := os.Create(filepath.Join(testDir, ".stfolder")); err != nil {
-		t.Fatalf("could not create .stfolder: %s", err)
+	if fd, err := os.Create(filepath.Join(testDir, ".syncthing")); err != nil {
+		t.Fatalf("could not create .syncthing: %s", err)
 	} else {
 		fd.Close()
 	}
@@ -379,7 +379,7 @@ func assertDir(t *testing.T, fs Filesystem, directory string, filenames []string
 	}
 
 	if path.Clean(directory) == "/" {
-		filenames = append(filenames, ".stfolder")
+		filenames = append(filenames, ".syncthing")
 	}
 	sort.Strings(filenames)
 	sort.Strings(got)
@@ -928,7 +928,7 @@ func TestReadWriteContent(t *testing.T) {
 func cleanup(fs Filesystem) error {
 	filenames, _ := fs.DirNames("/")
 	for _, filename := range filenames {
-		if filename != ".stfolder" {
+		if filename != ".syncthing" {
 			if err := fs.RemoveAll(filename); err != nil {
 				return err
 			}

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -209,8 +209,8 @@ func NewFilesystem(fsType FilesystemType, uri string) Filesystem {
 // root, represents an internal file that should always be ignored. The file
 // path must be clean (i.e., in canonical shortest form).
 func IsInternal(file string) bool {
-	// fs cannot import config, so we hard code .stfolder here (config.DefaultMarkerName)
-	internals := []string{".stfolder", ".stignore", ".stversions"}
+	// fs cannot import config, so we hard code .syncthing here (config.DefaultMarkerName)
+	internals := []string{".syncthing", ".stignore", ".stversions"}
 	for _, internal := range internals {
 		if file == internal {
 			return true

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -209,8 +209,8 @@ func NewFilesystem(fsType FilesystemType, uri string) Filesystem {
 // root, represents an internal file that should always be ignored. The file
 // path must be clean (i.e., in canonical shortest form).
 func IsInternal(file string) bool {
-	// fs cannot import config, so we hard code .syncthing here (config.DefaultMarkerName)
-	internals := []string{".syncthing", ".stignore", ".stversions"}
+	// fs cannot import config, so we hard code .syncthing and .stfolder here (config.DefaultMarkerName and its legacy value)
+	internals := []string{".syncthing", ".stfolder", ".stignore", ".stversions"}
 	for _, internal := range internals {
 		if file == internal {
 			return true

--- a/lib/fs/filesystem_test.go
+++ b/lib/fs/filesystem_test.go
@@ -20,10 +20,10 @@ func TestIsInternal(t *testing.T) {
 		{".stfolder", true},
 		{".stignore", true},
 		{".stversions", true},
+		{".syncthing", true},
 		{".stfolder/foo", true},
 		{".stignore/foo", true},
 		{".stversions/foo", true},
-		{".syncthing", true},
 		{".syncthing/foo", true},
 
 		{".stfolderfoo", false},

--- a/lib/fs/filesystem_test.go
+++ b/lib/fs/filesystem_test.go
@@ -23,16 +23,21 @@ func TestIsInternal(t *testing.T) {
 		{".stfolder/foo", true},
 		{".stignore/foo", true},
 		{".stversions/foo", true},
+		{".syncthing", true},
+		{".syncthing/foo", true},
 
 		{".stfolderfoo", false},
 		{".stignorefoo", false},
 		{".stversionsfoo", false},
+		{".syncthingfoo", false},
 		{"foo.stfolder", false},
 		{"foo.stignore", false},
 		{"foo.stversions", false},
+		{"foo.syncthing", false},
 		{"foo/.stfolder", false},
 		{"foo/.stignore", false},
 		{"foo/.stversions", false},
+		{"foo/.syncthing", false},
 	}
 
 	for _, tc := range cases {

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -32,7 +32,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 
 	// Create some test data
 
-	for _, dir := range []string{".stfolder", "ignDir", "unknownDir"} {
+	for _, dir := range []string{".syncthing", "ignDir", "unknownDir"} {
 		must(t, ffs.MkdirAll(dir, 0755))
 	}
 	must(t, writeFile(ffs, "ignDir/ignFile", []byte("hello\n"), 0644))
@@ -112,7 +112,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 
 	// Create some test data
 
-	must(t, ffs.MkdirAll(".stfolder", 0755))
+	must(t, ffs.MkdirAll(".syncthing", 0755))
 	oldData := []byte("hello\n")
 	knownFiles := setupKnownFiles(t, ffs, oldData)
 
@@ -200,7 +200,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 
 	// Create some test data
 
-	must(t, ffs.MkdirAll(".stfolder", 0755))
+	must(t, ffs.MkdirAll(".syncthing", 0755))
 	oldData := []byte("hello\n")
 	knownFiles := setupKnownFiles(t, ffs, oldData)
 
@@ -268,7 +268,7 @@ func TestRecvOnlyDeletedRemoteDrop(t *testing.T) {
 
 	// Create some test data
 
-	must(t, ffs.MkdirAll(".stfolder", 0755))
+	must(t, ffs.MkdirAll(".syncthing", 0755))
 	oldData := []byte("hello\n")
 	knownFiles := setupKnownFiles(t, ffs, oldData)
 

--- a/lib/model/folder_test.go
+++ b/lib/model/folder_test.go
@@ -63,18 +63,18 @@ func unifySubsCases() []unifySubsCase {
 			[]string{"usr/lib"},
 		},
 		{
-			// 6. .stignore and .stfolder are special and are passed on
+			// 6. .stignore and .syncthing are special and are passed on
 			// verbatim even though they are unknown
-			[]string{config.DefaultMarkerName, ".stignore"},
+			[]string{".stignore", config.DefaultMarkerName},
 			[]string{},
-			[]string{config.DefaultMarkerName, ".stignore"},
+			[]string{".stignore", config.DefaultMarkerName},
 		},
 		{
 			// 7. but the presence of something else unknown forces an actual
 			// scan
-			[]string{config.DefaultMarkerName, ".stignore", "foo/bar"},
+			[]string{".stignore", config.DefaultMarkerName, "foo/bar"},
 			[]string{},
-			[]string{config.DefaultMarkerName, ".stignore", "foo"},
+			[]string{".stignore", config.DefaultMarkerName, "foo"},
 		},
 		{
 			// 8. explicit request to scan all

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -803,7 +803,7 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 			if err := equalContents(filepath.Join(tmpDir, path), otherData); err != nil {
 				t.Error(`Sync conflict of "b" has unexptected content`)
 			}
-		case path == "." || strings.HasPrefix(path, ".stfolder"):
+		case path == "." || strings.HasPrefix(path, ".syncthing"):
 		default:
 			t.Error("Found unexpected file", path)
 		}

--- a/test/h1/config.xml
+++ b/test/h1/config.xml
@@ -19,7 +19,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <copyOwnershipFromParent>false</copyOwnershipFromParent>
         <modTimeWindowS>0</modTimeWindowS>
         <maxConcurrentWrites>0</maxConcurrentWrites>

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -18,7 +18,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <copyOwnershipFromParent>false</copyOwnershipFromParent>
         <modTimeWindowS>0</modTimeWindowS>
         <maxConcurrentWrites>0</maxConcurrentWrites>
@@ -43,7 +43,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <copyOwnershipFromParent>false</copyOwnershipFromParent>
         <modTimeWindowS>0</modTimeWindowS>
         <maxConcurrentWrites>0</maxConcurrentWrites>
@@ -68,7 +68,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <copyOwnershipFromParent>false</copyOwnershipFromParent>
         <modTimeWindowS>0</modTimeWindowS>
         <maxConcurrentWrites>0</maxConcurrentWrites>

--- a/test/h3/config.xml
+++ b/test/h3/config.xml
@@ -20,7 +20,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <copyOwnershipFromParent>false</copyOwnershipFromParent>
         <modTimeWindowS>0</modTimeWindowS>
         <maxConcurrentWrites>0</maxConcurrentWrites>
@@ -45,7 +45,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <copyOwnershipFromParent>false</copyOwnershipFromParent>
         <modTimeWindowS>0</modTimeWindowS>
         <maxConcurrentWrites>0</maxConcurrentWrites>

--- a/test/h4/config.xml
+++ b/test/h4/config.xml
@@ -16,7 +16,7 @@
         <disableTempIndexes>false</disableTempIndexes>
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
-        <markerName>.stfolder</markerName>
+        <markerName>.syncthing</markerName>
         <useLargeBlocks>false</useLargeBlocks>
     </folder>
     <device id="7PBCTLL-JJRYBSA-MOWZRKL-MSDMN4N-4US4OMX-SYEXUS4-HSBGNRY-CZXRXAT" name="s4" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">

--- a/test/reset_test.go
+++ b/test/reset_test.go
@@ -56,7 +56,7 @@ func TestReset(t *testing.T) {
 	if err := os.Mkdir("s1", 0755); err != nil {
 		t.Fatal(err)
 	}
-	if fd, err := os.Create("s1/.stfolder"); err != nil {
+	if fd, err := os.Create("s1/.syncthing"); err != nil {
 		t.Fatal(err)
 	} else {
 		fd.Close()

--- a/test/util.go
+++ b/test/util.go
@@ -127,7 +127,7 @@ func alterFiles(dir string) error {
 		}
 
 		switch filepath.Base(path) {
-		case ".stfolder":
+		case ".syncthing":
 			return nil
 		case ".stversions":
 			return nil
@@ -424,7 +424,7 @@ func startWalker(dir string, res chan<- fileInfo, abort <-chan struct{}) chan er
 		}
 
 		rn, _ := filepath.Rel(dir, path)
-		if rn == "." || rn == ".stfolder" {
+		if rn == "." || rn == ".syncthing" {
 			return nil
 		}
 		if rn == ".stversions" {


### PR DESCRIPTION
### Purpose

Attempt to fix #6844 

### Testing

`./build.sh test` passes, but I'm not sure if it covers all the users cases (esp. with previously existing `.stfolder`)
I let untouched a few test data with `<markerName>.stfolder</markerName>` on purpose

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.


