### PR TITLE
lib/db: Don't hang on double iterator release with Badger

### DIFF
--- a/lib/db/backend/badger_backend.go
+++ b/lib/db/backend/badger_backend.go
@@ -334,6 +334,7 @@ type badgerIterator struct {
 	first     []byte
 	last      []byte
 	releaseFn func()
+	released  bool
 	didSeek   bool
 	err       error
 }
@@ -397,6 +398,12 @@ func (i *badgerIterator) Error() error {
 }
 
 func (i *badgerIterator) Release() {
+	if i.released {
+		// We already closed this iterator, no need to do it again
+		// (and the releaseFn might hang if we do).
+		return
+	}
+	i.released = true
 	i.it.Close()
 	if i.releaseFn != nil {
 		i.releaseFn()


### PR DESCRIPTION
Since iterators must be released before committing or discarding a
transaction we have the pattern of both deferring a release plus doing
it manually. But we can't release twice because we track this with a
WaitGroup that will panic when there are more Done()s than Add()s. This
just adds a boolean to let an iterator keep track.

(This is needed to let the conversion back from Badger to LevelDB work, which is a required step in retiring the Badger experiment...)