### PR TITLE
lib/fs: More efficient casefs cache

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -16,12 +16,9 @@ import (
 	"time"
 )
 
-// Both values were chosen by magic.
 const (
+	// How long to consider cached dirnames valid
 	caseCacheTimeout = time.Second
-	// When the number of names (all lengths of []string from DirNames)
-	// exceeds this, we drop the cache.
-	caseMaxCachedNames = 1 << 20
 )
 
 type ErrCaseConflict struct {
@@ -47,10 +44,45 @@ type fskey struct {
 	uri    string
 }
 
-var (
-	caseFilesystems    = make(map[fskey]Filesystem)
-	caseFilesystemsMut sync.Mutex
-)
+// caseFilesystemRegistry caches caseFilesystems and runs a routine to drop
+// their cache every now and then.
+type caseFilesystemRegistry struct {
+	fss          map[fskey]*caseFilesystem
+	mut          sync.Mutex
+	startCleaner sync.Once
+}
+
+func (r *caseFilesystemRegistry) get(fs Filesystem) *caseFilesystem {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+
+	k := fskey{fs.Type(), fs.URI()}
+	caseFs, ok := r.fss[k]
+	if !ok {
+		caseFs = &caseFilesystem{
+			Filesystem: fs,
+			realCaser:  newDefaultRealCaser(fs),
+		}
+		r.fss[k] = caseFs
+		r.startCleaner.Do(func() {
+			go r.cleaner()
+		})
+	}
+
+	return caseFs
+}
+
+func (r *caseFilesystemRegistry) cleaner() {
+	for range time.NewTicker(time.Minute).C {
+		r.mut.Lock()
+		for _, caseFs := range r.fss {
+			caseFs.dropCache()
+		}
+		r.mut.Unlock()
+	}
+}
+
+var globalCaseFilesystemRegistry = caseFilesystemRegistry{fss: make(map[fskey]*caseFilesystem)}
 
 // caseFilesystem is a BasicFilesystem with additional checks to make a
 // potentially case insensitive underlying FS behave like it's case-sensitive.
@@ -66,18 +98,7 @@ type caseFilesystem struct {
 // case-sensitive one. However it will add some overhead and thus shouldn't be
 // used if the filesystem is known to already behave case-sensitively.
 func NewCaseFilesystem(fs Filesystem) Filesystem {
-	caseFilesystemsMut.Lock()
-	defer caseFilesystemsMut.Unlock()
-	k := fskey{fs.Type(), fs.URI()}
-	if caseFs, ok := caseFilesystems[k]; ok {
-		return caseFs
-	}
-	caseFs := &caseFilesystem{
-		Filesystem: fs,
-		realCaser:  newDefaultRealCaser(fs),
-	}
-	caseFilesystems[k] = caseFs
-	return caseFs
+	return globalCaseFilesystemRegistry.get(fs)
 }
 
 func (f *caseFilesystem) Chmod(name string, mode FileMode) error {
@@ -308,21 +329,16 @@ func (f *caseFilesystem) checkCaseExisting(name string) error {
 }
 
 type defaultRealCaser struct {
-	fs        Filesystem
-	root      *caseNode
-	count     int
-	timer     *time.Timer
-	timerStop chan struct{}
-	mut       sync.RWMutex
+	fs   Filesystem
+	root *caseNode
+	mut  sync.RWMutex
 }
 
 func newDefaultRealCaser(fs Filesystem) *defaultRealCaser {
 	caser := &defaultRealCaser{
-		fs:    fs,
-		root:  &caseNode{name: "."},
-		timer: time.NewTimer(0),
+		fs:   fs,
+		root: &caseNode{name: "."},
 	}
-	<-caser.timer.C
 	return caser
 }
 
@@ -333,84 +349,49 @@ func (r *defaultRealCaser) realCase(name string) (string, error) {
 	}
 
 	r.mut.Lock()
-	defer func() {
-		if r.count > caseMaxCachedNames {
-			select {
-			case r.timerStop <- struct{}{}:
-			default:
-			}
-			r.dropCacheLocked()
-		}
-		r.mut.Unlock()
-	}()
+	defer r.mut.Unlock()
 
 	node := r.root
 	for _, comp := range strings.Split(name, string(PathSeparator)) {
-		if node.dirNames == nil {
-			// Haven't called DirNames yet
+		if node.dirNames == nil || node.expires.Before(time.Now()) {
+			// Haven't called DirNames yet, or the node has expired
+
 			var err error
 			node.dirNames, err = r.fs.DirNames(out)
 			if err != nil {
 				return "", err
 			}
+
 			node.dirNamesLower = make([]string, len(node.dirNames))
 			for i, n := range node.dirNames {
 				node.dirNamesLower[i] = UnicodeLowercase(n)
 			}
-			node.children = make(map[string]*caseNode)
-			node.results = make(map[string]*caseNode)
-			r.count += len(node.dirNames)
-		} else if child, ok := node.results[comp]; ok {
-			// Check if this exact name has been queried before to shortcut
-			node = child
-			out = filepath.Join(out, child.name)
-			continue
+
+			node.expires = time.Now().Add(caseCacheTimeout)
+			node.child = nil
 		}
-		// Actually loop dirNames to search for a match
-		n, err := findCaseInsensitiveMatch(comp, node.dirNames, node.dirNamesLower)
-		if err != nil {
-			return "", err
+
+		// If we don't already have a correct cached child, try to find it.
+		if node.child == nil || node.child.name != comp {
+			// Actually loop dirNames to search for a match.
+			n, err := findCaseInsensitiveMatch(comp, node.dirNames, node.dirNamesLower)
+			if err != nil {
+				return "", err
+			}
+			node.child = &caseNode{name: n}
 		}
-		child, ok := node.children[n]
-		if !ok {
-			child = &caseNode{name: n}
-		}
-		node.results[comp] = child
-		node.children[n] = child
-		node = child
-		out = filepath.Join(out, n)
+
+		node = node.child
+		out = filepath.Join(out, node.name)
 	}
 
 	return out, nil
 }
 
-func (r *defaultRealCaser) startCaseResetTimerLocked() {
-	r.timerStop = make(chan struct{})
-	r.timer.Reset(caseCacheTimeout)
-	go func() {
-		select {
-		case <-r.timer.C:
-			r.dropCache()
-		case <-r.timerStop:
-			if !r.timer.Stop() {
-				<-r.timer.C
-			}
-			r.mut.Lock()
-			r.timerStop = nil
-			r.mut.Unlock()
-		}
-	}()
-}
-
 func (r *defaultRealCaser) dropCache() {
 	r.mut.Lock()
-	r.dropCacheLocked()
-	r.mut.Unlock()
-}
-
-func (r *defaultRealCaser) dropCacheLocked() {
 	r.root = &caseNode{name: "."}
-	r.count = 0
+	r.mut.Unlock()
 }
 
 // Both name and the key to children are "Real", case resolved names of the path
@@ -419,10 +400,10 @@ func (r *defaultRealCaser) dropCacheLocked() {
 // case resolved.
 type caseNode struct {
 	name          string
+	expires       time.Time
 	dirNames      []string
 	dirNamesLower []string
-	children      map[string]*caseNode
-	results       map[string]*caseNode
+	child         *caseNode
 }
 
 func findCaseInsensitiveMatch(name string, names, namesLower []string) (string, error) {

--- a/lib/fs/debug_symlink_unix.go
+++ b/lib/fs/debug_symlink_unix.go
@@ -29,19 +29,3 @@ func DebugSymlinkForTestsOnly(oldFs, newFs Filesystem, oldname, newname string) 
 	}
 	return nil
 }
-
-// unwrapFilesystem removes "wrapping" filesystems to expose the underlying filesystem.
-func unwrapFilesystem(fs Filesystem) Filesystem {
-	for {
-		switch sfs := fs.(type) {
-		case *logFilesystem:
-			fs = sfs.Filesystem
-		case *walkFilesystem:
-			fs = sfs.Filesystem
-		case *MtimeFS:
-			fs = sfs.Filesystem
-		default:
-			return sfs
-		}
-	}
-}

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -259,3 +259,19 @@ func Canonicalize(file string) (string, error) {
 
 	return file, nil
 }
+
+// unwrapFilesystem removes "wrapping" filesystems to expose the underlying filesystem.
+func unwrapFilesystem(fs Filesystem) Filesystem {
+	for {
+		switch sfs := fs.(type) {
+		case *logFilesystem:
+			fs = sfs.Filesystem
+		case *walkFilesystem:
+			fs = sfs.Filesystem
+		case *MtimeFS:
+			fs = sfs.Filesystem
+		default:
+			return sfs
+		}
+	}
+}

--- a/lib/fs/filesystem_test.go
+++ b/lib/fs/filesystem_test.go
@@ -170,19 +170,3 @@ func TestIsParent(t *testing.T) {
 		}
 	}
 }
-
-// unwrapFilesystem removes "wrapping" filesystems to expose the underlying filesystem.
-func unwrapFilesystem(fs Filesystem) Filesystem {
-	for {
-		switch sfs := fs.(type) {
-		case *logFilesystem:
-			fs = sfs.Filesystem
-		case *walkFilesystem:
-			fs = sfs.Filesystem
-		case *MtimeFS:
-			fs = sfs.Filesystem
-		default:
-			return sfs
-		}
-	}
-}

--- a/lib/fs/filesystem_test.go
+++ b/lib/fs/filesystem_test.go
@@ -170,3 +170,19 @@ func TestIsParent(t *testing.T) {
 		}
 	}
 }
