### PR TITLE
gui: Readd check if device exists (ref #7059)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1927,8 +1927,10 @@ angular.module('syncthing.core')
             // Bump time
             pendingFolder.time = (new Date()).toISOString();
 
-            $scope.devices[id].ignoredFolders.push(pendingFolder);
-            $scope.saveConfig();
+            if (id in $scope.devices) {
+                $scope.devices[id].ignoredFolders.push(pendingFolder);
+                $scope.saveConfig();
+            }
         };
 
         $scope.sharesFolder = function (folderCfg) {


### PR DESCRIPTION
This reverts PR #7059 / commit c7d40ccbaee867b579ccb291b258fd28299b3464.

I was speeding when merging that: There is no looping, it's just a safety check that the device in question actually exists.