### PR TITLE
lib/model: Correct completion perc. when globalBytes is 0

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -808,14 +808,6 @@ func (m *model) folderCompletion(device protocol.DeviceID, folder string) Folder
 	snap := rf.Snapshot()
 	defer snap.Release()
 
-	global := snap.GlobalSize()
-	if global.Bytes == 0 {
-		// Folder is empty, so we have all of it
-		return FolderCompletion{
-			CompletionPct: 100,
-		}
-	}
-
 	m.pmut.RLock()
 	downloaded := m.deviceDownloads[device].BytesDownloaded(folder)
 	m.pmut.RUnlock()
@@ -827,7 +819,7 @@ func (m *model) folderCompletion(device protocol.DeviceID, folder string) Folder
 		need.Bytes = 0
 	}
 
-	comp := newFolderCompletion(global, need, snap.Sequence(device))
+	comp := newFolderCompletion(snap.GlobalSize(), need, snap.Sequence(device))
 
 	l.Debugf("%v Completion(%s, %q): %v", m, device, folder, comp.Map())
 	return comp

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -4017,6 +4017,23 @@ func testConfigChangeClosesConnections(t *testing.T, expectFirstClosed, expectSe
 	}
 }
 
+func TestCompletionEmptyGlobal(t *testing.T) {
+	wcfg, fcfg := tmpDefaultWrapper()
+	m := setupModel(wcfg)
+	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem().URI())
+	files := []protocol.FileInfo{{Name: "foo", Version: protocol.Vector{}.Update(myID.Short()), Sequence: 1}}
+	m.fmut.Lock()
+	m.folderFiles[fcfg.ID].Update(protocol.LocalDeviceID, files)
+	m.fmut.Unlock()
+	files[0].Deleted = true
+	files[0].Version = files[0].Version.Update(device1.Short())
+	m.IndexUpdate(device1, fcfg.ID, files)
+	comp := m.Completion(protocol.LocalDeviceID, fcfg.ID)
+	if comp.CompletionPct != 95 {
+		t.Error("Expected completion of 95%, got", comp.CompletionPct)
+	}
+}
+
 func equalStringsInAnyOrder(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
Discovered this bug while creating a test for https://github.com/syncthing/syncthing/pull/6962. Not likely to ever be noticed in the wild: When everything is deleted globally, we will always be 100%, even if we still have things to delete (instead of 95%).