### PR TITLE
build: Replace hypen in -dirty for version (ref #6758)

### DIFF
--- a/build.go
+++ b/build.go
@@ -874,7 +874,10 @@ func getGitVersion() (string, error) {
 	}
 	v0 := string(bs)
 
-	versionRe := regexp.MustCompile(`-([0-9]{1,3}-g[0-9a-f]{5,10})`)
+	// To be more semantic-versionish and ensure proper ordering in our
+	// upgrade process, we make sure there's only one hypen in the version.
+
+	versionRe := regexp.MustCompile(`-([0-9]{1,3}-g[0-9a-f]{5,10}(-dirty)?)`)
 	if m := versionRe.FindStringSubmatch(vcur); len(m) > 0 {
 		suffix := strings.ReplaceAll(m[1], "-", ".")
 


### PR DESCRIPTION
Just wanted to switch one of my devices from "custom nightlies" to "official nightlies" and it didn't upgrade. Apparently I was running a dirty version, which contains two hyphens and was thus considered newer than the significantly newer "official nightlies". The printed version with this change before committing is now: 
```
$ ./bin/syncthing -version
syncthing v1.8.0-rc.2.dev.5.g08e0f938.dirty "Fermium Flea" (go1.14.4 linux-amd64)
```