+
+// unwrapFilesystem removes "wrapping" filesystems to expose the underlying filesystem.
+func unwrapFilesystem(fs Filesystem) Filesystem {
+	for {
+		switch sfs := fs.(type) {
+		case *logFilesystem:
+			fs = sfs.Filesystem
+		case *walkFilesystem:
+			fs = sfs.Filesystem
+		case *MtimeFS:
+			fs = sfs.Filesystem
+		default:
+			return sfs
+		}
+	}
+}


### PR DESCRIPTION
This changes the cache to cache less things, yet retain the required
efficiency for our walk usecase. This uses less memory.

Specifically, instead of keeping result and child caches for each path
level, only keep a single cached child. In practice our operations are
depth-first, or almost depth-first, and then we retain the same hit
ratio for a smaller cache size.

I improved the benchmark so that it counts the Lstat and DirNames
operations performed, and they do not change significantly. The amount
of allocated memory is reduced by 20% and the walk itself is actually
slightly faster.

This also removes the clear based on number of cached names (as that is
not a thing any more) and the timer based clear (which was unused). This
means we'll retain the last cache state forever until it's cleared by a
write operation, but we did that before too and that state is now a lot
smaller...

The overhead compared to not using a casefs, for our typical "double
walk" (walk the tree then stat everything again) is 2x the dirnames we
would otherwise call, and no overhead on the stats (unchanged from old
implementation)

