### PR TITLE
lib/api: Allow OPTIONS method in CORS preflight request handling.

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -504,7 +504,7 @@ func corsMiddleware(next http.Handler, allowFrameLoading bool) http.Handler {
 			// Add a generous access-control-allow-origin header for CORS requests
 			w.Header().Add("Access-Control-Allow-Origin", "*")
 			// Only GET/POST Methods are supported
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 			// Only these headers can be set
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key")
 			// The request is meant to be cached 10 minutes

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -503,7 +503,7 @@ func corsMiddleware(next http.Handler, allowFrameLoading bool) http.Handler {
 		if r.Method == "OPTIONS" {
 			// Add a generous access-control-allow-origin header for CORS requests
 			w.Header().Add("Access-Control-Allow-Origin", "*")
-			// Only GET/POST Methods are supported
+			// Only GET/POST/OPTIONS Methods are supported
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
 			// Only these headers can be set
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key")

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -1073,8 +1073,8 @@ func TestOptionsRequest(t *testing.T) {
 	if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
 		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Origin: *' header")
 	}
-	if resp.Header.Get("Access-Control-Allow-Methods") != "GET, POST" {
-		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Methods: GET, POST' header")
+	if resp.Header.Get("Access-Control-Allow-Methods") != "GET, POST, OPTIONS" {
+		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Methods: GET, POST, OPTIONS' header")
 	}
 	if resp.Header.Get("Access-Control-Allow-Headers") != "Content-Type, X-API-Key" {
 		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Headers: Content-Type, X-API-KEY' header")


### PR DESCRIPTION
### Purpose

Extracted from #7017, I think this change is of general utility.  It reports the HTTP OPTIONS method as part of the allowed methods for the API.  That is normally used as part of the CORS preflight check when doing a GET or POST request.  When just trying to check API availability, a deliberate OPTIONS request is enough, but currently it fails because of the returned `Access-Control-Allow-Methods` header.

I don't see any security risks here and was hoping to get this small change into a release before #7017 is finalized, so that the probing done there actually works with as many instances as possible.

### Testing

Verified that the header is set: `curl -X OPTIONS http://localhost:8384/ -v`.  Tested with Firefox (as part of #7017) that it no longer fails with a [CORS error](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMethodNotFound?utm_source=devtools&utm_medium=firefox-cors-errors&utm_campaign=default) when doing an OPTIONS request from within the JS code.
