### PR TITLE
lib/syncthing: Also cleanup on startup error

### DIFF
--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -78,7 +78,8 @@ func TestStartupFail(t *testing.T) {
 	}, events.NoopLogger)
 	defer os.Remove(cfg.ConfigPath())
 
-	app := New(cfg, backend.OpenMemory(), events.NoopLogger, cert, Options{})
+	db := backend.OpenMemory()
+	app := New(cfg, db, events.NoopLogger, cert, Options{})
 	startErr := app.Start()
 	if startErr == nil {
 		t.Fatal("Expected an error from Start, got nil")
@@ -103,5 +104,12 @@ func TestStartupFail(t *testing.T) {
 
 	if err = app.Error(); err != startErr {
 		t.Errorf(`Got different errors "%v" from Start and "%v" from Error`, startErr, err)
+	}
+
+	if trans, err := db.NewReadTransaction(); err == nil {
+		t.Error("Expected error due to db being closed, got nil")
+		trans.Release()
+	} else if !backend.IsClosed(err) {
+		t.Error("Expected error due to db being closed, got", err)
 	}
 }


### PR DESCRIPTION
I mostly implemented sutures new wip api (https://github.com/thejerf/suture/issues/39) so far and as is to be expected, the diff humongous and I touching all this stuff also uncovered some problems/possible improvements. This is one where we currently do not cleanup when an error occurs on startup (cleanup as in shutting down services and closing db). Now we first start the supervisor and routine waiting for it to exit and do said cleanup, before doing the startup operations.