### PR TITLE
lib/db: Don't put truncated files (ref #6855, ref #6501)

### DIFF
--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -7,6 +7,7 @@
 package backend
 
 import (
+	"errors"
 	"os"
 	"strings"
 	"sync"
@@ -157,13 +158,13 @@ type errNotFound struct{}
 func (*errNotFound) Error() string { return "key not found" }
 
 func IsClosed(err error) bool {
-	_, ok := err.(*errClosed)
-	return ok
+	e := &errClosed{}
+	return errors.As(err, &e)
 }
 
 func IsNotFound(err error) bool {
-	_, ok := err.(*errNotFound)
-	return ok
+	e := &errNotFound{}
+	return errors.As(err, &e)
 }
 
 // releaser manages counting on top of a waitgroup

--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -163,7 +163,7 @@ func IsClosed(err error) bool {
 }
 
 func IsNotFound(err error) bool {
-	var e *errClosed
+	var e *errNotFound
 	return errors.As(err, &e)
 }
 

--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -158,12 +158,12 @@ type errNotFound struct{}
 func (*errNotFound) Error() string { return "key not found" }
 
 func IsClosed(err error) bool {
-	e := &errClosed{}
+	var e *errClosed
 	return errors.As(err, &e)
 }
 
 func IsNotFound(err error) bool {
-	e := &errNotFound{}
+	var e *errClosed
 	return errors.As(err, &e)
 }
 

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -305,7 +305,8 @@ func TestRepairSequence(t *testing.T) {
 		{Name: "duplicate", Blocks: genBlocks(2)},
 		{Name: "missing", Blocks: genBlocks(3)},
 		{Name: "overwriting", Blocks: genBlocks(4)},
-		{Name: "inconsistent", Blocks: genBlocks(2)},
+		{Name: "inconsistent", Blocks: genBlocks(5)},
+		{Name: "inconsistentNotIndirected", Blocks: genBlocks(2)},
 	}
 	for i, f := range files {
 		files[i].Version = f.Version.Update(short)
@@ -367,10 +368,13 @@ func TestRepairSequence(t *testing.T) {
 	files[3].Sequence = seq
 	addFile(files[3], seq)
 
-	// Inconistent file
+	// Inconistent files
 	seq++
 	files[4].Sequence = 101
 	addFile(files[4], seq)
+	seq++
+	files[5].Sequence = 102
+	addFile(files[5], seq)
 
 	// And a sequence entry pointing at nothing because why not
 	sk, err = trans.keyer.GenerateSequenceKey(nil, folder, 100001)

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -305,7 +305,7 @@ func TestRepairSequence(t *testing.T) {
 		{Name: "duplicate", Blocks: genBlocks(2)},
 		{Name: "missing", Blocks: genBlocks(3)},
 		{Name: "overwriting", Blocks: genBlocks(4)},
-		{Name: "inconsistent", Blocks: genBlocks(5)},
+		{Name: "inconsistent", Blocks: genBlocks(2)},
 	}
 	for i, f := range files {
 		files[i].Version = f.Version.Update(short)
@@ -322,7 +322,7 @@ func TestRepairSequence(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := trans.putFile(dk, f, false); err != nil {
+		if err := trans.putFile(dk, f); err != nil {
 			t.Fatal(err)
 		}
 		sk, err := trans.keyer.GenerateSequenceKey(nil, folder, seq)

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -149,7 +149,7 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 		meta.addFile(devID, f)
 
 		l.Debugf("insert; folder=%q device=%v %v", folder, devID, f)
-		if err := t.putFile(dk, f, false); err != nil {
+		if err := t.putFile(dk, f); err != nil {
 			return err
 		}
 
@@ -240,7 +240,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		meta.addFile(protocol.LocalDeviceID, f)
 
 		l.Debugf("insert (local); folder=%q %v", folder, f)
-		if err := t.putFile(dk, f, false); err != nil {
+		if err := t.putFile(dk, f); err != nil {
 			return err
 		}
 
@@ -956,11 +956,11 @@ func (db *Lowlevel) repairSequenceGCLocked(folderStr string, meta *metadataTrack
 
 	var sk sequenceKey
 	for it.Next() {
-		intf, err := t.unmarshalTrunc(it.Value(), true)
+		intf, err := t.unmarshalTrunc(it.Value(), false)
 		if err != nil {
 			return 0, err
 		}
-		fi := intf.(FileInfoTruncated)
+		fi := intf.(protocol.FileInfo)
 		if sk, err = t.keyer.GenerateSequenceKey(sk, folder, fi.Sequence); err != nil {
 			return 0, err
 		}
@@ -979,7 +979,7 @@ func (db *Lowlevel) repairSequenceGCLocked(folderStr string, meta *metadataTrack
 			if err := t.Put(sk, it.Key()); err != nil {
 				return 0, err
 			}
-			if err := t.putFile(it.Key(), fi.copyToFileInfo(), true); err != nil {
+			if err := t.putFile(it.Key(), fi); err != nil {
 				return 0, err
 			}
 		}

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -537,7 +537,7 @@ func (db *schemaUpdater) rewriteFiles(t readWriteTransaction) error {
 		if fi.Blocks == nil {
 			continue
 		}
-		if err := t.putFile(it.Key(), fi, false); err != nil {
+		if err := t.putFile(it.Key(), fi); err != nil {
 			return err
 		}
 		if err := t.Checkpoint(); err != nil {

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -27,9 +27,10 @@ import (
 //   8-9: v1.4.0
 //   10-11: v1.6.0
 //   12-13: v1.7.0
+//   14: v1.9.0
 const (
-	dbVersion             = 13
-	dbMinSyncthingVersion = "v1.7.0"
+	dbVersion             = 14
+	dbMinSyncthingVersion = "v1.9.0"
 )
 
 var errFolderMissing = errors.New("folder present in global list but missing in keyer index")
@@ -95,6 +96,7 @@ func (db *schemaUpdater) updateSchema() error {
 		{10, db.updateSchemaTo10},
 		{11, db.updateSchemaTo11},
 		{13, db.updateSchemaTo13},
+		{14, db.updateSchemaTo14},
 	}
 
 	for _, m := range migrations {
@@ -681,6 +683,70 @@ func (db *schemaUpdater) updateSchemaTo13(prev int) error {
 	}
 
 	return t.Commit()
+}
+
+func (db *schemaUpdater) updateSchemaTo14(_ int) error {
+	// Checks for missing blocks and marks those entries as requiring a
+	// rehash/being invalid. The db is checked/repaired afterwards, i.e.
+	// no care is taken to get metadata and sequences right.
+	// If the corresponding files changed on disk compared to the global
+	// version, this will cause a conflict.
+
+	var key, gk []byte
+	for _, folderStr := range db.ListFolders() {
+		folder := []byte(folderStr)
+		meta := newMetadataTracker(db.keyer)
+		meta.counts.Created = 0 // Recalculate metadata afterwards
+
+		t, err := db.newReadWriteTransaction(meta.CommitHook(folder))
+		if err != nil {
+			return err
+		}
+		defer t.close()
+
+		key, err = t.keyer.GenerateDeviceFileKey(key, folder, protocol.LocalDeviceID[:], nil)
+		it, err := t.NewPrefixIterator(key)
+		if err != nil {
+			return err
+		}
+		defer it.Release()
+		for it.Next() {
+			var fi protocol.FileInfo
+			if err := fi.Unmarshal(it.Value()); err != nil {
+				return err
+			}
+			if len(fi.Blocks) > 0 || len(fi.BlocksHash) == 0 {
+				continue
+			}
+			key = t.keyer.GenerateBlockListKey(key, fi.BlocksHash)
+			_, err := t.Get(key)
+			if err == nil {
+				continue
+			}
+
+			fi.SetMustRescan(protocol.LocalDeviceID.Short())
+			if err = t.putFile(it.Key(), fi); err != nil {
+				return err
+			}
+
+			gk, err = t.keyer.GenerateGlobalVersionKey(gk, folder, []byte(fi.Name))
+			if err != nil {
+				return err
+			}
+			key, _, err = t.updateGlobal(gk, key, folder, protocol.LocalDeviceID[:], fi, meta)
+			if err != nil {
+				return err
+			}
+		}
+		it.Release()
+
+		if err = t.Commit(); err != nil {
+			return err
+		}
+		t.close()
+	}
+
+	return nil
 }
 
 func (db *schemaUpdater) rewriteGlobals(t readWriteTransaction) error {


### PR DESCRIPTION
> Calling `.putFile` with `truncate == true` and a file with less blocks than `blocksIndirectionCutoff` puts a fileinfo without blocks. `truncate == true` is only the case when repairing sequence indexes, so this "shoudn't happen"™. However it does, so it's a real practical issue.

https://github.com/syncthing/syncthing/issues/6855

The tiny change in `TestRepairSequence` triggers the problem described above. To prevent it, don't ever write truncated files infos. If we wanted to write truncated files, we'd need to always redirect blocklists and check that a block list for the given `BlocksHash` of the truncated file already exists. Given we only write truncated files when repairing sequences and it's just an irrelevant "optimisation", I don't want to go there and instead just write full file infos.

I also added context to errors in `fillFileInfo` and adjusted the `IsClosed` etc. checks to use `errors.As`, to make the "no file info at all" distinguishable from "blocks/version not found".

I really need to pay more attention to numbers in sentry. The "missing-entry-panic" already affects 30 users on v1.8.0 (https://sentry.syncthing.net/syncthing/syncthing/?query=is%3Aunresolved+release%3Av1.8.0+device+present&statsPeriod=14d) and over 300 in total (https://sentry.syncthing.net/syncthing/syncthing/?query=is%3Aunresolved+device+present&statsPeriod=14d). I usually just notice newly occurring events and then either take action or shelf them...