### PR TITLE
cmd/stcrashreceiver, lib/db: Improve panic message handling

### DIFF
--- a/cmd/stcrashreceiver/main.go
+++ b/cmd/stcrashreceiver/main.go
@@ -88,6 +88,7 @@ func handleFailureFn(dsn string) func(w http.ResponseWriter, req *http.Request) 
 			pkt.Extra = raven.Extra{
 				"count": r.Count,
 			}
+			pkt.Fingerprint = []string{r.Description}
 
 			if err := sendReport(dsn, pkt, userIDFor(req)); err != nil {
 				log.Println("Failed to send  crash report:", err)

--- a/cmd/stcrashreceiver/sentry.go
+++ b/cmd/stcrashreceiver/sentry.go
@@ -158,6 +158,11 @@ func crashReportFingerprint(message string) []string {
 
 	message = indexRe.ReplaceAllString(message, "[x]")
 	message = sizeRe.ReplaceAllString(message, "$1 x")
+
+	// {{ default }} is what sentry uses as a fingerprint by default. While
+	// never specified, the docs point at this being some hash derived from the
+	// stack trace. Here we include the filtered panic message on top of that.
+	// https://docs.sentry.io/platforms/go/data-management/event-grouping/sdk-fingerprinting/#basic-example
 	return []string{"{{ default }}", message}
 }
 

--- a/cmd/stcrashreceiver/sentry_test.go
+++ b/cmd/stcrashreceiver/sentry_test.go
@@ -76,3 +76,66 @@ func TestParseReport(t *testing.T) {
 
 	fmt.Printf("%s\n", bs)
 }
+
+func TestCrashReportFingerprint(t *testing.T) {
+	cases := []struct {
+		message, exp string
+		ldb          bool
+	}{
+		{
+			message: "panic: leveldb/table: corruption on data-block (pos=51308946): checksum mismatch, want=0xa89f9aa0 got=0xd27cc4c7 [file=004003.ldb]",
+			exp:     "panic: leveldb/table: corruption on data-block (pos=x): checksum mismatch, want=0xX got=0xX [file=x.ldb]",
+			ldb:     true,
+		},
+		{
+			message: "panic: leveldb/table: corruption on table-footer (pos=248): bad magic number [file=001370.ldb]",
+			exp:     "panic: leveldb/table: corruption on table-footer (pos=x): bad magic number [file=x.ldb]",
+			ldb:     true,
+		},
+		{
+			message: "panic: runtime error: slice bounds out of range [4294967283:4194304]",
+			exp:     "panic: runtime error: slice bounds out of range [x]",
+		},
+		{
+			message: "panic: runtime error: slice bounds out of range [-2:]",
+			exp:     "panic: runtime error: slice bounds out of range [x]",
+		},
+		{
+			message: "panic: runtime error: slice bounds out of range [:4294967283] with capacity 32768",
+			exp:     "panic: runtime error: slice bounds out of range [x] with capacity x",
+		},
+		{
+			message: "panic: runtime error: index out of range [0] with length 0",
+			exp:     "panic: runtime error: index out of range [x] with length x",
+		},
+		{
+			message: `panic: leveldb: internal key "\x01", len=1: invalid length`,
+			exp:     `panic: leveldb: internal key "x", len=x: invalid length`,
+			ldb:     true,
+		},
+		{
+			message: `panic: write /var/syncthing/config/index-v0.14.0.db/2732813.log: cannot allocate memory`,
+			exp:     `panic: write x: cannot allocate memory`,
+			ldb:     true,
+		},
+		{
+			message: `panic: filling Blocks: read C:\Users\Serv-Resp-Tizayuca\AppData\Local\Syncthing\index-v0.14.0.db\006561.ldb: Error de datos (comprobación de redundancia cíclica).`,
+			exp:     `panic: filling Blocks: read x: Error de datos (comprobación de redundancia cíclica).`,
+			ldb:     true,
+		},
+	}
+
+	for i, tc := range cases {
+		fingerprint := crashReportFingerprint(tc.message)
+
+		expLen := 2
+		if tc.ldb {
+			expLen = 1
+		}
+		if l := len(fingerprint); l != expLen {
+			t.Errorf("tc %v: Unexpected fingerprint length: %v != %v", i, l, expLen)
+		} else if msg := fingerprint[expLen-1]; msg != tc.exp {
+			t.Errorf("tc %v:\n\"%v\" !=\n\"%v\"", i, msg, tc.exp)
+		}
+	}
+}

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -531,6 +531,5 @@ func fatalError(err error, opStr string, db *Lowlevel) {
 			}
 		}
 	}
-	l.Warnf("Fatal error: %v: %v", opStr, err)
-	panic(err)
+	warnAndPanic(fmt.Errorf("%v: %w:", opStr, err))
 }


### PR DESCRIPTION
This PR does a few related things regarding panics:

 - We have plenty of IO errors from leveldb including the db path, which become panics. Yes they should be errors, yes the goal is still to do that. In the meantime lets remove the paths from the panic message. And anyway, even with errors those would be fatal so the path will have to be filtered eventually.

- Added the panic message to the fingerprint. That's absolutely necessary for https://github.com/syncthing/syncthing/pull/6925, otherwise all events from it will be merged together (as they don't have traces). I also did it for panics to prevent merging different errors with the same trace. There's some pattern matching to prevent stuff like indexes or db paths (old clients without the change above will keep sending them) prevent matching events together.

 - Do not use the fingerprint for pattern matching for db corruption or fatal db io errors. It doesn't matter where those occur. This should reduce the noise in the sentry issue list. This could be extended to other kinds of errors that may occur regardless of time/place. 

No need to tell me the regexyness is terrible (and possibly terrifying), I know it is. I think the benefits are worth the ugliness though, but that's obviously open to discussion.