### PR TITLE
lib/db, lib/model: Cover exec-paths with debug logging

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -140,6 +140,7 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 			return err
 		}
 		if ok && unchanged(f, ef) {
+			l.Debugf("not inserting unchanged (remote); folder=%q device=%v %v", folder, devID, f)
 			continue
 		}
 
@@ -148,7 +149,7 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 		}
 		meta.addFile(devID, f)
 
-		l.Debugf("insert; folder=%q device=%v %v", folder, devID, f)
+		l.Debugf("insert (remote); folder=%q device=%v %v", folder, devID, f)
 		if err := t.putFile(dk, f); err != nil {
 			return err
 		}
@@ -196,6 +197,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 			return err
 		}
 		if ok && unchanged(f, ef) {
+			l.Debugf("not inserting unchanged (local); folder=%q %v", folder, f)
 			continue
 		}
 		blocksHashSame := ok && bytes.Equal(ef.BlocksHash, f.BlocksHash)

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -628,17 +628,20 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 				if f.localFlags&protocol.FlagLocalReceiveOnly != 0 && len(snap.Availability(file.Name)) == 0 {
 					file.LocalFlags &^= protocol.FlagLocalReceiveOnly
 				}
+				l.Debugln("marking file as deleted", nf)
 				batchAppend(nf, snap)
 				changes++
 			case file.IsDeleted() && file.IsReceiveOnlyChanged() && f.localFlags&protocol.FlagLocalReceiveOnly != 0 && len(snap.Availability(file.Name)) == 0:
 				file.Version = protocol.Vector{}
 				file.LocalFlags &^= protocol.FlagLocalReceiveOnly
+				l.Debugln("marking deleted item that doesn't exist anywhere as not receive-only", file)
 				batchAppend(file.ConvertDeletedToFileInfo(), snap)
 				changes++
 			case file.IsDeleted() && file.LocalFlags != f.localFlags:
 				// No need to bump the version for a file that was
 				// and is deleted and just the local flags changed.
 				file.LocalFlags = f.localFlags
+				l.Debugln("changing localflags on deleted item", file)
 				batchAppend(file.ConvertDeletedToFileInfo(), snap)
 				changes++
 			}


### PR DESCRIPTION
This adds debug logging to a few previously uncovered places. Relevant for debugging https://forum.syncthing.net/t/v1-8-0-local-and-global-state-swapped-between-two-nodes/15209/20.