### PR TITLE
lib/db: Include blocks in db check (ref #6855)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -497,7 +497,7 @@ func checkGlobalsFilterDevices(dk, folder, name []byte, devices [][]byte, vl *Ve
 		if err != nil {
 			return false, err
 		}
-		f, ok, err := t.getFileTrunc(dk, true)
+		f, ok, err := t.getFileTrunc(dk, false)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This is not a fix for #6855 or anything else, but given missing blocks are a thing, I don't see why we should do all the expensive db checking but omit blocklists from it.