### PR TITLE
lib/model: Don't acquire io token for send-only pull

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -344,13 +344,17 @@ func (f *folder) pull() (success bool) {
 		return false
 	}
 
-	f.setState(FolderSyncWaiting)
+	// Send only folder doesn't do any io, it only checks for out-of-sync
+	// items that differ in metadata and updates those.
+	if f.Type != config.FolderTypeSendOnly {
+		f.setState(FolderSyncWaiting)
 
-	if err := f.ioLimiter.takeWithContext(f.ctx, 1); err != nil {
-		f.setError(err)
-		return true
+		if err := f.ioLimiter.takeWithContext(f.ctx, 1); err != nil {
+			f.setError(err)
+			return true
+		}
+		defer f.ioLimiter.give(1)
 	}
-	defer f.ioLimiter.give(1)
 
 	startTime := time.Now()
 

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -40,13 +40,6 @@ func (f *sendOnlyFolder) PullErrors() []FileError {
 
 // pull checks need for files that only differ by metadata (no changes on disk)
 func (f *sendOnlyFolder) pull() bool {
-	select {
-	case <-f.initialScanFinished:
-	default:
-		// Once the initial scan finished, a pull will be scheduled
-		return false
-	}
-
 	batch := make([]protocol.FileInfo, 0, maxBatchSizeFiles)
 	batchSizeBytes := 0
 


### PR DESCRIPTION
There's no point in send-only folders acquiring an io-limiter token on pull. They only check for out-of-sync items that don't actually differ from the local state and resolve those, there's no io happening. Came up in https://forum.syncthing.net/t/waiting-to-sync-95-0b-again/15564

Also there's no need for the initial scan check on the send-only folder, that already happens in `folder.pull`.