### PR TITLE
lib/fs: Optimize UnicodeLowercase

### DIFF
--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -34,6 +34,9 @@ func UnicodeLowercase(s string) string {
 // Byte index of the first rune r s.t. lower(upper(r)) != r.
 func firstCaseChange(s string) int {
 	for i, r := range s {
+		if r <= unicode.MaxASCII && (r < 'A' || r > 'Z') {
+			continue
+		}
 		if unicode.ToLower(unicode.ToUpper(r)) != r {
 			return i
 		}

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -7,13 +7,36 @@
 package fs
 
 import (
+	"strings"
 	"unicode"
+	"unicode/utf8"
 )
 
 func UnicodeLowercase(s string) string {
-	rs := []rune(s)
-	for i, r := range rs {
-		rs[i] = unicode.ToLower(unicode.ToUpper(r))
+	i := firstCaseChange(s)
+	if i == -1 {
+		return s
 	}
-	return string(rs)
+
+	var rs strings.Builder
+	// WriteRune always reserves utf8.UTFMax bytes for non-ASCII runes,
+	// even if it doesn't need all that space. Overallocate now to prevent
+	// it from ever triggering a reallocation.
+	rs.Grow(utf8.UTFMax - 1 + len(s))
+	rs.WriteString(s[:i])
+
+	for _, r := range s[i:] {
+		rs.WriteRune(unicode.ToLower(unicode.ToUpper(r)))
+	}
+	return rs.String()
+}
+
+// Byte index of the first rune r s.t. lower(upper(r)) != r.
+func firstCaseChange(s string) int {
+	for i, r := range s {
+		if unicode.ToLower(unicode.ToUpper(r)) != r {
+			return i
+		}
+	}
+	return -1
 }

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -6,45 +6,71 @@
 
 package fs
 
-import "testing"
+import (
+	"testing"
+)
+
+var caseCases = [][2]string{
+	{"", ""},
+	{"hej", "hej"},
+	{"HeJ!@#", "hej!@#"},
+	// Western Europe diacritical stuff is trivial.
+	{"ÜBERRÄKSMÖRGÅS", "überräksmörgås"},
+	// As are ligatures.
+	{"Æglefinus", "æglefinus"},
+	{"Ĳssel", "ĳssel"},
+	// Cyrillic seems regular as well.
+	{"Привет", "привет"},
+	// Greek has multiple lower case characters for things depending on
+	// context; we should always choose the same one.
+	{"Ὀδυσσεύς", "ὀδυσσεύσ"},
+	{"ὈΔΥΣΣΕΎΣ", "ὀδυσσεύσ"},
+	// German ß doesn't really have an upper case variant, and we
+	// shouldn't mess things up when lower casing it either. We don't
+	// attempt to make ß equivalent to "ss".
+	{"Reichwaldstraße", "reichwaldstraße"},
+	// The Turks do their thing with the Is.... Like the Greek example
+	// we pick just the one canonicalized "i" although you can argue
+	// with this... From what I understand most operating systems don't
+	// get this right anyway.
+	{"İI", "ii"},
+	// Arabic doesn't do case folding.
+	{"العَرَبِيَّة", "العَرَبِيَّة"},
+	// Neither does Hebrew.
+	{"עברית", "עברית"},
+	// Nor Chinese, in any variant.
+	{"汉语/漢語 or 中文", "汉语/漢語 or 中文"},
+	// Nor katakana, as far as I can tell.
+	{"チャーハン", "チャーハン"},
+	// Some special Unicode characters, however, are folded by OSes.
+	{"\u212A", "k"},
+}
 
 func TestUnicodeLowercase(t *testing.T) {
-	cases := [][2]string{
-		{"", ""},
-		{"hej", "hej"},
-		{"HeJ!@#", "hej!@#"},
-		// Western Europe diacritical stuff is trivial
-		{"ÜBERRÄKSMÖRGÅS", "überräksmörgås"},
-		// Cyrillic seems regular as well
-		{"Привет", "привет"},
-		// Greek has multiple lower case characters for things depending on
-		// context; we should always choose the right one.
-		{"Ὀδυσσεύς", "ὀδυσσεύσ"},
-		{"ὈΔΥΣΣΕΎΣ", "ὀδυσσεύσ"},
-		// German ß doesn't really have an upper case variant, and we
-		// shouldn't mess things up when lower casing it either. We don't
-		// attempt to make ß equivalent to "ss".
-		{"Reichwaldstraße", "reichwaldstraße"},
-		// The Turks do their thing with the Is.... Like the Greek example
-		// we pick just the one canonicalized "i" although you can argue
-		// with this... From what I understand most operating systems don't
-		// get this right anyway.
-		{"İI", "ii"},
-		// Arabic doesn't do case folding.
-		{"العَرَبِيَّة", "العَرَبِيَّة"},
-		// Neither does Hebrew.
-		{"עברית", "עברית"},
-		// Nor Chinese, in any variant.
-		{"汉语/漢語 or 中文", "汉语/漢語 or 中文"},
-		// Niether katakana as far as I can tell.
-		{"チャーハン", "チャーハン"},
-		// Some special unicode characters, however, are folded by OSes
-		{"\u212A", "k"},
-	}
-	for _, tc := range cases {
+	for _, tc := range caseCases {
 		res := UnicodeLowercase(tc[0])
 		if res != tc[1] {
 			t.Errorf("UnicodeLowercase(%q) => %q, expected %q", tc[0], res, tc[1])
+		}
+	}
+}
+
+func BenchmarkUnicodeLowercaseMaybeChange(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, s := range caseCases {
+			UnicodeLowercase(s[0])
+		}
+	}
+}
+
+func BenchmarkUnicodeLowercaseNoChange(b *testing.B) {
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		for _, s := range caseCases {
+			UnicodeLowercase(s[1])
 		}
 	}
 }


### PR DESCRIPTION
Most notably, it now detects all-lowercase files and returns these as-is. The tests have been expanded with two cases and are now used as a benchmark (admittedly a rather trivial one).

Benchmark results on Linux/amd64 (note that WalkCaseFakeFS100k creates all-lowercase filenames):

    name                           old time/op         new time/op         delta
    WalkCaseFakeFS100k/rawfs-8             388ms ± 1%          312ms ± 3%   -19.64%  (p=0.000 n=10+8)
    WalkCaseFakeFS100k/casefs-8            718ms ± 1%          587ms ± 1%   -18.30%  (p=0.000 n=10+10)
    UnicodeLowercaseMaybeChange-8         5.45µs ± 5%         4.57µs ± 1%   -16.20%  (p=0.000 n=10+10)
    UnicodeLowercaseNoChange-8            5.33µs ± 4%         3.09µs ± 1%   -42.01%  (p=0.000 n=10+10)

    name                           old B/entry         new B/entry         delta
    WalkCaseFakeFS100k/rawfs-8               590 ± 0%            530 ± 0%   -10.17%  (p=0.000 n=10+10)
    WalkCaseFakeFS100k/casefs-8              869 ± 0%            760 ± 0%   -12.54%  (p=0.000 n=10+10)
    
    name                           old allocs/entry    new allocs/entry    delta
    WalkCaseFakeFS100k/rawfs-8              15.7 ± 0%           12.1 ± 0%   -22.93%  (p=0.000 n=10+10)
    WalkCaseFakeFS100k/casefs-8             26.1 ± 0%           20.1 ± 0%   -22.99%  (p=0.000 n=10+10)
    
    name                           old ns/entry        new ns/entry        delta
    WalkCaseFakeFS100k/rawfs-8             2.57k ± 1%          2.06k ± 3%   -19.65%  (p=0.000 n=10+8)
    WalkCaseFakeFS100k/casefs-8            4.75k ± 1%          3.86k ± 1%   -18.63%  (p=0.000 n=10+10)
    
    name                           old alloc/op        new alloc/op        delta
    WalkCaseFakeFS100k/rawfs-8            89.2MB ± 0%         80.2MB ± 0%   -10.08%  (p=0.000 n=9+10)
    WalkCaseFakeFS100k/casefs-8            131MB ± 0%          115MB ± 0%   -12.54%  (p=0.000 n=9+10)
    UnicodeLowercaseMaybeChange-8           320B ± 0%           192B ± 0%   -40.00%  (p=0.000 n=10+10)
    UnicodeLowercaseNoChange-8              320B ± 0%             0B       -100.00%  (p=0.000 n=10+10)
    
    name                           old allocs/op       new allocs/op       delta
    WalkCaseFakeFS100k/rawfs-8             2.38M ± 0%          1.82M ± 0%   -23.44%  (p=0.002 n=8+10)
    WalkCaseFakeFS100k/casefs-8            3.95M ± 0%          3.04M ± 0%   -23.10%  (p=0.000 n=10+9)
    UnicodeLowercaseMaybeChange-8           16.0 ± 0%           10.0 ± 0%   -37.50%  (p=0.000 n=10+10)
    UnicodeLowercaseNoChange-8              16.0 ± 0%            0.0       -100.00%  (p=0.000 n=10+10)