### PR TITLE
lib/db: Add mechanism to repair db without schema update (ref #7044)

### DIFF
--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -87,6 +87,10 @@ func (db *schemaUpdater) updateSchema() error {
 	if err != nil {
 		return err
 	}
+	// Cover versions before adding `dbMigrationVersion` (== 0) and possible future weirdness.
+	if prevMigration < prevVersion {
+		prevMigration = prevVersion
+	}
 
 	if prevVersion == dbVersion && prevMigration >= dbMigrationVersion {
 		return nil


### PR DESCRIPTION
This adds a similar db transition mechanism to the one already existing for schema changes. Schema transitions have in the past been "abused" for operations that did not actually change the db. This puts unnecessary limitations on downgrading. The added mechanism is meant to be used in these cases.

I also added the first such repair transition for #7044, which fixes a bug that could lead to corrupt metadata, and thus requires a metadata recalculation.