### PR TITLE
lib/fs: Be more clear about invalid file names (ref #7010)

### DIFF
--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -19,8 +19,11 @@ import (
 )
 
 var (
-	ErrInvalidFilename = errors.New("filename is invalid")
-	ErrNotRelative     = errors.New("not a relative path")
+	errInvalidFilenameEmpty               = errors.New("filename is invalid, must not be empty")
+	errInvalidFilenameWindowsSpacePeriod  = errors.New("filename is invalid, must not end in space or period on Windows")
+	errInvalidFilenameWindowsReservedName = errors.New("filename is invalid, contains Windows reserved name (NUL, COM1, etc.)")
+	errInvalidFilenameWindowsReservedChar = errors.New("filename is invalid, contains Windows reserved character (?, *, :, etc.)")
+	errNotRelative                        = errors.New("not a relative path")
 )
 
 func WithJunctionsAsDirs() Option {
@@ -95,7 +98,7 @@ func (f *BasicFilesystem) rooted(rel string) (string, error) {
 func rooted(rel, root string) (string, error) {
 	// The root must not be empty.
 	if root == "" {
-		return "", ErrInvalidFilename
+		return "", errInvalidFilenameEmpty
 	}
 
 	var err error

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -22,7 +22,7 @@ var (
 	errInvalidFilenameEmpty               = errors.New("name is invalid, must not be empty")
 	errInvalidFilenameWindowsSpacePeriod  = errors.New("name is invalid, must not end in space or period on Windows")
 	errInvalidFilenameWindowsReservedName = errors.New("name is invalid, contains Windows reserved name (NUL, COM1, etc.)")
-	errInvalidFilenameWindowsReservedChar = errors.New("name is invalid, contains Windows reserved character (?, *, :, etc.)")
+	errInvalidFilenameWindowsReservedChar = errors.New("name is invalid, contains Windows reserved character (?, *, etc.)")
 	errNotRelative                        = errors.New("not a relative path")
 )
 

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -19,10 +19,10 @@ import (
 )
 
 var (
-	errInvalidFilenameEmpty               = errors.New("filename is invalid, must not be empty")
-	errInvalidFilenameWindowsSpacePeriod  = errors.New("filename is invalid, must not end in space or period on Windows")
-	errInvalidFilenameWindowsReservedName = errors.New("filename is invalid, contains Windows reserved name (NUL, COM1, etc.)")
-	errInvalidFilenameWindowsReservedChar = errors.New("filename is invalid, contains Windows reserved character (?, *, :, etc.)")
+	errInvalidFilenameEmpty               = errors.New("name is invalid, must not be empty")
+	errInvalidFilenameWindowsSpacePeriod  = errors.New("name is invalid, must not end in space or period on Windows")
+	errInvalidFilenameWindowsReservedName = errors.New("name is invalid, contains Windows reserved name (NUL, COM1, etc.)")
+	errInvalidFilenameWindowsReservedChar = errors.New("name is invalid, contains Windows reserved character (?, *, :, etc.)")
 	errNotRelative                        = errors.New("not a relative path")
 )
 

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -234,7 +234,7 @@ func Canonicalize(file string) (string, error) {
 		// The relative path may pretend to be an absolute path within
 		// the root, but the double path separator on Windows implies
 		// something else and is out of spec.
-		return "", ErrNotRelative
+		return "", errNotRelative
 	}
 
 	// The relative path should be clean from internal dotdots and similar
@@ -244,10 +244,10 @@ func Canonicalize(file string) (string, error) {
 	// It is not acceptable to attempt to traverse upwards.
 	switch file {
 	case "..":
-		return "", ErrNotRelative
+		return "", errNotRelative
 	}
 	if strings.HasPrefix(file, ".."+pathSep) {
-		return "", ErrNotRelative
+		return "", errNotRelative
 	}
 
 	if strings.HasPrefix(file, pathSep) {

--- a/lib/fs/util.go
+++ b/lib/fs/util.go
@@ -7,18 +7,11 @@
 package fs
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
-)
-
-var (
-	errInvalidSpacePeriod  = errors.New("name ends with space or period")
-	errInvalidReservedName = errors.New("name is reserved")
-	errInvalidReservedChar = errors.New("name contains reserved character")
 )
 
 func ExpandTilde(path string) (string, error) {
@@ -70,20 +63,20 @@ func WindowsInvalidFilename(name string) error {
 		switch part[len(part)-1] {
 		case ' ', '.':
 			// Names ending in space or period are not valid.
-			return fmt.Errorf("%w: %v", ErrInvalidFilename, errInvalidSpacePeriod)
+			return errInvalidFilenameWindowsSpacePeriod
 		}
-		switch part {
+		switch strings.ToUpper(part) {
 		case "CON", "PRN", "AUX", "NUL",
 			"COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9",
 			"LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9":
 			// These reserved names are not valid.
-			return fmt.Errorf("%w: %v", ErrInvalidFilename, errInvalidReservedName)
+			return errInvalidFilenameWindowsReservedName
 		}
 	}
 
 	// The path must not contain any disallowed characters
 	if strings.ContainsAny(name, windowsDisallowedCharacters) {
-		return fmt.Errorf("%w: %v", ErrInvalidFilename, errInvalidReservedChar)
+		return errInvalidFilenameWindowsReservedChar
 	}
 
 	return nil


### PR DESCRIPTION
Add specific errors for the failures, resulting in this rather than just
the generic "invalid filename":

```
[MRIW7] 08:50:50 INFO: Puller (folder default, item "NUL"): syncing: filename is invalid: name is reserved
[MRIW7] 08:50:50 INFO: Puller (folder default, item "fail."): syncing: filename is invalid: name ends with space or period
[MRIW7] 08:50:50 INFO: Puller (folder default, item "sup:yo"): syncing: filename is invalid: name contains reserved character
[MRIW7] 08:50:50 INFO: default: Failed to sync 3 items
```
