### PR TITLE
lib/api: Fix debug endpoints (ref #7001)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -323,7 +323,7 @@ func (s *service) serve(ctx context.Context) {
 	debugMux.HandleFunc("/rest/debug/cpuprof", s.getCPUProf) // duration
 	debugMux.HandleFunc("/rest/debug/heapprof", s.getHeapProf)
 	debugMux.HandleFunc("/rest/debug/support", s.getSupportBundle)
-	restMux.Handler(http.MethodGet, "/rest/debug/", s.whenDebugging(debugMux))
+	restMux.Handler(http.MethodGet, "/rest/debug/*method", s.whenDebugging(debugMux))
 
 	// A handler that disables caching
 	noCacheRestMux := noCacheMiddleware(metricsMiddleware(restMux))


### PR DESCRIPTION
I missed adjusting the debug endpoint in #7001 to the new httprouter library: It doesn't match subpaths automatically, one needs to specify desired matching behaviour. Thus it returned 404s for the debug endpoints.