### PR TITLE
test, lib/model: Various integration test updates & improvements

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -1031,11 +1031,13 @@ func (f *folder) updateLocals(fs []protocol.FileInfo) {
 	}
 	f.forcedRescanPathsMut.Unlock()
 
+	seq := f.fset.Sequence(protocol.LocalDeviceID)
 	f.evLogger.Log(events.LocalIndexUpdated, map[string]interface{}{
 		"folder":    f.ID,
 		"items":     len(fs),
 		"filenames": filenames,
-		"version":   f.fset.Sequence(protocol.LocalDeviceID),
+		"sequence":  seq,
+		"version":   seq, // legacy for sequence
 	})
 }
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3929,16 +3929,16 @@ func TestConnectionTerminationOnFolderUnpause(t *testing.T) {
 
 func TestAddFolderCompletion(t *testing.T) {
 	// Empty folders are always 100% complete.
-	comp := newFolderCompletion(db.Counts{}, db.Counts{})
-	comp.add(newFolderCompletion(db.Counts{}, db.Counts{}))
+	comp := newFolderCompletion(db.Counts{}, db.Counts{}, 0)
+	comp.add(newFolderCompletion(db.Counts{}, db.Counts{}, 0))
 	if comp.CompletionPct != 100 {
 		t.Error(comp.CompletionPct)
 	}
 
 	// Completion is of the whole
-	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{})             // 100% complete
-	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50})) // 82.5% complete
-	if comp.CompletionPct != 90 {                                              // 100 * (1 - 50/500)
+	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{}, 0)             // 100% complete
+	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50}, 0)) // 82.5% complete
+	if comp.CompletionPct != 90 {                                                 // 100 * (1 - 50/500)
 		t.Error(comp.CompletionPct)
 	}
 }

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -27,6 +27,7 @@ import (
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
 )
@@ -661,4 +662,18 @@ func (p *Process) SystemVersion() (SystemVersion, error) {
 	}
 
 	return res, nil
+}
+
+func (p *Process) RemoteInSync(folder string, dev protocol.DeviceID) (bool, error) {
+	bs, err := p.Get(fmt.Sprintf("/rest/db/completion?folder=%v&device=%v", url.QueryEscape(folder), dev))
+	if err != nil {
+		return false, err
+	}
+
+	var comp model.FolderCompletion
+	if err := json.Unmarshal(bs, &comp); err != nil {
+		return false, err
+	}
+
+	return comp.NeedItems+comp.NeedDeletes == 0, nil
 }

