### PR TITLE
lib/config: Use correct var in MaxConcurrentIncomingRequestKiB()

### DIFF
--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -127,7 +127,7 @@ func (opts OptionsConfiguration) MaxConcurrentIncomingRequestKiB() int {
 		return 0
 	}
 
-	if opts.RawMaxFolderConcurrency == 0 {
+	if opts.RawMaxCIRequestKiB == 0 {
 		// The default is 256 MiB
 		return 256 * 1024 // KiB
 	}


### PR DESCRIPTION
Somehow `RawMaxFolderConcurrency` sneaked its way into a method that's actually concerned with `RawMaxCIRequestKiB`.