### PR TITLE
gui: Incorrect recv-enc folder status after revert

### DIFF
--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -887,13 +887,11 @@ angular.module('syncthing.core')
             if ($scope.hasFailedFiles(folderCfg.id)) {
                 return 'faileditems';
             }
-            if (folderInfo.receiveOnlyTotalItems) {
-                switch (folderCfg.type) {
-                case 'receiveonly':
-                    return 'localadditions';
-                case 'receiveencrypted':
-                    return 'localunencrypted';
-                }
+            if ($scope.hasReceiveOnlyChanged(folderCfg)) {
+                return 'localadditions';
+            }
+            if ($scope.hasReceiveEncryptedItems(folderCfg)) {
+                return 'localunencrypted';
             }
             if (folderCfg.devices.length <= 1) {
                 return 'unshared';


### PR DESCRIPTION
After reverting the folder was still shown as having locally changed items in the header (not in the folder details). That's because deleted items don't count. Fix: Use `hasReceiveEncryptedItems` which takes care of that.