### PR TITLE
all: Subscribe to config changes on Serve

### DIFF
--- a/cmd/stcli/main.go
+++ b/cmd/stcli/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/syncthing/syncthing/lib/build"
 	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/locations"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/urfave/cli"
@@ -85,7 +84,7 @@ func main() {
 		myID := protocol.NewDeviceID(cert.Certificate[0])
 
 		// Load the config
-		cfg, err := config.Load(locations.Get(locations.ConfigFile), myID, events.NoopLogger)
+		cfg, err := config.Load(locations.Get(locations.ConfigFile), myID)
 		if err != nil {
 			log.Fatalln(errors.Wrap(err, "loading config"))
 		}

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/build"
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/relay/protocol"
 	"github.com/syncthing/syncthing/lib/tlsutil"
@@ -184,7 +183,7 @@ func main() {
 		log.Println("ID:", id)
 	}
 
-	wrapper := config.Wrap("config", config.New(id), events.NoopLogger)
+	wrapper := config.Wrap("config", config.New(id))
 	wrapper.SetOptions(config.OptionsConfiguration{
 		NATLeaseM:   natLease,
 		NATRenewalM: natRenewal,

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -442,7 +442,7 @@ func main() {
 }
 
 func openGUI(myID protocol.DeviceID) error {
-	cfg, err := loadOrDefaultConfig(myID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig(myID)
 	if err != nil {
 		return err
 	}
@@ -485,11 +485,11 @@ func generate(generateDir string) error {
 		l.Warnln("Config exists; will not overwrite.")
 		return nil
 	}
-	cfg, err := syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder)
+	cfg, err := syncthing.DefaultConfig(cfgFile, myID, noDefaultFolder)
 	if err != nil {
 		return err
 	}
-	err = cfg.Save()
+	_, err = cfg.Save()
 	if err != nil {
 		return errors.Wrap(err, "save config")
 	}
@@ -527,7 +527,7 @@ func (e *errNoUpgrade) Error() string {
 }
 
 func checkUpgrade() (upgrade.Release, error) {
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID)
 	if err != nil {
 		return upgrade.Release{}, err
 	}
@@ -546,7 +546,7 @@ func checkUpgrade() (upgrade.Release, error) {
 }
 
 func upgradeViaRest() error {
-	cfg, _ := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, _ := loadOrDefaultConfig(protocol.EmptyDeviceID)
 	u, err := url.Parse(cfg.GUI().URL())
 	if err != nil {
 		return err
@@ -604,7 +604,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	go evLogger.Serve()
 	defer evLogger.Stop()
 
-	cfg, err := syncthing.LoadConfigAtStartup(locations.Get(locations.ConfigFile), cert, evLogger, runtimeOptions.allowNewerConfig, noDefaultFolder)
+	cfg, err := syncthing.LoadConfigAtStartup(locations.Get(locations.ConfigFile), cert, runtimeOptions.allowNewerConfig, noDefaultFolder)
 	if err != nil {
 		l.Warnln("Failed to initialize config:", err)
 		os.Exit(syncthing.ExitError.AsInt())
@@ -748,12 +748,12 @@ func setupSignalHandling(app *syncthing.App) {
 	}()
 }
 
-func loadOrDefaultConfig(myID protocol.DeviceID, evLogger events.Logger) (config.Wrapper, error) {
+func loadOrDefaultConfig(myID protocol.DeviceID) (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
-	cfg, err := config.Load(cfgFile, myID, evLogger)
+	cfg, err := config.Load(cfgFile, myID)
 
 	if err != nil {
-		cfg, err = syncthing.DefaultConfig(cfgFile, myID, evLogger, noDefaultFolder)
+		cfg, err = syncthing.DefaultConfig(cfgFile, myID, noDefaultFolder)
 	}
 
 	return cfg, err

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -20,7 +20,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/locations"
 	"github.com/syncthing/syncthing/lib/osutil"
@@ -563,7 +562,7 @@ func childEnv() []string {
 // panicUploadMaxWait uploading panics...
 func maybeReportPanics() {
 	// Try to get a config to see if/where panics should be reported.
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID)
 	if err != nil {
 		l.Warnln("Couldn't load config; not reporting crash")
 		return

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -106,7 +106,7 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 			RawUseTLS:  false,
 		},
 	}
-	w := config.Wrap("/dev/null", cfg, events.NoopLogger)
+	w := config.Wrap("/dev/null", cfg)
 
 	srv := New(protocol.LocalDeviceID, w, "", "syncthing", nil, nil, nil, events.NoopLogger, nil, nil, nil, nil, nil, nil, nil, false).(*service)
 	defer os.Remove(token)

--- a/lib/api/mocked_config_test.go
+++ b/lib/api/mocked_config_test.go
@@ -42,7 +42,9 @@ func (c *mockedConfig) Replace(cfg config.Configuration) (config.Waiter, error) 
 	return noopWaiter{}, nil
 }
 
-func (c *mockedConfig) Subscribe(cm config.Committer) {}
+func (c *mockedConfig) Subscribe(cm config.Committer) config.Configuration {
+	return config.Configuration{}
+}
 
 func (c *mockedConfig) Unsubscribe(cm config.Committer) {}
 
@@ -62,8 +64,8 @@ func (c *mockedConfig) SetDevices([]config.DeviceConfiguration) (config.Waiter, 
 	return noopWaiter{}, nil
 }
 
-func (c *mockedConfig) Save() error {
-	return nil
+func (c *mockedConfig) Save() (config.Configuration, error) {
+	return config.Configuration{}, nil
 }
 
 func (c *mockedConfig) RequiresRestart() bool {

--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/thejerf/suture"
 
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 type recv struct {
@@ -33,8 +33,8 @@ type Interface interface {
 type cast struct {
 	*suture.Supervisor
 	name    string
-	reader  util.ServiceWithError
-	writer  util.ServiceWithError
+	reader  serviceutil.ServiceWithError
+	writer  serviceutil.ServiceWithError
 	outbox  chan recv
 	inbox   chan []byte
 	stopped chan struct{}
@@ -74,8 +74,8 @@ func (c *cast) addWriter(svc func(ctx context.Context) error) {
 	c.Add(c.writer)
 }
 
-func (c *cast) createService(svc func(context.Context) error, suffix string) util.ServiceWithError {
-	return util.AsServiceWithError(func(ctx context.Context) error {
+func (c *cast) createService(svc func(context.Context) error, suffix string) serviceutil.ServiceWithError {
+	return serviceutil.AsServiceWithError(func(ctx context.Context) error {
 		l.Debugln("Starting", c.name, suffix)
 		err := svc(ctx)
 		l.Debugf("Stopped %v %v: %v", c.name, suffix, err)

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	"github.com/d4l3k/messagediff"
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/protocol"
 )
@@ -529,7 +528,7 @@ func TestNewSaveLoad(t *testing.T) {
 		t.Error(path, "exists")
 	}
 
-	err := cfg.Save()
+	_, err := cfg.Save()
 	if err != nil {
 		t.Error(err)
 	}
@@ -1168,11 +1167,11 @@ func defaultConfigAsMap() map[string]interface{} {
 }
 
 func load(path string, myID protocol.DeviceID) (Wrapper, error) {
-	return Load(path, myID, events.NoopLogger)
+	return Load(path, myID)
 }
 
 func wrap(path string, cfg Configuration) Wrapper {
-	return Wrap(path, cfg, events.NoopLogger)
+	return Wrap(path, cfg)
 }
 
 func TestInternalVersioningConfiguration(t *testing.T) {

--- a/lib/connections/lan_test.go
+++ b/lib/connections/lan_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/events"
 )
 
 func TestIsLANHost(t *testing.T) {
@@ -36,7 +35,7 @@ func TestIsLANHost(t *testing.T) {
 		Options: config.OptionsConfiguration{
 			AlwaysLocalNets: []string{"10.20.30.0/24"},
 		},
-	}, events.NoopLogger)
+	})
 	s := &service{cfg: cfg}
 
 	for _, tc := range cases {

--- a/lib/connections/limiter.go
+++ b/lib/connections/limiter.go
@@ -40,20 +40,14 @@ const (
 	maxSingleWriteSize = 8 << 10
 )
 
-func newLimiter(cfg config.Wrapper) *limiter {
-	l := &limiter{
+func newLimiter() *limiter {
+	return &limiter{
 		write:               rate.NewLimiter(rate.Inf, limiterBurstSize),
 		read:                rate.NewLimiter(rate.Inf, limiterBurstSize),
 		mu:                  sync.NewMutex(),
 		deviceReadLimiters:  make(map[protocol.DeviceID]*rate.Limiter),
 		deviceWriteLimiters: make(map[protocol.DeviceID]*rate.Limiter),
 	}
-
-	cfg.Subscribe(l)
-	prev := config.Configuration{Options: config.OptionsConfiguration{MaxRecvKbps: -1, MaxSendKbps: -1}}
-
-	l.CommitConfiguration(prev, cfg.RawCopy())
-	return l
 }
 
 // This function sets limiters according to corresponding DeviceConfiguration
@@ -173,6 +167,11 @@ func (lim *limiter) CommitConfiguration(from, to config.Configuration) bool {
 	}
 
 	return true
+}
+
+func (lim *limiter) initCfg(cfg config.Configuration) {
+	prev := config.Configuration{Options: config.OptionsConfiguration{MaxRecvKbps: -1, MaxSendKbps: -1}}
+	lim.CommitConfiguration(prev, cfg)
 }
 
 func (lim *limiter) String() string {

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -24,7 +24,7 @@ import (
 	"github.com/syncthing/syncthing/lib/connections/registry"
 	"github.com/syncthing/syncthing/lib/nat"
 	"github.com/syncthing/syncthing/lib/stun"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 func init() {
@@ -35,7 +35,7 @@ func init() {
 }
 
 type quicListener struct {
-	util.ServiceWithError
+	serviceutil.ServiceWithError
 	nat atomic.Value
 
 	onAddressesChangedNotifier
@@ -203,7 +203,7 @@ func (f *quicListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls.
 		conns:   conns,
 		factory: f,
 	}
-	l.ServiceWithError = util.AsServiceWithError(l.serve, l.String())
+	l.ServiceWithError = serviceutil.AsServiceWithError(l.serve, l.String())
 	l.nat.Store(stun.NATUnknown)
 	return l
 }

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -19,7 +19,7 @@ import (
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/nat"
 	"github.com/syncthing/syncthing/lib/relay/client"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 func init() {
@@ -30,7 +30,7 @@ func init() {
 }
 
 type relayListener struct {
-	util.ServiceWithError
+	serviceutil.ServiceWithError
 	onAddressesChangedNotifier
 
 	uri     *url.URL
@@ -185,7 +185,7 @@ func (f *relayListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls
 		conns:   conns,
 		factory: f,
 	}
-	t.ServiceWithError = util.AsServiceWithError(t.serve, t.String())
+	t.ServiceWithError = serviceutil.AsServiceWithError(t.serve, t.String())
 	return t
 }
 

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -18,7 +18,7 @@ import (
 	"github.com/syncthing/syncthing/lib/connections/registry"
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/nat"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 func init() {
@@ -29,7 +29,7 @@ func init() {
 }
 
 type tcpListener struct {
-	util.ServiceWithError
+	serviceutil.ServiceWithError
 	onAddressesChangedNotifier
 
 	uri     *url.URL
@@ -205,7 +205,7 @@ func (f *tcpListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls.C
 		natService: natService,
 		factory:    f,
 	}
-	l.ServiceWithError = util.AsServiceWithError(l.serve, l.String())
+	l.ServiceWithError = serviceutil.AsServiceWithError(l.serve, l.String())
 	return l
 }
 

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -18,6 +18,7 @@ import (
 	"github.com/syncthing/syncthing/lib/db/backend"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/syncthing/syncthing/lib/util"
@@ -81,7 +82,7 @@ func NewLowlevel(backend backend.Backend, opts ...Option) *Lowlevel {
 		opt(db)
 	}
 	db.keyer = newDefaultKeyer(db.folderIdx, db.deviceIdx)
-	db.Add(util.AsService(db.gcRunner, "db.Lowlevel/gcRunner"))
+	db.Add(serviceutil.AsService(db.gcRunner, "db.Lowlevel/gcRunner"))
 	return db
 }
 

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -25,7 +25,7 @@ import (
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 type globalClient struct {
@@ -132,7 +132,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 		noLookup:       opts.noLookup,
 		evLogger:       evLogger,
 	}
-	cl.Service = util.AsService(cl.serve, cl.String())
+	cl.Service = serviceutil.AsService(cl.serve, cl.String())
 	if !opts.noAnnounce {
 		// If we are supposed to annonce, it's an error until we've done so.
 		cl.setError(errors.New("not announced"))

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -24,7 +24,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 	"github.com/thejerf/suture"
 )
 
@@ -83,9 +83,9 @@ func NewLocal(id protocol.DeviceID, addr string, addrList AddressLister, evLogge
 		c.beacon = beacon.NewMulticast(addr)
 	}
 	c.Add(c.beacon)
-	c.Add(util.AsService(c.recvAnnouncements, fmt.Sprintf("%s/recv", c)))
+	c.Add(serviceutil.AsService(c.recvAnnouncements, fmt.Sprintf("%s/recv", c)))
 
-	c.Add(util.AsService(c.sendLocalAnnouncements, fmt.Sprintf("%s/sendLocal", c)))
+	c.Add(serviceutil.AsService(c.sendLocalAnnouncements, fmt.Sprintf("%s/sendLocal", c)))
 
 	return c, nil
 }

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/thejerf/suture"
 
+	"github.com/syncthing/syncthing/lib/serviceutil"
 	"github.com/syncthing/syncthing/lib/sync"
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 type EventType int
@@ -262,7 +262,7 @@ func NewLogger() Logger {
 		funcs:         make(chan func(context.Context)),
 		toUnsubscribe: make(chan *subscription),
 	}
-	l.Service = util.AsService(l.serve, l.String())
+	l.Service = serviceutil.AsService(l.serve, l.String())
 	// Make sure the timer is in the stopped state and hasn't fired anything
 	// into the channel.
 	if !l.timeout.Stop() {

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -13,7 +13,7 @@ import (
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
 	"github.com/syncthing/syncthing/lib/protocol"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 	"github.com/syncthing/syncthing/lib/versioner"
 )
 
@@ -30,7 +30,7 @@ func newSendOnlyFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, 
 		folder: newFolder(model, fset, ignores, cfg, evLogger, ioLimiter, nil),
 	}
 	f.folder.puller = f
-	f.folder.Service = util.AsService(f.serve, f.String())
+	f.folder.Service = serviceutil.AsService(f.serve, f.String())
 	return f
 }
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -28,7 +28,7 @@ import (
 	"github.com/syncthing/syncthing/lib/scanner"
 	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/sync"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 	"github.com/syncthing/syncthing/lib/versioner"
 	"github.com/syncthing/syncthing/lib/weakhash"
 )
@@ -144,7 +144,7 @@ func newSendReceiveFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 		pullErrorsMut:      sync.NewMutex(),
 	}
 	f.folder.puller = f
-	f.folder.Service = util.AsService(f.serve, f.String())
+	f.folder.Service = serviceutil.AsService(f.serve, f.String())
 
 	if f.Copiers == 0 {
 		f.Copiers = defaultCopiers

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -18,8 +18,8 @@ import (
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 	"github.com/syncthing/syncthing/lib/sync"
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 const maxDurationSinceLastEventReq = time.Minute
@@ -65,8 +65,8 @@ func NewFolderSummaryService(cfg config.Wrapper, m Model, id protocol.DeviceID, 
 		lastEventReqMut: sync.NewMutex(),
 	}
 
-	service.Add(util.AsService(service.listenForUpdates, fmt.Sprintf("%s/listenForUpdates", service)))
-	service.Add(util.AsService(service.calculateSummaries, fmt.Sprintf("%s/calculateSummaries", service)))
+	service.Add(serviceutil.AsService(service.listenForUpdates, fmt.Sprintf("%s/listenForUpdates", service)))
+	service.Add(serviceutil.AsService(service.calculateSummaries, fmt.Sprintf("%s/calculateSummaries", service)))
 
 	return service
 }

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -115,7 +115,7 @@ func createTmpWrapper(cfg config.Configuration) config.Wrapper {
 	if err != nil {
 		panic(err)
 	}
-	wrapper := config.Wrap(tmpFile.Name(), cfg, events.NoopLogger)
+	wrapper := config.Wrap(tmpFile.Name(), cfg)
 	tmpFile.Close()
 	return wrapper
 }
@@ -304,7 +304,7 @@ func TestDeviceRename(t *testing.T) {
 			DeviceID: device1,
 		},
 	}
-	cfg := config.Wrap("testdata/tmpconfig.xml", rawCfg, events.NoopLogger)
+	cfg := config.Wrap("testdata/tmpconfig.xml", rawCfg)
 
 	db := db.NewLowlevel(backend.OpenMemory())
 	m := newModel(cfg, myID, "syncthing", "dev", db, nil)
@@ -340,7 +340,7 @@ func TestDeviceRename(t *testing.T) {
 		t.Errorf("Device name got overwritten")
 	}
 
-	cfgw, err := config.Load("testdata/tmpconfig.xml", myID, events.NoopLogger)
+	cfgw, err := config.Load("testdata/tmpconfig.xml", myID)
 	if err != nil {
 		t.Error(err)
 		return

--- a/lib/nat/structs_test.go
+++ b/lib/nat/structs_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
@@ -64,7 +63,7 @@ func TestMappingClearAddresses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w := config.Wrap(tmpFile.Name(), config.Configuration{}, events.NoopLogger)
+	w := config.Wrap(tmpFile.Name(), config.Configuration{})
 	defer os.RemoveAll(tmpFile.Name())
 	tmpFile.Close()
 

--- a/lib/pmp/pmp.go
+++ b/lib/pmp/pmp.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/syncthing/syncthing/lib/nat"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 func init() {
@@ -27,7 +27,7 @@ func init() {
 
 func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device {
 	var ip net.IP
-	err := util.CallWithContext(ctx, func() error {
+	err := serviceutil.CallWithContext(ctx, func() error {
 		var err error
 		ip, err = gateway.DiscoverGateway()
 		return err
@@ -45,7 +45,7 @@ func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device 
 	c := natpmp.NewClientWithTimeout(ip, timeout)
 	// Try contacting the gateway, if it does not respond, assume it does not
 	// speak NAT-PMP.
-	err = util.CallWithContext(ctx, func() error {
+	err = serviceutil.CallWithContext(ctx, func() error {
 		_, ierr := c.GetExternalAddress()
 		return ierr
 	})
@@ -105,7 +105,7 @@ func (w *wrapper) AddPortMapping(ctx context.Context, protocol nat.Protocol, int
 		duration = w.renewal
 	}
 	var result *natpmp.AddPortMappingResult
-	err := util.CallWithContext(ctx, func() error {
+	err := serviceutil.CallWithContext(ctx, func() error {
 		var err error
 		result, err = w.client.AddPortMapping(strings.ToLower(string(protocol)), internalPort, externalPort, int(duration/time.Second))
 		return err
@@ -119,7 +119,7 @@ func (w *wrapper) AddPortMapping(ctx context.Context, protocol nat.Protocol, int
 
 func (w *wrapper) GetExternalIPAddress(ctx context.Context) (net.IP, error) {
 	var result *natpmp.GetExternalAddressResult
-	err := util.CallWithContext(ctx, func() error {
+	err := serviceutil.CallWithContext(ctx, func() error {
 		var err error
 		result, err = w.client.GetExternalAddress()
 		return err

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/dialer"
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
 )
@@ -499,7 +498,7 @@ func (p *Process) eventLoop() {
 				p.id = id
 
 				home := data["home"].(string)
-				w, err := config.Load(filepath.Join(home, "config.xml"), protocol.LocalDeviceID, events.NoopLogger)
+				w, err := config.Load(filepath.Join(home, "config.xml"), protocol.LocalDeviceID)
 				if err != nil {
 					log.Println("eventLoop: Starting:", err)
 					continue

--- a/lib/relay/client/client.go
+++ b/lib/relay/client/client.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/relay/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 
 	"github.com/thejerf/suture"
 )
@@ -45,7 +45,7 @@ func NewClient(uri *url.URL, certs []tls.Certificate, invitations chan protocol.
 }
 
 type commonClient struct {
-	util.ServiceWithError
+	serviceutil.ServiceWithError
 
 	invitations              chan protocol.SessionInvitation
 	closeInvitationsOnFinish bool
@@ -61,7 +61,7 @@ func newCommonClient(invitations chan protocol.SessionInvitation, serve func(con
 		defer c.cleanup()
 		return serve(ctx)
 	}
-	c.ServiceWithError = util.AsServiceWithError(newServe, creator)
+	c.ServiceWithError = serviceutil.AsServiceWithError(newServe, creator)
 	if c.invitations == nil {
 		c.closeInvitationsOnFinish = true
 		c.invitations = make(chan protocol.SessionInvitation)

--- a/lib/serviceutil/serviceutil.go
+++ b/lib/serviceutil/serviceutil.go
@@ -1,0 +1,167 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package serviceutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/sync"
+
+	"github.com/thejerf/suture"
+)
+
+// AsService wraps the given function to implement suture.Service by calling
+// that function on serve and closing the passed channel when Stop is called.
+func AsService(fn func(ctx context.Context), creator string, opts ...Option) suture.Service {
+	return asServiceWithError(func(ctx context.Context) error {
+		fn(ctx)
+		return nil
+	}, creator, opts...)
+}
+
+type ServiceWithError interface {
+	suture.Service
+	fmt.Stringer
+	Error() error
+	SetError(error)
+}
+
+type Option interface {
+	apply(*service)
+}
+
+type option struct {
+	fn func(*service)
+}
+
+func (o *option) apply(s *service) {
+	o.fn(s)
+}
+
+func WithConfigSubscription(w config.Wrapper, c config.Committer, initCfg func(config.Configuration)) Option {
+	return &option{func(s *service) {
+		oldServe := s.serve
+		s.serve = func(ctx context.Context) error {
+			cfg := w.Subscribe(c)
+			initCfg(cfg)
+			defer w.Unsubscribe(c)
+			return oldServe(ctx)
+		}
+	}}
+}
+
+// AsServiceWithError does the same as AsService, except that it keeps track
+// of an error returned by the given function.
+func AsServiceWithError(fn func(ctx context.Context) error, creator string, opts ...Option) ServiceWithError {
+	return asServiceWithError(fn, creator, opts...)
+}
+
+func asServiceWithError(fn func(ctx context.Context) error, creator string, opts ...Option) ServiceWithError {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &service{
+		serve:   fn,
+		ctx:     ctx,
+		cancel:  cancel,
+		stopped: make(chan struct{}),
+		creator: creator,
+		mut:     sync.NewMutex(),
+	}
+	close(s.stopped) // not yet started, don't block on Stop()
+	for _, opt := range opts {
+		opt.apply(s)
+	}
+	return s
+}
+
+type service struct {
+	creator string
+	serve   func(ctx context.Context) error
+	ctx     context.Context
+	cancel  context.CancelFunc
+	stopped chan struct{}
+	err     error
+	mut     sync.Mutex
+}
+
+func (s *service) Serve() {
+	s.mut.Lock()
+	select {
+	case <-s.ctx.Done():
+		s.mut.Unlock()
+		return
+	default:
+	}
+	s.err = nil
+	s.stopped = make(chan struct{})
+	s.mut.Unlock()
+
+	var err error
+	defer func() {
+		if err == context.Canceled {
+			err = nil
+		}
+		s.mut.Lock()
+		s.err = err
+		close(s.stopped)
+		s.mut.Unlock()
+	}()
+	err = s.serve(s.ctx)
+}
+
+func (s *service) Stop() {
+	s.mut.Lock()
+	select {
+	case <-s.ctx.Done():
+		s.mut.Unlock()
+		panic(fmt.Sprintf("Stop called more than once on %v", s))
+	default:
+		s.cancel()
+	}
+
+	// Cache s.stopped in a variable while we hold the mutex
+	// to prevent a data race with Serve's resetting it.
+	stopped := s.stopped
+	s.mut.Unlock()
+	<-stopped
+}
+
+func (s *service) Error() error {
+	s.mut.Lock()
+	defer s.mut.Unlock()
+	return s.err
+}
+
+func (s *service) SetError(err error) {
+	s.mut.Lock()
+	s.err = err
+	s.mut.Unlock()
+}
+
+func (s *service) String() string {
+	return fmt.Sprintf("Service@%p created by %v", s, s.creator)
+}
+
+func CallWithContext(ctx context.Context, fn func() error) error {
+	var err error
+	done := make(chan struct{})
+	go func() {
+		err = fn()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func ConfigSubscriptionService(w config.Wrapper, c config.Committer, initCfg func(config.Configuration)) suture.Service {
+	return AsService(func(ctx context.Context) { <-ctx.Done() }, c.String(), WithConfigSubscription(w, c, initCfg))
+}

--- a/lib/serviceutil/serviceutil_test.go
+++ b/lib/serviceutil/serviceutil_test.go
@@ -1,0 +1,30 @@
+// Copyright (C) 2016 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package serviceutil
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestUtilStopTwicePanic(t *testing.T) {
+	name := "foo"
+	s := AsService(func(ctx context.Context) {
+		<-ctx.Done()
+	}, name)
+
+	go s.Serve()
+	s.Stop()
+
+	defer func() {
+		if r := recover(); r == nil || !strings.Contains(r.(string), name) {
+			t.Fatalf(`expected panic containing "%v", got "%v"`, name, r)
+		}
+	}()
+	s.Stop()
+}

--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -17,7 +17,7 @@ import (
 	"github.com/thejerf/suture"
 
 	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 const stunRetryInterval = 5 * time.Minute
@@ -105,7 +105,7 @@ func New(cfg config.Wrapper, subscriber Subscriber, conn net.PacketConn) (*Servi
 		natType: NATUnknown,
 		addr:    nil,
 	}
-	s.Service = util.AsService(s.serve, s.String())
+	s.Service = serviceutil.AsService(s.serve, s.String())
 	return s, otherDataConn
 }
 
@@ -187,7 +187,7 @@ func (s *Service) runStunForServer(ctx context.Context, addr string) {
 
 	var natType stun.NATType
 	var extAddr *stun.Host
-	err = util.CallWithContext(ctx, func() error {
+	err = serviceutil.CallWithContext(ctx, func() error {
 		natType, extAddr, err = s.client.Discover()
 		return err
 	})

--- a/lib/syncthing/auditservice.go
+++ b/lib/syncthing/auditservice.go
@@ -15,7 +15,7 @@ import (
 	"github.com/thejerf/suture"
 
 	"github.com/syncthing/syncthing/lib/events"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 // The auditService subscribes to events and writes these in JSON format, one
@@ -31,7 +31,7 @@ func newAuditService(w io.Writer, evLogger events.Logger) *auditService {
 		w:   w,
 		sub: evLogger.Subscribe(events.AllEvents),
 	}
-	s.Service = util.AsService(s.serve, s.String())
+	s.Service = serviceutil.AsService(s.serve, s.String())
 	return s
 }
 

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -324,7 +324,9 @@ func (a *App) startup() error {
 		if opts.URAccepted != ur.Version {
 			opts.URAccepted = ur.Version
 			a.cfg.SetOptions(opts)
-			a.cfg.Save()
+			if cfg, err := a.cfg.Save(); err == nil { // best effort
+				a.evLogger.Log(events.ConfigSaved, cfg)
+			}
 			// Unique ID will be set and config saved below if necessary.
 		}
 	}
@@ -333,7 +335,9 @@ func (a *App) startup() error {
 	if opts := a.cfg.Options(); opts.URAccepted > 0 && opts.URUniqueID == "" {
 		opts.URUniqueID = rand.String(8)
 		a.cfg.SetOptions(opts)
-		a.cfg.Save()
+		if cfg, err := a.cfg.Save(); err == nil { // best effort
+			a.evLogger.Log(events.ConfigSaved, cfg)
+		}
 	}
 
 	usageReportingSvc := ur.New(a.cfg, m, connectionsService, a.opts.NoUpgrade)

--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -36,7 +36,7 @@ func TestShortIDCheck(t *testing.T) {
 			{DeviceID: protocol.DeviceID{8, 16, 24, 32, 40, 48, 56, 0, 0}},
 			{DeviceID: protocol.DeviceID{8, 16, 24, 32, 40, 48, 56, 1, 1}}, // first 56 bits same, differ in the first 64 bits
 		},
-	}, events.NoopLogger)
+	})
 	defer os.Remove(cfg.ConfigPath())
 
 	if err := checkShortIDs(cfg); err != nil {
@@ -48,7 +48,7 @@ func TestShortIDCheck(t *testing.T) {
 			{DeviceID: protocol.DeviceID{8, 16, 24, 32, 40, 48, 56, 64, 0}},
 			{DeviceID: protocol.DeviceID{8, 16, 24, 32, 40, 48, 56, 64, 1}}, // first 64 bits same
 		},
-	}, events.NoopLogger)
+	})
 
 	if err := checkShortIDs(cfg); err == nil {
 		t.Error("Should have gotten an error")
@@ -75,7 +75,7 @@ func TestStartupFail(t *testing.T) {
 			{DeviceID: id},
 			{DeviceID: conflID},
 		},
-	}, events.NoopLogger)
+	})
 	defer os.Remove(cfg.ConfigPath())
 
 	app := New(cfg, backend.OpenMemory(), events.NoopLogger, cert, Options{})

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -13,7 +13,7 @@ import (
 	"github.com/thejerf/suture"
 
 	"github.com/syncthing/syncthing/lib/events"
-	"github.com/syncthing/syncthing/lib/util"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 )
 
 // The verbose logging service subscribes to events and prints these in
@@ -27,7 +27,7 @@ func newVerboseService(evLogger events.Logger) *verboseService {
 	s := &verboseService{
 		sub: evLogger.Subscribe(events.AllEvents),
 	}
-	s.Service = util.AsService(s.serve, s.String())
+	s.Service = serviceutil.AsService(s.serve, s.String())
 	return s
 }
 

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -27,9 +27,9 @@ import (
 	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/scanner"
+	"github.com/syncthing/syncthing/lib/serviceutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur/contract"
-	"github.com/syncthing/syncthing/lib/util"
 
 	"github.com/thejerf/suture"
 )
@@ -58,7 +58,7 @@ func New(cfg config.Wrapper, m model.Model, connectionsService connections.Servi
 		noUpgrade:          noUpgrade,
 		forceRun:           make(chan struct{}, 1), // Buffered to prevent locking
 	}
-	svc.Service = util.AsService(svc.serve, svc.String())
+	svc.Service = serviceutil.AsService(svc.serve, svc.String(), serviceutil.WithConfigSubscription(cfg, svc, func(config.Configuration) {}))
 	return svc
 }
 
@@ -357,9 +357,6 @@ func (s *Service) sendUsageReport(ctx context.Context) error {
 }
 
 func (s *Service) serve(ctx context.Context) {
-	s.cfg.Subscribe(s)
-	defer s.cfg.Unsubscribe(s)
-
 	t := time.NewTimer(time.Duration(s.cfg.Options().URInitialDelayS) * time.Second)
 	for {
 		select {

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -7,7 +7,6 @@
 package util
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -15,10 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/syncthing/syncthing/lib/sync"
-
-	"github.com/thejerf/suture"
 )
 
 type defaultParser interface {
@@ -227,125 +222,6 @@ func AddressUnspecifiedLess(a, b net.Addr) bool {
 		return len(a.Network()) < len(b.Network())
 	}
 	return aIsUnspecified
-}
-
-// AsService wraps the given function to implement suture.Service by calling
-// that function on serve and closing the passed channel when Stop is called.
-func AsService(fn func(ctx context.Context), creator string) suture.Service {
-	return asServiceWithError(func(ctx context.Context) error {
-		fn(ctx)
-		return nil
-	}, creator)
-}
-
-type ServiceWithError interface {
-	suture.Service
-	fmt.Stringer
-	Error() error
-	SetError(error)
-}
-
-// AsServiceWithError does the same as AsService, except that it keeps track
-// of an error returned by the given function.
-func AsServiceWithError(fn func(ctx context.Context) error, creator string) ServiceWithError {
-	return asServiceWithError(fn, creator)
-}
-
-func asServiceWithError(fn func(ctx context.Context) error, creator string) ServiceWithError {
-	ctx, cancel := context.WithCancel(context.Background())
-	s := &service{
-		serve:   fn,
-		ctx:     ctx,
-		cancel:  cancel,
-		stopped: make(chan struct{}),
-		creator: creator,
-		mut:     sync.NewMutex(),
-	}
-	close(s.stopped) // not yet started, don't block on Stop()
-	return s
-}
-
-type service struct {
-	creator string
-	serve   func(ctx context.Context) error
-	ctx     context.Context
-	cancel  context.CancelFunc
-	stopped chan struct{}
-	err     error
-	mut     sync.Mutex
-}
-
-func (s *service) Serve() {
-	s.mut.Lock()
-	select {
-	case <-s.ctx.Done():
-		s.mut.Unlock()
-		return
-	default:
-	}
-	s.err = nil
-	s.stopped = make(chan struct{})
-	s.mut.Unlock()
-
-	var err error
-	defer func() {
-		if err == context.Canceled {
-			err = nil
-		}
-		s.mut.Lock()
-		s.err = err
-		close(s.stopped)
-		s.mut.Unlock()
-	}()
-	err = s.serve(s.ctx)
-}
-
-func (s *service) Stop() {
-	s.mut.Lock()
-	select {
-	case <-s.ctx.Done():
-		s.mut.Unlock()
-		panic(fmt.Sprintf("Stop called more than once on %v", s))
-	default:
-		s.cancel()
-	}
-
-	// Cache s.stopped in a variable while we hold the mutex
-	// to prevent a data race with Serve's resetting it.
-	stopped := s.stopped
-	s.mut.Unlock()
-	<-stopped
-}
-
-func (s *service) Error() error {
-	s.mut.Lock()
-	defer s.mut.Unlock()
-	return s.err
-}
-
-func (s *service) SetError(err error) {
-	s.mut.Lock()
-	s.err = err
-	s.mut.Unlock()
-}
-
-func (s *service) String() string {
-	return fmt.Sprintf("Service@%p created by %v", s, s.creator)
-}
-
-func CallWithContext(ctx context.Context, fn func() error) error {
-	var err error
-	done := make(chan struct{})
-	go func() {
-		err = fn()
-		close(done)
-	}()
-	select {
-	case <-done:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
 }
 
 func NiceDurationString(d time.Duration) string {

--- a/lib/util/utils_test.go
+++ b/lib/util/utils_test.go
@@ -7,8 +7,6 @@
 package util
 
 import (
-	"context"
-	"strings"
 	"testing"
 )
 
@@ -269,23 +267,6 @@ func TestInspecifiedAddressLess(t *testing.T) {
 			t.Error(i, "unexpected")
 		}
 	}
-}
-
-func TestUtilStopTwicePanic(t *testing.T) {
-	name := "foo"
-	s := AsService(func(ctx context.Context) {
-		<-ctx.Done()
-	}, name)
-
-	go s.Serve()
-	s.Stop()
-
-	defer func() {
-		if r := recover(); r == nil || !strings.Contains(r.(string), name) {
-			t.Fatalf(`expected panic containing "%v", got "%v"`, name, r)
-		}
-	}()
-	s.Stop()
 }
 
 func TestFillNil(t *testing.T) {

--- a/lib/watchaggregator/aggregator_test.go
+++ b/lib/watchaggregator/aggregator_test.go
@@ -47,7 +47,7 @@ var (
 	}
 	defaultCfg = config.Wrap("", config.Configuration{
 		Folders: []config.FolderConfiguration{defaultFolderCfg},
-	}, events.NoopLogger)
+	})
 )
 
 // Represents possibly multiple (different event types) expected paths from


### PR DESCRIPTION
This is a first step towards the new suture API discussed in https://github.com/thejerf/suture/issues/39:

Currently we subscribe to config updates with different methods. The problematic one is when we subscribe in the constructor and unsubscribe in `Stop`. That won't be possible anymore with the new suture api, and regardless is a bad idea (the object being constructed is no guarantee that `Serve` and `Stop` will ever be called). Thus I added a `WithConfigSubscription` option to our service wrappers, that subscribes to config, takes care of the initial config setup and unsubscribes when `Serve` returns. To facilitate the initial config setup I changed `Wrapper.Subscribe` to return a copy of the config that's active at the time of subscribing.

That produced an import cycle on events, config and util package, thus I removed usage of events from config and split services into a new serviceutil package (just service doesn't work as a name as it's way too general, conflicts e.g. with connections.service). That has the nice side-effect of removing lots of `events.NoopLogger` usages all over. 

For supervisors that need to subscribe to config updates, it's a bit more complicated, as `ServeBackground` needs to work, where we don't know when `Serve` returns. However overloading supervisor methods to do setup/cleanup was always a hack and is actually unnecessary: The more elegant option is to add a tiny service to the supervisor that takes care of that. I did that on model and connections.service.

The entire diff is terribly long due to search&replace, but the relevant bit's are not that much: `serviceutil.WithConfigSubscription` and connected code (the rest is copy&paste, even if github doesn't mark it thus unfortunately), wrapper.go, connections.go and model.go.