### PR TITLE
lib/db: Add local need check&repair

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -1117,6 +1117,11 @@ func (db *Lowlevel) checkLocalNeed(folder []byte) (int, error) {
 		next()
 	}
 
+	if err := dbi.Error(); err != nil {
+		return 0, err
+	}
+	dbi.Release()
+
 	if err = t.Commit(); err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
I hate this as much as everyone else if not more, but it turns out it is needed: Wracking my brain on https://forum.syncthing.net/t/syncthing-stuck-syncing-because-of-device-that-doesnt-exist/15501 and the out-of-sync folders with nothing in the out-of-sync list, I realized we do check and repair all kinds of things but never our "cached" list of files we need locally. In this PR I add the check and run it in the usual place. I ran it on my devices and on both it did repair stuff. I don't know what the underlying issue is. It would be nice to have https://github.com/syncthing/syncthing/pull/6925 to report if there's anything to repair, to know if this is an ongoing problem or if I have just been cleaning up relics of the past on my devices (wishful thinking).

