### PR TITLE
gui: Fix & improve sharing with untrusted device

### DIFF
--- a/gui/default/untrusted/syncthing/core/editShareTemplate.html
+++ b/gui/default/untrusted/syncthing/core/editShareTemplate.html
@@ -15,8 +15,13 @@
         <input class="form-control input-sm" type="password" placeholder="{{'Received data is already encrypted' | translate}}" disabled />
       </span>
       <span ng-switch-default ng-switch="selected[id]">
-        <span ng-switch-when='true' ng-class="{'has-error': untrusted && !encryptionPasswords[id]}">
-          <input class="form-control input-sm" type="{{plain ? 'text' : 'password'}}" ng-model="encryptionPasswords[id]" ng-required="untrusted" placeholder="{{'If untrusted, enter encryption password' | translate}}" />
+        <span ng-switch-when='true' ng-switch="untrusted">
+          <span ng-switch-when='true' ng-class="{'has-error': !encryptionPasswords[id]}">
+            <input class="form-control input-sm" type="{{plain ? 'text' : 'password'}}" ng-model="encryptionPasswords[id]" required placeholder="{{'Device is untrusted, enter encryption password' | translate}}" />
+          </span>
+          <span ng-switch-default>
+            <input class="form-control input-sm" type="{{plain ? 'text' : 'password'}}" ng-model="encryptionPasswords[id]" placeholder="{{'If untrusted, enter encryption password' | translate}}" />
+          </span>
         </span>
         <span ng-switch-default>
           <input class="form-control input-sm" type="password" placeholder="{{'Not shared' | translate}}" disabled />

--- a/gui/default/untrusted/syncthing/device/editDeviceModalView.html
+++ b/gui/default/untrusted/syncthing/device/editDeviceModalView.html
@@ -72,7 +72,7 @@
                   <a href="#" ng-click="selectAllSharedFolders(false)" translate>Deselect All</a></small>
               </p>
               <div class="form-group" ng-repeat="folder in currentSharing.shared">
-                <share-template selected="currentSharing.selected" encryption-passwords="currentSharing.encryptionPasswords" id="{{folder.id}}" label="{{folderLabel(folder.id)}}" folder-type="{{folder.type}}" untrusted="{{device.untrusted}}" />
+                <share-template selected="currentSharing.selected" encryption-passwords="currentSharing.encryptionPasswords" id="{{folder.id}}" label="{{folderLabel(folder.id)}}" folder-type="{{folder.type}}" untrusted="{{currentDevice.untrusted}}" />
               </div>
             </div>
             <div class="form-horizontal" ng-if="currentSharing.unrelated.length">
@@ -83,7 +83,7 @@
                   <a href="#" ng-click="selectAllUnrelatedFolders(false)" translate>Deselect All</a></small>
               </p>
               <div class="form-group" ng-repeat="folder in currentSharing.unrelated">
-                <share-template selected="currentSharing.selected" encryption-passwords="currentSharing.encryptionPasswords" id="{{folder.id}}" label="{{folderLabel(folder.id)}}" folder-type="{{folder.type}}" untrusted="{{device.untrusted}}" />
+                <share-template selected="currentSharing.selected" encryption-passwords="currentSharing.encryptionPasswords" id="{{folder.id}}" label="{{folderLabel(folder.id)}}" folder-type="{{folder.type}}" untrusted="{{currentDevice.untrusted}}" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Fix a copy&paste error in the sharing tab of the device edit modal and change the help text in the password input field if the device is untrusted.