### PR TITLE
lib: Remove HelloResult type, same as Hello

### DIFF
--- a/lib/api/mocked_model_test.go
+++ b/lib/api/mocked_model_test.go
@@ -149,9 +149,9 @@ func (m *mockedModel) DownloadProgress(deviceID protocol.DeviceID, folder string
 	return nil
 }
 
-func (m *mockedModel) AddConnection(conn connections.Connection, hello protocol.HelloResult) {}
+func (m *mockedModel) AddConnection(conn connections.Connection, hello protocol.Hello) {}
 
-func (m *mockedModel) OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult) error {
+func (m *mockedModel) OnHello(protocol.DeviceID, net.Addr, protocol.Hello) error {
 	return nil
 }
 

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -202,9 +202,9 @@ type genericListener interface {
 
 type Model interface {
 	protocol.Model
-	AddConnection(conn Connection, hello protocol.HelloResult)
+	AddConnection(conn Connection, hello protocol.Hello)
 	Connection(remoteID protocol.DeviceID) (Connection, bool)
-	OnHello(protocol.DeviceID, net.Addr, protocol.HelloResult) error
+	OnHello(protocol.DeviceID, net.Addr, protocol.Hello) error
 	GetHello(protocol.DeviceID) protocol.HelloIntf
 }
 

--- a/lib/model/fakeconns_test.go
+++ b/lib/model/fakeconns_test.go
@@ -196,7 +196,7 @@ func (f *fakeConnection) sendIndexUpdate() {
 
 func addFakeConn(m *model, dev protocol.DeviceID) *fakeConnection {
 	fc := &fakeConnection{id: dev, model: m}
-	m.AddConnection(fc, protocol.HelloResult{})
+	m.AddConnection(fc, protocol.Hello{})
 
 	m.ClusterConfig(dev, protocol.ClusterConfig{
 		Folders: []protocol.Folder{

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -147,7 +147,7 @@ type model struct {
 	conn                map[protocol.DeviceID]connections.Connection
 	connRequestLimiters map[protocol.DeviceID]*byteSemaphore
 	closed              map[protocol.DeviceID]chan struct{}
-	helloMessages       map[protocol.DeviceID]protocol.HelloResult
+	helloMessages       map[protocol.DeviceID]protocol.Hello
 	deviceDownloads     map[protocol.DeviceID]*deviceDownloadState
 	remotePausedFolders map[protocol.DeviceID][]string // deviceID -> folders
 
@@ -219,7 +219,7 @@ func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersio
 		conn:                make(map[protocol.DeviceID]connections.Connection),
 		connRequestLimiters: make(map[protocol.DeviceID]*byteSemaphore),
 		closed:              make(map[protocol.DeviceID]chan struct{}),
-		helloMessages:       make(map[protocol.DeviceID]protocol.HelloResult),
+		helloMessages:       make(map[protocol.DeviceID]protocol.Hello),
 		deviceDownloads:     make(map[protocol.DeviceID]*deviceDownloadState),
 		remotePausedFolders: make(map[protocol.DeviceID][]string),
 	}
@@ -1750,7 +1750,7 @@ func (m *model) SetIgnores(folder string, content []string) error {
 // OnHello is called when an device connects to us.
 // This allows us to extract some information from the Hello message
 // and add it to a list of known devices ahead of any checks.
-func (m *model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protocol.HelloResult) error {
+func (m *model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protocol.Hello) error {
 	if m.cfg.IgnoredDevice(remoteID) {
 		return errDeviceIgnored
 	}
@@ -1799,7 +1799,7 @@ func (m *model) GetHello(id protocol.DeviceID) protocol.HelloIntf {
 // AddConnection adds a new peer connection to the model. An initial index will
 // be sent to the connected peer, thereafter index updates whenever the local
 // folder changes.
-func (m *model) AddConnection(conn connections.Connection, hello protocol.HelloResult) {
+func (m *model) AddConnection(conn connections.Connection, hello protocol.Hello) {
 	deviceID := conn.ID()
 	device, ok := m.cfg.Device(deviceID)
 	if !ok {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -126,7 +126,7 @@ func newState(cfg config.Configuration) *model {
 	m := setupModel(wcfg)
 
 	for _, dev := range cfg.Devices {
-		m.AddConnection(&fakeConnection{id: dev.DeviceID, model: m}, protocol.HelloResult{})
+		m.AddConnection(&fakeConnection{id: dev.DeviceID, model: m}, protocol.Hello{})
 	}
 
 	return m
@@ -254,7 +254,7 @@ func BenchmarkRequestOut(b *testing.B) {
 	for _, f := range files {
 		fc.addFile(f.Name, 0644, protocol.FileInfoTypeFile, []byte("some data to return"))
 	}
-	m.AddConnection(fc, protocol.HelloResult{})
+	m.AddConnection(fc, protocol.Hello{})
 	m.Index(device1, "default", files)
 
 	b.ResetTimer()
@@ -292,7 +292,7 @@ func BenchmarkRequestInSingleFile(b *testing.B) {
 }
 
 func TestDeviceRename(t *testing.T) {
-	hello := protocol.HelloResult{
+	hello := protocol.Hello{
 		ClientName:    "syncthing",
 		ClientVersion: "v0.9.4",
 	}
@@ -2313,9 +2313,9 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 	defer cleanupModel(m)
 
 	conn1 := &fakeConnection{id: device1, model: m}
-	m.AddConnection(conn1, protocol.HelloResult{})
+	m.AddConnection(conn1, protocol.Hello{})
 	conn2 := &fakeConnection{id: device2, model: m}
-	m.AddConnection(conn2, protocol.HelloResult{})
+	m.AddConnection(conn2, protocol.Hello{})
 
 	m.ClusterConfig(device1, protocol.ClusterConfig{
 		Folders: []protocol.Folder{
@@ -3331,7 +3331,7 @@ func TestConnCloseOnRestart(t *testing.T) {
 
 	br := &testutils.BlockingRW{}
 	nw := &testutils.NoopRW{}
-	m.AddConnection(newFakeProtoConn(protocol.NewConnection(device1, br, nw, m, "testConn", protocol.CompressNever)), protocol.HelloResult{})
+	m.AddConnection(newFakeProtoConn(protocol.NewConnection(device1, br, nw, m, "testConn", protocol.CompressNever)), protocol.Hello{})
 	m.pmut.RLock()
 	if len(m.closed) != 1 {
 		t.Fatalf("Expected just one conn (len(m.conn) == %v)", len(m.conn))
@@ -4001,8 +4001,8 @@ func testConfigChangeClosesConnections(t *testing.T, expectFirstClosed, expectSe
 
 	fc1 := &fakeConnection{id: device1, model: m}
 	fc2 := &fakeConnection{id: device2, model: m}
-	m.AddConnection(fc1, protocol.HelloResult{})
-	m.AddConnection(fc2, protocol.HelloResult{})
+	m.AddConnection(fc1, protocol.Hello{})
+	m.AddConnection(fc2, protocol.Hello{})
 
 	t.Log("Applying config change")
 


### PR DESCRIPTION
For all I see `protocol.Hello` and `protocol.HelloResult` are the exact same thing - looks like legacy that didn't get cleaned up.