### PR TITLE
lib/model: Warn when folder fails to stop in time

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -425,7 +425,13 @@ func (m *model) stopFolder(cfg config.FolderConfiguration, err error) {
 	m.fmut.RUnlock()
 
 	if ok {
-		m.RemoveAndWait(token, 0)
+		if err := m.RemoveAndWait(token, 0); err != nil {
+			if err == suture.ErrTimeout {
+				l.Warnf("Folder %v failed to stop in time", cfg.Description())
+			} else {
+				l.Warnln("Failed to stop folder:", err)
+			}
+		}
 	}
 
 	// Wait for connections to stop to ensure that no more calls to methods


### PR DESCRIPTION
If the folder fails to stop, we might create a new fileset while the folder is still running. This can result in the same situation that was fixed in #6939, i.e. the old folder still does updates while the new is already being started. It's less likely to be a problem since #6939, as filesets are reused on folder restart, but it might still be problematic (e.g. when quickly pausing and unpausing). Thus I propose to make it a warning, such that it will likely catch attention when debugging any db inconsistencies.