### PR TITLE
lib/model, lib/scanner: Prevent races aborting scans (fixes #6994)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -520,6 +520,11 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 		}
 
 		if err := batch.flushIfFull(); err != nil {
+			// Prevent a race between the scan aborting due to context
+			// cancellation and releasing the snapshot in defer here.
+			scanCancel()
+			for range fchan {
+			}
 			return err
 		}
 

--- a/lib/scanner/blockqueue.go
+++ b/lib/scanner/blockqueue.go
@@ -94,35 +94,40 @@ func (ph *parallelHasher) hashFiles(ctx context.Context) {
 	defer ph.wg.Done()
 
 	for {
-		f, ok := <-ph.inbox
-		if !ok {
-			return
-		}
-
-		if f.IsDirectory() || f.IsDeleted() {
-			panic("Bug. Asked to hash a directory or a deleted file.")
-		}
-
-		blocks, err := HashFile(ctx, ph.fs, f.Name, f.BlockSize(), ph.counter, true)
-		if err != nil {
-			l.Debugln("hash error:", f.Name, err)
-			continue
-		}
-
-		f.Blocks = blocks
-		f.BlocksHash = protocol.BlocksHash(blocks)
-
-		// The size we saw when initially deciding to hash the file
-		// might not have been the size it actually had when we hashed
-		// it. Update the size from the block list.
-
-		f.Size = 0
-		for _, b := range blocks {
-			f.Size += int64(b.Size)
-		}
-
 		select {
-		case ph.outbox <- ScanResult{File: f}:
+		case f, ok := <-ph.inbox:
+			if !ok {
+				return
+			}
+
+			if f.IsDirectory() || f.IsDeleted() {
+				panic("Bug. Asked to hash a directory or a deleted file.")
+			}
+
+			blocks, err := HashFile(ctx, ph.fs, f.Name, f.BlockSize(), ph.counter, true)
+			if err != nil {
+				l.Debugln("hash error:", f.Name, err)
+				continue
+			}
+
+			f.Blocks = blocks
+			f.BlocksHash = protocol.BlocksHash(blocks)
+
+			// The size we saw when initially deciding to hash the file
+			// might not have been the size it actually had when we hashed
+			// it. Update the size from the block list.
+
+			f.Size = 0
+			for _, b := range blocks {
+				f.Size += int64(b.Size)
+			}
+
+			select {
+			case ph.outbox <- ScanResult{File: f}:
+			case <-ctx.Done():
+				return
+			}
+
 		case <-ctx.Done():
 			return
 		}
@@ -131,6 +136,8 @@ func (ph *parallelHasher) hashFiles(ctx context.Context) {
 
 func (ph *parallelHasher) closeWhenDone() {
 	ph.wg.Wait()
+	for range ph.inbox {
+	}
 	if ph.done != nil {
 		close(ph.done)
 	}

--- a/lib/scanner/blockqueue.go
+++ b/lib/scanner/blockqueue.go
@@ -136,6 +136,8 @@ func (ph *parallelHasher) hashFiles(ctx context.Context) {
 
 func (ph *parallelHasher) closeWhenDone() {
 	ph.wg.Wait()
+	// In case the hasher aborted on context, wait for filesystem
+	// walking/progress routine to finish.
 	for range ph.inbox {
 	}
 	if ph.done != nil {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -188,14 +188,9 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 			}
 		}()
 
-	loop:
 		for _, file := range filesToHash {
 			l.Debugln("real to hash:", file.Name)
-			select {
-			case realToHashChan <- file:
-			case <-ctx.Done():
-				break loop
-			}
+			realToHashChan <- file
 		}
 		close(realToHashChan)
 	}()
@@ -369,11 +364,7 @@ func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileIn
 
 	l.Debugln("to hash:", relPath, f)
 
-	select {
-	case toHashChan <- f:
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	toHashChan <- f
 
 	return nil
 }

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -188,13 +188,14 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 			}
 		}()
 
-		// We do not abort on context here because the link between the
-		// filesystem walker and the hasher must not be interrupted, otherwise
-		// the hasher might close finishedChan (returned to caller) before
-		// the filesystem walker is done.
+	loop:
 		for _, file := range filesToHash {
 			l.Debugln("real to hash:", file.Name)
-			realToHashChan <- file
+			select {
+			case realToHashChan <- file:
+			case <-ctx.Done():
+				break loop
+			}
 		}
 		close(realToHashChan)
 	}()


### PR DESCRIPTION
This addresses two races which may lead to the panic reported in https://github.com/syncthing/syncthing/issues/6994:

One when a db error occurs: We immediately return in `folder.scanSubDirs`, not waiting for the scanner to terminate (close the returned chan).

Another when the scan is cancelled by context: The hasher aborts on context, and if it does so faster than the walker routine, it may close the returned channel while the walker is still working. Now the context is only checked when sending to the returned channel. Sends to "internal channels" are done without consideration of context, such that we can be sure everything is done when closing the returned channel.

I can't actually be sure this fixes #6994, as I can't deduct what exactly is happening from the trace, but the fixed scenarios might cause a panic with such a trace. Thus I believe it's fine to close that issue - we can always reopen if the same panic comes up again afterwards.