### PR TITLE
gui: Initialise sharing when accepting new device (fixes #7113)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1535,6 +1535,7 @@ angular.module('syncthing.core')
                         ignoredFolders: []
                     };
                     $scope.editingExisting = false;
+                    initShareEditing('device');
                     $scope.deviceEditor.$setPristine();
                     $('#editDevice').modal();
                 });

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1556,6 +1556,7 @@ angular.module('syncthing.core')
                         ignoredFolders: []
                     };
                     $scope.editingExisting = false;
+                    initShareEditing('device');
                     $scope.deviceEditor.$setPristine();
                     $('#editDevice').modal();
                 });


### PR DESCRIPTION
I missed this code path in https://github.com/syncthing/syncthing/pull/7049

This affects the current RC.