### PR TITLE
cmd/stindex, lib/db: Use same condition to check for needed files

### DIFF
--- a/cmd/stindex/idxck.go
+++ b/cmd/stindex/idxck.go
@@ -333,10 +333,10 @@ func idxck(ldb backend.Backend) (success bool) {
 }
 
 func needsLocally(vl db.VersionList) bool {
-	fv, ok := vl.Get(protocol.LocalDeviceID[:])
-	if !ok {
-		return true // proviosinally, it looks like we need the file
+	gfv, gok := vl.GetGlobal()
+	if !gok { // That's weird, but we hardly need something non-existant
+		return false
 	}
-	gfv, _ := vl.GetGlobal() // Can't not have a global if we got something above
-	return !fv.Version.GreaterEqual(gfv.Version)
+	fv, ok := vl.Get(protocol.LocalDeviceID[:])
+	return db.Need(gfv, ok, fv.Version)
 }


### PR DESCRIPTION
Makes stindex/idxck use the same utility function as lib/db to check if a file is needed. Previously there were false positives if we didn't have a file info locally, but the global one was invalid or deleted.