### PR TITLE
lib/model: Prevent localflag flipflopping on del. item (ref #6865)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -637,11 +637,11 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 				l.Debugln("marking deleted item that doesn't exist anywhere as not receive-only", file)
 				batchAppend(file.ConvertDeletedToFileInfo(), snap)
 				changes++
-			case file.IsDeleted() && file.LocalFlags != f.localFlags:
-				// No need to bump the version for a file that was
-				// and is deleted and just the local flags changed.
-				file.LocalFlags = f.localFlags
-				l.Debugln("changing localflags on deleted item", file)
+			case file.IsDeleted() && file.IsReceiveOnlyChanged() && f.Type != config.FolderTypeReceiveOnly:
+				// No need to bump the version for a file that was and is
+				// deleted and just the folder type/local flags changed.
+				file.LocalFlags &^= protocol.FlagLocalReceiveOnly
+				l.Debugln("removing receive-only flag on deleted item", file)
 				batchAppend(file.ConvertDeletedToFileInfo(), snap)
 				changes++
 			}


### PR DESCRIPTION
Unfortunately, this is RC material:  
The fix for #6864 in #6865 was way too general: E.g. a deleted file in a receive-only folder, that doesn't exist anywhere else, gets the receive-only flag removed (because there's no local change). Thus it's local flags are different from the folder, which triggered the previous condition to readd the receive-only flag. And then the check for the first condition removes the flag again. And so on and so forth. Now the check is specific to the problem in #6864: If a deleted file has the receive-only flag set, but the folder is not receive-only, the flag is removed.