### PR TITLE
lib/db: Update global meta even if unchanged (fixes #6850)

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -662,13 +662,11 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 		}
 	}
 
-	// Update global size counter if necessary
-
-	if !globalChanged {
-		// Neither the global state nor the needs of any devices, except
-		// the one updated, changed.
-		return keyBuf, true, nil
-	}
+	// Update global size counter.
+	// It's done regardless of if the global changed, as two files might
+	// both be invalid, but for different reasons i.e. have different flags
+	// (e.g. ignored vs receive only).
+	// https://github.com/syncthing/syncthing/issues/6850
 
 	// Remove the old global from the global size counter
 	if haveOldGlobal {
@@ -690,6 +688,12 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 		gotGlobal = true
 	}
 	meta.addFile(protocol.GlobalDeviceID, global)
+
+	if !globalChanged {
+		// Neither the global state nor the needs of any devices, except
+		// the one updated, changed.
+		return keyBuf, true, nil
+	}
 
 	// check for local (if not already done before)
 	if !bytes.Equal(device, protocol.LocalDeviceID[:]) {


### PR DESCRIPTION
In the global list we don't have an info on why a file is invalid, e.g. if it's a receive-only item or ignored. However that's relevant for metadata accounting. Thus we now always remove the old global and add the new global from metadata, even if from the perspective of the global list nothing changed (i.e. versions equal and both invalid or not).