### PR TITLE
lib/db: Undo adding user info to panic msgs (ref #7029)

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -531,5 +531,6 @@ func fatalError(err error, opStr string, db *Lowlevel) {
 			}
 		}
 	}
-	warnAndPanic(fmt.Errorf("%v: %w:", opStr, err))
+	l.Warnf("Fatal error: %v: %v", opStr, err)
+	obfuscateAndPanic(err)
 }


### PR DESCRIPTION
Removes context including user info like device IDs from panic message.

Was introduced in #7029, i.e. is RC material.