### PR TITLE
lib/model: Don't fail over case-conflict on tempfile (fixes #6973)

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -25,11 +25,11 @@ const (
 )
 
 type ErrCaseConflict struct {
-	given, real string
+	Given, Real string
 }
 
 func (e *ErrCaseConflict) Error() string {
-	return fmt.Sprintf(`given name "%v" differs from name in filesystem "%v"`, e.given, e.real)
+	return fmt.Sprintf(`given name "%v" differs from name in filesystem "%v"`, e.Given, e.Real)
 }
 
 func IsErrCaseConflict(err error) bool {


### PR DESCRIPTION
Currently we fail pulling if an old tempfile with a case-conflicting name is laying around. Now the temp file is renamed to the new name when such an error occurs.