### PR TITLE
lib/nat: Don't hang on draining timer chan (fixes #6908)

### DIFF
--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -85,7 +85,10 @@ func (s *Service) serve(ctx context.Context) {
 		case <-timer.C:
 		case <-s.processScheduled:
 			if !timer.Stop() {
-				<-timer.C
+				select {
+				case <-timer.C:
+				default:
+				}
 			}
 		case <-ctx.Done():
 			timer.Stop()


### PR DESCRIPTION
The timer chan might already be drained at this point.