### PR TITLE
lib/dialer: Try dialing without reuse in parallel (fixes #6892)

### DIFF
--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -159,6 +159,7 @@ func dialTwicePreferFirst(ctx context.Context, first, second dialFunc, firstName
 		case <-firstDone:
 			if firstErr == nil {
 				// First succeeded, no point doing anything in second
+				secondErr = errors.New("didn't dial")
 				close(secondDone)
 				return
 			}

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -83,37 +83,15 @@ func dialContextWithFallback(ctx context.Context, fallback proxy.ContextDialer, 
 		return dialerConn{conn, newDialerAddr(network, addr)}, nil
 	}
 
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-	var proxyConn, fallbackConn net.Conn
-	var proxyErr, fallbackErr error
-	proxyDone := make(chan struct{})
-	fallbackDone := make(chan struct{})
-	go func() {
-		proxyConn, proxyErr = dialer.DialContext(ctx, network, addr)
-		l.Debugf("Dialing proxy result %s %s: %v %v", network, addr, proxyConn, proxyErr)
-		if proxyErr == nil {
-			proxyConn = dialerConn{proxyConn, newDialerAddr(network, addr)}
+	proxyDialFudgeAddress := func(ctx context.Context, network, address string) (net.Conn, error) {
+		conn, err := dialer.DialContext(ctx, network, addr)
+		if err != nil {
+			return nil, err
 		}
-		close(proxyDone)
-	}()
-	go func() {
-		fallbackConn, fallbackErr = fallback.DialContext(ctx, network, addr)
-		l.Debugf("Dialing fallback result %s %s: %v %v", network, addr, fallbackConn, fallbackErr)
-		close(fallbackDone)
-	}()
-	<-proxyDone
-	if proxyErr == nil {
-		go func() {
-			<-fallbackDone
-			if fallbackErr == nil {
-				_ = fallbackConn.Close()
-			}
-		}()
-		return proxyConn, nil
+		return dialerConn{conn, newDialerAddr(network, addr)}, err
 	}
-	<-fallbackDone
-	return fallbackConn, fallbackErr
+
+	return dialTwicePreferFirst(ctx, proxyDialFudgeAddress, fallback.DialContext, "proxy", "fallback", network, addr)
 }
 
 // DialContext dials via context and/or directly, depending on how it is configured.
@@ -145,32 +123,43 @@ func DialContextReusePort(ctx context.Context, network, addr string) (net.Conn, 
 
 	// Dial twice, once reusing the listen address, another time not reusing it, just in case reusing the address
 	// influences routing and we fail to reach our destination.
-	var reuseConn, nonReuseConn net.Conn
-	var reuseErr, nonReuseErr error
-	reuseDone := make(chan struct{})
-	nonReuseDone := make(chan struct{})
+	dialer := net.Dialer{
+		Control:   ReusePortControl,
+		LocalAddr: laddr,
+	}
+	return dialTwicePreferFirst(ctx, dialer.DialContext, (net.Dialer{}).DialContext, "reuse", "non-reuse", network, addr)
+}
+
+type dialFunc func(ctx context.Context, network, address string) (net.Conn, error)
+
+func dialTwicePreferFirst(ctx context.Context, first, second dialFunc, firstName, secondName, network, address string) (net.Conn, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var firstConn, secondConn net.Conn
+	var firstErr, secondErr error
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
 	go func() {
-		dialer := &net.Dialer{
-			Control:   ReusePortControl,
-			LocalAddr: laddr,
-		}
-		reuseConn, reuseErr = dialContextWithFallback(ctx, dialer, network, addr)
-		close(reuseDone)
+		firstConn, firstErr = first(ctx, network, address)
+		l.Debugf("Dialing %s result %s %s: %v %v", firstName, network, address, firstConn, firstErr)
+		close(firstDone)
 	}()
 	go func() {
-		nonReuseConn, nonReuseErr = DialContext(ctx, network, addr)
-		close(nonReuseDone)
+		secondConn, secondErr = second(ctx, network, address)
+		l.Debugf("Dialing %s result %s %s: %v %v", secondName, network, address, secondConn, secondErr)
+		close(secondDone)
 	}()
-	<-reuseDone
-	if reuseErr == nil {
+	<-firstDone
+	if firstErr == nil {
 		go func() {
-			<-nonReuseDone
-			if nonReuseErr == nil {
-				_ = nonReuseConn.Close()
+			<-secondDone
+			if secondErr == nil {
+				_ = secondConn.Close()
 			}
 		}()
-		return reuseConn, nil
+		return firstConn, firstErr
 	}
-	<-nonReuseDone
-	return nonReuseConn, nonReuseErr
+	<-secondDone
+	return secondConn, secondErr
 }

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -127,7 +127,7 @@ func DialContextReusePort(ctx context.Context, network, addr string) (net.Conn, 
 		Control:   ReusePortControl,
 		LocalAddr: laddr,
 	}
-	return dialTwicePreferFirst(ctx, dialer.DialContext, (net.Dialer{}).DialContext, "reuse", "non-reuse", network, addr)
+	return dialTwicePreferFirst(ctx, dialer.DialContext, (&net.Dialer{}).DialContext, "reuse", "non-reuse", network, addr)
 }
 
 type dialFunc func(ctx context.Context, network, address string) (net.Conn, error)

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -151,7 +151,7 @@ func DialContextReusePort(ctx context.Context, network, addr string) (net.Conn, 
 	nonReuseDone := make(chan struct{})
 	go func() {
 		dialer := &net.Dialer{
-			Control: ReusePortControl,
+			Control:   ReusePortControl,
 			LocalAddr: laddr,
 		}
 		reuseConn, reuseErr = dialContextWithFallback(ctx, dialer, network, addr)

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -163,6 +163,7 @@ func dialTwicePreferFirst(ctx context.Context, first, second dialFunc, firstName
 				return
 			}
 		case <-ctx.Done():
+			secondErr = ctx.Err()
 			close(secondDone)
 			return
 		case <-time.After(sleep):


### PR DESCRIPTION
Reusing the listen address influences the routing decision, which is not what we want in some cases.