### PR TITLE
lib/api, lib/db: Add file debug endpoint

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -290,6 +290,18 @@ func (s *Snapshot) Availability(file string) []protocol.DeviceID {
 	return av
 }
 
+func (s *Snapshot) DebugGlobalVersions(file string) VersionList {
+	opStr := fmt.Sprintf("%s DebugGlobalVersions(%v)", s.folder, file)
+	l.Debugf(opStr)
+	vl, err := s.t.getGlobalVersions(nil, []byte(s.folder), []byte(osutil.NormalizedFilename(file)))
+	if backend.IsClosed(err) {
+		return VersionList{}
+	} else if err != nil {
+		s.fatalError(err, opStr)
+	}
+	return vl
+}
+
 func (s *Snapshot) Sequence(device protocol.DeviceID) int64 {
 	return s.meta.Counts(device, 0).Sequence
 }


### PR DESCRIPTION
The `/rest/db/file` endpoint already has a good amount of helpful info when debugging weird out-of-sync issues, but it doesn't give the full picture. I added a `/rest/debug/file` endpoint which in addition to the info already contained in `/rest/db/file` also prints the global versions. Thus one can see at a glance all involved devices and at which versions they are (plus if ignored and/or deleted). I named all the involved method with `Debug` and the api data is a string, as it is an internal implementation detail and should not be used for anything but debugging.