### PR TITLE
lib/db: Don't count invalid items to global state (ref #6850)

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -288,9 +288,7 @@ func (s *Snapshot) ReceiveOnlyChangedSize() Counts {
 }
 
 func (s *Snapshot) GlobalSize() Counts {
-	global := s.meta.Counts(protocol.GlobalDeviceID, 0)
-	recvOnlyChanged := s.meta.Counts(protocol.GlobalDeviceID, protocol.FlagLocalReceiveOnly)
-	return global.Add(recvOnlyChanged)
+	return s.meta.Counts(protocol.GlobalDeviceID, 0)
 }
 
 func (s *Snapshot) NeedSize(device protocol.DeviceID) Counts {

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -1720,8 +1720,8 @@ func TestIgnoreLocalChanged(t *testing.T) {
 	}
 	s.Update(protocol.LocalDeviceID, files)
 
-	if c := globalSize(s).Files; c != 1 {
-		t.Error("Expected one global file, got", c)
+	if c := globalSize(s).Files; c != 0 {
+		t.Error("Expected no global file, got", c)
 	}
 	if c := localSize(s).Files; c != 1 {
 		t.Error("Expected one local file, got", c)

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -46,11 +46,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 	m.Index(device1, "ro", knownFiles)
 	f.updateLocalsFromScanning(knownFiles)
 
-	m.fmut.RLock()
-	snap := m.folderFiles["ro"].Snapshot()
-	m.fmut.RUnlock()
-	size := snap.GlobalSize()
-	snap.Release()
+	size := globalSize(t, m, "ro")
 	if size.Files != 1 || size.Directories != 1 {
 		t.Fatalf("Global: expected 1 file and 1 directory: %+v", size)
 	}
@@ -59,10 +55,10 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 
 	must(t, m.ScanFolder("ro"))
 
-	// We should now have two files and two directories.
+	// We should now have two files and two directories, with global state unchanged.
 
 	size = globalSize(t, m, "ro")
-	if size.Files != 2 || size.Directories != 2 {
+	if size.Files != 1 || size.Directories != 1 {
 		t.Fatalf("Global: expected 2 files and 2 directories: %+v", size)
 	}
 	size = localSize(t, m, "ro")


### PR DESCRIPTION
### Purpose

https://github.com/syncthing/syncthing/issues/6850#issuecomment-665031731:  
> [...] why do we include receive-only changed items in the global count in the first place? That seems completely wrong to me: The global state is what everyone agrees upon. Receive-only changed items are the complete antithesis to that. If we didn't add it to the global state, receive-only items would lead to a higher local than global state, which seems right. It also removes the need for the workaround added in #6852. Thus I propose to not add invalid items to the global state. 

This behaviour also fixes #6850, and in addition to the previous fix (which is reverted here) covers removing items from the global state as well.