### PR TITLE
lib/config: Sanity checks on MaxConcurrentWrites (ref #7064)

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -129,6 +129,7 @@ func TestDeviceConfig(t *testing.T) {
 				WeakHashThresholdPct: 25,
 				MarkerName:           DefaultMarkerName,
 				JunctionsAsDirs:      true,
+				MaxConcurrentWrites:  maxConcurrentWritesDefault,
 			},
 		}
 

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -26,7 +26,11 @@ var (
 	ErrMarkerMissing    = errors.New("folder marker missing (this indicates potential data loss, search docs/forum to get information about how to proceed)")
 )
 
-const DefaultMarkerName = ".stfolder"
+const (
+	DefaultMarkerName          = ".stfolder"
+	maxConcurrentWritesDefault = 2
+	maxConcurrentWritesLimit   = 64
+)
 
 func NewFolderConfiguration(myID protocol.DeviceID, id, label string, fsType fs.FilesystemType, path string) FolderConfiguration {
 	f := FolderConfiguration{
@@ -205,6 +209,12 @@ func (f *FolderConfiguration) prepare() {
 
 	if f.MarkerName == "" {
 		f.MarkerName = DefaultMarkerName
+	}
+
+	if f.MaxConcurrentWrites <= 0 {
+		f.MaxConcurrentWrites = maxConcurrentWritesDefault
+	} else if f.MaxConcurrentWrites > maxConcurrentWritesLimit {
+		f.MaxConcurrentWrites = maxConcurrentWritesLimit
 	}
 }
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -38,6 +38,9 @@ var (
 	blockStatsMut = sync.NewMutex()
 )
 
+// No matter what is configured, we won't exceed this amount of concurrent writes per folder.
+const maxConcurrentWritesLimit = 64
+
 func init() {
 	folderFactories[config.FolderTypeSendReceive] = newSendReceiveFolder
 }
@@ -139,7 +142,6 @@ func newSendReceiveFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 		fs:                 fs,
 		queue:              newJobQueue(),
 		blockPullReorderer: newBlockPullReorderer(cfg.BlockPullOrder, model.id, cfg.DeviceIDs()),
-		writeLimiter:       newByteSemaphore(cfg.MaxConcurrentWrites),
 		pullErrorsMut:      sync.NewMutex(),
 	}
 	f.folder.puller = f
@@ -157,6 +159,15 @@ func newSendReceiveFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 	}
 	if blockSizeKiB := protocol.MaxBlockSize / 1024; f.PullerMaxPendingKiB < blockSizeKiB {
 		f.PullerMaxPendingKiB = blockSizeKiB
+	}
+
+	if cfg.MaxConcurrentWrites <= 0 {
+		f.writeLimiter = newByteSemaphore(2)
+	} else if cfg.MaxConcurrentWrites > maxConcurrentWritesLimit {
+		l.Infof("Configured MaxConcurrentWrites of %v too large, using %v instead on folder %v", cfg.MaxConcurrentWrites, maxConcurrentWritesLimit, f.Description())
+		f.writeLimiter = newByteSemaphore(maxConcurrentWritesLimit)
+	} else {
+		f.writeLimiter = newByteSemaphore(cfg.MaxConcurrentWrites)
 	}
 
 	return f


### PR DESCRIPTION
This changes the meaning of `MaxConcurrentWrites <= 0` to mean default and additional puts an upper limit on the config value too. I guess the latter is going to be controversial, as it's clearly user error. My reasoning is that I'd rather check for that than have to explain the error to a user. And the limit of 64 is entirely randomly chosen, I do not know anything about concurrent IO, so if there is a technical reason to change that or drop it alltogether, please let me know.