### PR TITLE
lib/osutil: Preserve perms in AtomicWriter (fixes #6886)

### DIFF
--- a/lib/osutil/atomic.go
+++ b/lib/osutil/atomic.go
@@ -93,7 +93,12 @@ func (w *AtomicWriter) Close() error {
 		return err
 	}
 
-	err := w.fs.Rename(w.next.Name(), w.path)
+	info, err := w.fs.Lstat(w.path)
+	if err != nil && !fs.IsNotExist(err) {
+		w.err = err
+		return err
+	}
+	err = w.fs.Rename(w.next.Name(), w.path)
 	if runtime.GOOS == "windows" && fs.IsPermission(err) {
 		// On Windows, we might not be allowed to rename over the file
 		// because it's read-only. Get us some write permissions and try
@@ -104,6 +109,12 @@ func (w *AtomicWriter) Close() error {
 	if err != nil {
 		w.err = err
 		return err
+	}
+	if info != nil {
+		if err := w.fs.Chmod(w.path, info.Mode()); err != nil {
+			w.err = err
+			return err
+		}
 	}
 
 	// fsync the directory too

--- a/lib/osutil/atomic_test.go
+++ b/lib/osutil/atomic_test.go
@@ -110,4 +110,10 @@ func testCreateAtomicReplace(t *testing.T, oldPerms os.FileMode) {
 	if !bytes.Equal(bs, []byte("hello")) {
 		t.Error("incorrect data")
 	}
+
+	if info, err := os.Stat(testfile); err != nil {
+		t.Fatal(err)
+	} else if info.Mode() != oldPerms {
+		t.Fatalf("Perms changed during atomic write: 0%o", info.Mode())
+	}
 }


### PR DESCRIPTION
Preserves permissions if a file is replaced/truncated. Reported in https://forum.syncthing.net/t/preserve-chmod-permission-after-editing-stignore-via-webui/15461, waiting for the issue (number) to fix the commit msg.