### PR TITLE
lib: Remove USE_BADGER experiment

### DIFF
--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -43,7 +43,6 @@ var (
 		"STHASHING",
 		"STNORESTART",
 		"STNOUPGRADE",
-		"USE_BADGER",
 	}
 )
 

--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -131,24 +131,14 @@ const (
 )
 
 func Open(path string, tuning Tuning) (Backend, error) {
-	if os.Getenv("USE_BADGER") != "" {
-		l.Warnln("Using experimental badger db")
-		if err := maybeCopyDatabase(path, strings.Replace(path, locations.BadgerDir, locations.LevelDBDir, 1), OpenBadger, OpenLevelDBRO); err != nil {
-			return nil, err
-		}
-		return OpenBadger(path)
-	}
-
 	if err := maybeCopyDatabase(path, strings.Replace(path, locations.LevelDBDir, locations.BadgerDir, 1), OpenLevelDBAuto, OpenBadger); err != nil {
 		return nil, err
 	}
+
 	return OpenLevelDB(path, tuning)
 }
 
 func OpenMemory() Backend {
-	if os.Getenv("USE_BADGER") != "" {
-		return OpenBadgerMemory()
-	}
 	return OpenLevelDBMemory()
 }
 

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/syncthing/syncthing/lib/db/backend"
@@ -800,11 +799,6 @@ func TestUpdateTo14(t *testing.T) {
 func TestFlushRecursion(t *testing.T) {
 	// Verify that a commit hook can write to the transaction without
 	// causing another flush and thus recursion.
-
-	// Badger doesn't work like this.
-	if os.Getenv("USE_BADGER") != "" {
-		t.Skip("Not supported on Badger")
-	}
 
 	db := NewLowlevel(backend.OpenMemory())
 	defer db.Close()

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -53,11 +53,6 @@ const (
 var baseDirs = make(map[BaseDirEnum]string, 3)
 
 func init() {
-	if os.Getenv("USE_BADGER") != "" {
-		// XXX: Replace the leveldb name with the badger name.
-		locationTemplates[Database] = strings.Replace(locationTemplates[Database], LevelDBDir, BadgerDir, 1)
-	}
-
 	userHome := userHomeDir()
 	config := defaultConfigDir(userHome)
 	baseDirs[UserHomeBaseDir] = userHome


### PR DESCRIPTION
This removes the switch for using a Badger database, because it has bugs
that it seems there is no interest in fixing, and no actual bug tracker
to track them in.

It retains the actual implementation for the sole purpose of being able
to do the conversion back to LevelDB if anyone is actually running with
USE_BADGER. At some point in a couple of versions we can remove the
implementation as well.
