### PR TITLE
gui: Remove erronous $ from scope in directive (fixes #7124)

### DIFF
--- a/gui/default/syncthing/core/validDeviceidDirective.js
+++ b/gui/default/syncthing/core/validDeviceidDirective.js
@@ -16,7 +16,7 @@ angular.module('syncthing.core')
                             }
                         });
                         //Prevents user from adding a duplicate ID
-                        if ($scope.devices.hasOwnProperty(viewValue)) {
+                        if (scope.devices.hasOwnProperty(viewValue)) {
                             ctrl.$setValidity('unique', false);
                         } else {
                             ctrl.$setValidity('unique', true);


### PR DESCRIPTION
Fixes #7124, which is a regression introduced in #7049. The function argument `scope` doesn't get a `$` here, while it does in the main controller - I don't know why that is, but I'd rather not touch it (as in add the `$` for consistency) and just fix the newly introduced code by removing the `$`.