### PR TITLE
lib/db: Ignore not found on delete in recalcGlobal (ref #7026)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -457,7 +457,7 @@ func (db *Lowlevel) checkGlobals(folder []byte) error {
 	for dbi.Next() {
 		var vl VersionList
 		if err := vl.Unmarshal(dbi.Value()); err != nil || vl.Empty() {
-			if err := t.Delete(dbi.Key()); err != nil {
+			if err := t.Delete(dbi.Key()); err != nil && !backend.IsNotFound(err) {
 				return err
 			}
 			continue
@@ -486,7 +486,7 @@ func (db *Lowlevel) checkGlobals(folder []byte) error {
 		}
 
 		if newVL.Empty() {
-			if err := t.Delete(dbi.Key()); err != nil {
+			if err := t.Delete(dbi.Key()); err != nil && !backend.IsNotFound(err) {
 				return err
 			}
 		} else if changed {
@@ -880,7 +880,7 @@ func (db *Lowlevel) recalcMeta(folderStr string) (*metadataTracker, error) {
 
 	meta := newMetadataTracker(db.keyer)
 	if err := db.checkGlobals(folder); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("checking globals: %w", err)
 	}
 
 	t, err := db.newReadWriteTransaction(meta.CommitHook(folder))


### PR DESCRIPTION
The added context on the error/panic message shows the `key not found` error still happens during metadata recalculation:

https://sentry.syncthing.net/syncthing/syncthing/issues/4397/?query=is%3Aunresolved%20version%3Av1.11.0-rc.1

Again it makes no sense at all that we get a `key not found` when deleting a key which just got from an db iterator, but nevertheless ignoring it feels more appropriate than panicking.