### PR TITLE
lib/protocol: Fix OOR panic on recv-only folders

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -542,6 +542,11 @@ func isEncryptedParentFromComponents(pathComponents []string) bool {
 		return false
 	} else if l == 2 && len(pathComponents[1]) != 2 {
 		return false
+	} else if l == 0 {
+		return false
 	}
-	return pathComponents[0][1:1+len(encryptedDirExtension)] == encryptedDirExtension
+	if len(pathComponents[0]) == 0 {
+		return false
+	}
+	return pathComponents[0][1:] == encryptedDirExtension
 }

--- a/lib/protocol/encryption_test.go
+++ b/lib/protocol/encryption_test.go
@@ -95,3 +95,26 @@ func TestEnDecryptFileInfo(t *testing.T) {
 		t.Error("mismatch after decryption")
 	}
 }
+
+func TestIsEncryptedParent(t *testing.T) {
+	cases := []struct {
+		path string
+		is   bool
+	}{
+		{"", false},
+		{".", false},
+		{"/", false},
+		{"12" + encryptedDirExtension, false},
+		{"1" + encryptedDirExtension, true},
+		{"1" + encryptedDirExtension + "/b", false},
+		{"1" + encryptedDirExtension + "/bc", true},
+		{"1" + encryptedDirExtension + "/bcd", false},
+		{"1" + encryptedDirExtension + "/bc/foo", false},
+		{"1.12/22", false},
+	}
+	for _, tc := range cases {
+		if res := IsEncryptedParent(tc.path); res != tc.is {
+			t.Errorf("%v: got %v, expected %v", tc.path, res, tc.is)
+		}
+	}
+}


### PR DESCRIPTION
That code just asks for the panic - luckily my testing folder answered. There's a unit test now.