### PR TITLE
lib/ur: Fix panics in failure-reporting (fixes #7090)

### DIFF
--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -102,7 +102,7 @@ outer:
 			url = opts.CRURL + "/failure"
 		case e, ok := <-evChan:
 			if !ok {
-				// Just to be save - shouldn't ever happen, as
+				// Just to be safe - shouldn't ever happen, as
 				// evChan is set to nil when unsubscribing.
 				h.addReport(evChanClosed, time.Now())
 				evChan = nil

--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -49,6 +49,7 @@ func NewFailureHandler(cfg config.Wrapper, evLogger events.Logger) FailureHandle
 		cfg:      cfg,
 		evLogger: evLogger,
 		optsChan: make(chan config.OptionsConfiguration),
+		buf:      make(map[string]*failureStat),
 	}
 	h.Service = util.AsServiceWithError(h.serve, h.String())
 	return h


### PR DESCRIPTION
The main fix is in setting the channel variable to nil when unsubscribing (line 97). In addition I removed that var from the struct, because it's only used in `serve` and for good measure added a check that the channel wasn't closed when receiving from it. And finally added a context escape hatch to the goroutine doing the initial config setup.

EDIT: Actually if putting in extra safeties, lets do it right and also check the type conversion itself. And report if either of those two checks fail, because they shouldn't ever fail so I want to know if they do.