### PR TITLE
lib/model, lib/util: Replace IsComplete with NoRestartErr (ref #6947)

### DIFF
--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -246,6 +246,31 @@ func (e *FatalErr) Is(target error) bool {
 	return target == suture.ErrTerminateSupervisorTree
 }
 
+// NoRestartErr wraps the given error err (which may be nil) to make sure that
+// `errors.Is(err, suture.ErrDoNotRestart) == true`.
+func NoRestartErr(err error) error {
+	if err == nil {
+		return suture.ErrDoNotRestart
+	}
+	return &noRestartErr{err}
+}
+
+type noRestartErr struct {
+	err error
+}
+
+func (e *noRestartErr) Error() string {
+	return e.err.Error()
+}
+
+func (e *noRestartErr) Unwrap() error {
+	return e.err
+}
+
+func (e *noRestartErr) Is(target error) bool {
+	return target == suture.ErrDoNotRestart
+}
+
 type ExitStatus int
 
 const (


### PR DESCRIPTION
In #6947 I missed that the `suture.IsComplete` interface has been removed in suture/v4. I replaced that with a function to wrap errors such that the returned error fulfils `errors.Is(err, suture.ErrDoNotRestart) == true`.

I discovered this while investigating https://forum.syncthing.net/t/device-stays-out-of-sync-until-restart/15891 - that's what the additional debug line is for.