### PR TITLE
lib/api: Fix /rest/config path and add methods to cors (ref #7001)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -302,7 +302,7 @@ func (s *service) serve(ctx context.Context) {
 		mut:    sync.NewMutex(),
 	}
 
-	configBuilder.registerConfig("/rest/config/")
+	configBuilder.registerConfig("/rest/config")
 	configBuilder.registerConfigInsync("/rest/config/insync")
 	configBuilder.registerFolders("/rest/config/folders")
 	configBuilder.registerDevices("/rest/config/devices")
@@ -504,7 +504,7 @@ func corsMiddleware(next http.Handler, allowFrameLoading bool) http.Handler {
 			// Add a generous access-control-allow-origin header for CORS requests
 			w.Header().Add("Access-Control-Allow-Origin", "*")
 			// Only GET/POST/OPTIONS Methods are supported
-			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
 			// Only these headers can be set
 			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, X-API-Key")
 			// The request is meant to be cached 10 minutes

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -404,6 +404,12 @@ func TestAPIServiceRequests(t *testing.T) {
 
 		// /rest/config
 		{
+			URL:    "/rest/config",
+			Code:   200,
+			Type:   "application/json",
+			Prefix: "",
+		},
+		{
 			URL:    "/rest/config/folders",
 			Code:   200,
 			Type:   "application/json",
@@ -1073,8 +1079,8 @@ func TestOptionsRequest(t *testing.T) {
 	if resp.Header.Get("Access-Control-Allow-Origin") != "*" {
 		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Origin: *' header")
 	}
-	if resp.Header.Get("Access-Control-Allow-Methods") != "GET, POST, OPTIONS" {
-		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Methods: GET, POST, OPTIONS' header")
+	if resp.Header.Get("Access-Control-Allow-Methods") != "GET, POST, PUT, PATCH, DELETE, OPTIONS" {
+		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' header")
 	}
 	if resp.Header.Get("Access-Control-Allow-Headers") != "Content-Type, X-API-Key" {
 		t.Fatal("OPTIONS on /rest/system/status should return a 'Access-Control-Allow-Headers: Content-Type, X-API-KEY' header")


### PR DESCRIPTION
Just noticed through #7079 that there's a method whitelist and thus added the new methods used in the `/rest/config` endpoints. And this also fixes an issue with `/rest/config` the only endpoint added in #7001 that I didn't add a test for. Weirdly enough adding the test wouldn't have helped: It doesn't fail (neither does the UI, which uses it too), while it does fail using curl. Anyway, works with curl too now.