### PR TITLE
lib/model: Disallow reserved names, and names ending with period on Windows (fixes #7008)

### DIFF
--- a/lib/fs/util.go
+++ b/lib/fs/util.go
@@ -56,13 +56,23 @@ var windowsDisallowedCharacters = string([]rune{
 })
 
 func WindowsInvalidFilename(name string) bool {
-	// None of the path components should end in space
+	// None of the path components should end in space or period, or be a
+	// reserved name.
+	// (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
 	for _, part := range strings.Split(name, `\`) {
 		if len(part) == 0 {
 			continue
 		}
-		if part[len(part)-1] == ' ' {
-			// Names ending in space are not valid.
+		switch part[len(part)-1] {
+		case ' ', '.':
+			// Names ending in space or period are not valid.
+			return true
+		}
+		switch part {
+		case "CON", "PRN", "AUX", "NUL",
+			"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
+			"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
+			// These reserved names are not valid.
 			return true
 		}
 	}


### PR DESCRIPTION
Like we already do with names ending in space or containing invalid
characters.
