### PR TITLE
lib/db: Remove need for the right dev removing globals (fixes #7036)

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -859,7 +859,7 @@ func (t readWriteTransaction) removeFromGlobal(gk, keyBuf, folder, device, file 
 			continue
 		}
 		if fv, have := fl.Get(dev[:]); Need(removedFV, have, fv.Version) {
-			meta.removeNeeded(deviceID, f)
+			meta.removeNeeded(dev, f)
 		}
 	}
 


### PR DESCRIPTION
Huge thanks to @tomasz1986 for not letting loose on this issue until discovering a reproducer so... lacking a better word lets say intricate, and also providing all the logs and screenshots I could wish for. Really, this fix is your achievement!

Not much to say about the fix: Stupid little slip. The code in question was even test covered before, but apparently not checked.

There's one question: There's a good chance this affects a few users. Recalculating metadata when releasing the fix seems in order - how should we trigger that? A db transition would work, but is a bit ingenious as there isn't any actual transition. We could also add an "upgrade hook" to syncthing.go that can do arbitrary stuff when updating to specific version, and export the db repair function again to call it there. Better ideas?