### PR TITLE
gui: Add warning when JavaScript is disabled in Web browser (fixes #7099)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -21,7 +21,7 @@ ul+h5 {
     margin-top: 1.5em;
 }
 
-#content {
+.content {
     margin-bottom: 50px;
 }
 

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -53,7 +53,7 @@
             </div>
             <div class="panel-body">
               <p>
-              <span translate>The Syncthing admin interface requires JavaScript to function correctly. Please enable JavaScript in your Web browser and try again.</span>
+              The Syncthing admin interface requires JavaScript. Please enable JavaScript in your Web browser and try again.
               </p>
             </div>
           </div>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -7,7 +7,7 @@
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
 -->
-<html lang="en" ng-app="syncthing" ng-controller="SyncthingController" class="ng-cloak">
+<html lang="en" ng-app="syncthing" ng-controller="SyncthingController">
 <head>
   <meta charset="utf-8"/>
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
@@ -29,200 +29,190 @@
 </head>
 
 <body>
-  <script type="text/javascript" src="syncthing/development/logbar.js"></script>
-  <div ng-if="version.isBeta" ng-include="'syncthing/development/logbar.html'"></div>
-  <!-- Top bar -->
-
-  <nav class="navbar navbar-top navbar-default" role="navigation">
-    <div class="container">
-      <span class="navbar-brand" aria-hidden="true">
-        <img class="logo hidden-xs" src="assets/img/logo-horizontal.svg" height="32" width="117" alt=""/>
-        <img class="logo hidden visible-xs" src="assets/img/favicon-default.png" height="32" alt=""/>
-      </span>
-      <p class="navbar-text hidden-xs" ng-class="{'hidden-sm':upgradeInfo && upgradeInfo.newer}">{{thisDeviceName()}}</p>
-      <ul class="nav navbar-nav navbar-right">
-        <li ng-if="upgradeInfo && upgradeInfo.newer" class="upgrade-newer">
-          <button type="button" class="btn navbar-btn btn-primary btn-sm" data-toggle="modal" data-target="#upgrade">
-            <span class="fas fa-arrow-circle-up"></span>
-            <span class="hidden-xs" translate translate-value-version="{{upgradeInfo.latest}}">Upgrade To {%version%}</span>
-          </button>
-        </li>
-        <li ng-if="upgradeInfo && upgradeInfo.majorNewer" class="upgrade-newer-major">
-          <button type="button" class="btn navbar-btn btn-danger btn-sm" data-toggle="modal" data-target="#majorUpgrade">
-            <span class="fas fa-arrow-circle-up"></span>
-            <span class="hidden-xs" translate translate-value-version="{{upgradeInfo.latest}}">Upgrade To {%version%}</span>
-          </button>
-        </li>
-        <li class="dropdown" language-select></li>
-        <li>
-          <a class="navbar-link" href="https://docs.syncthing.net/intro/gui.html" target="_blank">
-            <span class="fas fa-question-circle"></span>
-            <span class="hidden-xs" translate>Help</span>
-          </a>
-        </li>
-        <li class="dropdown action-menu">
-          <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-            <span class="fas fa-cog"></span>
-            <span class="hidden-xs" translate>Actions</span>
-            <span class="caret"></span>
-          </a>
-          <ul class="dropdown-menu">
-            <li><a href="" ng-click="showSettings()"><span class="fas fa-fw fa-cog"></span>&nbsp;<span translate>Settings</span></a></li>
-            <li><a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()"><span class="fas fa-fw fa-qrcode"></span>&nbsp;<span translate>Show ID</span></a></li>
-            <li class="divider" aria-hidden="true"></li>
-            <li><a href="" ng-click="shutdown()"><span class="fas fa-fw fa-power-off"></span>&nbsp;<span translate>Shutdown</span></a></li>
-            <li><a href="" ng-click="restart()"><span class="fas fa-fw fa-refresh"></span>&nbsp;<span translate>Restart</span></a></li>
-            <li class="divider" aria-hidden="true"></li>
-            <li class="visible-xs">
-              <a href="https://docs.syncthing.net/intro/gui.html" target="_blank">
-                <span class="fas fa-fw fa-question-circle"></span>&nbsp;<span translate>Help</span>
-              </a>
-            </li>
-            <li><a href="" data-toggle="modal" data-target="#about"><span class="far fa-fw fa-heart"></span>&nbsp;<span translate>About</span></a></li>
-            <li class="divider" aria-hidden="true"></li>
-            <li><a href="" ng-click="advanced()"><span class="fas fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
-            <li><a href="" ng-click="logging.show()"><span class="far fa-fw fa-file-alt"></span>&nbsp;<span translate>Logs</span></a></li>
-            <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
-            <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
-          </ul>
-        </li>
-      </ul>
-    </div>
-  </nav>
-
-  <div class="container" id="content">
-
-    <!-- Panel: Open, no auth -->
-
-    <div ng-if="openNoAuth" class="row">
-      <div class="col-md-12">
-        <div class="panel panel-danger">
-          <div class="panel-heading">
-            <h3 class="panel-title">
-              <div class="panel-icon">
-                <span class="fas fa-exclamation-circle"></span>
-              </div>
-              <span translate>Danger!</span>
-            </h3>
-          </div>
-          <div class="panel-body">
-            <p>
-            <span translate>The Syncthing admin interface is configured to allow remote access without a password.</span>
-            <b><span translate>This can easily give hackers access to read and change any files on your computer.</span></b>
-            <span translate>Please set a GUI Authentication User and Password in the Settings dialog.</span>
-            </p>
-          </div>
-          <div class="panel-footer">
-            <button type="button" class="btn btn-sm btn-default pull-right" ng-click="showSettings()">
-              <span class="fas fa-cog"></span>&nbsp;<span translate>Settings</span>
-            </button>
-            <div class="clearfix"></div>
-          </div>
-        </div>
+  <noscript>
+    <nav class="navbar navbar-top navbar-default" role="navigation">
+      <div class="container">
+        <span class="navbar-brand" aria-hidden="true">
+          <img class="logo hidden-xs" src="assets/img/logo-horizontal.svg" height="32" width="117" alt=""/>
+          <img class="logo hidden visible-xs" src="assets/img/favicon-default.png" height="32" alt=""/>
+        </span>
       </div>
-    </div>
+    </nav>
 
-    <!-- Panel: Restart Needed -->
-
-    <div ng-if="!configInSync" class="row">
-      <div class="col-md-12">
-        <div class="panel panel-warning">
-          <div class="panel-heading">
-            <h3 class="panel-title">
-              <div class="panel-icon">
-                <span class="fas fa-exclamation-circle"></span>
-              </div>
-              <span translate>Restart Needed</span>
-            </h3>
-          </div>
-          <div class="panel-body">
-            <p translate>The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.</p>
-          </div>
-          <div class="panel-footer">
-            <button type="button" class="btn btn-sm btn-default pull-right" ng-click="restart()">
-              <span class="fas fa-refresh"></span>&nbsp;<span translate>Restart</span>
-            </button>
-            <div class="clearfix"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div ng-if="config">
-
-      <!-- Panel: Notifications -->
-
-      <div ng-if="config.options && config.options.unackedNotificationIDs" ng-include="'syncthing/core/notifications.html'"></div>
-
-      <!-- Panel: New Device -->
-
-      <div ng-repeat="pendingDevice in config.pendingDevices" class="row">
+    <div class="container content">
+      <div class="row">
         <div class="col-md-12">
-          <div class="panel panel-warning">
+          <div class="panel panel-danger">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <identicon class="panel-icon" data-value="device"></identicon>
-                <span translate>New Device</span>
-                <span class="pull-right">{{ pendingDevice.time | date:"yyyy-MM-dd HH:mm:ss" }}</span>
+                <div class="panel-icon">
+                  <span class="fas fa-exclamation-circle"></span>
+                </div>
+                <span translate>Warning!</span>
               </h3>
             </div>
             <div class="panel-body">
               <p>
-                <span translate translate-value-device="{{ pendingDevice.deviceID }}" translate-value-address="{{ pendingDevice.address }}" translate-value-name="{{ pendingDevice.name }}">
-                  Device "{%name%}" ({%device%} at {%address%}) wants to connect. Add new device?
-                </span>
+              <span translate>The Syncthing admin interface requires JavaScript to function correctly. Please enable JavaScript in your Web browser and try again.</span>
               </p>
             </div>
