### PR TITLE
lib/model: Don't send locally changed on recv-enc (fixes #7137)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -250,6 +250,7 @@ github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-b
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/lucas-clemente/quic-go v0.18.1 h1:DMR7guC0NtVS8zNZR3IO7NARZvZygkSC56GGtC6cyys=
 github.com/lucas-clemente/quic-go v0.18.1/go.mod h1:yXttHsSNxQi8AWijC/vLP+OJczXqzHSOcJrM5ITUlCg=
+github.com/lucas-clemente/quic-go v0.19.2 h1:w8BBYUx5Z+kNpeaOeQW/KzcNsKWhh4O6PeQhb0nURPg=
 github.com/lucas-clemente/quic-go v0.19.2/go.mod h1:ZUygOqIoai0ASXXLJ92LTnKdbqh9MHCLTX6Nr1jUrK0=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
@@ -260,6 +261,7 @@ github.com/marten-seemann/qpack v0.2.1/go.mod h1:F7Gl5L1jIgN1D11ucXefiuJS9UMVP2o
 github.com/marten-seemann/qtls v0.10.0/go.mod h1:UvMd1oaYDACI99/oZUYLzMCkBXQVT0aGm99sJhbT8hs=
 github.com/marten-seemann/qtls-go1-15 v0.1.0 h1:i/YPXVxz8q9umso/5y474CNcHmTpA+5DH+mFPjx6PZg=
 github.com/marten-seemann/qtls-go1-15 v0.1.0/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
+github.com/marten-seemann/qtls-go1-15 v0.1.1 h1:LIH6K34bPVttyXnUWixk0bzH6/N07VxbSabxn5A5gZQ=
 github.com/marten-seemann/qtls-go1-15 v0.1.1/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=
 github.com/maruel/panicparse v1.5.1 h1:hUPcXI7ubtEqj/k+P34KsHQqb86zuVk7zBfkP6tBBPc=
 github.com/maruel/panicparse v1.5.1/go.mod h1:aOutY/MUjdj80R0AEVI9qE2zHqig+67t2ffUDDiLzAM=

--- a/lib/model/indexsender.go
+++ b/lib/model/indexsender.go
@@ -312,14 +312,15 @@ func (r *indexSenderRegistry) addLocked(folder config.FolderConfiguration, fset 
 	}
 
 	is := &indexSender{
-		conn:         r.conn,
-		connClosed:   r.closed,
-		folder:       folder.ID,
-		fset:         fset,
-		prevSequence: startSequence,
-		evLogger:     r.evLogger,
-		pauseChan:    make(chan struct{}),
-		resumeChan:   make(chan *db.FileSet),
+		conn:                     r.conn,
+		connClosed:               r.closed,
+		folder:                   folder.ID,
+		folderIsReceiveEncrypted: folder.Type == config.FolderTypeReceiveEncrypted,
+		fset:                     fset,
+		prevSequence:             startSequence,
+		evLogger:                 r.evLogger,
+		pauseChan:                make(chan struct{}),
+		resumeChan:               make(chan *db.FileSet),
 	}
 	is.token = r.sup.Add(is)
 	r.indexSenders[folder.ID] = is


### PR DESCRIPTION
I lost the line

```
 		folderIsReceiveEncrypted: folder.Type == config.FolderTypeReceiveEncrypted,
```

in some merge/rebase operation.

Added a unit test ensuring that we don't send indexes for locally changed items on receive-encrypted folders.
