### PR TITLE
lib/db, lib/model: Avoid accounting mishap on folder restart (fixes #6938)

### DIFF
--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -392,6 +392,7 @@ func (m *metadataTracker) nextLocalSeq() int64 {
 
 	c := m.countsPtr(protocol.LocalDeviceID, 0)
 	c.Sequence++
+
 	return c.Sequence
 }
 

--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -392,7 +392,6 @@ func (m *metadataTracker) nextLocalSeq() int64 {
 
 	c := m.countsPtr(protocol.LocalDeviceID, 0)
 	c.Sequence++
-
 	return c.Sequence
 }
 


### PR DESCRIPTION
### Purpose

We created a new fileset before stopping the folder during restart. When
we create that fileset it loads the current metadata and sequence
numbers from the database. But the folder may have time to update those
before stopping, leaving the new fileset with bad data.

This would cause wrong accounting (forgotten files) and potentially
sequence reuse causing files not sent to other devices.

This change reuses the fileset on restart, skipping the issue entirely.
It also moves the creation of the fileset back under the lock so there
should be no chance of concurrency issues here.

### Testing

Restarting a folder during initial scan no longer causes badness for me.