-            <div class="panel-footer clearfix">
-              <div class="pull-right">
-                <button type="button" class="btn btn-sm btn-success" ng-click="addDevice(pendingDevice.deviceID, pendingDevice.name)">
-                  <span class="fas fa-plus"></span>&nbsp;<span translate>Add Device</span>
-                </button>
-                <button type="button" class="btn btn-sm btn-danger" ng-click="ignoreDevice(pendingDevice)">
-                  <span class="fas fa-times"></span>&nbsp;<span translate>Ignore</span>
-                </button>
-              </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </noscript>
+
+  <div class="ng-cloak">
+    <script type="text/javascript" src="syncthing/development/logbar.js"></script>
+    <div ng-if="version.isBeta" ng-include="'syncthing/development/logbar.html'"></div>
+    <!-- Top bar -->
+
+    <nav class="navbar navbar-top navbar-default" role="navigation">
+      <div class="container">
+        <span class="navbar-brand" aria-hidden="true">
+          <img class="logo hidden-xs" src="assets/img/logo-horizontal.svg" height="32" width="117" alt=""/>
+          <img class="logo hidden visible-xs" src="assets/img/favicon-default.png" height="32" alt=""/>
+        </span>
+        <p class="navbar-text hidden-xs" ng-class="{'hidden-sm':upgradeInfo && upgradeInfo.newer}">{{thisDeviceName()}}</p>
+        <ul class="nav navbar-nav navbar-right">
+          <li ng-if="upgradeInfo && upgradeInfo.newer" class="upgrade-newer">
+            <button type="button" class="btn navbar-btn btn-primary btn-sm" data-toggle="modal" data-target="#upgrade">
+              <span class="fas fa-arrow-circle-up"></span>
+              <span class="hidden-xs" translate translate-value-version="{{upgradeInfo.latest}}">Upgrade To {%version%}</span>
+            </button>
+          </li>
+          <li ng-if="upgradeInfo && upgradeInfo.majorNewer" class="upgrade-newer-major">
+            <button type="button" class="btn navbar-btn btn-danger btn-sm" data-toggle="modal" data-target="#majorUpgrade">
+              <span class="fas fa-arrow-circle-up"></span>
+              <span class="hidden-xs" translate translate-value-version="{{upgradeInfo.latest}}">Upgrade To {%version%}</span>
+            </button>
+          </li>
+          <li class="dropdown" language-select></li>
+          <li>
+            <a class="navbar-link" href="https://docs.syncthing.net/intro/gui.html" target="_blank">
+              <span class="fas fa-question-circle"></span>
+              <span class="hidden-xs" translate>Help</span>
+            </a>
+          </li>
+          <li class="dropdown action-menu">
+            <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
+              <span class="fas fa-cog"></span>
+              <span class="hidden-xs" translate>Actions</span>
+              <span class="caret"></span>
+            </a>
+            <ul class="dropdown-menu">
+              <li><a href="" ng-click="showSettings()"><span class="fas fa-fw fa-cog"></span>&nbsp;<span translate>Settings</span></a></li>
+              <li><a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()"><span class="fas fa-fw fa-qrcode"></span>&nbsp;<span translate>Show ID</span></a></li>
+              <li class="divider" aria-hidden="true"></li>
+              <li><a href="" ng-click="shutdown()"><span class="fas fa-fw fa-power-off"></span>&nbsp;<span translate>Shutdown</span></a></li>
+              <li><a href="" ng-click="restart()"><span class="fas fa-fw fa-refresh"></span>&nbsp;<span translate>Restart</span></a></li>
+              <li class="divider" aria-hidden="true"></li>
+              <li class="visible-xs">
+                <a href="https://docs.syncthing.net/intro/gui.html" target="_blank">
+                  <span class="fas fa-fw fa-question-circle"></span>&nbsp;<span translate>Help</span>
+                </a>
+              </li>
+              <li><a href="" data-toggle="modal" data-target="#about"><span class="far fa-fw fa-heart"></span>&nbsp;<span translate>About</span></a></li>
+              <li class="divider" aria-hidden="true"></li>
+              <li><a href="" ng-click="advanced()"><span class="fas fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
+              <li><a href="" ng-click="logging.show()"><span class="far fa-fw fa-file-alt"></span>&nbsp;<span translate>Logs</span></a></li>
+              <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
+              <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
+            </ul>
+          </li>
+        </ul>
+      </div>
+    </nav>
+
+    <div class="container content">
+
+      <!-- Panel: Open, no auth -->
+
+      <div ng-if="openNoAuth" class="row">
+        <div class="col-md-12">
+          <div class="panel panel-danger">
+            <div class="panel-heading">
+              <h3 class="panel-title">
+                <div class="panel-icon">
+                  <span class="fas fa-exclamation-circle"></span>
+                </div>
+                <span translate>Danger!</span>
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p>
+              <span translate>The Syncthing admin interface is configured to allow remote access without a password.</span>
+              <b><span translate>This can easily give hackers access to read and change any files on your computer.</span></b>
+              <span translate>Please set a GUI Authentication User and Password in the Settings dialog.</span>
+              </p>
+            </div>
+            <div class="panel-footer">
+              <button type="button" class="btn btn-sm btn-default pull-right" ng-click="showSettings()">
+                <span class="fas fa-cog"></span>&nbsp;<span translate>Settings</span>
+              </button>
+              <div class="clearfix"></div>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Panel: New Folder -->
-      <div ng-repeat="device in config.devices">
-        <div ng-repeat="pendingFolder in device.pendingFolders" class="row reject">
+      <!-- Panel: Restart Needed -->
+
+      <div ng-if="!configInSync" class="row">
+        <div class="col-md-12">
+          <div class="panel panel-warning">
+            <div class="panel-heading">
+              <h3 class="panel-title">
+                <div class="panel-icon">
+                  <span class="fas fa-exclamation-circle"></span>
+                </div>
+                <span translate>Restart Needed</span>
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p translate>The configuration has been saved but not activated. Syncthing must restart to activate the new configuration.</p>
+            </div>
+            <div class="panel-footer">
+              <button type="button" class="btn btn-sm btn-default pull-right" ng-click="restart()">
+                <span class="fas fa-refresh"></span>&nbsp;<span translate>Restart</span>
+              </button>
+              <div class="clearfix"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div ng-if="config">
+
+        <!-- Panel: Notifications -->
+
+        <div ng-if="config.options && config.options.unackedNotificationIDs" ng-include="'syncthing/core/notifications.html'"></div>
+
+        <!-- Panel: New Device -->
+
+        <div ng-repeat="pendingDevice in config.pendingDevices" class="row">
           <div class="col-md-12">
             <div class="panel panel-warning">
               <div class="panel-heading">
                 <h3 class="panel-title">
-                  <div class="panel-icon">
-                    <span class="fas fa-folder"></span>
-                  </div>
-                  <span translate ng-if="!folders[pendingFolder.id]">New Folder</span>
-                  <span translate ng-if="folders[pendingFolder.id]">Share Folder</span>
-                  <span class="pull-right">{{ pendingFolder.time | date:"yyyy-MM-dd HH:mm:ss" }}</span>
+                  <identicon class="panel-icon" data-value="device"></identicon>
+                  <span translate>New Device</span>
+                  <span class="pull-right">{{ pendingDevice.time | date:"yyyy-MM-dd HH:mm:ss" }}</span>
                 </h3>
               </div>
               <div class="panel-body">
                 <p>
-                  <span ng-if="pendingFolder.label.length == 0" translate translate-value-device="{{ deviceName(devices[device.deviceID]) }}" translate-value-folder="{{ pendingFolder.id }}">
-                    {%device%} wants to share folder "{%folder%}".
+                  <span translate translate-value-device="{{ pendingDevice.deviceID }}" translate-value-address="{{ pendingDevice.address }}" translate-value-name="{{ pendingDevice.name }}">
+                    Device "{%name%}" ({%device%} at {%address%}) wants to connect. Add new device?
                   </span>
-                  <span ng-if="pendingFolder.label.length != 0" translate translate-value-device="{{ deviceName(devices[device.deviceID]) }}" translate-value-folder="{{ pendingFolder.id }}" translate-value-folderlabel="{{ pendingFolder.label }}">
-                    {%device%} wants to share folder "{%folderlabel%}" ({%folder%}).
-                  </span>
-                  <span translate ng-if="folders[pendingFolder.id]">Share this folder?</span>
-                  <span translate ng-if="!folders[pendingFolder.id]">Add new folder?</span>
                 </p>
               </div>
               <div class="panel-footer clearfix">
                 <div class="pull-right">
-                  <button type="button" class="btn btn-sm btn-success" ng-click="addFolderAndShare(pendingFolder.id, pendingFolder.label, device.deviceID)" ng-if="!folders[pendingFolder.id]">
-                    <span class="fas fa-check"></span>&nbsp;<span translate>Add</span>
+                  <button type="button" class="btn btn-sm btn-success" ng-click="addDevice(pendingDevice.deviceID, pendingDevice.name)">
+                    <span class="fas fa-plus"></span>&nbsp;<span translate>Add Device</span>
                   </button>
-                  <button type="button" class="btn btn-sm btn-success" ng-click="shareFolderWithDevice(pendingFolder.id, device.deviceID)" ng-if="folders[pendingFolder.id]">
-                    <span class="fas fa-check"></span>&nbsp;<span translate>Share</span>
-                  </button>
-                  <button type="button" class="btn btn-sm btn-danger" ng-click="ignoreFolder(device.deviceID, pendingFolder)">
+                  <button type="button" class="btn btn-sm btn-danger" ng-click="ignoreDevice(pendingDevice)">
                     <span class="fas fa-times"></span>&nbsp;<span translate>Ignore</span>
                   </button>
                 </div>
@@ -230,585 +220,630 @@
             </div>
           </div>
         </div>
-      </div>
 
-    </div>
-
-    <!-- Panel: Notice -->
-
-    <div ng-if="errorList().length > 0" class="row">
-      <div class="col-md-12">
-        <div class="panel panel-warning">
-          <div class="panel-heading">
-            <h3 class="panel-title">
-              <div class="panel-icon">
-                <span class="fas fa-exclamation-circle"></span>
-              </div>
-              <span translate>Notice</span>
-            </h3>
-          </div>
-          <div class="panel-body">
-            <p ng-repeat="err in errorList()">
-              <small>{{err.when | date:"yyyy-MM-dd HH:mm:ss"}}:</small>
-              <span ng-bind-html="friendlyDevices(err.message) | linky: '_blank'"></span>
-            </p>
-          </div>
-          <div class="panel-footer">
-            <button type="button" class="btn btn-sm btn-default pull-right" ng-click="clearErrors()">
-              <span class="fas fa-check"></span>&nbsp;<span translate>OK</span>
-            </button>
-            <div class="clearfix"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Panel: FS watcher errors -->
-
-    <div ng-if="sizeOf(fsWatcherErrorMap()) > 0" class="row">
-      <div class="col-md-12">
-        <div class="panel panel-warning">
-          <div class="panel-heading">
-            <h3 class="panel-title">
-              <div class="panel-icon">
-                <span class="fas fa-exclamation-circle"></span>
-              </div>
-              <span translate>Filesystem Watcher Errors</span>
-            </h3>
-          </div>
-          <div class="panel-body">
-            <p>
-              <span translate>For the following folders an error occurred while starting to watch for changes. It will be retried every minute, so the errors might go away soon. If they persist, try to fix the underlying issue and ask for help if you can't.</span>&emsp;<a href="https://forum.syncthing.net" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Support</span></a>
-            </p>
-            <table>
-              <tr ng-repeat="(id, err) in fsWatcherErrorMap()">
-                <td>{{folderLabel(id)}}</td><td>{{err}}</td>
-              </tr>
-            </table>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- First regular row -->
-
-    <div class="row">
-
-      <!-- Folder list (top left) -->
-
-      <div class="col-md-6" aria-labelledby="folder_list" role="region" >
-        <h3 id="folder_list" translate>Folders</h3>
-        <div class="panel-group" id="folders">
-          <div class="panel panel-default" ng-repeat="folder in folderList()">
-            <button class="btn panel-heading" data-toggle="collapse" data-parent="#folders" data-target="#folder-{{$index}}" aria-expanded="false">
-              <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id) | percent}}"></div>
-              <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id) | percent}}"></div>
-              <h4 class="panel-title">
-                <div class="panel-icon hidden-xs">
-                  <span ng-if="folder.type == 'sendreceive'" class="fas fa-fw fa-folder"></span>
-                  <span ng-if="folder.type == 'sendonly'" class="fas fa-fw fa-upload"></span>
-                  <span ng-if="folder.type == 'receiveonly'" class="fas fa-fw fa-download"></span>
+        <!-- Panel: New Folder -->
+        <div ng-repeat="device in config.devices">
+          <div ng-repeat="pendingFolder in device.pendingFolders" class="row reject">
+            <div class="col-md-12">
+              <div class="panel panel-warning">
+                <div class="panel-heading">
+                  <h3 class="panel-title">
+                    <div class="panel-icon">
+                      <span class="fas fa-folder"></span>
+                    </div>
+                    <span translate ng-if="!folders[pendingFolder.id]">New Folder</span>
+                    <span translate ng-if="folders[pendingFolder.id]">Share Folder</span>
+                    <span class="pull-right">{{ pendingFolder.time | date:"yyyy-MM-dd HH:mm:ss" }}</span>
+                  </h3>
                 </div>
