### PR TITLE
lib/model: Fix enc file size when pulling (fixes #7152)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1695,6 +1695,7 @@ func (f *sendReceiveFolder) dbUpdaterRoutine(dbUpdateChan <-chan dbUpdateJob) {
 		return nil
 	}
 
+	recvEnc := f.Type == config.FolderTypeReceiveEncrypted
 loop:
 	for {
 		select {
@@ -1706,6 +1707,9 @@ loop:
 			switch job.jobType {
 			case dbUpdateHandleFile, dbUpdateShortcutFile:
 				changedDirs[filepath.Dir(job.file.Name)] = struct{}{}
+				if recvEnc {
+					job.file.Size += encryptionTrailerSize(job.file)
+				}
 			case dbUpdateHandleDir:
 				changedDirs[job.file.Name] = struct{}{}
 			case dbUpdateHandleSymlink, dbUpdateInvalidate:


### PR DESCRIPTION
The problem in #7152 is the trailer we add to the file containing the encrypted file info and the connected file size change: We adjust that when actually pulling the file. On index retransfer, we get a new global file, as the version always changes when encrypting a file info. That triggers a pull, but as the contents didn't change, that can be shortcutted. In the shortcut we do not adjust the filesize. So on next scan, the scanner notices the changed file size and thus the file gets marked as locally changed.

Now the file size adjustment happens in the db updater routine of the puller, not in the shared puller state.