### PR TITLE
gui: Fix NaN percentage for zero byte files (fixes #7002)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -848,10 +848,11 @@ angular.module('syncthing.core')
             if ($scope.model[folder].needTotalItems === 0) {
                 return 100;
             }
-            if ($scope.model[folder].needBytes == 0 && $scope.model[folder].needDeletes > 0) {
+            if (($scope.model[folder].needBytes == 0 && $scope.model[folder].needDeletes > 0) || $scope.model[folder].globalBytes == 0) {
                 // We don't need any data, but we have deletes that we need
                 // to do. Drop down the completion percentage to indicate
                 // that we have stuff to do.
+                // Do the same thing in case we only have zero byte files to sync.
                 return 95;
             }
             var pct = 100 * $scope.model[folder].inSyncBytes / $scope.model[folder].globalBytes;


### PR DESCRIPTION
### Purpose

Fixes #7002 by preventing division by zero.

### Testing

Tested manually with two SyncThing instances running on the same Windows 10 machine, by reproducing a situation as described in #7002.

### Screenshots

New behaviour:
![grafik](https://user-images.githubusercontent.com/35843701/95194445-91c57f00-07d5-11eb-8b34-abec2eacb4b5.png)