--- a/test/filetype_test.go
+++ b/test/filetype_test.go
@@ -22,7 +22,7 @@ import (
 func TestFileTypeChange(t *testing.T) {
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{}
 	cfg.SetFolder(fld)
@@ -36,7 +36,7 @@ func TestFileTypeChange(t *testing.T) {
 func TestFileTypeChangeSimpleVersioning(t *testing.T) {
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type:   "simple",
@@ -53,7 +53,7 @@ func TestFileTypeChangeSimpleVersioning(t *testing.T) {
 func TestFileTypeChangeStaggeredVersioning(t *testing.T) {
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type: "staggered",

--- a/test/h1/config.xml
+++ b/test/h1/config.xml
@@ -1,4 +1,4 @@
-<configuration version="31">
+<configuration version="32">
     <folder id="default" label="" path="s1/" type="sendreceive" rescanIntervalS="10" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
@@ -6,7 +6,9 @@
         <device id="373HSRP-QLPNLIE-JYKZVQF-P4PKZ63-R2ZE6K3-YD442U2-JHBGBQG-WWXAHAU" introducedBy=""></device>
         <device id="7PBCTLL-JJRYBSA-MOWZRKL-MSDMN4N-4US4OMX-SYEXUS4-HSBGNRY-CZXRXAT" introducedBy=""></device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+        </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -25,13 +27,18 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <folder id="¯\_(ツ)_/¯ Räksmörgås 动作 Адрес" label="" path="s12-1/" type="sendreceive" rescanIntervalS="10" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
         <device id="MRIW7OK-NETT3M4-N6SBWME-N25O76W-YJKVXPH-FUMQJ3S-P57B74J-GBITBAC" introducedBy=""></device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+        </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -50,6 +57,9 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <device id="EJHMPAQ-OGCVORE-ISB4IS3-SYYVJXF-TKJGLTU-66DIQPF-GJ5D2GX-GQ3OWQK" name="s4" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22004</address>
@@ -144,5 +154,6 @@
         <stunServer>default</stunServer>
         <databaseTuning>auto</databaseTuning>
         <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
+        <announceLANAddresses>true</announceLANAddresses>
     </options>
 </configuration>

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -1,11 +1,13 @@
-<configuration version="29">
+<configuration version="32">
     <folder id="default" label="" path="s2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
         <device id="MRIW7OK-NETT3M4-N6SBWME-N25O76W-YJKVXPH-FUMQJ3S-P57B74J-GBITBAC" introducedBy=""></device>
         <device id="373HSRP-QLPNLIE-JYKZVQF-P4PKZ63-R2ZE6K3-YD442U2-JHBGBQG-WWXAHAU" introducedBy=""></device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+        </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -24,13 +26,18 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <folder id="s23" label="" path="s23-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="MRIW7OK-NETT3M4-N6SBWME-N25O76W-YJKVXPH-FUMQJ3S-P57B74J-GBITBAC" introducedBy=""></device>
         <device id="373HSRP-QLPNLIE-JYKZVQF-P4PKZ63-R2ZE6K3-YD442U2-JHBGBQG-WWXAHAU" introducedBy=""></device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+        </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -49,13 +56,18 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <folder id="¯\_(ツ)_/¯ Räksmörgås 动作 Адрес" label="" path="s12-2" type="sendreceive" rescanIntervalS="15" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
         <device id="MRIW7OK-NETT3M4-N6SBWME-N25O76W-YJKVXPH-FUMQJ3S-P57B74J-GBITBAC" introducedBy=""></device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+        </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -74,6 +86,9 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" name="s1" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22001</address>
@@ -151,5 +166,6 @@
         <stunServer>default</stunServer>
         <databaseTuning>auto</databaseTuning>
         <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
+        <announceLANAddresses>true</announceLANAddresses>
     </options>
 </configuration>

--- a/test/h3/config.xml
+++ b/test/h3/config.xml
@@ -1,4 +1,4 @@
-<configuration version="31">
+<configuration version="32">
     <folder id="default" label="" path="s3" type="sendreceive" rescanIntervalS="20" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" introducedBy=""></device>
@@ -7,6 +7,7 @@
         <minDiskFree unit="%">1</minDiskFree>
         <versioning type="simple">
             <param key="keep" val="5"></param>
+            <cleanupIntervalS>3600</cleanupIntervalS>
         </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
@@ -26,13 +27,18 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <folder id="s23" label="" path="s23-3" type="sendreceive" rescanIntervalS="20" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="true">
         <filesystemType>basic</filesystemType>
         <device id="MRIW7OK-NETT3M4-N6SBWME-N25O76W-YJKVXPH-FUMQJ3S-P57B74J-GBITBAC" introducedBy=""></device>
         <device id="373HSRP-QLPNLIE-JYKZVQF-P4PKZ63-R2ZE6K3-YD442U2-JHBGBQG-WWXAHAU" introducedBy=""></device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+        </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>0</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -51,6 +57,9 @@
         <maxConcurrentWrites>0</maxConcurrentWrites>
         <disableFsync>false</disableFsync>
         <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <device id="I6KAH76-66SLLLB-5PFXSOA-UFJCDZC-YAOMLEK-CP2GB32-BV5RQST-3PSROAU" name="s1" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>tcp://127.0.0.1:22001</address>
@@ -128,5 +137,6 @@
         <stunServer>default</stunServer>
         <databaseTuning>auto</databaseTuning>
         <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
+        <announceLANAddresses>true</announceLANAddresses>
     </options>
 </configuration>

--- a/test/h4/config.xml
+++ b/test/h4/config.xml
@@ -1,9 +1,11 @@
-<configuration version="28">
-    <folder id="default" label="" path="s4/" type="readwrite" rescanIntervalS="60" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="false">
+<configuration version="32">
+    <folder id="default" label="" path="s4/" type="sendreceive" rescanIntervalS="60" fsWatcherEnabled="false" fsWatcherDelayS="10" ignorePerms="false" autoNormalize="false">
         <filesystemType>basic</filesystemType>
         <device id="7PBCTLL-JJRYBSA-MOWZRKL-MSDMN4N-4US4OMX-SYEXUS4-HSBGNRY-CZXRXAT" introducedBy=""></device>
         <minDiskFree unit="%">1</minDiskFree>
-        <versioning></versioning>
+        <versioning>
+            <cleanupIntervalS>3600</cleanupIntervalS>
+        </versioning>
         <copiers>1</copiers>
         <pullerMaxPendingKiB>2048</pullerMaxPendingKiB>
         <hashers>0</hashers>
@@ -17,7 +19,14 @@
         <paused>false</paused>
         <weakHashThresholdPct>25</weakHashThresholdPct>
         <markerName>.stfolder</markerName>
-        <useLargeBlocks>false</useLargeBlocks>
+        <copyOwnershipFromParent>false</copyOwnershipFromParent>
+        <modTimeWindowS>0</modTimeWindowS>
+        <maxConcurrentWrites>0</maxConcurrentWrites>
+        <disableFsync>false</disableFsync>
+        <blockPullOrder>standard</blockPullOrder>
+        <copyRangeMethod>standard</copyRangeMethod>
+        <caseSensitiveFS>false</caseSensitiveFS>
+        <junctionsAsDirs>true</junctionsAsDirs>
     </folder>
     <device id="7PBCTLL-JJRYBSA-MOWZRKL-MSDMN4N-4US4OMX-SYEXUS4-HSBGNRY-CZXRXAT" name="s4" compression="metadata" introducer="false" skipIntroductionRemovals="false" introducedBy="">
         <address>dynamic</address>
@@ -25,12 +34,14 @@
         <autoAcceptFolders>false</autoAcceptFolders>
         <maxSendKbps>0</maxSendKbps>
         <maxRecvKbps>0</maxRecvKbps>
+        <maxRequestKiB>0</maxRequestKiB>
     </device>
     <gui enabled="true" tls="false" debugging="true">
         <address>127.0.0.1:8084</address>
         <apikey>PMA5yUTG-Mw98nJ0YEtWTCHlM5O4aNi0</apikey>
         <theme>default</theme>
     </gui>
+    <ldap></ldap>
     <options>
         <listenAddress>dynamic+https://relays.syncthing.net/endpoint</listenAddress>
         <listenAddress>tcp://127.0.0.1:22004</listenAddress>
@@ -69,6 +80,14 @@
         <trafficClass>0</trafficClass>
         <defaultFolderPath>~</defaultFolderPath>
         <setLowPriority>true</setLowPriority>
-        <minHomeDiskFreePct>0</minHomeDiskFreePct>
+        <maxFolderConcurrency>0</maxFolderConcurrency>
+        <crashReportingURL>https://crash.syncthing.net/newcrash</crashReportingURL>
+        <crashReportingEnabled>true</crashReportingEnabled>
+        <stunKeepaliveStartS>180</stunKeepaliveStartS>
+        <stunKeepaliveMinS>20</stunKeepaliveMinS>
+        <stunServer>default</stunServer>
+        <databaseTuning>auto</databaseTuning>
+        <maxConcurrentIncomingRequestKiB>0</maxConcurrentIncomingRequestKiB>
+        <announceLANAddresses>true</announceLANAddresses>
     </options>
 </configuration>

--- a/test/override_test.go
+++ b/test/override_test.go
@@ -25,7 +25,7 @@ import (
 func TestOverride(t *testing.T) {
 	// Enable "send-only" on s1/default
 	id, _ := protocol.DeviceIDFromString(id1)
-	cfg, _ := config.Load("h1/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h1/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Type = config.FolderTypeSendOnly
 	cfg.SetFolder(fld)
@@ -157,7 +157,7 @@ get to completion when in sendOnly/sendRecv mode. Needs fixing.
 func TestOverrideIgnores(t *testing.T) {
 	// Enable "sendOnly" on s1/default
 	id, _ := protocol.DeviceIDFromString(id1)
-	cfg, _ := config.Load("h1/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h1/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.ReadOnly = true
 	cfg.SetFolder(fld)

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -117,6 +117,10 @@ func testReconnectDuringTransfer(t *testing.T, restartSender, restartReceiver bo
 	log.Println("Comparing directories...")
 	err = compareDirectories("s1", "s2")
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+	}
+
+	if err := checkRemoteInSync("default", receiver, sender); err != nil {
+		t.Error(err)
 	}
 }

--- a/test/reconnect_test.go
+++ b/test/reconnect_test.go
@@ -12,6 +12,8 @@ import (
 	"log"
 	"testing"
 	"time"
+
+	"github.com/syncthing/syncthing/lib/rc"
 )
 
 func TestReconnectReceiverDuringTransfer(t *testing.T) {
@@ -45,7 +47,7 @@ func testReconnectDuringTransfer(t *testing.T, restartSender, restartReceiver bo
 
 	receiver := startInstance(t, 2)
 	defer func() {
-		// We need a receiver over sender, since we'll update it later to
+		// We need a closure over sender, since we'll update it later to
 		// point at another process.
 		checkedStop(t, receiver)
 	}()
@@ -72,7 +74,7 @@ func testReconnectDuringTransfer(t *testing.T, restartSender, restartReceiver bo
 			t.Fatal(err)
 		}
 
-		if recv.InSyncBytes > 0 && recv.InSyncBytes == recv.GlobalBytes {
+		if recv.InSyncBytes > 0 && recv.InSyncBytes == recv.GlobalBytes && rc.InSync("default", receiver, sender) {
 			// Receiver is done
 			break
 		} else if recv.InSyncBytes > prevBytes+recv.GlobalBytes/10 {

--- a/test/symlink_test.go
+++ b/test/symlink_test.go
@@ -26,7 +26,7 @@ func TestSymlinks(t *testing.T) {
 
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{}
 	cfg.SetFolder(fld)
@@ -44,7 +44,7 @@ func TestSymlinksSimpleVersioning(t *testing.T) {
 
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type:   "simple",
@@ -65,7 +65,7 @@ func TestSymlinksStaggeredVersioning(t *testing.T) {
 
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
-	cfg, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
 	fld := cfg.Folders()["default"]
 	fld.Versioning = config.VersioningConfiguration{
 		Type: "staggered",

--- a/test/sync_test.go
+++ b/test/sync_test.go
@@ -293,6 +293,19 @@ func scSyncAndCompare(p []*rc.Process, expected [][]fileInfo) error {
 		}
 	}
 
+	if err := checkRemoteInSync("default", p[0], p[1]); err != nil {
+		return err
+	}
+	if err := checkRemoteInSync("default", p[0], p[2]); err != nil {
+		return err
+	}
+	if err := checkRemoteInSync(s12Folder, p[0], p[1]); err != nil {
+		return err
+	}
+	if err := checkRemoteInSync("s23", p[1], p[2]); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/test/util.go
+++ b/test/util.go
@@ -562,3 +562,19 @@ func symlinksSupported() bool {
 	err = os.Symlink("tmp", filepath.Join(tmp, "link"))
 	return err == nil
 }
+
+// checkRemoteInSync checks if the devices associated twith the given processes
+// are in sync according to the remote status on both sides.
+func checkRemoteInSync(folder string, p1, p2 *rc.Process) error {
+	if inSync, err := p1.RemoteInSync(folder, p2.ID()); err != nil {
+		return err
+	} else if !inSync {
+		return fmt.Errorf(`from device %v folder "%v" is not in sync on device %v`, p1.ID(), folder, p2.ID())
+	}
+	if inSync, err := p2.RemoteInSync(folder, p1.ID()); err != nil {
+		return err
+	} else if !inSync {
+		return fmt.Errorf(`from device %v folder "%v" is not in sync on device %v`, p2.ID(), folder, p1.ID())
+	}
+	return nil
+}


### PR DESCRIPTION
 - Didn't compile due to recent `config.Load` changes
 - Reconnect tests were flaky. In the process of fixing that I added the sequence to the completion endpoints and added `sequence` fields in addition to the legacy `version` ones where those were missing (was already in place for folder summaries).
 - Sync and reconnect tests now also consider remote device status and fail if those are not in sync.
 - Update configs.

Integration tests now pass for me.