### PR TITLE
gui: Fix undefined variables fallout from #7049.

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1105,7 +1105,7 @@ angular.module('syncthing.core')
         };
 
         $scope.setDevicePause = function (device, pause) {
-            $scope.devices[id].paused = pause;
+            $scope.devices[device].paused = pause;
             $scope.config.devices = $scope.deviceList();
             $scope.saveConfig();
         };
@@ -1466,6 +1466,7 @@ angular.module('syncthing.core')
                 return;
             }
 
+	    var id = $scope.currentDevice.deviceID
             delete $scope.devices[id];
             $scope.config.devices = $scope.deviceList();
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1466,7 +1466,7 @@ angular.module('syncthing.core')
                 return;
             }
 
-	    var id = $scope.currentDevice.deviceID
+            var id = $scope.currentDevice.deviceID
             delete $scope.devices[id];
             $scope.config.devices = $scope.deviceList();
 


### PR DESCRIPTION
Some accesses to the new $scope.devices object (instead of previously
array) used wrong / inexistent names for the index variable.