### PR TITLE
lib/connections: Fix LAN addresses begin advertised even when disabled (fixes #7035)

### DIFF
--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -160,7 +160,7 @@ func (t *quicListener) URI() *url.URL {
 }
 
 func (t *quicListener) WANAddresses() []*url.URL {
-	uris := t.LANAddresses()
+	uris := []*url.URL{t.uri}
 	t.mut.Lock()
 	if t.address != nil {
 		uris = append(uris, t.address)

--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -146,7 +146,7 @@ func (t *tcpListener) URI() *url.URL {
 }
 
 func (t *tcpListener) WANAddresses() []*url.URL {
-	uris := t.LANAddresses()
+	uris := []*url.URL{t.uri}
 	t.mut.RLock()
 	if t.mapping != nil {
 		addrs := t.mapping.ExternalAddresses()


### PR DESCRIPTION
A clear oversight. Verified manually by checking the logs.