### PR TITLE
gui: Don't show pull order on SO folders (ref #6807)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -456,7 +456,7 @@
                         </div>
                       </td>
                     </tr>
-                    <tr ng-if="folder.order != 'random'">
+                    <tr ng-if="folder.order != 'random' && folder.type != 'sendonly'">
                       <th><span class="fas fa-fw fa-sort"></span>&nbsp;<span translate>File Pull Order</span></th>
                       <td class="text-right" ng-switch="folder.order">
                         <span ng-switch-when="random" translate>Random</span>


### PR DESCRIPTION
### Purpose

https://github.com/syncthing/syncthing/issues/6807#issuecomment-667172474:
> [...] I have just noticed that the "File Pull Order" is still shown in the GUI for "Send Only" folders, after unfolding the folder's details. This only happens when it has been set to a non-default value before setting the folder type to "Send Only".
> 
> I think that it should be hidden here too.

### Testing

Didn't test.