### PR TITLE
gui: Remove needless looping in ignoreFolder().

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1927,10 +1927,8 @@ angular.module('syncthing.core')
             // Bump time
             pendingFolder.time = (new Date()).toISOString();
 
-            if (id in $scope.devices) {
-                    $scope.devices[id].ignoredFolders.push(pendingFolder);
-                    $scope.saveConfig();
-            }
+            $scope.devices[id].ignoredFolders.push(pendingFolder);
+            $scope.saveConfig();
         };
 
         $scope.sharesFolder = function (folderCfg) {


### PR DESCRIPTION
Another fallout from #7049.

Iterating over $scope.devices was done because of its array nature.
Since making it an object, the change can be targeted directly, so
remove the loop completely.