### PR TITLE
all: Implement suture v4-api

### DIFF
--- a/cmd/stdisco/main.go
+++ b/cmd/stdisco/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/binary"
 	"flag"
@@ -47,14 +48,16 @@ func main() {
 		log.Println("My ID:", myID)
 	}
 
-	runbeacon(beacon.NewMulticast(mc), fake)
-	runbeacon(beacon.NewBroadcast(bc), fake)
+	ctx := context.Background()
+
+	runbeacon(ctx, beacon.NewMulticast(mc), fake)
+	runbeacon(ctx, beacon.NewBroadcast(bc), fake)
 
 	select {}
 }
 
-func runbeacon(bc beacon.Interface, fake bool) {
-	go bc.Serve()
+func runbeacon(ctx context.Context, bc beacon.Interface, fake bool) {
+	go bc.Serve(ctx)
 	go recv(bc)
 	if fake {
 		go send(bc)

--- a/cmd/stdiscosrv/apisrv.go
+++ b/cmd/stdiscosrv/apisrv.go
@@ -66,12 +66,12 @@ func newAPISrv(addr string, cert tls.Certificate, db database, repl replicator, 
 	}
 }
 
-func (s *apiSrv) Serve() {
+func (s *apiSrv) Serve(ctx context.Context) error {
 	if s.useHTTP {
 		listener, err := net.Listen("tcp", s.addr)
 		if err != nil {
 			log.Println("Listen:", err)
-			return
+			return err
 		}
 		s.listener = listener
 	} else {
@@ -93,7 +93,7 @@ func (s *apiSrv) Serve() {
 		tlsListener, err := tls.Listen("tcp", s.addr, tlsCfg)
 		if err != nil {
 			log.Println("Listen:", err)
-			return
+			return err
 		}
 		s.listener = tlsListener
 	}
@@ -107,9 +107,11 @@ func (s *apiSrv) Serve() {
 		MaxHeaderBytes: httpMaxHeaderBytes,
 	}
 
-	if err := srv.Serve(s.listener); err != nil {
+	err := srv.Serve(s.listener)
+	if err != nil {
 		log.Println("Serve:", err)
 	}
+	return err
 }
 
 var topCtx = context.Background()

--- a/cmd/stdiscosrv/database.go
+++ b/cmd/stdiscosrv/database.go
@@ -10,6 +10,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"sort"
 	"time"
@@ -37,7 +38,6 @@ type database interface {
 type levelDBStore struct {
 	db         *leveldb.DB
 	inbox      chan func()
-	stop       chan struct{}
 	clock      clock
 	marshalBuf []byte
 }
@@ -50,7 +50,6 @@ func newLevelDBStore(dir string) (*levelDBStore, error) {
 	return &levelDBStore{
 		db:    db,
 		inbox: make(chan func(), 16),
-		stop:  make(chan struct{}),
 		clock: defaultClock{},
 	}, nil
 }
@@ -155,7 +154,7 @@ func (s *levelDBStore) get(key string) (DatabaseRecord, error) {
 	return rec, nil
 }
 
-func (s *levelDBStore) Serve() {
+func (s *levelDBStore) Serve(ctx context.Context) error {
 	t := time.NewTimer(0)
 	defer t.Stop()
 	defer s.db.Close()
@@ -183,7 +182,7 @@ loop:
 			// the next.
 			t.Reset(databaseStatisticsInterval)
 
-		case <-s.stop:
+		case <-ctx.Done():
 			// We're done.
 			close(statisticsTrigger)
 			break loop
@@ -192,6 +191,8 @@ loop:
 
 	// Also wait for statisticsServe to return
 	<-statisticsDone
+
+	return nil
 }
 
 func (s *levelDBStore) statisticsServe(trigger <-chan struct{}, done chan<- struct{}) {
@@ -253,10 +254,6 @@ func (s *levelDBStore) statisticsServe(trigger <-chan struct{}, done chan<- stru
 		// Signal that we are done and can be scheduled again.
 		done <- struct{}{}
 	}
-}
-
-func (s *levelDBStore) Stop() {
-	close(s.stop)
 }
 
 // merge returns the merged result of the two database records a and b. The

--- a/cmd/stdiscosrv/database_test.go
+++ b/cmd/stdiscosrv/database_test.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -20,8 +21,9 @@ func TestDatabaseGetSet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	go db.Serve()
-	defer db.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go db.Serve(ctx)
+	defer cancel()
 
 	// Check missing record
 

--- a/cmd/stdiscosrv/main.go
+++ b/cmd/stdiscosrv/main.go
@@ -7,6 +7,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"log"
@@ -21,7 +22,7 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syndtr/goleveldb/leveldb/opt"
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 )
 
 const (
@@ -183,5 +184,5 @@ func main() {
 	}
 
 	// Engage!
-	main.Serve()
+	main.Serve(context.Background())
 }

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
@@ -194,7 +195,9 @@ func main() {
 	mapping := mapping{natSvc.NewMapping(nat.TCP, addr.IP, addr.Port)}
 
 	if natEnabled {
-		go natSvc.Serve()
+		ctx, cancel := context.WithCancel(context.Background())
+		go natSvc.Serve(ctx)
+		defer cancel()
 		found := make(chan struct{})
 		mapping.OnChanged(func(_ *nat.Mapping, _, _ []nat.Address) {
 			select {

--- a/cmd/strelaysrv/testutil/main.go
+++ b/cmd/strelaysrv/testutil/main.go
@@ -20,7 +20,8 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	log.SetOutput(os.Stdout)
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -62,7 +63,7 @@ func main() {
 		}
 		log.Println("Created client")
 
-		go relay.Serve()
+		go relay.Serve(ctx)
 
 		recv := make(chan protocol.SessionInvitation)
 

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/syncthing/syncthing/lib/syncthing"
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
+	"github.com/syncthing/syncthing/lib/util"
 
 	"github.com/pkg/errors"
 )
@@ -322,7 +323,7 @@ func main() {
 	}
 	if err != nil {
 		l.Warnln("Command line options:", err)
-		os.Exit(syncthing.ExitError.AsInt())
+		os.Exit(util.ExitError.AsInt())
 	}
 
 	if options.logFile == "default" || options.logFile == "" {
@@ -359,7 +360,7 @@ func main() {
 		)
 		if err != nil {
 			l.Warnln("Error reading device ID:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 
 		fmt.Println(protocol.NewDeviceID(cert.Certificate[0]))
@@ -369,7 +370,7 @@ func main() {
 	if options.browserOnly {
 		if err := openGUI(protocol.EmptyDeviceID); err != nil {
 			l.Warnln("Failed to open web UI:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 		return
 	}
@@ -377,7 +378,7 @@ func main() {
 	if options.generateDir != "" {
 		if err := generate(options.generateDir); err != nil {
 			l.Warnln("Failed to generate config and keys:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 		return
 	}
@@ -385,14 +386,14 @@ func main() {
 	// Ensure that our home directory exists.
 	if err := ensureDir(locations.GetBaseDir(locations.ConfigBaseDir), 0700); err != nil {
 		l.Warnln("Failure on home directory:", err)
-		os.Exit(syncthing.ExitError.AsInt())
+		os.Exit(util.ExitError.AsInt())
 	}
 
 	if options.upgradeTo != "" {
 		err := upgrade.ToURL(options.upgradeTo)
 		if err != nil {
 			l.Warnln("Error while Upgrading:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 		l.Infoln("Upgraded from", options.upgradeTo)
 		return
@@ -423,13 +424,13 @@ func main() {
 			os.Exit(exitCodeForUpgrade(err))
 		}
 		l.Infof("Upgraded to %q", release.Tag)
-		os.Exit(syncthing.ExitUpgrade.AsInt())
+		os.Exit(util.ExitUpgrade.AsInt())
 	}
 
 	if options.resetDatabase {
 		if err := resetDB(); err != nil {
 			l.Warnln("Resetting database:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 		l.Infoln("Successfully reset database - it will be rebuilt after next start.")
 		return
@@ -609,7 +610,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	cfg, err := syncthing.LoadConfigAtStartup(locations.Get(locations.ConfigFile), cert, evLogger, runtimeOptions.allowNewerConfig, noDefaultFolder)
 	if err != nil {
 		l.Warnln("Failed to initialize config:", err)
-		os.Exit(syncthing.ExitError.AsInt())
+		os.Exit(util.ExitError.AsInt())
 	}
 
 	// Candidate builds should auto upgrade. Make sure the option is set,
@@ -655,7 +656,7 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 			}
 		} else {
 			l.Infof("Upgraded to %q, exiting now.", release.Tag)
-			os.Exit(syncthing.ExitUpgrade.AsInt())
+			os.Exit(util.ExitUpgrade.AsInt())
 		}
 	}
 
@@ -696,18 +697,18 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 		f, err := os.Create(fmt.Sprintf("cpu-%d.pprof", os.Getpid()))
 		if err != nil {
 			l.Warnln("Creating profile:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 		if err := pprof.StartCPUProfile(f); err != nil {
 			l.Warnln("Starting profile:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 	}
 
 	go standbyMonitor(app, cfg)
 
 	if err := app.Start(); err != nil {
-		os.Exit(syncthing.ExitError.AsInt())
+		os.Exit(util.ExitError.AsInt())
 	}
 
 	cleanConfigDirectory()
@@ -735,7 +736,7 @@ func setupSignalHandling(app *syncthing.App) {
 	signal.Notify(restartSign, sigHup)
 	go func() {
 		<-restartSign
-		app.Stop(syncthing.ExitRestart)
+		app.Stop(util.ExitRestart)
 	}()
 
 	// Exit with "success" code (no restart) on INT/TERM
@@ -744,7 +745,7 @@ func setupSignalHandling(app *syncthing.App) {
 	signal.Notify(stopSign, os.Interrupt, sigTerm)
 	go func() {
 		<-stopSign
-		app.Stop(syncthing.ExitSuccess)
+		app.Stop(util.ExitSuccess)
 	}()
 }
 
@@ -781,7 +782,7 @@ func auditWriter(auditFile string) io.Writer {
 		fd, err = os.OpenFile(auditFile, auditFlags, 0600)
 		if err != nil {
 			l.Warnln("Audit:", err)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 		auditDest = auditFile
 	}
@@ -831,7 +832,7 @@ func standbyMonitor(app *syncthing.App, cfg config.Wrapper) {
 			// things a moment to stabilize.
 			time.Sleep(restartDelay)
 
-			app.Stop(syncthing.ExitRestart)
+			app.Stop(util.ExitRestart)
 			return
 		}
 		now = time.Now()
@@ -901,7 +902,7 @@ func autoUpgrade(cfg config.Wrapper, app *syncthing.App, evLogger events.Logger)
 		sub.Unsubscribe()
 		l.Warnf("Automatically upgraded to version %q. Restarting in 1 minute.", rel.Tag)
 		time.Sleep(time.Minute)
-		app.Stop(syncthing.ExitUpgrade)
+		app.Stop(util.ExitUpgrade)
 		return
 	}
 }
@@ -989,13 +990,13 @@ func setPauseState(cfg config.Wrapper, paused bool) {
 	}
 	if _, err := cfg.Replace(raw); err != nil {
 		l.Warnln("Cannot adjust paused state:", err)
-		os.Exit(syncthing.ExitError.AsInt())
+		os.Exit(util.ExitError.AsInt())
 	}
 }
 
 func exitCodeForUpgrade(err error) int {
 	if _, ok := err.(*errNoUpgrade); ok {
-		return syncthing.ExitNoUpgradeAvailable.AsInt()
+		return util.ExitNoUpgradeAvailable.AsInt()
 	}
-	return syncthing.ExitError.AsInt()
+	return util.ExitError.AsInt()
 }

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"flag"
 	"fmt"
@@ -601,8 +602,9 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 	}
 
 	evLogger := events.NewLogger()
-	go evLogger.Serve()
-	defer evLogger.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go evLogger.Serve(ctx)
+	defer cancel()
 
 	cfg, err := syncthing.LoadConfigAtStartup(locations.Get(locations.ConfigFile), cert, evLogger, runtimeOptions.allowNewerConfig, noDefaultFolder)
 	if err != nil {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -721,6 +721,10 @@ func syncthingMain(runtimeOptions RuntimeOptions) {
 
 	status := app.Wait()
 
+	if status == util.ExitError {
+		l.Warnln("Syncthing stopped with error:", app.Error())
+	}
+
 	if runtimeOptions.cpuProfile {
 		pprof.StopCPUProfile()
 	}

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -26,7 +26,7 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
-	"github.com/syncthing/syncthing/lib/syncthing"
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 var (
@@ -99,7 +99,7 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 
 		if t := time.Since(restarts[0]); t < loopThreshold {
 			l.Warnf("%d restarts in %v; not retrying further", countRestarts, t)
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 
 		copy(restarts[0:], restarts[1:])
@@ -169,7 +169,7 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 
 		if err == nil {
 			// Successful exit indicates an intentional shutdown
-			os.Exit(syncthing.ExitSuccess.AsInt())
+			os.Exit(util.ExitSuccess.AsInt())
 		}
 
 		if exiterr, ok := err.(*exec.ExitError); ok {
@@ -177,7 +177,7 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 			if stopped || runtimeOptions.noRestart {
 				os.Exit(exitCode)
 			}
-			if exitCode == syncthing.ExitUpgrade.AsInt() {
+			if exitCode == util.ExitUpgrade.AsInt() {
 				// Restart the monitor process to release the .old
 				// binary as part of the upgrade process.
 				l.Infoln("Restarting monitor...")
@@ -189,7 +189,7 @@ func monitorMain(runtimeOptions RuntimeOptions) {
 		}
 
 		if runtimeOptions.noRestart {
-			os.Exit(syncthing.ExitError.AsInt())
+			os.Exit(util.ExitError.AsInt())
 		}
 
 		l.Infoln("Syncthing exited:", err)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/shirou/gopsutil v3.20.10+incompatible
 	github.com/syncthing/notify v0.0.0-20201109091751-9a0e44181151
 	github.com/syndtr/goleveldb v1.0.1-0.20200815071216-d9e9293bd0f7
-	github.com/thejerf/suture v4.0.0+incompatible
+	github.com/thejerf/suture/v4 v4.0.0
 	github.com/urfave/cli v1.22.4
 	github.com/vitrun/qart v0.0.0-20160531060029-bf64b92db6b0
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897

--- a/go.sum
+++ b/go.sum
@@ -17,11 +17,9 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
-github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
@@ -85,7 +83,6 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/d4l3k/messagediff v1.2.1 h1:ZcAIMYsUg0EAp9X+tt8/enBE/Q8Yd5kzPynLyKptt9U=
 github.com/d4l3k/messagediff v1.2.1/go.mod h1:Oozbb1TVXFac9FtSIxHBMnBCq2qeH/2KkEQxENCrlLo=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dchest/siphash v1.2.2 h1:9DFz8tQwl9pTVt5iok/9zKyzA1Q6bRGiF3HPiEEVr9I=
 github.com/dchest/siphash v1.2.2/go.mod h1:q+IRvb2gOSrUnYoPqHiyHXS0FOBBOdl6tONBlVnOnt4=
@@ -114,7 +111,6 @@ github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiD
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/getsentry/raven-go v0.2.0 h1:no+xWJRb5ZI7eE8TWgIq1jLulQiIoLG0IfYxv5JYMGs=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
@@ -131,7 +127,6 @@ github.com/go-ldap/ldap/v3 v3.2.4/go.mod h1:iYS1MdmrmceOJ1QOTnRXrIs7i3kloqtmGQjR
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
-github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -153,7 +148,6 @@ github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200j
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
-github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -174,7 +168,6 @@ github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
-github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
@@ -247,11 +240,9 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
-github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lib/pq v1.8.0 h1:9xohqzkUwzR4Ga4ivdTcawVS89YSDVxXMa3xJX3cGzg=
 github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
@@ -264,7 +255,6 @@ github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0Q
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marten-seemann/qpack v0.2.0/go.mod h1:F7Gl5L1jIgN1D11ucXefiuJS9UMVP2opoCp2jDKb7wc=
-github.com/marten-seemann/qtls v0.10.0 h1:ECsuYUKalRL240rRD4Ri33ISb7kAQ3qGDlrrl55b2pc=
 github.com/marten-seemann/qtls v0.10.0/go.mod h1:UvMd1oaYDACI99/oZUYLzMCkBXQVT0aGm99sJhbT8hs=
 github.com/marten-seemann/qtls-go1-15 v0.1.0 h1:i/YPXVxz8q9umso/5y474CNcHmTpA+5DH+mFPjx6PZg=
 github.com/marten-seemann/qtls-go1-15 v0.1.0/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
@@ -309,7 +299,6 @@ github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxzi
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
@@ -317,11 +306,9 @@ github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:v
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
@@ -351,7 +338,6 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -435,7 +421,6 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
@@ -453,17 +438,14 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/syncthing/notify v0.0.0-20201101120444-a28a0bd0f5ee h1:Q2dajND8VmNqXOi+N3IQQP77VkuXMA7tvPzXosDS1vA=
-github.com/syncthing/notify v0.0.0-20201101120444-a28a0bd0f5ee/go.mod h1:Sn4ChoS7e4FxjCN1XHPVBT43AgnRLbuaB8pEc1Zcdjg=
 github.com/syncthing/notify v0.0.0-20201109091751-9a0e44181151 h1:aKnLuEFWn/7u42UR82PxsPOMkoBAhq+06oRtUnK3Z1o=
 github.com/syncthing/notify v0.0.0-20201109091751-9a0e44181151/go.mod h1:Sn4ChoS7e4FxjCN1XHPVBT43AgnRLbuaB8pEc1Zcdjg=
 github.com/syndtr/goleveldb v1.0.1-0.20200815071216-d9e9293bd0f7 h1:udtnv1cokhJYqnUfCMCppJ71bFN9VKfG1BQ6UsYZnx8=
 github.com/syndtr/goleveldb v1.0.1-0.20200815071216-d9e9293bd0f7/go.mod h1:u2MKkTVTVJWe5D1rCvame8WqhBd88EuIwODJZ1VHCPM=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/thejerf/suture v4.0.0+incompatible h1:luAwgEo87y1X30wEYa64N4SKMrsAm9qXRwNxnLVuuwg=
-github.com/thejerf/suture v4.0.0+incompatible/go.mod h1:ibKwrVj+Uzf3XZdAiNWUouPaAbSoemxOHLmJmwheEMc=
+github.com/thejerf/suture/v4 v4.0.0 h1:GX3X+1Qaewtj9flL2wgoTBfLA5NcmrCY39TJRpPbUrI=
+github.com/thejerf/suture/v4 v4.0.0/go.mod h1:g0e8vwskm9tI0jRjxrnA6lSr0q6OfPdWJVX7G5bVWRs=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
@@ -617,7 +599,6 @@ golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapK
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
@@ -657,7 +638,6 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
@@ -665,7 +645,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
-gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
@@ -673,9 +652,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -917,7 +917,7 @@ func (s *service) postSystemReset(w http.ResponseWriter, r *http.Request) {
 func (s *service) postSystemShutdown(w http.ResponseWriter, r *http.Request) {
 	s.flushResponse(`{"ok": "shutting down"}`, w)
 	s.fatal(&util.FatalErr{
-		Err:    errors.New("shutdown after db reset initiated by rest API"),
+		Err:    errors.New("shutdown initiated by rest API"),
 		Status: util.ExitSuccess,
 	})
 }

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -33,7 +33,7 @@ import (
 
 	"github.com/julienschmidt/httprouter"
 	metrics "github.com/rcrowley/go-metrics"
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 	"github.com/vitrun/qart/qr"
 
 	"github.com/syncthing/syncthing/lib/build"
@@ -53,7 +53,6 @@ import (
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur"
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 // matches a bcrypt hash and not too much else
@@ -108,7 +107,7 @@ type Service interface {
 }
 
 func New(id protocol.DeviceID, cfg config.Wrapper, assetDir, tlsDefaultCommonName string, m model.Model, defaultSub, diskSub events.BufferedSubscription, evLogger events.Logger, discoverer discover.Manager, connectionsService connections.Service, urService *ur.Service, fss model.FolderSummaryService, errors, systemLog logger.Recorder, contr Controller, noUpgrade bool) Service {
-	s := &service{
+	return &service{
 		id:      id,
 		cfg:     cfg,
 		statics: newStaticsServer(cfg.GUI().Theme, assetDir, cfg.Options().FeatureFlag(featureFlagUntrusted)),
@@ -131,8 +130,6 @@ func New(id protocol.DeviceID, cfg config.Wrapper, assetDir, tlsDefaultCommonNam
 		configChanged:        make(chan struct{}),
 		startedOnce:          make(chan struct{}),
 	}
-	s.Service = util.AsService(s.serve, s.String())
-	return s
 }
 
 func (s *service) WaitForStart() error {
@@ -211,7 +208,7 @@ func sendJSON(w http.ResponseWriter, jsonObject interface{}) {
 	fmt.Fprintf(w, "%s\n", bs)
 }
 
-func (s *service) serve(ctx context.Context) {
+func (s *service) Serve(ctx context.Context) error {
 	listener, err := s.getListener(s.cfg.GUI())
 	if err != nil {
 		select {
@@ -227,13 +224,13 @@ func (s *service) serve(ctx context.Context) {
 			s.startupErr = err
 			close(s.startedOnce)
 		}
-		return
+		return err
 	}
 
 	if listener == nil {
 		// Not much we can do here other than exit quickly. The supervisor
 		// will log an error at some point.
-		return
+		return nil
 	}
 
 	s.listenerAddr = listener.Addr()
@@ -422,6 +419,8 @@ func (s *service) serve(ctx context.Context) {
 		l.Warnln("GUI/API:", err, "(restarting)")
 	}
 	srv.Close()
+
+	return nil
 }
 
 // Complete implements suture.IsCompletable, which signifies to the supervisor

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syncthing/syncthing/lib/ur"
+	"github.com/syncthing/syncthing/lib/util"
 	"github.com/thejerf/suture"
 )
 
@@ -117,9 +118,7 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 	defer os.Remove(token)
 	srv.started = make(chan string)
 
-	sup := suture.New("test", suture.Spec{
-		PassThroughPanics: true,
-	})
+	sup := suture.New("test", util.Spec())
 	sup.Add(srv)
 	sup.ServeBackground()
 

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -115,7 +115,7 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 	}
 	w := config.Wrap("/dev/null", cfg, events.NoopLogger)
 
-	srv := New(protocol.LocalDeviceID, w, "", "syncthing", nil, nil, nil, events.NoopLogger, nil, nil, nil, nil, nil, nil, nil, false).(*service)
+	srv := New(protocol.LocalDeviceID, w, "", "syncthing", nil, nil, nil, events.NoopLogger, nil, nil, nil, nil, nil, nil, false).(*service)
 	defer os.Remove(token)
 	srv.started = make(chan string)
 
@@ -593,7 +593,7 @@ func startHTTP(cfg config.Wrapper) (string, context.CancelFunc, error) {
 
 	// Instantiate the API service
 	urService := ur.New(cfg, m, connections, false)
-	svc := New(protocol.LocalDeviceID, cfg, assetDir, "syncthing", m, eventSub, diskEventSub, events.NoopLogger, discoverer, connections, urService, &mockedFolderSummaryService{}, errorLog, systemLog, nil, false).(*service)
+	svc := New(protocol.LocalDeviceID, cfg, assetDir, "syncthing", m, eventSub, diskEventSub, events.NoopLogger, discoverer, connections, urService, &mockedFolderSummaryService{}, errorLog, systemLog, false).(*service)
 	defer os.Remove(token)
 	svc.started = addrChan
 
@@ -1093,7 +1093,7 @@ func TestEventMasks(t *testing.T) {
 	cfg := new(mockedConfig)
 	defSub := new(mockedEventSub)
 	diskSub := new(mockedEventSub)
-	svc := New(protocol.LocalDeviceID, cfg, "", "syncthing", nil, defSub, diskSub, events.NoopLogger, nil, nil, nil, nil, nil, nil, nil, false).(*service)
+	svc := New(protocol.LocalDeviceID, cfg, "", "syncthing", nil, defSub, diskSub, events.NoopLogger, nil, nil, nil, nil, nil, nil, false).(*service)
 	defer os.Remove(token)
 
 	if mask := svc.getEventMask(""); mask != DefaultEventMask {

--- a/lib/api/mocked_connections_test.go
+++ b/lib/api/mocked_connections_test.go
@@ -7,6 +7,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/syncthing/syncthing/lib/connections"
 )
 
@@ -24,9 +26,7 @@ func (m *mockedConnections) NATType() string {
 	return ""
 }
 
-func (m *mockedConnections) Serve() {}
-
-func (m *mockedConnections) Stop() {}
+func (m *mockedConnections) Serve(ctx context.Context) error { return nil }
 
 func (m *mockedConnections) ExternalAddresses() []string { return nil }
 

--- a/lib/api/mocked_discovery_test.go
+++ b/lib/api/mocked_discovery_test.go
@@ -17,11 +17,8 @@ type mockedCachingMux struct{}
 
 // from suture.Service
 
-func (m *mockedCachingMux) Serve() {
+func (m *mockedCachingMux) Serve(ctx context.Context) error {
 	select {}
-}
-
-func (m *mockedCachingMux) Stop() {
 }
 
 // from events.Finder

--- a/lib/api/mocked_model_test.go
+++ b/lib/api/mocked_model_test.go
@@ -7,6 +7,7 @@
 package api
 
 import (
+	"context"
 	"net"
 	"time"
 
@@ -124,8 +125,7 @@ func (m *mockedModel) WatchError(folder string) error {
 	return nil
 }
 
-func (m *mockedModel) Serve() {}
-func (m *mockedModel) Stop()  {}
+func (m *mockedModel) Serve(ctx context.Context) error { return nil }
 
 func (m *mockedModel) Index(deviceID protocol.DeviceID, folder string, files []protocol.FileInfo) error {
 	return nil
@@ -167,9 +167,7 @@ func (m *mockedModel) DBSnapshot(_ string) (*db.Snapshot, error) {
 
 type mockedFolderSummaryService struct{}
 
-func (m *mockedFolderSummaryService) Serve() {}
-
-func (m *mockedFolderSummaryService) Stop() {}
+func (m *mockedFolderSummaryService) Serve(context.Context) error { return nil }
 
 func (m *mockedFolderSummaryService) Summary(folder string) (map[string]interface{}, error) {
 	return map[string]interface{}{"mocked": true}, nil

--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -12,7 +12,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/util"
 )
@@ -51,16 +51,18 @@ func newCast(name string) *cast {
 	spec.FailureThreshold = 2
 	spec.FailureBackoff = 60 * time.Second
 	// Only log restarts in debug mode.
-	spec.Log = func(line string) {
-		l.Debugln(line)
+	spec.EventHook = func(e suture.Event) {
+		l.Debugln(e)
 	}
-	return &cast{
+	c := &cast{
 		Supervisor: suture.New(name, spec),
 		name:       name,
 		inbox:      make(chan []byte),
 		outbox:     make(chan recv, 16),
 		stopped:    make(chan struct{}),
 	}
+	util.OnSupervisorDone(c.Supervisor, func() { close(c.stopped) })
+	return c
 }
 
 func (c *cast) addReader(svc func(context.Context) error) {
@@ -74,17 +76,7 @@ func (c *cast) addWriter(svc func(ctx context.Context) error) {
 }
 
 func (c *cast) createService(svc func(context.Context) error, suffix string) util.ServiceWithError {
-	return util.AsServiceWithError(func(ctx context.Context) error {
-		l.Debugln("Starting", c.name, suffix)
-		err := svc(ctx)
-		l.Debugf("Stopped %v %v: %v", c.name, suffix, err)
-		return err
-	}, fmt.Sprintf("%s/%s", c, suffix))
-}
-
-func (c *cast) Stop() {
-	c.Supervisor.Stop()
-	close(c.stopped)
+	return util.AsService(svc, fmt.Sprintf("%s/%s", c, suffix))
 }
 
 func (c *cast) String() string {

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -41,7 +41,7 @@ func writeBroadcasts(ctx context.Context, inbox <-chan []byte, port int) error {
 		select {
 		case bs = <-inbox:
 		case <-doneCtx.Done():
-			return nil
+			return doneCtx.Err()
 		}
 
 		intfs, err := net.Interfaces()
@@ -138,7 +138,7 @@ func readBroadcasts(ctx context.Context, outbox chan<- recv, port int) error {
 		select {
 		case outbox <- recv{c, addr}:
 		case <-doneCtx.Done():
-			return nil
+			return doneCtx.Err()
 		default:
 			l.Debugln("dropping message")
 		}

--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -56,7 +56,7 @@ func writeMulticasts(ctx context.Context, inbox <-chan []byte, addr string) erro
 		select {
 		case bs = <-inbox:
 		case <-doneCtx.Done():
-			return nil
+			return doneCtx.Err()
 		}
 
 		intfs, err := net.Interfaces()
@@ -87,7 +87,7 @@ func writeMulticasts(ctx context.Context, inbox <-chan []byte, addr string) erro
 
 			select {
 			case <-doneCtx.Done():
-				return nil
+				return doneCtx.Err()
 			default:
 			}
 		}
@@ -144,7 +144,7 @@ func readMulticasts(ctx context.Context, outbox chan<- recv, addr string) error 
 	for {
 		select {
 		case <-doneCtx.Done():
-			return nil
+			return doneCtx.Err()
 		default:
 		}
 		n, _, addr, err := pconn.ReadFrom(bs)

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -91,8 +91,7 @@ func (t *quicListener) serve(ctx context.Context) error {
 	svc, conn := stun.New(t.cfg, t, packetConn)
 	defer func() { _ = conn.Close() }()
 
-	go svc.Serve()
-	defer svc.Stop()
+	go svc.Serve(ctx)
 
 	registry.Register(t.uri.Scheme, conn)
 	defer registry.Unregister(t.uri.Scheme, conn)
@@ -206,7 +205,7 @@ func (f *quicListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls.
 		conns:   conns,
 		factory: f,
 	}
-	l.ServiceWithError = util.AsServiceWithError(l.serve, l.String())
+	l.ServiceWithError = util.AsService(l.serve, l.String())
 	l.nat.Store(stun.NATUnknown)
 	return l
 }

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -114,7 +114,7 @@ func (t *quicListener) serve(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		default:
 		}
 

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -53,8 +53,7 @@ func (t *relayListener) serve(ctx context.Context) error {
 
 	t.mut.Lock()
 	t.client = clnt
-	go clnt.Serve()
-	defer clnt.Stop()
+	go clnt.Serve(ctx)
 	t.mut.Unlock()
 
 	// Start with nil, so that we send a addresses changed notification as soon as we connect somewhere.
@@ -185,7 +184,7 @@ func (f *relayListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls
 		conns:   conns,
 		factory: f,
 	}
-	t.ServiceWithError = util.AsServiceWithError(t.serve, t.String())
+	t.ServiceWithError = util.AsService(t.serve, t.String())
 	return t
 }
 

--- a/lib/connections/relay_listen.go
+++ b/lib/connections/relay_listen.go
@@ -119,7 +119,7 @@ func (t *relayListener) serve(ctx context.Context) error {
 			}
 
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -132,13 +132,12 @@ type service struct {
 }
 
 func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *tls.Config, discoverer discover.Finder, bepProtocolName string, tlsDefaultCommonName string, evLogger events.Logger) Service {
+	spec := util.Spec()
+	spec.Log = func(line string) {
+		l.Infoln(line)
+	}
 	service := &service{
-		Supervisor: suture.New("connections.Service", suture.Spec{
-			Log: func(line string) {
-				l.Infoln(line)
-			},
-			PassThroughPanics: true,
-		}),
+		Supervisor:              suture.New("connections.Service", spec),
 		connectionStatusHandler: newConnectionStatusHandler(),
 
 		cfg:                  cfg,

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -31,7 +31,7 @@ import (
 	_ "github.com/syncthing/syncthing/lib/upnp"
 
 	"github.com/pkg/errors"
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 	"golang.org/x/time/rate"
 )
 
@@ -133,8 +133,8 @@ type service struct {
 
 func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *tls.Config, discoverer discover.Finder, bepProtocolName string, tlsDefaultCommonName string, evLogger events.Logger) Service {
 	spec := util.Spec()
-	spec.Log = func(line string) {
-		l.Infoln(line)
+	spec.EventHook = func(e suture.Event) {
+		l.Infoln(e)
 	}
 	service := &service{
 		Supervisor:              suture.New("connections.Service", spec),
@@ -161,8 +161,8 @@ func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *t
 		// due to config are done by removing and adding services, so are
 		// not subject to these limitations.
 		listenerSupervisor: suture.New("c.S.listenerSupervisor", suture.Spec{
-			Log: func(line string) {
-				l.Infoln(line)
+			EventHook: func(e suture.Event) {
+				l.Infoln(e)
 			},
 			FailureThreshold:  2,
 			FailureBackoff:    600 * time.Second,
@@ -188,21 +188,20 @@ func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *t
 	service.Add(service.listenerSupervisor)
 	service.Add(service.natService)
 
+	util.OnSupervisorDone(service.Supervisor, func() {
+		service.cfg.Unsubscribe(service.limiter)
+		service.cfg.Unsubscribe(service)
+	})
+
 	return service
 }
 
-func (s *service) Stop() {
-	s.cfg.Unsubscribe(s.limiter)
-	s.cfg.Unsubscribe(s)
-	s.Supervisor.Stop()
-}
-
-func (s *service) handle(ctx context.Context) {
+func (s *service) handle(ctx context.Context) error {
 	var c internalConn
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case c = <-s.conns:
 		}
 
@@ -337,9 +336,10 @@ func (s *service) handle(ctx context.Context) {
 		s.model.AddConnection(modelConn, hello)
 		continue
 	}
+	return nil
 }
 
-func (s *service) connect(ctx context.Context) {
+func (s *service) connect(ctx context.Context) error {
 	nextDial := make(map[string]time.Time)
 
 	// Used as delay for the first few connection attempts, increases
@@ -370,7 +370,7 @@ func (s *service) connect(ctx context.Context) {
 		for _, deviceCfg := range cfg.Devices {
 			select {
 			case <-ctx.Done():
-				return
+				return nil
 			default:
 			}
 
@@ -502,9 +502,10 @@ func (s *service) connect(ctx context.Context) {
 		select {
 		case <-time.After(sleep):
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
+	return nil
 }
 
 func (s *service) isLANHost(host string) bool {

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -201,7 +201,7 @@ func (s *service) handle(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case c = <-s.conns:
 		}
 
@@ -370,7 +370,7 @@ func (s *service) connect(ctx context.Context) error {
 		for _, deviceCfg := range cfg.Devices {
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			default:
 			}
 
@@ -502,7 +502,7 @@ func (s *service) connect(ctx context.Context) error {
 		select {
 		case <-time.After(sleep):
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 	return nil

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -18,6 +18,8 @@ import (
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/nat"
 	"github.com/syncthing/syncthing/lib/protocol"
+
+	"github.com/thejerf/suture/v4"
 )
 
 // Connection is what we expose to the outside. It is a protocol.Connection
@@ -181,8 +183,7 @@ type ListenerAddresses struct {
 }
 
 type genericListener interface {
-	Serve()
-	Stop()
+	suture.Service
 	URI() *url.URL
 	// A given address can potentially be mutated by the listener.
 	// For example we bind to tcp://0.0.0.0, but that for example might return

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -207,7 +207,7 @@ func (f *tcpListenerFactory) New(uri *url.URL, cfg config.Wrapper, tlsCfg *tls.C
 		natService: natService,
 		factory:    f,
 	}
-	l.ServiceWithError = util.AsServiceWithError(l.serve, l.String())
+	l.ServiceWithError = util.AsService(l.serve, l.String())
 	return l
 }
 

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -68,14 +68,13 @@ type Lowlevel struct {
 }
 
 func NewLowlevel(backend backend.Backend, opts ...Option) *Lowlevel {
+	spec := util.Spec()
+	// Only log restarts in debug mode.
+	spec.Log = func(line string) {
+		l.Debugln(line)
+	}
 	db := &Lowlevel{
-		Supervisor: suture.New("db.Lowlevel", suture.Spec{
-			// Only log restarts in debug mode.
-			Log: func(line string) {
-				l.Debugln(line)
-			},
-			PassThroughPanics: true,
-		}),
+		Supervisor:         suture.New("db.Lowlevel", spec),
 		Backend:            backend,
 		folderIdx:          newSmallIndex(backend, []byte{KeyTypeFolderIdx}),
 		deviceIdx:          newSmallIndex(backend, []byte{KeyTypeDeviceIdx}),

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -25,7 +25,7 @@ import (
 	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/syncthing/syncthing/lib/util"
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 )
 
 const (
@@ -70,8 +70,8 @@ type Lowlevel struct {
 func NewLowlevel(backend backend.Backend, opts ...Option) *Lowlevel {
 	spec := util.Spec()
 	// Only log restarts in debug mode.
-	spec.Log = func(line string) {
-		l.Debugln(line)
+	spec.EventHook = func(e suture.Event) {
+		l.Debugln(e)
 	}
 	db := &Lowlevel{
 		Supervisor:         suture.New("db.Lowlevel", spec),
@@ -585,7 +585,7 @@ func (db *Lowlevel) dropPrefix(prefix []byte) error {
 	return t.Commit()
 }
 
-func (db *Lowlevel) gcRunner(ctx context.Context) {
+func (db *Lowlevel) gcRunner(ctx context.Context) error {
 	// Calculate the time for the next GC run. Even if we should run GC
 	// directly, give the system a while to get up and running and do other
 	// stuff first. (We might have migrations and stuff which would be
@@ -601,7 +601,7 @@ func (db *Lowlevel) gcRunner(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-t.C:
 			if err := db.gcIndirect(ctx); err != nil {
 				l.Warnln("Database indirection GC failed:", err)

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -601,7 +601,7 @@ func (db *Lowlevel) gcRunner(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case <-t.C:
 			if err := db.gcIndirect(ctx); err != nil {
 				l.Warnln("Database indirection GC failed:", err)

--- a/lib/discover/cache.go
+++ b/lib/discover/cache.go
@@ -10,7 +10,7 @@ import (
 	stdsync "sync"
 	"time"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/protocol"
 )

--- a/lib/discover/cache_test.go
+++ b/lib/discover/cache_test.go
@@ -18,6 +18,14 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
+func setupCache() *manager {
+	cfg := config.New(protocol.LocalDeviceID)
+	cfg.Options.LocalAnnEnabled = false
+	cfg.Options.GlobalAnnEnabled = false
+
+	return NewManager(protocol.LocalDeviceID, config.Wrap("", cfg, events.NoopLogger), tls.Certificate{}, events.NoopLogger, nil).(*manager)
+}
+
 func TestCacheUnique(t *testing.T) {
 	addresses0 := []string{"tcp://192.0.2.44:22000", "tcp://192.0.2.42:22000"}
 	addresses1 := []string{"tcp://192.0.2.43:22000", "tcp://192.0.2.42:22000"}
@@ -33,13 +41,7 @@ func TestCacheUnique(t *testing.T) {
 		"tcp://192.0.2.44:22000",
 	}
 
-	cfg := config.New(protocol.LocalDeviceID)
-	cfg.Options.LocalAnnEnabled = false
-	cfg.Options.GlobalAnnEnabled = false
-
-	c := NewManager(protocol.LocalDeviceID, config.Wrap("", cfg, events.NoopLogger), tls.Certificate{}, events.NoopLogger, nil).(*manager)
-	c.ServeBackground()
-	defer c.Stop()
+	c := setupCache()
 
 	// Add a fake discovery service and verify we get its answers through the
 	// cache.
@@ -93,13 +95,7 @@ func (f *fakeDiscovery) Cache() map[protocol.DeviceID]CacheEntry {
 }
 
 func TestCacheSlowLookup(t *testing.T) {
-	cfg := config.New(protocol.LocalDeviceID)
-	cfg.Options.LocalAnnEnabled = false
-	cfg.Options.GlobalAnnEnabled = false
-
-	c := NewManager(protocol.LocalDeviceID, config.Wrap("", cfg, events.NoopLogger), tls.Certificate{}, events.NoopLogger, nil).(*manager)
-	c.ServeBackground()
-	defer c.Stop()
+	c := setupCache()
 
 	// Add a slow discovery service.
 

--- a/lib/discover/discover.go
+++ b/lib/discover/discover.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/protocol"
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 )
 
 // A Finder provides lookup services of some kind.

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -21,16 +21,12 @@ import (
 	stdsync "sync"
 	"time"
 
-	"github.com/thejerf/suture"
-
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 type globalClient struct {
-	suture.Service
 	server         string
 	addrList       AddressLister
 	announceClient httpClient
@@ -133,7 +129,6 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 		noLookup:       opts.noLookup,
 		evLogger:       evLogger,
 	}
-	cl.Service = util.AsService(cl.serve, cl.String())
 	if !opts.noAnnounce {
 		// If we are supposed to annonce, it's an error until we've done so.
 		cl.setError(errors.New("not announced"))
@@ -193,12 +188,12 @@ func (c *globalClient) String() string {
 	return "global@" + c.server
 }
 
-func (c *globalClient) serve(ctx context.Context) {
+func (c *globalClient) Serve(ctx context.Context) error {
 	if c.noAnnounce {
 		// We're configured to not do announcements, only lookups. To maintain
 		// the same interface, we just pause here if Serve() is run.
 		<-ctx.Done()
-		return
+		return nil
 	}
 
 	timer := time.NewTimer(5 * time.Second)
@@ -231,7 +226,7 @@ func (c *globalClient) serve(ctx context.Context) {
 			c.sendAnnouncement(ctx, timer)
 
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
 }

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -193,7 +193,7 @@ func (c *globalClient) Serve(ctx context.Context) error {
 		// We're configured to not do announcements, only lookups. To maintain
 		// the same interface, we just pause here if Serve() is run.
 		<-ctx.Done()
-		return nil
+		return ctx.Err()
 	}
 
 	timer := time.NewTimer(5 * time.Second)
@@ -226,7 +226,7 @@ func (c *globalClient) Serve(ctx context.Context) error {
 			c.sendAnnouncement(ctx, timer)
 
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }

--- a/lib/discover/global_test.go
+++ b/lib/discover/global_test.go
@@ -200,8 +200,9 @@ func TestGlobalAnnounce(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	go disco.Serve()
-	defer disco.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go disco.Serve(ctx)
+	defer cancel()
 
 	// The discovery thing should attempt an announcement immediately. We wait
 	// for it to succeed, a while.
@@ -223,8 +224,9 @@ func testLookup(url string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	go disco.Serve()
-	defer disco.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go disco.Serve(ctx)
+	defer cancel()
 
 	return disco.Lookup(context.Background(), protocol.LocalDeviceID)
 }

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -25,7 +25,7 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/util"
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 )
 
 type localClient struct {
@@ -135,7 +135,7 @@ func (c *localClient) announcementPkt(instanceID int64, msg []byte) ([]byte, boo
 	return msg, true
 }
 
-func (c *localClient) sendLocalAnnouncements(ctx context.Context) {
+func (c *localClient) sendLocalAnnouncements(ctx context.Context) error {
 	var msg []byte
 	var ok bool
 	instanceID := rand.Int63()
@@ -148,18 +148,18 @@ func (c *localClient) sendLocalAnnouncements(ctx context.Context) {
 		case <-c.localBcastTick:
 		case <-c.forcedBcastTick:
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
 }
 
-func (c *localClient) recvAnnouncements(ctx context.Context) {
+func (c *localClient) recvAnnouncements(ctx context.Context) error {
 	b := c.beacon
 	warnedAbout := make(map[string]bool)
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		default:
 		}
 

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -52,9 +52,7 @@ const (
 
 func NewLocal(id protocol.DeviceID, addr string, addrList AddressLister, evLogger events.Logger) (FinderService, error) {
 	c := &localClient{
-		Supervisor: suture.New("local", suture.Spec{
-			PassThroughPanics: true,
-		}),
+		Supervisor:      suture.New("local", util.Spec()),
 		myID:            id,
 		addrList:        addrList,
 		evLogger:        evLogger,

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -148,7 +148,7 @@ func (c *localClient) sendLocalAnnouncements(ctx context.Context) error {
 		case <-c.localBcastTick:
 		case <-c.forcedBcastTick:
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }
@@ -159,7 +159,7 @@ func (c *localClient) recvAnnouncements(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		default:
 		}
 

--- a/lib/discover/local_test.go
+++ b/lib/discover/local_test.go
@@ -8,6 +8,7 @@ package discover
 
 import (
 	"bytes"
+	"context"
 	"net"
 	"testing"
 
@@ -20,8 +21,9 @@ func TestLocalInstanceID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	go c.Serve()
-	defer c.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go c.Serve(ctx)
+	defer cancel()
 
 	lc := c.(*localClient)
 

--- a/lib/discover/manager.go
+++ b/lib/discover/manager.go
@@ -13,7 +13,7 @@ import (
 	"sort"
 	"time"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
@@ -46,7 +46,7 @@ type manager struct {
 }
 
 func NewManager(myID protocol.DeviceID, cfg config.Wrapper, cert tls.Certificate, evLogger events.Logger, lister AddressLister) Manager {
-	return &manager{
+	m := &manager{
 		Supervisor:    suture.New("discover.Manager", util.Spec()),
 		myID:          myID,
 		cfg:           cfg,
@@ -57,13 +57,16 @@ func NewManager(myID protocol.DeviceID, cfg config.Wrapper, cert tls.Certificate
 		finders: make(map[string]cachedFinder),
 		mut:     sync.NewRWMutex(),
 	}
+	m.Add(util.AsService(m.serve, m.String()))
+	return m
 }
 
-func (m *manager) Serve() {
+func (m *manager) serve(ctx context.Context) error {
 	m.cfg.Subscribe(m)
-	defer m.cfg.Unsubscribe(m)
 	m.CommitConfiguration(config.Configuration{}, m.cfg.RawCopy())
-	m.Supervisor.Serve()
+	<-ctx.Done()
+	m.cfg.Unsubscribe(m)
+	return nil
 }
 
 func (m *manager) addLocked(identity string, finder Finder, cacheTime, negCacheTime time.Duration) {

--- a/lib/discover/manager.go
+++ b/lib/discover/manager.go
@@ -47,9 +47,7 @@ type manager struct {
 
 func NewManager(myID protocol.DeviceID, cfg config.Wrapper, cert tls.Certificate, evLogger events.Logger, lister AddressLister) Manager {
 	return &manager{
-		Supervisor: suture.New("discover.Manager", suture.Spec{
-			PassThroughPanics: true,
-		}),
+		Supervisor:    suture.New("discover.Manager", util.Spec()),
 		myID:          myID,
 		cfg:           cfg,
 		cert:          cert,

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -15,10 +15,9 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/sync"
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 type EventType int64
@@ -219,7 +218,6 @@ type Logger interface {
 }
 
 type logger struct {
-	suture.Service
 	subs                []*subscription
 	nextSubscriptionIDs []int
 	nextGlobalID        int
@@ -267,7 +265,6 @@ func NewLogger() Logger {
 		funcs:         make(chan func(context.Context)),
 		toUnsubscribe: make(chan *subscription),
 	}
-	l.Service = util.AsService(l.serve, l.String())
 	// Make sure the timer is in the stopped state and hasn't fired anything
 	// into the channel.
 	if !l.timeout.Stop() {
@@ -276,7 +273,7 @@ func NewLogger() Logger {
 	return l
 }
 
-func (l *logger) serve(ctx context.Context) {
+func (l *logger) Serve(ctx context.Context) error {
 loop:
 	for {
 		select {
@@ -302,6 +299,8 @@ loop:
 	for _, s := range l.subs {
 		close(s.events)
 	}
+
+	return nil
 }
 
 func (l *logger) Log(t EventType, data interface{}) {
@@ -535,7 +534,7 @@ type noopLogger struct{}
 
 var NoopLogger Logger = &noopLogger{}
 
-func (*noopLogger) Serve() {}
+func (*noopLogger) Serve(ctx context.Context) error { return nil }
 
 func (*noopLogger) Stop() {}
 

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -7,6 +7,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -27,10 +28,16 @@ func TestNewLogger(t *testing.T) {
 	}
 }
 
-func TestSubscriber(t *testing.T) {
+func setupLogger() (Logger, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.Background())
 	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	go l.Serve(ctx)
+	return l, cancel
+}
+
+func TestSubscriber(t *testing.T) {
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(0)
 	defer s.Unsubscribe()
@@ -40,9 +47,8 @@ func TestSubscriber(t *testing.T) {
 }
 
 func TestTimeout(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(0)
 	defer s.Unsubscribe()
@@ -53,9 +59,8 @@ func TestTimeout(t *testing.T) {
 }
 
 func TestEventBeforeSubscribe(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	l.Log(DeviceConnected, "foo")
 	s := l.Subscribe(0)
@@ -68,9 +73,8 @@ func TestEventBeforeSubscribe(t *testing.T) {
 }
 
 func TestEventAfterSubscribe(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	defer s.Unsubscribe()
@@ -95,9 +99,8 @@ func TestEventAfterSubscribe(t *testing.T) {
 }
 
 func TestEventAfterSubscribeIgnoreMask(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(DeviceDisconnected)
 	defer s.Unsubscribe()
@@ -110,9 +113,8 @@ func TestEventAfterSubscribeIgnoreMask(t *testing.T) {
 }
 
 func TestBufferOverflow(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	defer s.Unsubscribe()
@@ -135,9 +137,8 @@ func TestBufferOverflow(t *testing.T) {
 }
 
 func TestUnsubscribe(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	l.Log(DeviceConnected, "foo")
@@ -157,9 +158,8 @@ func TestUnsubscribe(t *testing.T) {
 }
 
 func TestGlobalIDs(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	defer s.Unsubscribe()
@@ -189,9 +189,8 @@ func TestGlobalIDs(t *testing.T) {
 }
 
 func TestSubscriptionIDs(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(DeviceConnected)
 	defer s.Unsubscribe()
@@ -231,9 +230,8 @@ func TestSubscriptionIDs(t *testing.T) {
 }
 
 func TestBufferedSub(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	defer s.Unsubscribe()
@@ -262,9 +260,8 @@ func TestBufferedSub(t *testing.T) {
 }
 
 func BenchmarkBufferedSub(b *testing.B) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	defer s.Unsubscribe()
@@ -318,9 +315,8 @@ func BenchmarkBufferedSub(b *testing.B) {
 }
 
 func TestSinceUsesSubscriptionId(t *testing.T) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(DeviceConnected)
 	defer s.Unsubscribe()
@@ -375,9 +371,8 @@ func TestUnsubscribeContention(t *testing.T) {
 		senders   = 1000
 	)
 
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	// Start listeners. These will poll until the stop channel is closed,
 	// then exit and unsubscribe.
@@ -444,9 +439,8 @@ func TestUnsubscribeContention(t *testing.T) {
 }
 
 func BenchmarkLogEvent(b *testing.B) {
-	l := NewLogger()
-	defer l.Stop()
-	go l.Serve()
+	l, cancel := setupLogger()
+	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	defer s.Unsubscribe()

--- a/lib/model/fakeconns_test.go
+++ b/lib/model/fakeconns_test.go
@@ -31,7 +31,7 @@ type fakeConnection struct {
 	files                    []protocol.FileInfo
 	fileData                 map[string][]byte
 	folder                   string
-	model                    *model
+	model                    *testModel
 	indexFn                  func(context.Context, string, []protocol.FileInfo)
 	requestFn                func(ctx context.Context, folder, name string, offset int64, size int, hash []byte, fromTemporary bool) ([]byte, error)
 	closeFn                  func(error)
@@ -201,7 +201,7 @@ func (f *fakeConnection) sendIndexUpdate() {
 	f.model.IndexUpdate(f.id, f.folder, f.files)
 }
 
-func addFakeConn(m *model, dev protocol.DeviceID) *fakeConnection {
+func addFakeConn(m *testModel, dev protocol.DeviceID) *fakeConnection {
 	fc := &fakeConnection{id: dev, model: m}
 	m.AddConnection(fc, protocol.Hello{})
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -31,12 +31,9 @@ import (
 	"github.com/syncthing/syncthing/lib/util"
 	"github.com/syncthing/syncthing/lib/versioner"
 	"github.com/syncthing/syncthing/lib/watchaggregator"
-
-	"github.com/thejerf/suture"
 )
 
 type folder struct {
-	suture.Service
 	stateTracker
 	config.FolderConfiguration
 	*stats.FolderStatisticsReference
@@ -135,7 +132,7 @@ func newFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, cfg conf
 	return f
 }
 
-func (f *folder) serve(ctx context.Context) {
+func (f *folder) Serve(ctx context.Context) error {
 	atomic.AddInt32(&f.model.foldersRunning, 1)
 	defer atomic.AddInt32(&f.model.foldersRunning, -1)
 
@@ -168,7 +165,7 @@ func (f *folder) serve(ctx context.Context) {
 		select {
 		case <-f.ctx.Done():
 			close(f.done)
-			return
+			return nil
 
 		case <-f.pullScheduled:
 			f.pull()

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -441,7 +441,7 @@ func setupKnownFiles(t *testing.T, ffs fs.Filesystem, data []byte) []protocol.Fi
 	return knownFiles
 }
 
-func setupROFolder(t *testing.T) (*model, *receiveOnlyFolder) {
+func setupROFolder(t *testing.T) (*testModel, *receiveOnlyFolder) {
 	t.Helper()
 
 	w := createTmpWrapper(defaultCfg)
@@ -455,6 +455,7 @@ func setupROFolder(t *testing.T) (*model, *receiveOnlyFolder) {
 
 	m := newModel(w, myID, "syncthing", "dev", db.NewLowlevel(backend.OpenMemory()), nil)
 	m.ServeBackground()
+	<-m.started
 	must(t, m.ScanFolder("ro"))
 
 	m.fmut.RLock()

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -13,7 +13,6 @@ import (
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
 	"github.com/syncthing/syncthing/lib/protocol"
-	"github.com/syncthing/syncthing/lib/util"
 	"github.com/syncthing/syncthing/lib/versioner"
 )
 
@@ -30,7 +29,6 @@ func newSendOnlyFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, 
 		folder: newFolder(model, fset, ignores, cfg, evLogger, ioLimiter, nil),
 	}
 	f.folder.puller = f
-	f.folder.Service = util.AsService(f.serve, f.String())
 	return f
 }
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -28,7 +28,6 @@ import (
 	"github.com/syncthing/syncthing/lib/scanner"
 	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/sync"
-	"github.com/syncthing/syncthing/lib/util"
 	"github.com/syncthing/syncthing/lib/versioner"
 	"github.com/syncthing/syncthing/lib/weakhash"
 )
@@ -140,7 +139,6 @@ func newSendReceiveFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 		writeLimiter:       newByteSemaphore(cfg.MaxConcurrentWrites),
 	}
 	f.folder.puller = f
-	f.folder.Service = util.AsService(f.serve, f.String())
 
 	if f.Copiers == 0 {
 		f.Copiers = defaultCopiers

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -52,9 +52,7 @@ type folderSummaryService struct {
 
 func NewFolderSummaryService(cfg config.Wrapper, m Model, id protocol.DeviceID, evLogger events.Logger) FolderSummaryService {
 	service := &folderSummaryService{
-		Supervisor: suture.New("folderSummaryService", suture.Spec{
-			PassThroughPanics: true,
-		}),
+		Supervisor:      suture.New("folderSummaryService", util.Spec()),
 		cfg:             cfg,
 		model:           m,
 		id:              id,

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/db"
@@ -167,7 +167,7 @@ func (c *folderSummaryService) OnEventRequest() {
 
 // listenForUpdates subscribes to the event bus and makes note of folders that
 // need their data recalculated.
-func (c *folderSummaryService) listenForUpdates(ctx context.Context) {
+func (c *folderSummaryService) listenForUpdates(ctx context.Context) error {
 	sub := c.evLogger.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged | events.RemoteDownloadProgress | events.DeviceConnected | events.FolderWatchStateChanged | events.DownloadProgress)
 	defer sub.Unsubscribe()
 
@@ -178,7 +178,7 @@ func (c *folderSummaryService) listenForUpdates(ctx context.Context) {
 		case ev := <-sub.C():
 			c.processUpdate(ev)
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
 }
@@ -259,7 +259,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 
 // calculateSummaries periodically recalculates folder summaries and
 // completion percentage, and sends the results on the event bus.
-func (c *folderSummaryService) calculateSummaries(ctx context.Context) {
+func (c *folderSummaryService) calculateSummaries(ctx context.Context) error {
 	const pumpInterval = 2 * time.Second
 	pump := time.NewTimer(pumpInterval)
 
@@ -270,7 +270,7 @@ func (c *folderSummaryService) calculateSummaries(ctx context.Context) {
 			for _, folder := range c.foldersToHandle() {
 				select {
 				case <-ctx.Done():
-					return
+					return nil
 				default:
 				}
 				c.sendSummary(ctx, folder)
@@ -286,7 +286,7 @@ func (c *folderSummaryService) calculateSummaries(ctx context.Context) {
 			c.sendSummary(ctx, folder)
 
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
 }

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -178,7 +178,7 @@ func (c *folderSummaryService) listenForUpdates(ctx context.Context) error {
 		case ev := <-sub.C():
 			c.processUpdate(ev)
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }
@@ -270,7 +270,7 @@ func (c *folderSummaryService) calculateSummaries(ctx context.Context) error {
 			for _, folder := range c.foldersToHandle() {
 				select {
 				case <-ctx.Done():
-					return nil
+					return ctx.Err()
 				default:
 				}
 				c.sendSummary(ctx, folder)
@@ -286,7 +286,7 @@ func (c *folderSummaryService) calculateSummaries(ctx context.Context) error {
 			c.sendSummary(ctx, folder)
 
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }

--- a/lib/model/indexsender.go
+++ b/lib/model/indexsender.go
@@ -57,7 +57,7 @@ func (s *indexSender) Serve(ctx context.Context) error {
 	for err == nil {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case <-s.connClosed:
 			return nil
 		default:
@@ -70,7 +70,7 @@ func (s *indexSender) Serve(ctx context.Context) error {
 		if s.fset.Sequence(protocol.LocalDeviceID) <= s.prevSequence {
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			case <-s.connClosed:
 				return nil
 			case <-evChan:

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -192,13 +192,12 @@ var (
 // where it sends index information to connected peers and responds to requests
 // for file data without altering the local folder in any way.
 func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersion string, ldb *db.Lowlevel, protectedFiles []string, evLogger events.Logger) Model {
+	spec := util.Spec()
+	spec.Log = func(line string) {
+		l.Debugln(line)
+	}
 	m := &model{
-		Supervisor: suture.New("model", suture.Spec{
-			Log: func(line string) {
-				l.Debugln(line)
-			},
-			PassThroughPanics: true,
-		}),
+		Supervisor: suture.New("model", spec),
 
 		// constructor parameters
 		cfg:            cfg,

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -22,7 +22,7 @@ import (
 	"unicode"
 
 	"github.com/pkg/errors"
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/connections"
@@ -36,6 +36,7 @@ import (
 	"github.com/syncthing/syncthing/lib/stats"
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/syncthing/syncthing/lib/ur/contract"
+	"github.com/syncthing/syncthing/lib/util"
 	"github.com/syncthing/syncthing/lib/versioner"
 )
 
@@ -46,6 +47,7 @@ const (
 )
 
 type service interface {
+	suture.Service
 	BringToFront(string)
 	Override()
 	Revert()
@@ -53,8 +55,6 @@ type service interface {
 	SchedulePull()                                    // something relevant changed, we should try a pull
 	Jobs(page, perpage int) ([]string, []string, int) // In progress, Queued, skipped
 	Scan(subs []string) error
-	Serve()
-	Stop()
 	Errors() []FileError
 	WatchError() error
 	ScheduleForceRescan(path string)
@@ -154,7 +154,9 @@ type model struct {
 	remotePausedFolders map[protocol.DeviceID]map[string]struct{} // deviceID -> folders
 	indexSenders        map[protocol.DeviceID]*indexSenderRegistry
 
-	foldersRunning int32 // for testing only
+	// for testing only
+	foldersRunning int32
+	started        chan struct{}
 }
 
 type folderFactory func(*model, *db.FileSet, *ignore.Matcher, config.FolderConfiguration, versioner.Versioner, fs.Filesystem, events.Logger, *byteSemaphore) service
@@ -193,8 +195,8 @@ var (
 // for file data without altering the local folder in any way.
 func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersion string, ldb *db.Lowlevel, protectedFiles []string, evLogger events.Logger) Model {
 	spec := util.Spec()
-	spec.Log = func(line string) {
-		l.Debugln(line)
+	spec.EventHook = func(e suture.Event) {
+		l.Debugln(e)
 	}
 	m := &model{
 		Supervisor: suture.New("model", spec),
@@ -236,26 +238,20 @@ func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersio
 		deviceDownloads:     make(map[protocol.DeviceID]*deviceDownloadState),
 		remotePausedFolders: make(map[protocol.DeviceID]map[string]struct{}),
 		indexSenders:        make(map[protocol.DeviceID]*indexSenderRegistry),
+
+		// for testing only
+		started: make(chan struct{}),
 	}
 	for devID := range cfg.Devices() {
 		m.deviceStatRefs[devID] = stats.NewDeviceStatisticsReference(m.db, devID.String())
 	}
 	m.Add(m.progressEmitter)
+	m.Add(util.AsService(m.serve, m.String()))
 
 	return m
 }
 
-func (m *model) Serve() {
-	m.onServe()
-	m.Supervisor.Serve()
-}
-
-func (m *model) ServeBackground() {
-	m.onServe()
-	m.Supervisor.ServeBackground()
-}
-
-func (m *model) onServe() {
+func (m *model) serve(ctx context.Context) error {
 	// Add and start folders
 	cacheIgnoredFiles := m.cfg.Options().CacheIgnoredFiles
 	for _, folderCfg := range m.cfg.Folders() {
@@ -266,11 +262,11 @@ func (m *model) onServe() {
 		m.newFolder(folderCfg, cacheIgnoredFiles)
 	}
 	m.cfg.Subscribe(m)
-}
 
-func (m *model) Stop() {
+	close(m.started)
+	<-ctx.Done()
+
 	m.cfg.Unsubscribe(m)
-	m.Supervisor.Stop()
 	m.pmut.RLock()
 	closed := make([]chan struct{}, 0, len(m.conn))
 	for id, conn := range m.conn {
@@ -281,6 +277,7 @@ func (m *model) Stop() {
 	for _, c := range closed {
 		<-c
 	}
+	return nil
 }
 
 // StartDeadlockDetector starts a deadlock detector on the models locks which

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -120,7 +120,7 @@ func createTmpWrapper(cfg config.Configuration) config.Wrapper {
 	return wrapper
 }
 
-func newState(cfg config.Configuration) *model {
+func newState(cfg config.Configuration) *testModel {
 	wcfg := createTmpWrapper(cfg)
 
 	m := setupModel(wcfg)
@@ -1396,7 +1396,7 @@ func TestAutoAcceptEnc(t *testing.T) {
 	}
 }
 
-func changeIgnores(t *testing.T, m *model, expected []string) {
+func changeIgnores(t *testing.T, m *testModel, expected []string) {
 	arrEqual := func(a, b []string) bool {
 		if len(a) != len(b) {
 			return false
@@ -4205,7 +4205,7 @@ func TestNeedMetaAfterIndexReset(t *testing.T) {
 func TestCcCheckEncryption(t *testing.T) {
 	w, fcfg := tmpDefaultWrapper()
 	m := setupModel(w)
-	m.Stop()
+	m.cancel()
 	defer cleanupModel(m)
 
 	pw := "foo"

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -53,9 +53,10 @@ func expectTimeout(w events.Subscription, t *testing.T) {
 }
 
 func TestProgressEmitter(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
 	evLogger := events.NewLogger()
-	go evLogger.Serve()
-	defer evLogger.Stop()
+	go evLogger.Serve(ctx)
+	defer cancel()
 
 	w := evLogger.Subscribe(events.DownloadProgress)
 
@@ -66,8 +67,7 @@ func TestProgressEmitter(t *testing.T) {
 	})
 
 	p := NewProgressEmitter(c, evLogger)
-	go p.Serve()
-	defer p.Stop()
+	go p.Serve(ctx)
 	p.interval = 0
 
 	expectTimeout(w, t)
@@ -118,9 +118,10 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 
 	fc := &fakeConnection{}
 
+	ctx, cancel := context.WithCancel(context.Background())
 	evLogger := events.NewLogger()
-	go evLogger.Serve()
-	defer evLogger.Stop()
+	go evLogger.Serve(ctx)
+	defer cancel()
 
 	p := NewProgressEmitter(c, evLogger)
 	p.temporaryIndexSubscribe(fc, []string{"folder", "folder2"})

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -7,6 +7,7 @@
 package model
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -95,13 +96,13 @@ func testFolderConfigFake() config.FolderConfiguration {
 	return cfg
 }
 
-func setupModelWithConnection() (*model, *fakeConnection, config.FolderConfiguration) {
+func setupModelWithConnection() (*testModel, *fakeConnection, config.FolderConfiguration) {
 	w, fcfg := tmpDefaultWrapper()
 	m, fc := setupModelWithConnectionFromWrapper(w)
 	return m, fc, fcfg
 }
 
-func setupModelWithConnectionFromWrapper(w config.Wrapper) (*model, *fakeConnection) {
+func setupModelWithConnectionFromWrapper(w config.Wrapper) (*testModel, *fakeConnection) {
 	m := setupModel(w)
 
 	fc := addFakeConn(m, device1)
@@ -112,31 +113,57 @@ func setupModelWithConnectionFromWrapper(w config.Wrapper) (*model, *fakeConnect
 	return m, fc
 }
 
-func setupModel(w config.Wrapper) *model {
+func setupModel(w config.Wrapper) *testModel {
 	db := db.NewLowlevel(backend.OpenMemory())
 	m := newModel(w, myID, "syncthing", "dev", db, nil)
 	m.ServeBackground()
+	<-m.started
 
 	m.ScanFolders()
 
 	return m
 }
 
-func newModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersion string, ldb *db.Lowlevel, protectedFiles []string) *model {
-	evLogger := events.NewLogger()
-	m := NewModel(cfg, id, clientName, clientVersion, ldb, protectedFiles, evLogger).(*model)
-	go evLogger.Serve()
-	return m
+type testModel struct {
+	*model
+	cancel   context.CancelFunc
+	evCancel context.CancelFunc
+	stopped  chan struct{}
 }
 
-func cleanupModel(m *model) {
-	m.Stop()
+func newModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersion string, ldb *db.Lowlevel, protectedFiles []string) *testModel {
+	evLogger := events.NewLogger()
+	m := NewModel(cfg, id, clientName, clientVersion, ldb, protectedFiles, evLogger).(*model)
+	ctx, cancel := context.WithCancel(context.Background())
+	go evLogger.Serve(ctx)
+	return &testModel{
+		model:    m,
+		evCancel: cancel,
+		stopped:  make(chan struct{}),
+	}
+}
+
+func (m *testModel) ServeBackground() {
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	go func() {
+		m.model.Serve(ctx)
+		close(m.stopped)
+	}()
+	<-m.started
+}
+
+func cleanupModel(m *testModel) {
+	if m.cancel != nil {
+		m.cancel()
+		<-m.stopped
+	}
+	m.evCancel()
 	m.db.Close()
-	m.evLogger.Stop()
 	os.Remove(m.cfg.ConfigPath())
 }
 
-func cleanupModelAndRemoveDir(m *model, dir string) {
+func cleanupModelAndRemoveDir(m *testModel, dir string) {
 	cleanupModel(m)
 	os.RemoveAll(dir)
 }
@@ -223,7 +250,7 @@ func dbSnapshot(t *testing.T, m Model, folder string) *db.Snapshot {
 // reloads when asked to, instead of checking file mtimes. This is
 // because we will be changing the files on disk often enough that the
 // mtimes will be unreliable to determine change status.
-func folderIgnoresAlwaysReload(m *model, fcfg config.FolderConfiguration) {
+func folderIgnoresAlwaysReload(m *testModel, fcfg config.FolderConfiguration) {
 	m.removeFolder(fcfg)
 	fset := db.NewFileSet(fcfg.ID, fcfg.Filesystem(), m.db)
 	ignores := ignore.New(fcfg.Filesystem(), ignore.WithCache(true), ignore.WithChangeDetector(newAlwaysChanged()))
@@ -250,7 +277,7 @@ func basicClusterConfig(local, remote protocol.DeviceID, folders ...string) prot
 	return cc
 }
 
-func localIndexUpdate(m *model, folder string, fs []protocol.FileInfo) {
+func localIndexUpdate(m *testModel, folder string, fs []protocol.FileInfo) {
 	m.fmut.RLock()
 	fset := m.folderFiles[folder]
 	m.fmut.RUnlock()

--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -88,7 +88,7 @@ func (s *Service) Serve(ctx context.Context) error {
 				mapping.clearAddresses()
 			}
 			s.mut.RUnlock()
-			return nil
+			return ctx.Err()
 		}
 		s.mut.RLock()
 		enabled := s.enabled
@@ -342,7 +342,7 @@ func (s *Service) tryNATDevice(ctx context.Context, natd Device, intPort, extPor
 	for i := 0; i < 10; i++ {
 		select {
 		case <-ctx.Done():
-			return Address{}, nil
+			return Address{}, ctx.Err()
 		default:
 		}
 

--- a/lib/relay/client/client.go
+++ b/lib/relay/client/client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/syncthing/syncthing/lib/util"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 )
 
 type relayClientFactory func(uri *url.URL, certs []tls.Certificate, invitations chan protocol.SessionInvitation, timeout time.Duration) RelayClient
@@ -61,7 +61,7 @@ func newCommonClient(invitations chan protocol.SessionInvitation, serve func(con
 		defer c.cleanup()
 		return serve(ctx)
 	}
-	c.ServiceWithError = util.AsServiceWithError(newServe, creator)
+	c.ServiceWithError = util.AsService(newServe, creator)
 	if c.invitations == nil {
 		c.closeInvitationsOnFinish = true
 		c.invitations = make(chan protocol.SessionInvitation)

--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -93,7 +93,7 @@ func (c *dynamicClient) serve(ctx context.Context) error {
 			c.client = client
 			c.mut.Unlock()
 
-			c.client.Serve()
+			c.client.Serve(ctx)
 
 			c.mut.Lock()
 			c.client = nil
@@ -102,15 +102,6 @@ func (c *dynamicClient) serve(ctx context.Context) error {
 	}
 	l.Debugln(c, "could not find a connectable relay")
 	return errors.New("could not find a connectable relay")
-}
-
-func (c *dynamicClient) Stop() {
-	c.mut.RLock()
-	if c.client != nil {
-		c.client.Stop()
-	}
-	c.mut.RUnlock()
-	c.commonClient.Stop()
 }
 
 func (c *dynamicClient) Error() error {

--- a/lib/relay/client/methods.go
+++ b/lib/relay/client/methods.go
@@ -120,11 +120,12 @@ func TestRelay(ctx context.Context, uri *url.URL, certs []tls.Certificate, sleep
 		close(invs)
 		return fmt.Errorf("creating client: %w", err)
 	}
-	go c.Serve()
-	defer func() {
-		c.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		c.Serve(ctx)
 		close(invs)
 	}()
+	defer cancel()
 
 	for i := 0; i < times; i++ {
 		_, err = GetInvitationFromRelay(ctx, uri, id, certs, timeout)

--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/AudriusButkevicius/pfilter"
 	"github.com/ccding/go-stun/stun"
-	"github.com/thejerf/suture"
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/util"
@@ -60,8 +59,6 @@ type Subscriber interface {
 }
 
 type Service struct {
-	suture.Service
-
 	name       string
 	cfg        config.Wrapper
 	subscriber Subscriber
@@ -105,20 +102,16 @@ func New(cfg config.Wrapper, subscriber Subscriber, conn net.PacketConn) (*Servi
 		natType: NATUnknown,
 		addr:    nil,
 	}
-	s.Service = util.AsService(s.serve, s.String())
 	return s, otherDataConn
 }
 
-func (s *Service) Stop() {
-	_ = s.stunConn.Close()
-	s.Service.Stop()
-}
-
-func (s *Service) serve(ctx context.Context) {
+func (s *Service) Serve(ctx context.Context) error {
 	defer func() {
 		s.setNATType(NATUnknown)
 		s.setExternalAddress(nil, "")
 	}()
+
+	util.OnDone(ctx, func() { _ = s.stunConn.Close() })
 
 	timer := time.NewTimer(time.Millisecond)
 
@@ -126,7 +119,7 @@ func (s *Service) serve(ctx context.Context) {
 	disabled:
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-timer.C:
 		}
 
@@ -146,7 +139,7 @@ func (s *Service) serve(ctx context.Context) {
 			// Have we been asked to stop?
 			select {
 			case <-ctx.Done():
-				return
+				return nil
 			default:
 			}
 

--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -119,7 +119,7 @@ func (s *Service) Serve(ctx context.Context) error {
 	disabled:
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case <-timer.C:
 		}
 
@@ -139,7 +139,7 @@ func (s *Service) Serve(ctx context.Context) error {
 			// Have we been asked to stop?
 			select {
 			case <-ctx.Done():
-				return nil
+				return ctx.Err()
 			default:
 			}
 

--- a/lib/syncthing/auditservice.go
+++ b/lib/syncthing/auditservice.go
@@ -12,47 +12,38 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/thejerf/suture"
-
 	"github.com/syncthing/syncthing/lib/events"
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 // The auditService subscribes to events and writes these in JSON format, one
 // event per line, to the specified writer.
 type auditService struct {
-	suture.Service
-	w   io.Writer // audit destination
-	sub events.Subscription
+	w        io.Writer // audit destination
+	evLogger events.Logger
 }
 
 func newAuditService(w io.Writer, evLogger events.Logger) *auditService {
-	s := &auditService{
-		w:   w,
-		sub: evLogger.Subscribe(events.AllEvents),
+	return &auditService{
+		w:        w,
+		evLogger: evLogger,
 	}
-	s.Service = util.AsService(s.serve, s.String())
-	return s
 }
 
 // serve runs the audit service.
-func (s *auditService) serve(ctx context.Context) {
+func (s *auditService) Serve(ctx context.Context) error {
+	sub := s.evLogger.Subscribe(events.AllEvents)
+	defer sub.Unsubscribe()
+
 	enc := json.NewEncoder(s.w)
 
 	for {
 		select {
-		case ev := <-s.sub.C():
+		case ev := <-sub.C():
 			enc.Encode(ev)
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
-}
-
-// Stop stops the audit service.
-func (s *auditService) Stop() {
-	s.Service.Stop()
-	s.sub.Unsubscribe()
 }
 
 func (s *auditService) String() string {

--- a/lib/syncthing/auditservice.go
+++ b/lib/syncthing/auditservice.go
@@ -41,7 +41,7 @@ func (s *auditService) Serve(ctx context.Context) error {
 		case ev := <-sub.C():
 			enc.Encode(ev)
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -39,6 +39,7 @@ import (
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur"
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 const (
@@ -112,12 +113,11 @@ func New(cfg config.Wrapper, dbBackend backend.Backend, evLogger events.Logger, 
 func (a *App) Start() error {
 	// Create a main service manager. We'll add things to this as we go along.
 	// We want any logging it does to go through our log system.
-	a.mainService = suture.New("main", suture.Spec{
-		Log: func(line string) {
-			l.Debugln(line)
-		},
-		PassThroughPanics: true,
-	})
+	spec := util.Spec()
+	spec.Log = func(line string) {
+		l.Debugln(line)
+	}
+	a.mainService = suture.New("main", spec)
 
 	// Start the supervisor and wait for it to stop to handle cleanup.
 	a.stopped = make(chan struct{})

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -354,7 +354,8 @@ func (a *App) handleMainServiceError(err error) {
 	if err == nil || errors.Is(err, context.Canceled) {
 		return
 	}
-	if fatalErr, ok := err.(*util.FatalErr); ok {
+	var fatalErr *util.FatalErr
+	if errors.As(err, &fatalErr) {
 		a.exitStatus = fatalErr.Status
 		a.err = fatalErr.Err
 		return

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -19,7 +19,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/api"
 	"github.com/syncthing/syncthing/lib/build"
@@ -79,18 +79,18 @@ type Options struct {
 }
 
 type App struct {
-	myID        protocol.DeviceID
-	mainService *suture.Supervisor
-	cfg         config.Wrapper
-	ll          *db.Lowlevel
-	evLogger    events.Logger
-	cert        tls.Certificate
-	opts        Options
-	exitStatus  ExitStatus
-	err         error
-	stopOnce    sync.Once
-	stop        chan struct{}
-	stopped     chan struct{}
+	myID              protocol.DeviceID
+	mainService       *suture.Supervisor
+	cfg               config.Wrapper
+	ll                *db.Lowlevel
+	evLogger          events.Logger
+	cert              tls.Certificate
+	opts              Options
+	exitStatus        ExitStatus
+	err               error
+	stopOnce          sync.Once
+	mainServiceCancel context.CancelFunc
+	stopped           chan struct{}
 }
 
 func New(cfg config.Wrapper, dbBackend backend.Backend, evLogger events.Logger, cert tls.Certificate, opts Options) *App {
@@ -100,7 +100,6 @@ func New(cfg config.Wrapper, dbBackend backend.Backend, evLogger events.Logger, 
 		evLogger: evLogger,
 		opts:     opts,
 		cert:     cert,
-		stop:     make(chan struct{}),
 		stopped:  make(chan struct{}),
 	}
 	close(a.stopped) // Hasn't been started, so shouldn't block on Wait.
@@ -114,15 +113,16 @@ func (a *App) Start() error {
 	// Create a main service manager. We'll add things to this as we go along.
 	// We want any logging it does to go through our log system.
 	spec := util.Spec()
-	spec.Log = func(line string) {
-		l.Debugln(line)
+	spec.EventHook = func(e suture.Event) {
+		l.Debugln(e)
 	}
 	a.mainService = suture.New("main", spec)
 
 	// Start the supervisor and wait for it to stop to handle cleanup.
 	a.stopped = make(chan struct{})
-	a.mainService.ServeBackground()
-	go a.run()
+	ctx, cancel := context.WithCancel(context.Background())
+	a.mainServiceCancel = cancel
+	go a.run(ctx)
 
 	if err := a.startup(); err != nil {
 		a.stopWithErr(ExitError, err)
@@ -343,14 +343,13 @@ func (a *App) startup() error {
 	return nil
 }
 
-func (a *App) run() {
-	<-a.stop
-
-	if shouldDebug() {
-		l.Debugln("Services before stop:")
-		printServiceTree(os.Stdout, a.mainService, 0)
+func (a *App) run(ctx context.Context) {
+	switch err := a.mainService.Serve(ctx); err {
+	case nil, context.Canceled:
+	default:
+		a.err = err
+		a.exitStatus = ExitError
 	}
-	a.mainService.Stop()
 
 	done := make(chan struct{})
 	go func() {
@@ -379,7 +378,7 @@ func (a *App) Wait() ExitStatus {
 // for the app to stop before returning.
 func (a *App) Error() error {
 	select {
-	case <-a.stop:
+	case <-a.stopped:
 		return a.err
 	default:
 	}
@@ -396,7 +395,11 @@ func (a *App) stopWithErr(stopReason ExitStatus, err error) ExitStatus {
 	a.stopOnce.Do(func() {
 		a.exitStatus = stopReason
 		a.err = err
-		close(a.stop)
+		if shouldDebug() {
+			l.Debugln("Services before stop:")
+			printServiceTree(os.Stdout, a.mainService, 0)
+		}
+		a.mainServiceCancel()
 	})
 	<-a.stopped
 	return a.exitStatus

--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/tlsutil"
+	"github.com/syncthing/syncthing/lib/util"
 )
 
 func tempCfgFilename(t *testing.T) string {
@@ -86,7 +87,7 @@ func TestStartupFail(t *testing.T) {
 	}
 
 	done := make(chan struct{})
-	var waitE ExitStatus
+	var waitE util.ExitStatus
 	go func() {
 		waitE = app.Wait()
 		close(done)
@@ -98,8 +99,8 @@ func TestStartupFail(t *testing.T) {
 	case <-done:
 	}
 
-	if waitE != ExitError {
-		t.Errorf("Got exit status %v, expected %v", waitE, ExitError)
+	if waitE != util.ExitError {
+		t.Errorf("Got exit status %v, expected %v", waitE, util.ExitError)
 	}
 
 	if err = app.Error(); err != startErr {

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -10,47 +10,36 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/thejerf/suture"
-
 	"github.com/syncthing/syncthing/lib/events"
-	"github.com/syncthing/syncthing/lib/util"
 )
 
 // The verbose logging service subscribes to events and prints these in
 // verbose format to the console using INFO level.
 type verboseService struct {
-	suture.Service
-	sub events.Subscription
+	evLogger events.Logger
 }
 
 func newVerboseService(evLogger events.Logger) *verboseService {
-	s := &verboseService{
-		sub: evLogger.Subscribe(events.AllEvents),
+	return &verboseService{
+		evLogger: evLogger,
 	}
-	s.Service = util.AsService(s.serve, s.String())
-	return s
 }
 
 // serve runs the verbose logging service.
-func (s *verboseService) serve(ctx context.Context) {
+func (s *verboseService) Serve(ctx context.Context) error {
+	sub := s.evLogger.Subscribe(events.AllEvents)
+	defer sub.Unsubscribe()
 	for {
 		select {
-		case ev := <-s.sub.C():
+		case ev := <-sub.C():
 			formatted := s.formatEvent(ev)
 			if formatted != "" {
 				l.Verboseln(formatted)
 			}
 		case <-ctx.Done():
-			return
+			return nil
 		}
 	}
-}
-
-// Stop stops the verbose logging service.
-func (s *verboseService) Stop() {
-	s.Service.Stop()
-	s.sub.Unsubscribe()
-
 }
 
 func (s *verboseService) formatEvent(ev events.Event) string {

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -37,7 +37,7 @@ func (s *verboseService) Serve(ctx context.Context) error {
 				l.Verboseln(formatted)
 			}
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		}
 	}
 }

--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -17,9 +17,8 @@ import (
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/events"
-	"github.com/syncthing/syncthing/lib/util"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 )
 
 var (
@@ -45,18 +44,15 @@ type FailureHandler interface {
 }
 
 func NewFailureHandler(cfg config.Wrapper, evLogger events.Logger) FailureHandler {
-	h := &failureHandler{
+	return &failureHandler{
 		cfg:      cfg,
 		evLogger: evLogger,
 		optsChan: make(chan config.OptionsConfiguration),
 		buf:      make(map[string]*failureStat),
 	}
-	h.Service = util.AsServiceWithError(h.serve, h.String())
-	return h
 }
 
 type failureHandler struct {
-	suture.Service
 	cfg      config.Wrapper
 	evLogger events.Logger
 	optsChan chan config.OptionsConfiguration
@@ -68,7 +64,7 @@ type failureStat struct {
 	count       int
 }
 
-func (h *failureHandler) serve(ctx context.Context) error {
+func (h *failureHandler) Serve(ctx context.Context) error {
 	go func() {
 		select {
 		case h.optsChan <- h.cfg.Options():

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -364,7 +364,7 @@ func (s *Service) Serve(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
-			return nil
+			return ctx.Err()
 		case <-s.forceRun:
 			t.Reset(0)
 		case <-t.C:

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -29,9 +29,6 @@ import (
 	"github.com/syncthing/syncthing/lib/scanner"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur/contract"
-	"github.com/syncthing/syncthing/lib/util"
-
-	"github.com/thejerf/suture"
 )
 
 // Current version number of the usage report, for acceptance purposes. If
@@ -42,7 +39,6 @@ const Version = 3
 var StartTime = time.Now()
 
 type Service struct {
-	suture.Service
 	cfg                config.Wrapper
 	model              model.Model
 	connectionsService connections.Service
@@ -51,15 +47,13 @@ type Service struct {
 }
 
 func New(cfg config.Wrapper, m model.Model, connectionsService connections.Service, noUpgrade bool) *Service {
-	svc := &Service{
+	return &Service{
 		cfg:                cfg,
 		model:              m,
 		connectionsService: connectionsService,
 		noUpgrade:          noUpgrade,
 		forceRun:           make(chan struct{}, 1), // Buffered to prevent locking
 	}
-	svc.Service = util.AsService(svc.serve, svc.String())
-	return svc
 }
 
 // ReportData returns the data to be sent in a usage report with the currently
@@ -362,7 +356,7 @@ func (s *Service) sendUsageReport(ctx context.Context) error {
 	return nil
 }
 
-func (s *Service) serve(ctx context.Context) {
+func (s *Service) Serve(ctx context.Context) error {
 	s.cfg.Subscribe(s)
 	defer s.cfg.Unsubscribe(s)
 
@@ -370,7 +364,7 @@ func (s *Service) serve(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 		case <-s.forceRun:
 			t.Reset(0)
 		case <-t.C:

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -333,6 +333,12 @@ func (s *service) String() string {
 	return fmt.Sprintf("Service@%p created by %v", s, s.creator)
 }
 
+func Spec() suture.Spec {
+	return suture.Spec{
+		PassThroughPanics: true,
+	}
+}
+
 func CallWithContext(ctx context.Context, fn func() error) error {
 	var err error
 	done := make(chan struct{})

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -229,6 +229,37 @@ func AddressUnspecifiedLess(a, b net.Addr) bool {
 	return aIsUnspecified
 }
 
+type FatalErr struct {
+	Err    error
+	Status ExitStatus
+}
+
+func (e *FatalErr) Error() string {
+	return e.Err.Error()
+}
+
+func (e *FatalErr) Unwrap() error {
+	return e.Err
+}
+
+func (e *FatalErr) Is(target error) bool {
+	return target == suture.ErrTerminateSupervisorTree
+}
+
+type ExitStatus int
+
+const (
+	ExitSuccess            ExitStatus = 0
+	ExitError              ExitStatus = 1
+	ExitNoUpgradeAvailable ExitStatus = 2
+	ExitRestart            ExitStatus = 3
+	ExitUpgrade            ExitStatus = 4
+)
+
+func (s ExitStatus) AsInt() int {
+	return int(s)
+}
+
 type ServiceWithError interface {
 	suture.Service
 	fmt.Stringer

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/sync"
 
-	"github.com/thejerf/suture"
+	"github.com/thejerf/suture/v4"
 )
 
 type defaultParser interface {
@@ -229,15 +229,6 @@ func AddressUnspecifiedLess(a, b net.Addr) bool {
 	return aIsUnspecified
 }
 
-// AsService wraps the given function to implement suture.Service by calling
-// that function on serve and closing the passed channel when Stop is called.
-func AsService(fn func(ctx context.Context), creator string) suture.Service {
-	return asServiceWithError(func(ctx context.Context) error {
-		fn(ctx)
-		return nil
-	}, creator)
-}
-
 type ServiceWithError interface {
 	suture.Service
 	fmt.Stringer
@@ -245,76 +236,35 @@ type ServiceWithError interface {
 	SetError(error)
 }
 
-// AsServiceWithError does the same as AsService, except that it keeps track
-// of an error returned by the given function.
-func AsServiceWithError(fn func(ctx context.Context) error, creator string) ServiceWithError {
-	return asServiceWithError(fn, creator)
-}
-
-func asServiceWithError(fn func(ctx context.Context) error, creator string) ServiceWithError {
-	ctx, cancel := context.WithCancel(context.Background())
-	s := &service{
-		serve:   fn,
-		ctx:     ctx,
-		cancel:  cancel,
-		stopped: make(chan struct{}),
+// AsService wraps the given function to implement suture.Service. In addition
+// it keeps track of the returned error and allows querying and setting that error.
+func AsService(fn func(ctx context.Context) error, creator string) ServiceWithError {
+	return &service{
 		creator: creator,
+		serve:   fn,
 		mut:     sync.NewMutex(),
 	}
-	close(s.stopped) // not yet started, don't block on Stop()
-	return s
 }
 
 type service struct {
 	creator string
 	serve   func(ctx context.Context) error
-	ctx     context.Context
-	cancel  context.CancelFunc
-	stopped chan struct{}
 	err     error
 	mut     sync.Mutex
 }
 
-func (s *service) Serve() {
+func (s *service) Serve(ctx context.Context) error {
 	s.mut.Lock()
-	select {
-	case <-s.ctx.Done():
-		s.mut.Unlock()
-		return
-	default:
-	}
 	s.err = nil
-	s.stopped = make(chan struct{})
 	s.mut.Unlock()
 
-	var err error
-	defer func() {
-		if err == context.Canceled {
-			err = nil
-		}
-		s.mut.Lock()
-		s.err = err
-		close(s.stopped)
-		s.mut.Unlock()
-	}()
-	err = s.serve(s.ctx)
-}
+	err := s.serve(ctx)
 
-func (s *service) Stop() {
 	s.mut.Lock()
-	select {
-	case <-s.ctx.Done():
-		s.mut.Unlock()
-		panic(fmt.Sprintf("Stop called more than once on %v", s))
-	default:
-		s.cancel()
-	}
-
-	// Cache s.stopped in a variable while we hold the mutex
-	// to prevent a data race with Serve's resetting it.
-	stopped := s.stopped
+	s.err = err
 	s.mut.Unlock()
-	<-stopped
+
+	return err
 }
 
 func (s *service) Error() error {
@@ -331,11 +281,36 @@ func (s *service) SetError(err error) {
 
 func (s *service) String() string {
 	return fmt.Sprintf("Service@%p created by %v", s, s.creator)
+
+}
+
+// OnDone calls fn when ctx is cancelled.
+func OnDone(ctx context.Context, fn func()) {
+	go func() {
+		<-ctx.Done()
+		fn()
+	}()
+}
+
+type doneService struct {
+	fn func()
+}
+
+func (s *doneService) Serve(ctx context.Context) error {
+	<-ctx.Done()
+	s.fn()
+	return nil
+}
+
+// OnSupervisorDone calls fn when sup is done.
+func OnSupervisorDone(sup *suture.Supervisor, fn func()) {
+	sup.Add(&doneService{fn})
 }
 
 func Spec() suture.Spec {
 	return suture.Spec{
-		PassThroughPanics: true,
+		PassThroughPanics:        true,
+		DontPropagateTermination: false,
 	}
 }
 

--- a/lib/util/utils_test.go
+++ b/lib/util/utils_test.go
@@ -7,8 +7,6 @@
 package util
 
 import (
-	"context"
-	"strings"
 	"testing"
 )
 
@@ -269,23 +267,6 @@ func TestInspecifiedAddressLess(t *testing.T) {
 			t.Error(i, "unexpected")
 		}
 	}
-}
-
-func TestUtilStopTwicePanic(t *testing.T) {
-	name := "foo"
-	s := AsService(func(ctx context.Context) {
-		<-ctx.Done()
-	}, name)
-
-	go s.Serve()
-	s.Stop()
-
-	defer func() {
-		if r := recover(); r == nil || !strings.Contains(r.(string), name) {
-			t.Fatalf(`expected panic containing "%v", got "%v"`, name, r)
-		}
-	}()
-	s.Stop()
 }
 
 func TestFillNil(t *testing.T) {

--- a/lib/watchaggregator/aggregator_test.go
+++ b/lib/watchaggregator/aggregator_test.go
@@ -152,8 +152,9 @@ func TestAggregate(t *testing.T) {
 // TestInProgress checks that ignoring files currently edited by Syncthing works
 func TestInProgress(t *testing.T) {
 	evLogger := events.NewLogger()
-	go evLogger.Serve()
-	defer evLogger.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	go evLogger.Serve(ctx)
+	defer cancel()
 	testCase := func(c chan<- fs.Event) {
 		evLogger.Log(events.ItemStarted, map[string]string{
 			"item": "inprogress",


### PR DESCRIPTION
This PR adapts to the new suture API (jcontext branch, https://github.com/thejerf/suture/issues/39). The diff is huge, but the actual changes arent:  
The first commit just adds a convenience function to create a default supervisor spec to make the next commits nicer (no behaviour change).
The second, main commit implements the new API with minimal changes. Meaning I stayed as close as possible to how things worked before (e.g. moving code in `Stop` to a `OnSupervisorStop` utility service that executes that code when the supervisor and thus the service is stopped).  
The third commit changes lib/syncthing and lib/api to make use of the new interface. Meaning instead of getting a controller from lib/syncthing, api now exits with the new "fatal-error" that takes down all services and bubbles the error to lib/syncthing.

This seems to work (runs and can shutdown syncthing from web UI), however suture v4 isn't released yet. So there's some time to hone this out.

One followup to this will be exposing errors on lib/db and let consumers react to those errors, i.e. terminate through the suture api instead of panic unless the db error can be handled. I started on it and that's going to be huge change (tons of functions in db and model need to gain error returns...), so I'll open a PR against this PR when ready.