### PR TITLE
lib/model: Use winning version instead of merge on conflict

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -488,7 +488,7 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 			case !ok:
 			case gf.IsEquivalentOptional(fi, f.modTimeWindow, false, false, protocol.FlagLocalReceiveOnly):
 				// What we have locally is equivalent to the global file.
-				fi.Version = fi.Version.Merge(gf.Version)
+				fi.Version = gf.Version
 				fallthrough
 			case fi.IsDeleted() && (gf.IsReceiveOnlyChanged() || gf.IsDeleted()):
 				// Our item is deleted and the global item is our own

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -74,7 +74,6 @@ func (f *sendOnlyFolder) pull() bool {
 			return true
 		}
 
-		file.Version = file.Version.Merge(curFile.Version)
 		batch = append(batch, file)
 		batchSizeBytes += file.ProtoSize()
 		l.Debugln(f, "Merging versions of identical file", file)

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -594,11 +594,9 @@ func (f *sendReceiveFolder) handleDir(file protocol.FileInfo, snap *db.Snapshot,
 		if !curFile.IsSymlink() && f.inConflict(curFile.Version, file.Version) {
 			// The new file has been changed in conflict with the existing one. We
 			// should file it away as a conflict instead of just removing or
-			// archiving. Also merge with the version vector we had, to indicate
-			// we have resolved the conflict.
+			// archiving.
 			// Symlinks aren't checked for conflicts.
 
-			file.Version = file.Version.Merge(curFile.Version)
 			err = f.inWritableDir(func(name string) error {
 				return f.moveForConflict(name, file.ModifiedBy.String(), scanChan)
 			}, curFile.Name)
@@ -772,11 +770,9 @@ func (f *sendReceiveFolder) handleSymlinkCheckExisting(file protocol.FileInfo, s
 	if !curFile.IsDirectory() && !curFile.IsSymlink() && f.inConflict(curFile.Version, file.Version) {
 		// The new file has been changed in conflict with the existing one. We
 		// should file it away as a conflict instead of just removing or
-		// archiving. Also merge with the version vector we had, to indicate
-		// we have resolved the conflict.
+		// archiving.
 		// Directories and symlinks aren't checked for conflicts.
 
-		file.Version = file.Version.Merge(curFile.Version)
 		return f.inWritableDir(func(name string) error {
 			return f.moveForConflict(name, file.ModifiedBy.String(), scanChan)
 		}, curFile.Name)
@@ -1210,10 +1206,6 @@ func (f *sendReceiveFolder) shortcutFile(file, curFile protocol.FileInfo, dbUpda
 
 	f.fs.Chtimes(file.Name, file.ModTime(), file.ModTime()) // never fails
 
-	// This may have been a conflict. We should merge the version vectors so
-	// that our clock doesn't move backwards.
-	file.Version = file.Version.Merge(curFile.Version)
-
 	dbUpdateChan <- dbUpdateJob{file, dbUpdateShortcutFile}
 }
 
@@ -1540,11 +1532,9 @@ func (f *sendReceiveFolder) performFinish(file, curFile protocol.FileInfo, hasCu
 		if !curFile.IsDirectory() && !curFile.IsSymlink() && f.inConflict(curFile.Version, file.Version) {
 			// The new file has been changed in conflict with the existing one. We
 			// should file it away as a conflict instead of just removing or
-			// archiving. Also merge with the version vector we had, to indicate
-			// we have resolved the conflict.
+			// archiving.
 			// Directories and symlinks aren't checked for conflicts.
 
-			file.Version = file.Version.Merge(curFile.Version)
 			err = f.inWritableDir(func(name string) error {
 				return f.moveForConflict(name, file.ModifiedBy.String(), scanChan)
 			}, curFile.Name)


### PR DESCRIPTION
This PR changes how we handle versions on resolving conflicts. What happens now is: The device losing the conflict pulls the file, moves it's own file to conflict and merges both versions on the pulled file. This PR changes this, such that no merging happens any more and we just keep the version of the pulled file (conflict winner).

The main advantage is that this saves syncing steps: If there's a conflict between A and B (loser), there are now 2 steps: B resolves conflicts and merges vectors, thus creating a new global file (which is the same except for the version to the old). Then A syncs that file back. Now after B resolves the conflict the global stays, A doesn't need to sync anything. This is minor in this scenario, but if you e.g. imagine 10 devices, all with pre-populated data, all connected at about the same time, it might take lots of rounds of version vectors until all the version merging is done.

In my opinion the resulting versions are also cleaner, i.e. on a conflict only the counter of the device that actually modified the file (won the conflict) gets a version bump, instead of bumping the counter of everyone involved in the conflict.