```
name                         old time/op         new time/op         delta
WalkCaseFakeFS100k/rawfs-8           306ms ± 1%          305ms ± 2%     ~     (p=0.182 n=9+10)
WalkCaseFakeFS100k/casefs-8          579ms ± 5%          557ms ± 1%   -3.77%  (p=0.000 n=10+10)

name                         old B/entry         new B/entry         delta
WalkCaseFakeFS100k/rawfs-8             590 ± 0%            590 ± 0%     ~     (all equal)
WalkCaseFakeFS100k/casefs-8          1.09k ± 0%          0.87k ± 0%  -19.98%  (p=0.000 n=10+10)

name                         old DirNames/entry  new DirNames/entry  delta
WalkCaseFakeFS100k/rawfs-8            0.51 ± 0%           0.51 ± 0%     ~     (all equal)
WalkCaseFakeFS100k/casefs-8           1.02 ± 0%           1.02 ± 0%     ~     (all equal)

name                         old DirNames/op     new DirNames/op     delta
WalkCaseFakeFS100k/rawfs-8           51.2k ± 0%          51.2k ± 0%     ~     (all equal)
WalkCaseFakeFS100k/casefs-8           102k ± 0%           102k ± 0%     ~     (all equal)

name                         old Lstat/entry     new Lstat/entry     delta
WalkCaseFakeFS100k/rawfs-8            3.02 ± 0%           3.02 ± 0%     ~     (all equal)
WalkCaseFakeFS100k/casefs-8           3.02 ± 0%           3.02 ± 0%     ~     (all equal)

name                         old Lstat/op        new Lstat/op        delta
WalkCaseFakeFS100k/rawfs-8            302k ± 0%           302k ± 0%     ~     (all equal)
WalkCaseFakeFS100k/casefs-8           302k ± 0%           302k ± 0%     ~     (all equal)

name                         old allocs/entry    new allocs/entry    delta
WalkCaseFakeFS100k/rawfs-8            15.7 ± 0%           15.7 ± 0%     ~     (all equal)
WalkCaseFakeFS100k/casefs-8           27.5 ± 0%           26.1 ± 0%   -5.09%  (p=0.000 n=10+10)

name                         old ns/entry        new ns/entry        delta
WalkCaseFakeFS100k/rawfs-8           2.02k ± 1%          2.02k ± 2%     ~     (p=0.163 n=9+10)
WalkCaseFakeFS100k/casefs-8          3.83k ± 5%          3.68k ± 1%   -3.77%  (p=0.000 n=10+10)

name                         old alloc/op        new alloc/op        delta
WalkCaseFakeFS100k/rawfs-8          89.2MB ± 0%         89.2MB ± 0%     ~     (p=0.364 n=9+10)
WalkCaseFakeFS100k/casefs-8          164MB ± 0%          131MB ± 0%  -19.97%  (p=0.000 n=10+10)

name                         old allocs/op       new allocs/op       delta
WalkCaseFakeFS100k/rawfs-8           2.38M ± 0%          2.38M ± 0%     ~     (all equal)
WalkCaseFakeFS100k/casefs-8          4.16M ± 0%          3.95M ± 0%   -5.05%  (p=0.000 n=10+10)
```