### PR TITLE
BUILDHOST name changed for Arch

### DIFF
--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -54,7 +54,7 @@ var (
 		{regexp.MustCompile("jenkins@build.syncthing.net"), "GitHub"},
 		{regexp.MustCompile("snap@build.syncthing.net"), "Snapcraft"},
 		{regexp.MustCompile("android-.*vagrant@basebox-stretch64"), "F-Droid"},
-		{regexp.MustCompile("builduser@svetlemodry"), "Arch (3rd party)"},
+		{regexp.MustCompile("builduser@archlinux"), "Arch (3rd party)"},
 		{regexp.MustCompile("synology@kastelo.net"), "Synology (Kastelo)"},
 		{regexp.MustCompile("@debian"), "Debian (3rd party)"},
 		{regexp.MustCompile("@fedora"), "Fedora (3rd party)"},

--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -54,7 +54,7 @@ var (
 		{regexp.MustCompile("jenkins@build.syncthing.net"), "GitHub"},
 		{regexp.MustCompile("snap@build.syncthing.net"), "Snapcraft"},
 		{regexp.MustCompile("android-.*vagrant@basebox-stretch64"), "F-Droid"},
-		{regexp.MustCompile("builduser@archlinux"), "Arch (3rd party)"},
+		{regexp.MustCompile("builduser@(archlinux|svetlemodry)"), "Arch (3rd party)"},
 		{regexp.MustCompile("synology@kastelo.net"), "Synology (Kastelo)"},
 		{regexp.MustCompile("@debian"), "Debian (3rd party)"},
 		{regexp.MustCompile("@fedora"), "Fedora (3rd party)"},


### PR DESCRIPTION
Hi all!
To make the Arch Linux syncthing package reproducible, I've fixed the BUILDHOST variable in the build instructions. So I belive this code needs to be changed too, to reflect the change.

Some more details are in the bug report [here](https://bugs.archlinux.org/task/67279). The change was implemented in the last  [PKGBUILD](https://github.com/archlinux/svntogit-community/commit/705393bbda70210db9825da85c031435d1f2a5dc#diff-8d0411b338c83cd8cd8ad9d9db127101).
Cheers!
J