### PR TITLE
lib/model: Never send unpaused folder without index info

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2194,7 +2194,6 @@ func (m *model) generateClusterConfig(device protocol.DeviceID) protocol.Cluster
 		// Even if we aren't paused, if we haven't started the folder yet
 		// pretend we are. Otherwise the remote might get confused about
 		// the missing index info (and drop all the info). We will send
-		// another cluster config once the folder is started We will send
 		// another cluster config once the folder is started.
 		protocolFolder.Paused = folderCfg.Paused || fs == nil
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2187,13 +2187,16 @@ func (m *model) generateClusterConfig(device protocol.DeviceID) protocol.Cluster
 			IgnorePermissions:  folderCfg.IgnorePerms,
 			IgnoreDelete:       folderCfg.IgnoreDelete,
 			DisableTempIndexes: folderCfg.DisableTempIndexes,
-			Paused:             folderCfg.Paused,
 		}
 
-		var fs *db.FileSet
-		if !folderCfg.Paused {
-			fs = m.folderFiles[folderCfg.ID]
-		}
+		fs := m.folderFiles[folderCfg.ID]
+
+		// Even if we aren't paused, if we haven't started the folder yet
+		// pretend we are. Otherwise the remote might get confused about
+		// the missing index info (and drop all the info). We will send
+		// another cluster config once the folder is started We will send
+		// another cluster config once the folder is started.
+		protocolFolder.Paused = folderCfg.Paused || fs == nil
 
 		for _, device := range folderCfg.Devices {
 			deviceCfg, _ := m.cfg.Device(device.DeviceID)


### PR DESCRIPTION
More fixes regarding races between folders being started and cluster configs based on the logs provided in https://forum.syncthing.net/t/device-stays-out-of-sync-until-restart/15891

There's an issue with sending cluster configs: When a folder is not paused, but hasn't been started yet, we send an info that says that the folder is running, but there's no index id/sequence. The remote then drops all info on us. Once the folder is started, we happily start sending from a non-zero starting sequence. Thus the remote will be missing index info from us between 0 and that starting sequence.  
The fix for this is to pretend the folder is paused if it isn't running, even if it isn't paused in config. Then when it is actually started resend the cluster-config including the proper index info.

How I think this problem persists goes like this (didn't check it):

1. Devices A and B in sync, B not runnig.
2. B starts.
3. Connection happens before folder on B is started. A sends valid index info, B sends zeros (as fset is missing).
4. A drops index info about B, because of the zero index info, while B starts sending index info starting with the non-zero index received from A.  
For reasons we do retain the index ID of B on A when dropping index info.

Result: A is missing index info between sequence 0 and sequence sent to B in step 3 above.

Even if they reconnect, index IDs still match -> no index retransfer.

### Testing

Added a unit test that makes sure we don't send a unpaused folder with zero index id.