-                <div class="panel-status pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
-                  <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs" aria-label="{{'Paused' | translate}}"><i class="fas fa-fw fa-pause"></i></span></span>
-                  <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs" aria-label="{{'Unknown' | translate}}"><i class="fas fa-fw fa-question-circle"></i></span></span>
-                  <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs" aria-label="{{'Unshared' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
-                  <span ng-switch-when="scan-waiting"><span class="hidden-xs" translate>Waiting to Scan</span><span class="visible-xs" aria-label="{{'Waiting to Scan' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span></span>
-                  <span ng-switch-when="cleaning"><span class="hidden-xs" translate>Cleaning Versions</span><span class="visible-xs" aria-label="{{'Cleaning Versions' | translate}}"><i class="fas fa-fw fa-recycle"></i></span></span>
-                  <span ng-switch-when="clean-waiting"><span class="hidden-xs" translate>Waiting to Clean</span><span class="visible-xs" aria-label="{{'Waiting to Clean' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span></span>
-                  <span ng-switch-when="stopped"><span class="hidden-xs" translate>Stopped</span><span class="visible-xs" aria-label="{{'Stopped' | translate}}"><i class="fas fa-fw fa-stop"></i></span></span>
-                  <span ng-switch-when="scanning">
-                    <span class="hidden-xs" translate>Scanning</span>
-                    <span class="hidden-xs" ng-if="scanPercentage(folder.id) != undefined">
-                      ({{scanPercentage(folder.id) | percent}})
+                <div class="panel-body">
+                  <p>
+                    <span ng-if="pendingFolder.label.length == 0" translate translate-value-device="{{ deviceName(devices[device.deviceID]) }}" translate-value-folder="{{ pendingFolder.id }}">
+                      {%device%} wants to share folder "{%folder%}".
                     </span>
-                    <span class="visible-xs" aria-label="{{'Scanning' | translate}}"><i class="fas fa-fw fa-search"></i></span>
-                  </span>
-                  <span ng-switch-when="idle"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs" aria-label="{{'Up to Date' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
-                  <span ng-switch-when="localadditions"><span class="hidden-xs" translate>Local Additions</span><span class="visible-xs" aria-label="{{'Local Additions' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
-                  <span ng-switch-when="sync-waiting">
-                    <span class="hidden-xs" translate>Waiting to Sync</span>
-                    <span class="visible-xs" aria-label="{{'Waiting to Sync' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span>
-                  </span>
-                  <span ng-switch-when="sync-preparing">
-                    <span class="hidden-xs" translate>Preparing to Sync</span>
-                    <span class="visible-xs" aria-label="{{'Preparing to Sync' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span>
-                  </span>
-                  <span ng-switch-when="syncing">
-                    <span class="hidden-xs" translate>Syncing</span>
-                    <span>({{syncPercentage(folder.id) | percent}}, {{model[folder.id].needBytes | binary}}B)</span>
-                  </span>
-                  <span ng-switch-when="outofsync"><span class="hidden-xs" translate>Out of Sync</span><span class="visible-xs" aria-label="{{'Out of Sync' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
-                  <span ng-switch-when="faileditems"><span class="hidden-xs" translate>Failed Items</span><span class="visible-xs" aria-label="{{'Failed Items' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
+                    <span ng-if="pendingFolder.label.length != 0" translate translate-value-device="{{ deviceName(devices[device.deviceID]) }}" translate-value-folder="{{ pendingFolder.id }}" translate-value-folderlabel="{{ pendingFolder.label }}">
+                      {%device%} wants to share folder "{%folderlabel%}" ({%folder%}).
+                    </span>
+                    <span translate ng-if="folders[pendingFolder.id]">Share this folder?</span>
+                    <span translate ng-if="!folders[pendingFolder.id]">Add new folder?</span>
+                  </p>
                 </div>
-                <div class="panel-title-text">
-                  <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>
+                <div class="panel-footer clearfix">
+                  <div class="pull-right">
+                    <button type="button" class="btn btn-sm btn-success" ng-click="addFolderAndShare(pendingFolder.id, pendingFolder.label, device.deviceID)" ng-if="!folders[pendingFolder.id]">
+                      <span class="fas fa-check"></span>&nbsp;<span translate>Add</span>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-success" ng-click="shareFolderWithDevice(pendingFolder.id, device.deviceID)" ng-if="folders[pendingFolder.id]">
+                      <span class="fas fa-check"></span>&nbsp;<span translate>Share</span>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-danger" ng-click="ignoreFolder(device.deviceID, pendingFolder)">
+                      <span class="fas fa-times"></span>&nbsp;<span translate>Ignore</span>
+                    </button>
+                  </div>
                 </div>
-              </h4>
-            </button>
-            <div id="folder-{{$index}}" class="panel-collapse collapse">
-              <div class="panel-body">
-                <table class="table table-condensed table-striped table-auto">
-                  <tbody>
-                    <tr ng-show="folder.label != undefined && folder.label.length > 0">
-                      <th><span class="fas fa-fw fa-info-circle"></span>&nbsp;<span translate>Folder ID</span></th>
-                      <td class="text-right no-overflow-ellipse">{{folder.id}}</td>
-                    </tr>
-                    <tr>
-                      <th><span class="fas fa-fw fa-folder-open"></span>&nbsp;<span translate>Folder Path</span></th>
-                      <td class="text-right">
-                        <span tooltip data-original-title="{{folder.path}}">{{folder.path}}</span>
-                      </td>
-                    </tr>
-                    <tr ng-if="!folder.paused && (model[folder.id].invalid || model[folder.id].error)">
-                      <th><span class="fas fa-fw fa-exclamation-triangle"></span>&nbsp;<span translate>Error</span></th>
-                      <td class="text-right">{{model[folder.id].invalid || model[folder.id].error}}</td>
-                    </tr>
-                    <tr ng-if="!folder.paused">
-                      <th><span class="fas fa-fw fa-globe"></span>&nbsp;<span translate>Global State</span></th>
-                      <td class="text-right">
-                        <span tooltip data-original-title="{{model[folder.id].globalFiles | alwaysNumber | localeNumber}} {{'files' | translate}}, {{model[folder.id].globalDirectories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{model[folder.id].globalBytes | binary}}B">
-                          <span class="far fa-copy"></span>&nbsp;{{model[folder.id].globalFiles | alwaysNumber | localeNumber}}&ensp;
-                          <span class="far fa-folder"></span>&nbsp;{{model[folder.id].globalDirectories | alwaysNumber | localeNumber}}&ensp;
-                          <span class="far fa-hdd"></span>&nbsp;~{{model[folder.id].globalBytes | binary}}B
-                        </span>
-                      </td>
-                    </tr>
-                    <tr ng-if="!folder.paused">
-                      <th><span class="fas fa-fw fa-home"></span>&nbsp;<span translate>Local State</span></th>
-                      <td class="text-right">
-                        <span tooltip data-original-title="{{model[folder.id].localFiles | alwaysNumber | localeNumber}} {{'files' | translate}}, {{model[folder.id].localDirectories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{model[folder.id].localBytes | binary}}B">
-                          <span class="far fa-copy"></span>&nbsp;{{model[folder.id].localFiles | alwaysNumber | localeNumber}}&ensp;
-                          <span class="far fa-folder"></span>&nbsp;{{model[folder.id].localDirectories | alwaysNumber | localeNumber}}&ensp;
-                          <span class="far fa-hdd"></span>&nbsp;~{{model[folder.id].localBytes | binary}}B<!-- get rid of the annoying trailing whitespace
-                          --><span ng-if="model[folder.id].ignorePatterns"><br/><i><small translate class="text-muted">Reduced by ignore patterns</small></i></span>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr ng-if="model[folder.id].needTotalItems > 0">
-                      <th><span class="fas fa-fw fa-cloud-download-alt"></span>&nbsp;<span translate>Out of Sync Items</span></th>
-                      <td class="text-right">
-                        <a href="" ng-click="showNeed(folder.id)">{{model[folder.id].needTotalItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{model[folder.id].needBytes | binary}}B</a>
-                      </td>
-                    </tr>
-                    <tr ng-if="folderStatus(folder) === 'scanning' && scanRate(folder.id) > 0">
-                      <th><span class="fas fa-fw fa-hourglass-half"></span>&nbsp;<span translate>Scan Time Remaining</span></th>
-                      <td class="text-right">
-                        <span tooltip data-original-title="{{scanRate(folder.id) | binary}}B/s">~ {{scanRemaining(folder.id)}}</span>
-                      </td>
-                    </tr>
-                    <tr ng-if="hasFailedFiles(folder.id)">
-                      <th><span class="fas fa-fw fa-exclamation-circle"></span>&nbsp;<span translate>Failed Items</span></th>
-                      <!-- Show the number of failed items as a link to bring up the list. -->
-                      <td class="text-right">
-                        <a href="" ng-click="showFailed(folder.id)">{{model[folder.id].pullErrors | alwaysNumber | localeNumber}}&nbsp;<span translate>items</span></a>
-                      </td>
-                    </tr>
-                    <tr ng-if="folder.type == 'receiveonly' && canRevert(folder.id)">
-                      <th><span class="fas fa-fw fa-exclamation-circle"></span>&nbsp;<span translate>Locally Changed Items</span></th>
-                      <td class="text-right">
-                        <a href="" ng-click="showLocalChanged(folder.id)">{{model[folder.id].receiveOnlyTotalItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{model[folder.id].receiveOnlyChangedBytes | binary}}B</a>
-                      </td>
-                    </tr>
-                    <tr ng-if="folder.type != 'sendreceive'">
-                      <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folder Type</span></th>
-                      <td class="text-right">
-                        <span ng-if="folder.type == 'sendonly'" translate>Send Only</span>
-                        <span ng-if="folder.type == 'receiveonly'" translate>Receive Only</span>
-                      </td>
-                    </tr>
-                    <tr ng-if="folder.ignorePerms">
-                      <th><span class="far fa-fw fa-minus-square"></span>&nbsp;<span translate>Ignore Permissions</span></th>
-                      <td class="text-right">
-                        <span translate>Yes</span>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th><span class="fas fa-fw fa-refresh"></span>&nbsp;<span translate>Rescans</span></th>
-                      <td class="text-right">
-                        <div ng-if="folder.rescanIntervalS > 0">
-                          <span ng-if="!folder.fsWatcherEnabled" tooltip data-original-title="{{'Periodic scanning at given interval and disabled watching for changes' | translate}}">
-                            <span class="far fa-clock"></span>&nbsp;{{folder.rescanIntervalS | duration}}&ensp;
-                            <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Disabled</span>
-                          </span>
-                          <span ng-if="folder.fsWatcherEnabled && (!model[folder.id].watchError || folder.paused || folderStatus(folder) === 'stopped')" tooltip data-original-title="{{'Periodic scanning at given interval and enabled watching for changes' | translate}}">
-                            <span class="far fa-clock"></span>&nbsp;{{folder.rescanIntervalS | duration}}&ensp;
-                            <span class="fas fa-eye"></span>&nbsp;<span translate>Enabled</span>
-                          </span>
-                          <span ng-if="folder.fsWatcherEnabled && !folder.paused && folderStatus(folder) !== 'stopped' && model[folder.id].watchError" tooltip data-original-title="{{'Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:' | translate}}<br/>{{model[folder.id].watchError}}">
-                            <span class="far fa-clock"></span>&nbsp;{{folder.rescanIntervalS | duration}}&ensp;
-                            <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Failed to setup, retrying</span>
-                          </span>
-                        </div>
-                        <div ng-if="folder.rescanIntervalS <= 0">
-                          <span ng-if="!folder.fsWatcherEnabled" tooltip data-original-title="{{'Disabled periodic scanning and disabled watching for changes' | translate}}">
-                            <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
-                            <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Disabled</span>
-                          </span>
-                          <span ng-if="folder.fsWatcherEnabled && (!model[folder.id].watchError || folder.paused || folderStatus(folder) === 'stopped')" tooltip data-original-title="{{'Disabled periodic scanning and enabled watching for changes' | translate}}">
-                            <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
-                            <span class="fas fa-eye"></span>&nbsp;<span translate>Enabled</span>
-                          </span>
-                          <span ng-if="folder.fsWatcherEnabled && !folder.paused && folderStatus(folder) !== 'stopped' && model[folder.id].watchError" tooltip data-original-title="{{'Disabled periodic scanning and failed setting up watching for changes, retrying every 1m:' | translate}}<br/>{{model[folder.id].watchError}}">
-                            <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
-                            <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Failed to setup, retrying</span>
-                          </span>
-                        </div>
-                      </td>
-                    </tr>
-                    <tr ng-if="folder.order != 'random' && folder.type != 'sendonly'">
-                      <th><span class="fas fa-fw fa-sort"></span>&nbsp;<span translate>File Pull Order</span></th>
-                      <td class="text-right" ng-switch="folder.order">
-                        <span ng-switch-when="random" translate>Random</span>
-                        <span ng-switch-when="alphabetic" translate>Alphabetic</span>
-                        <span ng-switch-when="smallestFirst" translate>Smallest First</span>
-                        <span ng-switch-when="largestFirst" translate>Largest First</span>
-                        <span ng-switch-when="oldestFirst" translate>Oldest First</span>
-                        <span ng-switch-when="newestFirst" translate>Newest First</span>
-                      </td>
-                    </tr>
-                    <tr ng-if="folder.versioning.type">
-                      <th><span class="far fa-fw fa-copy"></span>&nbsp;<span translate>File Versioning</span></th>
-                      <td class="text-right" ng-switch="folder.versioning.type">
-                        <span ng-switch-when="trashcan" translate>Trash Can File Versioning</span>
-                        <span ng-switch-when="staggered" translate>Staggered File Versioning</span>
-                        <span ng-switch-when="simple" translate>Simple File Versioning</span>
-                        <span ng-switch-when="external" translate>External File Versioning</span>
-                      </td>
-                    </tr>
-                    <tr>
-                      <th><span class="fas fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span></th>
-                      <td class="text-right" ng-attr-title="{{sharesFolder(folder)}}">{{sharesFolder(folder)}}</td>
-                    </tr>
-                    <tr ng-if="folderStats[folder.id].lastScan">
-                      <th><span class="far fa-fw fa-clock"></span>&nbsp;<span translate>Last Scan</span></th>
-                      <td translate ng-if="folderStats[folder.id].lastScanDays >= 365" class="text-right">Never</td>
-                      <td ng-if="folderStats[folder.id].lastScanDays < 365" class="text-right">
-                        <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
-                      </td>
-                    </tr>
-                    <tr ng-if="folder.type != 'sendonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">
-                      <th><span class="fas fa-fw fa-exchange-alt"></span>&nbsp;<span translate>Latest Change</span></th>
-                      <td class="text-right">
-                        <span tooltip data-original-title="{{folderStats[folder.id].lastFile.filename}} @ {{folderStats[folder.id].lastFile.at | date:'yyyy-MM-dd HH:mm:ss'}}">
-                          <span translate ng-if="!folderStats[folder.id].lastFile.deleted">Updated</span>
-                          <span translate ng-if="folderStats[folder.id].lastFile.deleted">Deleted</span>
-                          {{folderStats[folder.id].lastFile.filename | basename}}
-                        </span>
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <div class="panel-footer">
-                <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="override(folder.id)" ng-if="folderStatus(folder) == 'outofsync' && folder.type == 'sendonly'">
-                  <span class="fas fa-arrow-circle-up"></span>&nbsp;<span translate>Override Changes</span>
-                </button>
-                <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revert(folder.id)" ng-if="canRevert(folder.id)">
-                  <span class="fa fa-arrow-circle-down"></span>&nbsp;<span translate>Revert Local Changes</span>
-                </button>
-                <span class="pull-right">
-                  <button ng-if="!folder.paused" type="button" class="btn btn-sm btn-default" ng-click="setFolderPause(folder.id, true)">
-                    <span class="fas fa-pause"></span>&nbsp;<span translate>Pause</span>
-                  </button>
-                  <button ng-if="folder.paused" type="button" class="btn btn-sm btn-default" ng-click="setFolderPause(folder.id, false)">
-                    <span class="fas fa-play"></span>&nbsp;<span translate>Resume</span>
-                  </button>
-                  <button type="button" class="btn btn-default btn-sm" ng-click="restoreVersions.show(folder.id)" ng-if="folder.versioning.type">
-                    <span class="fas fa-undo"></span>&nbsp;<span translate>Versions</span>
-                  </button>
-                  <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-disabled="['idle', 'stopped', 'unshared', 'outofsync', 'faileditems', 'localadditions'].indexOf(folderStatus(folder)) < 0">
-                    <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan</span>
-                  </button>
-                  <button type="button" class="btn btn-sm btn-default" ng-click="editFolder(folder)">
-                    <span class="fas fa-pencil-alt"></span>&nbsp;<span translate>Edit</span>
-                  </button>
-                </span>
-                <div class="clearfix"></div>
               </div>
             </div>
           </div>
         </div>
-        <span class="pull-right">
-          <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(true)" ng-if="isAtleastOneFolderPausedStateSetTo(false)">
-            <span class="fas fa-pause"></span>&nbsp;<span translate>Pause All</span>
-          </button>
-          <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
-            <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
-          </button>
-          <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()">
-            <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
-          </button>
-          <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">
-            <span class="fas fa-plus"></span>&nbsp;<span translate>Add Folder</span>
-          </button>
-        </span>
-        <div class="clearfix"></div>
-        <hr class="visible-sm"/>
+
       </div>
 
-      <!-- Device list (top right) -->
+      <!-- Panel: Notice -->
 
-      <!-- This device -->
-
-      <div class="col-md-6" aria-label="{{'Devices' | translate}}" role="region">
-        <h3 translate>This Device</h3>
-        <div class="panel panel-default" ng-repeat="deviceCfg in [thisDevice()]">
-          <button class="btn panel-heading" data-toggle="collapse" data-target="#device-this" aria-expanded="true">
-            <h4 class="panel-title">
-              <identicon class="panel-icon" data-value="deviceCfg.deviceID"></identicon>
-              <div class="panel-title-text">{{deviceName(deviceCfg)}}</div>
-            </h4>
-          </button>
-          <div id="device-this" class="panel-collapse collapse in">
+      <div ng-if="errorList().length > 0" class="row">
+        <div class="col-md-12">
+          <div class="panel panel-warning">
+            <div class="panel-heading">
+              <h3 class="panel-title">
+                <div class="panel-icon">
+                  <span class="fas fa-exclamation-circle"></span>
+                </div>
+                <span translate>Notice</span>
+              </h3>
+            </div>
             <div class="panel-body">
-              <table class="table table-condensed table-striped table-auto">
-                <tbody>
-                  <tr>
-                    <th><span class="fas fa-fw fa-cloud-download-alt"></span>&nbsp;<span translate>Download Rate</span></th>
-                    <td class="text-right">
-                      <a href="#" class="toggler" ng-click="toggleUnits()">
-                        <span ng-if="!metricRates">{{connectionsTotal.inbps | binary}}B/s</span>
-                        <span ng-if="metricRates">{{connectionsTotal.inbps*8 | metric}}bps</span>
-                        ({{connectionsTotal.inBytesTotal | binary}}B)
-                        <small ng-if="config.options.maxRecvKbps > 0"><br/>
-                          <i class="text-muted"><span translate>Limit</span>:
-                            <span ng-if="!metricRates">{{config.options.maxRecvKbps*1024 | binary}}B/s</span>
-                            <span ng-if="metricRates">{{config.options.maxRecvKbps*1024*8 | metric}}bps</span>
-                          </i>
-                        </small>
-                      </a>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th><span class="fas fa-fw fa-cloud-upload-alt"></span>&nbsp;<span translate>Upload Rate</span></th>
-                    <td class="text-right">
-                      <a href="#" class="toggler" ng-click="toggleUnits()">
-                        <span ng-if="!metricRates">{{connectionsTotal.outbps | binary}}B/s</span>
-                        <span ng-if="metricRates">{{connectionsTotal.outbps*8 | metric}}bps</span>
-                        ({{connectionsTotal.outBytesTotal | binary}}B)
-                        <small ng-if="config.options.maxSendKbps > 0"><br/>
-                          <i class="text-muted"><span translate>Limit</span>:
-                            <span ng-if="!metricRates">{{config.options.maxSendKbps*1024 | binary}}B/s</span>
-                            <span ng-if="metricRates">{{config.options.maxSendKbps*1024*8 | metric}}bps</span>
-                          </i>
-                        </small>
-                      </a>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th><span class="fas fa-fw fa-home"></span>&nbsp;<span translate>Local State (Total)</span></th>
-                    <td class="text-right">
-                        <span tooltip data-original-title="{{localStateTotal.files | alwaysNumber | localeNumber}} {{'files' | translate}}, {{ localStateTotal.directories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{ localStateTotal.bytes | binary}}B">
-                          <span class="far fa-copy"></span>&nbsp;{{localStateTotal.files | alwaysNumber | localeNumber}}&ensp;
-                          <span class="far fa-folder"></span>&nbsp;{{localStateTotal.directories| alwaysNumber | localeNumber}}&ensp;
-                          <span class="far fa-hdd"></span>&nbsp;~{{localStateTotal.bytes | binary}}B
-                        </span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th><span class="fas fa-fw fa-sitemap"></span>&nbsp;<span translate>Listeners</span></th>
-                    <td class="text-right">
-                      <span ng-if="listenersFailed.length == 0" class="data text-success">
-                        <span>{{listenersTotal}}/{{listenersTotal}}</span>
-                      </span>
-                      <span ng-if="listenersFailed.length != 0" class="data" ng-class="{'text-danger': listenersFailed.length == listenersTotal}">
-                        <span popover data-trigger="hover" data-placement="bottom" data-html="true" data-content="{{listenersFailed.join('<br>\n')}}">
-                          {{listenersTotal-listenersFailed.length}}/{{listenersTotal}}
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr ng-if="system.discoveryEnabled">
-                    <th><span class="fas fa-fw fa-map-signs"></span>&nbsp;<span translate>Discovery</span></th>
-                    <td class="text-right">
-                      <span ng-if="discoveryFailed.length == 0" class="data text-success">
-                        <span>{{discoveryTotal}}/{{discoveryTotal}}</span>
-                      </span>
-                      <span ng-if="discoveryFailed.length != 0" class="data" ng-class="{'text-danger': discoveryFailed.length == discoveryTotal}">
-                        <span popover data-trigger="hover" data-placement="bottom" data-content="{{'Click to see discovery failures' | translate}}.">
-                          <a href="" style="color:inherit" ng-click="showDiscoveryFailures()">{{discoveryTotal-discoveryFailed.length}}/{{discoveryTotal}}</a>
-                        </span>
-                      </span>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th><span class="far fa-fw fa-clock"></span>&nbsp;<span translate>Uptime</span></th>
-                    <td class="text-right">{{system.uptime | duration:"m"}}</td>
-                  </tr>
-                  <tr>
-                    <th><span class="fas fa-fw fa-tag"></span>&nbsp;<span translate>Version</span></th>
-                    <td class="text-right">
-                      <span tooltip data-original-title="{{versionString()}}">{{versionString()}}</span>
-                    </td>
-                  </tr>
-                </tbody>
+              <p ng-repeat="err in errorList()">
+                <small>{{err.when | date:"yyyy-MM-dd HH:mm:ss"}}:</small>
+                <span ng-bind-html="friendlyDevices(err.message) | linky: '_blank'"></span>
+              </p>
+            </div>
+            <div class="panel-footer">
+              <button type="button" class="btn btn-sm btn-default pull-right" ng-click="clearErrors()">
+                <span class="fas fa-check"></span>&nbsp;<span translate>OK</span>
+              </button>
+              <div class="clearfix"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Panel: FS watcher errors -->
+
+      <div ng-if="sizeOf(fsWatcherErrorMap()) > 0" class="row">
+        <div class="col-md-12">
+          <div class="panel panel-warning">
+            <div class="panel-heading">
+              <h3 class="panel-title">
+                <div class="panel-icon">
+                  <span class="fas fa-exclamation-circle"></span>
+                </div>
+                <span translate>Filesystem Watcher Errors</span>
+              </h3>
+            </div>
+            <div class="panel-body">
+              <p>
+                <span translate>For the following folders an error occurred while starting to watch for changes. It will be retried every minute, so the errors might go away soon. If they persist, try to fix the underlying issue and ask for help if you can't.</span>&emsp;<a href="https://forum.syncthing.net" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Support</span></a>
+              </p>
+              <table>
+                <tr ng-repeat="(id, err) in fsWatcherErrorMap()">
+                  <td>{{folderLabel(id)}}</td><td>{{err}}</td>
+                </tr>
               </table>
             </div>
           </div>
         </div>
+      </div>
 
-        <!-- Remote devices -->
-        <h3 translate>Remote Devices</h3>
-        <div class="panel-group" id="devices">
-          <div class="panel panel-default" ng-repeat="deviceCfg in otherDevices()">
-            <button class="btn panel-heading" data-toggle="collapse" data-parent="#devices" data-target="#device-{{$index}}" aria-expanded="false">
-              <div class="panel-progress" ng-show="deviceStatus(deviceCfg) == 'syncing'" ng-attr-style="width: {{completion[deviceCfg.deviceID]._total | percent}}"></div>
+      <!-- First regular row -->
+
+      <div class="row">
+
+        <!-- Folder list (top left) -->
+
+        <div class="col-md-6" aria-labelledby="folder_list" role="region" >
+          <h3 id="folder_list" translate>Folders</h3>
+          <div class="panel-group" id="folders">
+            <div class="panel panel-default" ng-repeat="folder in folderList()">
+              <button class="btn panel-heading" data-toggle="collapse" data-parent="#folders" data-target="#folder-{{$index}}" aria-expanded="false">
+                <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id) | percent}}"></div>
+                <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id) | percent}}"></div>
+                <h4 class="panel-title">
+                  <div class="panel-icon hidden-xs">
+                    <span ng-if="folder.type == 'sendreceive'" class="fas fa-fw fa-folder"></span>
+                    <span ng-if="folder.type == 'sendonly'" class="fas fa-fw fa-upload"></span>
+                    <span ng-if="folder.type == 'receiveonly'" class="fas fa-fw fa-download"></span>
+                  </div>
+                  <div class="panel-status pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
+                    <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs" aria-label="{{'Paused' | translate}}"><i class="fas fa-fw fa-pause"></i></span></span>
+                    <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs" aria-label="{{'Unknown' | translate}}"><i class="fas fa-fw fa-question-circle"></i></span></span>
+                    <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs" aria-label="{{'Unshared' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
+                    <span ng-switch-when="scan-waiting"><span class="hidden-xs" translate>Waiting to Scan</span><span class="visible-xs" aria-label="{{'Waiting to Scan' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span></span>
+                    <span ng-switch-when="cleaning"><span class="hidden-xs" translate>Cleaning Versions</span><span class="visible-xs" aria-label="{{'Cleaning Versions' | translate}}"><i class="fas fa-fw fa-recycle"></i></span></span>
+                    <span ng-switch-when="clean-waiting"><span class="hidden-xs" translate>Waiting to Clean</span><span class="visible-xs" aria-label="{{'Waiting to Clean' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span></span>
+                    <span ng-switch-when="stopped"><span class="hidden-xs" translate>Stopped</span><span class="visible-xs" aria-label="{{'Stopped' | translate}}"><i class="fas fa-fw fa-stop"></i></span></span>
+                    <span ng-switch-when="scanning">
+                      <span class="hidden-xs" translate>Scanning</span>
+                      <span class="hidden-xs" ng-if="scanPercentage(folder.id) != undefined">
+                        ({{scanPercentage(folder.id) | percent}})
+                      </span>
+                      <span class="visible-xs" aria-label="{{'Scanning' | translate}}"><i class="fas fa-fw fa-search"></i></span>
+                    </span>
+                    <span ng-switch-when="idle"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs" aria-label="{{'Up to Date' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
+                    <span ng-switch-when="localadditions"><span class="hidden-xs" translate>Local Additions</span><span class="visible-xs" aria-label="{{'Local Additions' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
+                    <span ng-switch-when="sync-waiting">
+                      <span class="hidden-xs" translate>Waiting to Sync</span>
+                      <span class="visible-xs" aria-label="{{'Waiting to Sync' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span>
+                    </span>
+                    <span ng-switch-when="sync-preparing">
+                      <span class="hidden-xs" translate>Preparing to Sync</span>
+                      <span class="visible-xs" aria-label="{{'Preparing to Sync' | translate}}"><i class="fas fa-fw fa-hourglass-half"></i></span>
+                    </span>
+                    <span ng-switch-when="syncing">
+                      <span class="hidden-xs" translate>Syncing</span>
+                      <span>({{syncPercentage(folder.id) | percent}}, {{model[folder.id].needBytes | binary}}B)</span>
+                    </span>
+                    <span ng-switch-when="outofsync"><span class="hidden-xs" translate>Out of Sync</span><span class="visible-xs" aria-label="{{'Out of Sync' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
+                    <span ng-switch-when="faileditems"><span class="hidden-xs" translate>Failed Items</span><span class="visible-xs" aria-label="{{'Failed Items' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
+                  </div>
+                  <div class="panel-title-text">
+                    <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>
+                  </div>
+                </h4>
+              </button>
+              <div id="folder-{{$index}}" class="panel-collapse collapse">
+                <div class="panel-body">
+                  <table class="table table-condensed table-striped table-auto">
+                    <tbody>
+                      <tr ng-show="folder.label != undefined && folder.label.length > 0">
+                        <th><span class="fas fa-fw fa-info-circle"></span>&nbsp;<span translate>Folder ID</span></th>
+                        <td class="text-right no-overflow-ellipse">{{folder.id}}</td>
+                      </tr>
+                      <tr>
+                        <th><span class="fas fa-fw fa-folder-open"></span>&nbsp;<span translate>Folder Path</span></th>
+                        <td class="text-right">
+                          <span tooltip data-original-title="{{folder.path}}">{{folder.path}}</span>
+                        </td>
+                      </tr>
+                      <tr ng-if="!folder.paused && (model[folder.id].invalid || model[folder.id].error)">
+                        <th><span class="fas fa-fw fa-exclamation-triangle"></span>&nbsp;<span translate>Error</span></th>
+                        <td class="text-right">{{model[folder.id].invalid || model[folder.id].error}}</td>
+                      </tr>
+                      <tr ng-if="!folder.paused">
+                        <th><span class="fas fa-fw fa-globe"></span>&nbsp;<span translate>Global State</span></th>
+                        <td class="text-right">
+                          <span tooltip data-original-title="{{model[folder.id].globalFiles | alwaysNumber | localeNumber}} {{'files' | translate}}, {{model[folder.id].globalDirectories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{model[folder.id].globalBytes | binary}}B">
+                            <span class="far fa-copy"></span>&nbsp;{{model[folder.id].globalFiles | alwaysNumber | localeNumber}}&ensp;
+                            <span class="far fa-folder"></span>&nbsp;{{model[folder.id].globalDirectories | alwaysNumber | localeNumber}}&ensp;
+                            <span class="far fa-hdd"></span>&nbsp;~{{model[folder.id].globalBytes | binary}}B
+                          </span>
+                        </td>
+                      </tr>
+                      <tr ng-if="!folder.paused">
+                        <th><span class="fas fa-fw fa-home"></span>&nbsp;<span translate>Local State</span></th>
+                        <td class="text-right">
+                          <span tooltip data-original-title="{{model[folder.id].localFiles | alwaysNumber | localeNumber}} {{'files' | translate}}, {{model[folder.id].localDirectories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{model[folder.id].localBytes | binary}}B">
+                            <span class="far fa-copy"></span>&nbsp;{{model[folder.id].localFiles | alwaysNumber | localeNumber}}&ensp;
+                            <span class="far fa-folder"></span>&nbsp;{{model[folder.id].localDirectories | alwaysNumber | localeNumber}}&ensp;
+                            <span class="far fa-hdd"></span>&nbsp;~{{model[folder.id].localBytes | binary}}B<!-- get rid of the annoying trailing whitespace
+                            --><span ng-if="model[folder.id].ignorePatterns"><br/><i><small translate class="text-muted">Reduced by ignore patterns</small></i></span>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr ng-if="model[folder.id].needTotalItems > 0">
+                        <th><span class="fas fa-fw fa-cloud-download-alt"></span>&nbsp;<span translate>Out of Sync Items</span></th>
+                        <td class="text-right">
+                          <a href="" ng-click="showNeed(folder.id)">{{model[folder.id].needTotalItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{model[folder.id].needBytes | binary}}B</a>
+                        </td>
+                      </tr>
+                      <tr ng-if="folderStatus(folder) === 'scanning' && scanRate(folder.id) > 0">
+                        <th><span class="fas fa-fw fa-hourglass-half"></span>&nbsp;<span translate>Scan Time Remaining</span></th>
+                        <td class="text-right">
+                          <span tooltip data-original-title="{{scanRate(folder.id) | binary}}B/s">~ {{scanRemaining(folder.id)}}</span>
+                        </td>
+                      </tr>
+                      <tr ng-if="hasFailedFiles(folder.id)">
+                        <th><span class="fas fa-fw fa-exclamation-circle"></span>&nbsp;<span translate>Failed Items</span></th>
+                        <!-- Show the number of failed items as a link to bring up the list. -->
+                        <td class="text-right">
+                          <a href="" ng-click="showFailed(folder.id)">{{model[folder.id].pullErrors | alwaysNumber | localeNumber}}&nbsp;<span translate>items</span></a>
+                        </td>
+                      </tr>
+                      <tr ng-if="folder.type == 'receiveonly' && canRevert(folder.id)">
+                        <th><span class="fas fa-fw fa-exclamation-circle"></span>&nbsp;<span translate>Locally Changed Items</span></th>
+                        <td class="text-right">
+                          <a href="" ng-click="showLocalChanged(folder.id)">{{model[folder.id].receiveOnlyTotalItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{model[folder.id].receiveOnlyChangedBytes | binary}}B</a>
+                        </td>
+                      </tr>
+                      <tr ng-if="folder.type != 'sendreceive'">
+                        <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folder Type</span></th>
+                        <td class="text-right">
+                          <span ng-if="folder.type == 'sendonly'" translate>Send Only</span>
+                          <span ng-if="folder.type == 'receiveonly'" translate>Receive Only</span>
+                        </td>
+                      </tr>
+                      <tr ng-if="folder.ignorePerms">
+                        <th><span class="far fa-fw fa-minus-square"></span>&nbsp;<span translate>Ignore Permissions</span></th>
+                        <td class="text-right">
+                          <span translate>Yes</span>
+                        </td>
+                      </tr>
+                      <tr>
+                        <th><span class="fas fa-fw fa-refresh"></span>&nbsp;<span translate>Rescans</span></th>
+                        <td class="text-right">
+                          <div ng-if="folder.rescanIntervalS > 0">
+                            <span ng-if="!folder.fsWatcherEnabled" tooltip data-original-title="{{'Periodic scanning at given interval and disabled watching for changes' | translate}}">
+                              <span class="far fa-clock"></span>&nbsp;{{folder.rescanIntervalS | duration}}&ensp;
+                              <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Disabled</span>
+                            </span>
+                            <span ng-if="folder.fsWatcherEnabled && (!model[folder.id].watchError || folder.paused || folderStatus(folder) === 'stopped')" tooltip data-original-title="{{'Periodic scanning at given interval and enabled watching for changes' | translate}}">
+                              <span class="far fa-clock"></span>&nbsp;{{folder.rescanIntervalS | duration}}&ensp;
+                              <span class="fas fa-eye"></span>&nbsp;<span translate>Enabled</span>
+                            </span>
+                            <span ng-if="folder.fsWatcherEnabled && !folder.paused && folderStatus(folder) !== 'stopped' && model[folder.id].watchError" tooltip data-original-title="{{'Periodic scanning at given interval and failed setting up watching for changes, retrying every 1m:' | translate}}<br/>{{model[folder.id].watchError}}">
+                              <span class="far fa-clock"></span>&nbsp;{{folder.rescanIntervalS | duration}}&ensp;
+                              <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Failed to setup, retrying</span>
+                            </span>
+                          </div>
+                          <div ng-if="folder.rescanIntervalS <= 0">
+                            <span ng-if="!folder.fsWatcherEnabled" tooltip data-original-title="{{'Disabled periodic scanning and disabled watching for changes' | translate}}">
+                              <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
+                              <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Disabled</span>
+                            </span>
+                            <span ng-if="folder.fsWatcherEnabled && (!model[folder.id].watchError || folder.paused || folderStatus(folder) === 'stopped')" tooltip data-original-title="{{'Disabled periodic scanning and enabled watching for changes' | translate}}">
+                              <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
+                              <span class="fas fa-eye"></span>&nbsp;<span translate>Enabled</span>
+                            </span>
+                            <span ng-if="folder.fsWatcherEnabled && !folder.paused && folderStatus(folder) !== 'stopped' && model[folder.id].watchError" tooltip data-original-title="{{'Disabled periodic scanning and failed setting up watching for changes, retrying every 1m:' | translate}}<br/>{{model[folder.id].watchError}}">
+                              <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
+                              <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Failed to setup, retrying</span>
+                            </span>
+                          </div>
+                        </td>
+                      </tr>
+                      <tr ng-if="folder.order != 'random' && folder.type != 'sendonly'">
+                        <th><span class="fas fa-fw fa-sort"></span>&nbsp;<span translate>File Pull Order</span></th>
+                        <td class="text-right" ng-switch="folder.order">
+                          <span ng-switch-when="random" translate>Random</span>
+                          <span ng-switch-when="alphabetic" translate>Alphabetic</span>
+                          <span ng-switch-when="smallestFirst" translate>Smallest First</span>
+                          <span ng-switch-when="largestFirst" translate>Largest First</span>
+                          <span ng-switch-when="oldestFirst" translate>Oldest First</span>
+                          <span ng-switch-when="newestFirst" translate>Newest First</span>
+                        </td>
+                      </tr>
+                      <tr ng-if="folder.versioning.type">
+                        <th><span class="far fa-fw fa-copy"></span>&nbsp;<span translate>File Versioning</span></th>
+                        <td class="text-right" ng-switch="folder.versioning.type">
+                          <span ng-switch-when="trashcan" translate>Trash Can File Versioning</span>
+                          <span ng-switch-when="staggered" translate>Staggered File Versioning</span>
+                          <span ng-switch-when="simple" translate>Simple File Versioning</span>
+                          <span ng-switch-when="external" translate>External File Versioning</span>
+                        </td>
+                      </tr>
+                      <tr>
+                        <th><span class="fas fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span></th>
+                        <td class="text-right" ng-attr-title="{{sharesFolder(folder)}}">{{sharesFolder(folder)}}</td>
+                      </tr>
+                      <tr ng-if="folderStats[folder.id].lastScan">
+                        <th><span class="far fa-fw fa-clock"></span>&nbsp;<span translate>Last Scan</span></th>
+                        <td translate ng-if="folderStats[folder.id].lastScanDays >= 365" class="text-right">Never</td>
+                        <td ng-if="folderStats[folder.id].lastScanDays < 365" class="text-right">
+                          <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
+                        </td>
+                      </tr>
+                      <tr ng-if="folder.type != 'sendonly' && folderStats[folder.id].lastFile && folderStats[folder.id].lastFile.filename">
+                        <th><span class="fas fa-fw fa-exchange-alt"></span>&nbsp;<span translate>Latest Change</span></th>
+                        <td class="text-right">
+                          <span tooltip data-original-title="{{folderStats[folder.id].lastFile.filename}} @ {{folderStats[folder.id].lastFile.at | date:'yyyy-MM-dd HH:mm:ss'}}">
+                            <span translate ng-if="!folderStats[folder.id].lastFile.deleted">Updated</span>
+                            <span translate ng-if="folderStats[folder.id].lastFile.deleted">Deleted</span>
+                            {{folderStats[folder.id].lastFile.filename | basename}}
+                          </span>
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div class="panel-footer">
+                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="override(folder.id)" ng-if="folderStatus(folder) == 'outofsync' && folder.type == 'sendonly'">
+                    <span class="fas fa-arrow-circle-up"></span>&nbsp;<span translate>Override Changes</span>
+                  </button>
+                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revert(folder.id)" ng-if="canRevert(folder.id)">
+                    <span class="fa fa-arrow-circle-down"></span>&nbsp;<span translate>Revert Local Changes</span>
+                  </button>
+                  <span class="pull-right">
+                    <button ng-if="!folder.paused" type="button" class="btn btn-sm btn-default" ng-click="setFolderPause(folder.id, true)">
+                      <span class="fas fa-pause"></span>&nbsp;<span translate>Pause</span>
+                    </button>
+                    <button ng-if="folder.paused" type="button" class="btn btn-sm btn-default" ng-click="setFolderPause(folder.id, false)">
+                      <span class="fas fa-play"></span>&nbsp;<span translate>Resume</span>
+                    </button>
+                    <button type="button" class="btn btn-default btn-sm" ng-click="restoreVersions.show(folder.id)" ng-if="folder.versioning.type">
+                      <span class="fas fa-undo"></span>&nbsp;<span translate>Versions</span>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-disabled="['idle', 'stopped', 'unshared', 'outofsync', 'faileditems', 'localadditions'].indexOf(folderStatus(folder)) < 0">
+                      <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan</span>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-default" ng-click="editFolder(folder)">
+                      <span class="fas fa-pencil-alt"></span>&nbsp;<span translate>Edit</span>
+                    </button>
+                  </span>
+                  <div class="clearfix"></div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <span class="pull-right">
+            <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(true)" ng-if="isAtleastOneFolderPausedStateSetTo(false)">
+              <span class="fas fa-pause"></span>&nbsp;<span translate>Pause All</span>
+            </button>
+            <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
+              <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
+            </button>
+            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()">
+              <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
+            </button>
+            <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">
+              <span class="fas fa-plus"></span>&nbsp;<span translate>Add Folder</span>
+            </button>
+          </span>
+          <div class="clearfix"></div>
+          <hr class="visible-sm"/>
+        </div>
+
+        <!-- Device list (top right) -->
+
+        <!-- This device -->
+
+        <div class="col-md-6" aria-label="{{'Devices' | translate}}" role="region">
+          <h3 translate>This Device</h3>
+          <div class="panel panel-default" ng-repeat="deviceCfg in [thisDevice()]">
+            <button class="btn panel-heading" data-toggle="collapse" data-target="#device-this" aria-expanded="true">
               <h4 class="panel-title">
                 <identicon class="panel-icon" data-value="deviceCfg.deviceID"></identicon>
-                <span ng-switch="deviceStatus(deviceCfg)" class="pull-right text-{{deviceClass(deviceCfg)}}">
-                  <span ng-switch-when="insync"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs" aria-label="{{'Up to Date' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
-                  <span ng-switch-when="unused-insync"><span class="hidden-xs" translate>Connected (Unused)</span><span class="visible-xs" aria-label="{{'Connected (Unused)' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
-                  <span ng-switch-when="syncing">
-                    <span class="hidden-xs" translate>Syncing</span> ({{completion[deviceCfg.deviceID]._total | percent}}, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
-                  </span>
-                  <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs" aria-label="{{'Paused' | translate}}"><i class="fas fa-fw fa-pause"></i></span></span>
-                  <span ng-switch-when="unused-paused"><span class="hidden-xs" translate>Paused (Unused)</span><span class="visible-xs" aria-label="{{'Paused (Unused)' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
-                  <span ng-switch-when="disconnected"><span class="hidden-xs" translate>Disconnected</span><span class="visible-xs" aria-label="{{'Disconnected' | translate}}"><i class="fas fa-fw fa-power-off"></i></span></span>
-                  <span ng-switch-when="unused-disconnected"><span class="hidden-xs" translate>Disconnected (Unused)</span><span class="visible-xs" aria-label="{{'Disconnected (Unused)' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
-                </span>
-                <span>{{deviceName(deviceCfg)}}</span>
+                <div class="panel-title-text">{{deviceName(deviceCfg)}}</div>
               </h4>
             </button>
-            <div id="device-{{$index}}" class="panel-collapse collapse">
+            <div id="device-this" class="panel-collapse collapse in">
               <div class="panel-body">
                 <table class="table table-condensed table-striped table-auto">
                   <tbody>
-                    <tr ng-if="connections[deviceCfg.deviceID].connected">
+                    <tr>
                       <th><span class="fas fa-fw fa-cloud-download-alt"></span>&nbsp;<span translate>Download Rate</span></th>
                       <td class="text-right">
                         <a href="#" class="toggler" ng-click="toggleUnits()">
-                          <span ng-if="!metricRates">{{connections[deviceCfg.deviceID].inbps | binary}}B/s</span>
-                          <span ng-if="metricRates">{{connections[deviceCfg.deviceID].inbps*8 | metric}}bps</span>
-                          ({{connections[deviceCfg.deviceID].inBytesTotal | binary}}B)
-                          <small ng-if="deviceCfg.maxRecvKbps > 0"><br/>
+                          <span ng-if="!metricRates">{{connectionsTotal.inbps | binary}}B/s</span>
+                          <span ng-if="metricRates">{{connectionsTotal.inbps*8 | metric}}bps</span>
+                          ({{connectionsTotal.inBytesTotal | binary}}B)
+                          <small ng-if="config.options.maxRecvKbps > 0"><br/>
                             <i class="text-muted"><span translate>Limit</span>:
-                              <span ng-if="!metricRates">{{deviceCfg.maxRecvKbps*1024 | binary}}B/s</span>
-                              <span ng-if="metricRates">{{deviceCfg.maxRecvKbps*1024*8 | metric}}bps</span>
+                              <span ng-if="!metricRates">{{config.options.maxRecvKbps*1024 | binary}}B/s</span>
+                              <span ng-if="metricRates">{{config.options.maxRecvKbps*1024*8 | metric}}bps</span>
                             </i>
                           </small>
                         </a>
-                      </td>
-                    </tr>
-                    <tr ng-if="connections[deviceCfg.deviceID].connected">
-                      <th><span class="fas fa-fw fa-cloud-upload-alt"></span>&nbsp;<span translate>Upload Rate</span></th>
-                      <td class="text-right">
-                        <a href="#" class="toggler" ng-click="toggleUnits()">
-                          <span ng-if="!metricRates">{{connections[deviceCfg.deviceID].outbps | binary}}B/s</span>
-                          <span ng-if="metricRates">{{connections[deviceCfg.deviceID].outbps*8 | metric}}bps</span>
-                          ({{connections[deviceCfg.deviceID].outBytesTotal | binary}}B)
-                          <small ng-if="deviceCfg.maxSendKbps > 0"><br/>
-                            <i class="text-muted"><span translate>Limit</span>:
-                              <span ng-if="!metricRates">{{deviceCfg.maxSendKbps*1024 | binary}}B/s</span>
-                              <span ng-if="metricRates">{{deviceCfg.maxSendKbps*1024*8 | metric}}bps</span>
-                            </i>
-                          </small>
-                        </a>
-                      </td>
-                    </tr>
-                    <tr ng-if="deviceStatus(deviceCfg) == 'syncing'">
-                      <th><span class="fas fa-fw fa-exchange-alt"></span>&nbsp;<span translate>Out of Sync Items</span></th>
-                      <td class="text-right">
-                        <a href="" ng-click="showRemoteNeed(deviceCfg)">{{completion[deviceCfg.deviceID]._needItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{completion[deviceCfg.deviceID]._needBytes | binary}}B</a>
                       </td>
                     </tr>
                     <tr>
-                      <th><span class="fas fa-fw fa-link"></span>&nbsp<span translate>Address</span></th>
-                      <td ng-if="connections[deviceCfg.deviceID].connected" class="text-right">
-                        <span tooltip data-original-title="{{ connections[deviceCfg.deviceID].type.indexOf('Relay') > -1 ? '' : connections[deviceCfg.deviceID].type }} {{ connections[deviceCfg.deviceID].crypto }}">
-                          {{deviceAddr(deviceCfg)}}
-                        </span>
-                      </td>
-                      <td ng-if="!connections[deviceCfg.deviceID].connected" class="text-right">
-                        <span ng-repeat="addr in deviceCfg.addresses">
-                            <span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br>
-                            <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
-                        </span>
-                        <span ng-repeat="addr in discoveryCache[deviceCfg.deviceID].addresses">
-                          <span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br>
-                          <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
-                        </span>
-                      </td>
-                    </tr>
-                    <tr ng-if="connections[deviceCfg.deviceID].connected && connections[deviceCfg.deviceID].type.indexOf('Relay') > -1" tooltip data-original-title="Connections via relays might be rate limited by the relay">
-                      <th><span class="fas fa-fw fa-exclamation-triangle text-danger"></span>&nbsp;<span translate>Connection Type</span></th>
-                      <td class="text-right">{{connections[deviceCfg.deviceID].type}}</td>
-                    </tr>
-                    <tr ng-if="deviceCfg.allowedNetworks.length > 0">
-                      <th><span class="fas fa-fw fa-filter"></span>&nbsp;<span translate>Allowed Networks</span></th>
+                      <th><span class="fas fa-fw fa-cloud-upload-alt"></span>&nbsp;<span translate>Upload Rate</span></th>
                       <td class="text-right">
-                        <span>{{deviceCfg.allowedNetworks.join(", ")}}</span>
+                        <a href="#" class="toggler" ng-click="toggleUnits()">
+                          <span ng-if="!metricRates">{{connectionsTotal.outbps | binary}}B/s</span>
+                          <span ng-if="metricRates">{{connectionsTotal.outbps*8 | metric}}bps</span>
+                          ({{connectionsTotal.outBytesTotal | binary}}B)
+                          <small ng-if="config.options.maxSendKbps > 0"><br/>
+                            <i class="text-muted"><span translate>Limit</span>:
+                              <span ng-if="!metricRates">{{config.options.maxSendKbps*1024 | binary}}B/s</span>
+                              <span ng-if="metricRates">{{config.options.maxSendKbps*1024*8 | metric}}bps</span>
+                            </i>
+                          </small>
+                        </a>
                       </td>
                     </tr>
-                    <tr ng-if="deviceCfg.compression != 'metadata'">
-                      <th><span class="fas fa-fw fa-compress"></span>&nbsp;<span translate>Compression</span></th>
+                    <tr>
+                      <th><span class="fas fa-fw fa-home"></span>&nbsp;<span translate>Local State (Total)</span></th>
                       <td class="text-right">
-                        <span ng-if="deviceCfg.compression == 'always'" translate>All Data</span>
-                        <span ng-if="deviceCfg.compression == 'never'" translate>Off</span>
+                          <span tooltip data-original-title="{{localStateTotal.files | alwaysNumber | localeNumber}} {{'files' | translate}}, {{ localStateTotal.directories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{ localStateTotal.bytes | binary}}B">
+                            <span class="far fa-copy"></span>&nbsp;{{localStateTotal.files | alwaysNumber | localeNumber}}&ensp;
+                            <span class="far fa-folder"></span>&nbsp;{{localStateTotal.directories| alwaysNumber | localeNumber}}&ensp;
+                            <span class="far fa-hdd"></span>&nbsp;~{{localStateTotal.bytes | binary}}B
+                          </span>
                       </td>
                     </tr>
-                    <tr ng-if="deviceCfg.introducer">
-                      <th><span class="far fa-fw fa-thumbs-up"></span>&nbsp;<span translate>Introducer</span></th>
-                      <td translate class="text-right">Yes</td>
+                    <tr>
+                      <th><span class="fas fa-fw fa-sitemap"></span>&nbsp;<span translate>Listeners</span></th>
+                      <td class="text-right">
+                        <span ng-if="listenersFailed.length == 0" class="data text-success">
+                          <span>{{listenersTotal}}/{{listenersTotal}}</span>
+                        </span>
+                        <span ng-if="listenersFailed.length != 0" class="data" ng-class="{'text-danger': listenersFailed.length == listenersTotal}">
+                          <span popover data-trigger="hover" data-placement="bottom" data-html="true" data-content="{{listenersFailed.join('<br>\n')}}">
+                            {{listenersTotal-listenersFailed.length}}/{{listenersTotal}}
+                          </span>
+                        </span>
+                      </td>
                     </tr>
-                    <tr ng-if="deviceCfg.introducedBy">
-                      <th><span class="far fa-fw fa-handshake-o"></span>&nbsp;<span translate>Introduced By</span></th>
-                      <td class="text-right">{{ deviceName(devices[deviceCfg.introducedBy]) || deviceCfg.introducedBy.substring(0, 5) }}</td>
+                    <tr ng-if="system.discoveryEnabled">
+                      <th><span class="fas fa-fw fa-map-signs"></span>&nbsp;<span translate>Discovery</span></th>
+                      <td class="text-right">
+                        <span ng-if="discoveryFailed.length == 0" class="data text-success">
+                          <span>{{discoveryTotal}}/{{discoveryTotal}}</span>
+                        </span>
+                        <span ng-if="discoveryFailed.length != 0" class="data" ng-class="{'text-danger': discoveryFailed.length == discoveryTotal}">
+                          <span popover data-trigger="hover" data-placement="bottom" data-content="{{'Click to see discovery failures' | translate}}.">
+                            <a href="" style="color:inherit" ng-click="showDiscoveryFailures()">{{discoveryTotal-discoveryFailed.length}}/{{discoveryTotal}}</a>
+                          </span>
+                        </span>
+                      </td>
                     </tr>
-                    <tr ng-if="connections[deviceCfg.deviceID].clientVersion">
+                    <tr>
+                      <th><span class="far fa-fw fa-clock"></span>&nbsp;<span translate>Uptime</span></th>
+                      <td class="text-right">{{system.uptime | duration:"m"}}</td>
+                    </tr>
+                    <tr>
                       <th><span class="fas fa-fw fa-tag"></span>&nbsp;<span translate>Version</span></th>
-                      <td class="text-right">{{connections[deviceCfg.deviceID].clientVersion}}</td>
-                    </tr>
-                    <tr ng-if="!connections[deviceCfg.deviceID].connected">
-                      <th><span class="fas fa-fw fa-eye"></span>&nbsp;<span translate>Last seen</span></th>
-                      <td translate ng-if="!deviceStats[deviceCfg.deviceID].lastSeenDays || deviceStats[deviceCfg.deviceID].lastSeenDays >= 365" class="text-right">Never</td>
-                      <td ng-if="deviceStats[deviceCfg.deviceID].lastSeenDays < 365" class="text-right">{{deviceStats[deviceCfg.deviceID].lastSeen | date:"yyyy-MM-dd HH:mm:ss"}}</td>
-                    </tr>
-                    <tr ng-if="deviceFolders(deviceCfg).length > 0">
-                      <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folders</span></th>
-                      <td class="text-right" ng-attr-title="{{deviceFolders(deviceCfg).map(folderLabel).join(', ')}}">{{deviceFolders(deviceCfg).map(folderLabel).join(", ")}}</td>
+                      <td class="text-right">
+                        <span tooltip data-original-title="{{versionString()}}">{{versionString()}}</span>
+                      </td>
                     </tr>
                   </tbody>
                 </table>
               </div>
-              <div class="panel-footer">
-                <span class="pull-right">
-                  <button ng-if="!deviceCfg.paused" type="button" class="btn btn-sm btn-default" ng-click="setDevicePause(deviceCfg.deviceID, true)">
-                    <span class="fas fa-pause"></span>&nbsp;<span translate>Pause</span>
-                  </button>
-                  <button ng-if="deviceCfg.paused" type="button" class="btn btn-sm btn-default" ng-click="setDevicePause(deviceCfg.deviceID, false)">
-                    <span class="fas fa-play"></span>&nbsp;<span translate>Resume</span>
-                  </button>
-                  <button type="button" class="btn btn-sm btn-default" ng-click="editDevice(deviceCfg)">
-                    <span class="fas fa-pencil-alt"></span>&nbsp;<span translate>Edit</span>
-                  </button>
-                </span>
-                <div class="clearfix"></div>
+            </div>
+          </div>
+
+          <!-- Remote devices -->
+          <h3 translate>Remote Devices</h3>
+          <div class="panel-group" id="devices">
+            <div class="panel panel-default" ng-repeat="deviceCfg in otherDevices()">
+              <button class="btn panel-heading" data-toggle="collapse" data-parent="#devices" data-target="#device-{{$index}}" aria-expanded="false">
+                <div class="panel-progress" ng-show="deviceStatus(deviceCfg) == 'syncing'" ng-attr-style="width: {{completion[deviceCfg.deviceID]._total | percent}}"></div>
+                <h4 class="panel-title">
+                  <identicon class="panel-icon" data-value="deviceCfg.deviceID"></identicon>
+                  <span ng-switch="deviceStatus(deviceCfg)" class="pull-right text-{{deviceClass(deviceCfg)}}">
+                    <span ng-switch-when="insync"><span class="hidden-xs" translate>Up to Date</span><span class="visible-xs" aria-label="{{'Up to Date' | translate}}"><i class="fas fa-fw fa-check"></i></span></span>
+                    <span ng-switch-when="unused-insync"><span class="hidden-xs" translate>Connected (Unused)</span><span class="visible-xs" aria-label="{{'Connected (Unused)' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
+                    <span ng-switch-when="syncing">
+                      <span class="hidden-xs" translate>Syncing</span> ({{completion[deviceCfg.deviceID]._total | percent}}, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
+                    </span>
+                    <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs" aria-label="{{'Paused' | translate}}"><i class="fas fa-fw fa-pause"></i></span></span>
+                    <span ng-switch-when="unused-paused"><span class="hidden-xs" translate>Paused (Unused)</span><span class="visible-xs" aria-label="{{'Paused (Unused)' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
+                    <span ng-switch-when="disconnected"><span class="hidden-xs" translate>Disconnected</span><span class="visible-xs" aria-label="{{'Disconnected' | translate}}"><i class="fas fa-fw fa-power-off"></i></span></span>
+                    <span ng-switch-when="unused-disconnected"><span class="hidden-xs" translate>Disconnected (Unused)</span><span class="visible-xs" aria-label="{{'Disconnected (Unused)' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
+                  </span>
+                  <span>{{deviceName(deviceCfg)}}</span>
+                </h4>
+              </button>
+              <div id="device-{{$index}}" class="panel-collapse collapse">
+                <div class="panel-body">
+                  <table class="table table-condensed table-striped table-auto">
+                    <tbody>
+                      <tr ng-if="connections[deviceCfg.deviceID].connected">
+                        <th><span class="fas fa-fw fa-cloud-download-alt"></span>&nbsp;<span translate>Download Rate</span></th>
+                        <td class="text-right">
+                          <a href="#" class="toggler" ng-click="toggleUnits()">
+                            <span ng-if="!metricRates">{{connections[deviceCfg.deviceID].inbps | binary}}B/s</span>
+                            <span ng-if="metricRates">{{connections[deviceCfg.deviceID].inbps*8 | metric}}bps</span>
+                            ({{connections[deviceCfg.deviceID].inBytesTotal | binary}}B)
+                            <small ng-if="deviceCfg.maxRecvKbps > 0"><br/>
+                              <i class="text-muted"><span translate>Limit</span>:
+                                <span ng-if="!metricRates">{{deviceCfg.maxRecvKbps*1024 | binary}}B/s</span>
+                                <span ng-if="metricRates">{{deviceCfg.maxRecvKbps*1024*8 | metric}}bps</span>
+                              </i>
+                            </small>
+                          </a>
+                        </td>
+                      </tr>
+                      <tr ng-if="connections[deviceCfg.deviceID].connected">
+                        <th><span class="fas fa-fw fa-cloud-upload-alt"></span>&nbsp;<span translate>Upload Rate</span></th>
+                        <td class="text-right">
+                          <a href="#" class="toggler" ng-click="toggleUnits()">
+                            <span ng-if="!metricRates">{{connections[deviceCfg.deviceID].outbps | binary}}B/s</span>
+                            <span ng-if="metricRates">{{connections[deviceCfg.deviceID].outbps*8 | metric}}bps</span>
+                            ({{connections[deviceCfg.deviceID].outBytesTotal | binary}}B)
+                            <small ng-if="deviceCfg.maxSendKbps > 0"><br/>
+                              <i class="text-muted"><span translate>Limit</span>:
+                                <span ng-if="!metricRates">{{deviceCfg.maxSendKbps*1024 | binary}}B/s</span>
+                                <span ng-if="metricRates">{{deviceCfg.maxSendKbps*1024*8 | metric}}bps</span>
+                              </i>
+                            </small>
+                          </a>
+                        </td>
+                      </tr>
+                      <tr ng-if="deviceStatus(deviceCfg) == 'syncing'">
+                        <th><span class="fas fa-fw fa-exchange-alt"></span>&nbsp;<span translate>Out of Sync Items</span></th>
+                        <td class="text-right">
+                          <a href="" ng-click="showRemoteNeed(deviceCfg)">{{completion[deviceCfg.deviceID]._needItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{completion[deviceCfg.deviceID]._needBytes | binary}}B</a>
+                        </td>
+                      </tr>
+                      <tr>
+                        <th><span class="fas fa-fw fa-link"></span>&nbsp<span translate>Address</span></th>
+                        <td ng-if="connections[deviceCfg.deviceID].connected" class="text-right">
+                          <span tooltip data-original-title="{{ connections[deviceCfg.deviceID].type.indexOf('Relay') > -1 ? '' : connections[deviceCfg.deviceID].type }} {{ connections[deviceCfg.deviceID].crypto }}">
+                            {{deviceAddr(deviceCfg)}}
+                          </span>
+                        </td>
+                        <td ng-if="!connections[deviceCfg.deviceID].connected" class="text-right">
+                          <span ng-repeat="addr in deviceCfg.addresses">
+                              <span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br>
+                              <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
+                          </span>
+                          <span ng-repeat="addr in discoveryCache[deviceCfg.deviceID].addresses">
+                            <span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br>
+                            <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
+                          </span>
+                        </td>
+                      </tr>
+                      <tr ng-if="connections[deviceCfg.deviceID].connected && connections[deviceCfg.deviceID].type.indexOf('Relay') > -1" tooltip data-original-title="Connections via relays might be rate limited by the relay">
+                        <th><span class="fas fa-fw fa-exclamation-triangle text-danger"></span>&nbsp;<span translate>Connection Type</span></th>
+                        <td class="text-right">{{connections[deviceCfg.deviceID].type}}</td>
+                      </tr>
+                      <tr ng-if="deviceCfg.allowedNetworks.length > 0">
+                        <th><span class="fas fa-fw fa-filter"></span>&nbsp;<span translate>Allowed Networks</span></th>
+                        <td class="text-right">
+                          <span>{{deviceCfg.allowedNetworks.join(", ")}}</span>
+                        </td>
+                      </tr>
+                      <tr ng-if="deviceCfg.compression != 'metadata'">
+                        <th><span class="fas fa-fw fa-compress"></span>&nbsp;<span translate>Compression</span></th>
+                        <td class="text-right">
+                          <span ng-if="deviceCfg.compression == 'always'" translate>All Data</span>
+                          <span ng-if="deviceCfg.compression == 'never'" translate>Off</span>
+                        </td>
+                      </tr>
+                      <tr ng-if="deviceCfg.introducer">
+                        <th><span class="far fa-fw fa-thumbs-up"></span>&nbsp;<span translate>Introducer</span></th>
+                        <td translate class="text-right">Yes</td>
+                      </tr>
+                      <tr ng-if="deviceCfg.introducedBy">
+                        <th><span class="far fa-fw fa-handshake-o"></span>&nbsp;<span translate>Introduced By</span></th>
+                        <td class="text-right">{{ deviceName(devices[deviceCfg.introducedBy]) || deviceCfg.introducedBy.substring(0, 5) }}</td>
+                      </tr>
+                      <tr ng-if="connections[deviceCfg.deviceID].clientVersion">
+                        <th><span class="fas fa-fw fa-tag"></span>&nbsp;<span translate>Version</span></th>
+                        <td class="text-right">{{connections[deviceCfg.deviceID].clientVersion}}</td>
+                      </tr>
+                      <tr ng-if="!connections[deviceCfg.deviceID].connected">
+                        <th><span class="fas fa-fw fa-eye"></span>&nbsp;<span translate>Last seen</span></th>
+                        <td translate ng-if="!deviceStats[deviceCfg.deviceID].lastSeenDays || deviceStats[deviceCfg.deviceID].lastSeenDays >= 365" class="text-right">Never</td>
+                        <td ng-if="deviceStats[deviceCfg.deviceID].lastSeenDays < 365" class="text-right">{{deviceStats[deviceCfg.deviceID].lastSeen | date:"yyyy-MM-dd HH:mm:ss"}}</td>
+                      </tr>
+                      <tr ng-if="deviceFolders(deviceCfg).length > 0">
+                        <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folders</span></th>
+                        <td class="text-right" ng-attr-title="{{deviceFolders(deviceCfg).map(folderLabel).join(', ')}}">{{deviceFolders(deviceCfg).map(folderLabel).join(", ")}}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <div class="panel-footer">
+                  <span class="pull-right">
+                    <button ng-if="!deviceCfg.paused" type="button" class="btn btn-sm btn-default" ng-click="setDevicePause(deviceCfg.deviceID, true)">
+                      <span class="fas fa-pause"></span>&nbsp;<span translate>Pause</span>
+                    </button>
+                    <button ng-if="deviceCfg.paused" type="button" class="btn btn-sm btn-default" ng-click="setDevicePause(deviceCfg.deviceID, false)">
+                      <span class="fas fa-play"></span>&nbsp;<span translate>Resume</span>
+                    </button>
+                    <button type="button" class="btn btn-sm btn-default" ng-click="editDevice(deviceCfg)">
+                      <span class="fas fa-pencil-alt"></span>&nbsp;<span translate>Edit</span>
+                    </button>
+                  </span>
+                  <div class="clearfix"></div>
+                </div>
               </div>
             </div>
           </div>
+          <div class="form-group">
+            <span class="pull-right">
+              <button type="button" class="btn btn-sm btn-default" ng-click="setAllDevicesPause(true)" ng-if="isAtleastOneDevicePausedStateSetTo(false)">
+                <span class="fas fa-pause"></span>&nbsp;<span translate>Pause All</span>
+              </button>
+              <button type="button" class="btn btn-sm btn-default" ng-click="setAllDevicesPause(false)" ng-if="isAtleastOneDevicePausedStateSetTo(true)">
+                <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
+              </button>
+              <button type="button" class="btn btn-sm btn-default" ng-click="globalChanges()">
+                <span class="fas fa-fw fa-info-circle"></span>&nbsp;<span translate>Recent Changes</span>
+              </button>
+              <button type="button" class="btn btn-sm btn-default" ng-click="addDevice()">
+                <span class="fas fa-plus"></span>&nbsp;<span translate>Add Remote Device</span>
+              </button>
+            </span>
+            <div class="clearfix"></div>
+          </div>
         </div>
-        <div class="form-group">
-          <span class="pull-right">
-            <button type="button" class="btn btn-sm btn-default" ng-click="setAllDevicesPause(true)" ng-if="isAtleastOneDevicePausedStateSetTo(false)">
-              <span class="fas fa-pause"></span>&nbsp;<span translate>Pause All</span>
-            </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="setAllDevicesPause(false)" ng-if="isAtleastOneDevicePausedStateSetTo(true)">
-              <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
-            </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="globalChanges()">
-              <span class="fas fa-fw fa-info-circle"></span>&nbsp;<span translate>Recent Changes</span>
-            </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="addDevice()">
-              <span class="fas fa-plus"></span>&nbsp;<span translate>Add Remote Device</span>
-            </button>
-          </span>
-          <div class="clearfix"></div>
-        </div>
-      </div>
-    </div> <!-- /row -->
+      </div> <!-- /row -->
 
-  </div> <!-- /container -->
+    </div> <!-- /container -->
+  </div> <!-- /ng-cloak -->
 
   <!-- Bottom bar -->
 

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -53,7 +53,7 @@
             </div>
             <div class="panel-body">
               <p>
-              The Syncthing admin interface requires JavaScript. Please enable JavaScript in your Web browser and try again.
+              The Syncthing admin interface requires JavaScript. Please enable JavaScript in your web browser and try again.
               </p>
             </div>
           </div>


### PR DESCRIPTION
When using a Web browser with JavaScript either disabled or unavailable,
show a warning to let the user know that the Web GUI requires JS in
order to operate.

To achieve this, add a `div` that wraps both the navbar and the main
content, and then move the CSS class `ng-cloak` from the `html` element to
that `div`. This way, only the JavaScript-dependent part is hidden when
JS is unavailable, and not the whole website, as it is the case right
now. Then, add a `<noscript>` element right at the start of the `body`
element, so that the warning is also shown right away in text-based Web
browsers. The `noscript` element includes a stripped down version of the
navbar showing only the Syncthing logo, and then a container with the
warning itself. Lastly, leave the footer untouched and always visible,
because it does not rely on JavaScript at all.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>