### PR TITLE
lib/model: Use RLock for deadlock detection

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -272,8 +272,8 @@ func (m *model) Stop() {
 func (m *model) StartDeadlockDetector(timeout time.Duration) {
 	l.Infof("Starting deadlock detector with %v timeout", timeout)
 	detector := newDeadlockDetector(timeout)
-	detector.Watch("fmut", m.fmut)
-	detector.Watch("pmut", m.pmut)
+	detector.Watch("fmut", m.fmut.RLocker())
+	detector.Watch("pmut", m.pmut.RLocker())
 }
 
 // Need to hold lock on m.fmut when calling this.

--- a/lib/sync/sync.go
+++ b/lib/sync/sync.go
@@ -34,6 +34,7 @@ type RWMutex interface {
 	Mutex
 	RLock()
 	RUnlock()
+	RLocker() sync.Locker
 }
 
 type WaitGroup interface {


### PR DESCRIPTION
I had a look at our deadlock detector events in sentry and while there isn't as many as there used to be, there's still a few happening: https://sentry.syncthing.net/syncthing/syncthing/issues/29/?query=is%3Aunresolved%20deadlock%20detected

The five I looked at were all doing a `FileSet.Drop` while holding a read-lock on fmut, i.e. they are false positive. It didn't occur to me until now that it is actually the detector which causes the hangs here: The detector tries to acquire a write-lock, which prevents any new read-lock from going through. To detect deadlocks, it's enough for the detector to try and acquire a read-lock, which it could have done instantly in all these cases.