### PR TITLE
lib/model: Send indexes for newly shared folder (fixes #7098)

### DIFF
--- a/lib/model/indexsender.go
+++ b/lib/model/indexsender.go
@@ -25,7 +25,6 @@ type indexSender struct {
 	suture.Service
 	conn         protocol.Connection
 	folder       string
-	dev          string
 	fset         *db.FileSet
 	prevSequence int64
 	evLogger     events.Logger
@@ -38,8 +37,8 @@ type indexSender struct {
 func (s *indexSender) serve(ctx context.Context) {
 	var err error
 
-	l.Debugf("Starting indexSender for %s to %s at %s (slv=%d)", s.folder, s.dev, s.conn, s.prevSequence)
-	defer l.Debugf("Exiting indexSender for %s to %s at %s: %v", s.folder, s.dev, s.conn, err)
+	l.Debugf("Starting indexSender for %s to %s at %s (slv=%d)", s.folder, s.conn.ID(), s.conn, s.prevSequence)
+	defer l.Debugf("Exiting indexSender for %s to %s at %s: %v", s.folder, s.conn.ID(), s.conn, err)
 
 	// We need to send one index, regardless of whether there is something to send or not
 	err = s.sendIndexTo(ctx)
@@ -204,7 +203,7 @@ func (s *indexSender) sendIndexTo(ctx context.Context) error {
 }
 
 func (s *indexSender) String() string {
-	return fmt.Sprintf("indexSender@%p for %s to %s at %s", s, s.folder, s.dev, s.conn)
+	return fmt.Sprintf("indexSender@%p for %s to %s at %s", s, s.folder, s.conn.ID(), s.conn)
 }
 
 type indexSenderRegistry struct {
@@ -239,15 +238,13 @@ func (r *indexSenderRegistry) add(folder config.FolderConfiguration, fset *db.Fi
 	r.mut.Unlock()
 }
 
-func (r *indexSenderRegistry) addLocked(folder config.FolderConfiguration, fset *db.FileSet, startInfo *indexSenderStartInfo) {
-	if is, ok := r.indexSenders[folder.ID]; ok {
-		r.sup.RemoveAndWait(is.token, 0)
-		delete(r.indexSenders, folder.ID)
-	}
-	if _, ok := r.startInfos[folder.ID]; ok {
-		delete(r.startInfos, folder.ID)
-	}
+func (r *indexSenderRegistry) addNew(folder config.FolderConfiguration, fset *db.FileSet) {
+	r.mut.Lock()
+	r.startLocked(folder.ID, fset, 0)
+	r.mut.Unlock()
+}
 
+func (r *indexSenderRegistry) addLocked(folder config.FolderConfiguration, fset *db.FileSet, startInfo *indexSenderStartInfo) {
 	myIndexID := fset.IndexID(protocol.LocalDeviceID)
 	mySequence := fset.Sequence(protocol.LocalDeviceID)
 	var startSequence int64
@@ -305,10 +302,22 @@ func (r *indexSenderRegistry) addLocked(folder config.FolderConfiguration, fset 
 		fset.SetIndexID(r.deviceID, startInfo.remote.IndexID)
 	}
 
+	r.startLocked(folder.ID, fset, startSequence)
+}
+
+func (r *indexSenderRegistry) startLocked(folderID string, fset *db.FileSet, startSequence int64) {
+	if is, ok := r.indexSenders[folderID]; ok {
+		r.sup.RemoveAndWait(is.token, 0)
+		delete(r.indexSenders, folderID)
+	}
+	if _, ok := r.startInfos[folderID]; ok {
+		delete(r.startInfos, folderID)
+	}
+
 	is := &indexSender{
 		conn:         r.conn,
 		connClosed:   r.closed,
-		folder:       folder.ID,
+		folder:       folderID,
 		fset:         fset,
 		prevSequence: startSequence,
 		evLogger:     r.evLogger,
@@ -317,7 +326,7 @@ func (r *indexSenderRegistry) addLocked(folder config.FolderConfiguration, fset 
 	}
 	is.Service = util.AsService(is.serve, is.String())
 	is.token = r.sup.Add(is)
-	r.indexSenders[folder.ID] = is
+	r.indexSenders[folderID] = is
 }
 
 // addPaused stores the given info to start an index sender once resume is called


### PR DESCRIPTION
Folders which are newly added/shared fell through the cracks regarding sending indexes, as we reject them in cluster config and that's where we initialise index sending. Now in `newFolder` and in `restartFolder` when a folder is shared to a new device, we call a new method `indexSenderRegistry.addNew`. This starts the index sender with no index info (the folder/device is new, we need to transfer everything).