### PR TITLE
lib/db: Do not reset index-id when dropping device (ref #7135)

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -74,13 +74,6 @@ func (s *FileSet) Drop(device protocol.DeviceID) {
 		// announced from the remote is newer than our current sequence
 		// number.
 		s.meta.resetAll(device)
-		// Also reset the index ID, as we do want a full index retransfer
-		// if we ever reconnect, regardless of if the index ID changed.
-		if err := s.db.setIndexID(device[:], []byte(s.folder), 0); backend.IsClosed(err) {
-			return
-		} else if err != nil {
-			fatalError(err, opStr, s.db)
-		}
 	}
 
 	t, err := s.db.newReadWriteTransaction()

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -1741,6 +1741,22 @@ func TestIgnoreLocalChanged(t *testing.T) {
 	}
 }
 
+// Dropping the index ID on Drop is bad, because Drop gets called when receiving
+// an Index (as opposed to an IndexUpdate), and we don't want to loose the index
+// ID when that happens.
+func TestNoIndexIDResetOnDrop(t *testing.T) {
+	ldb := db.NewLowlevel(backend.OpenMemory())
+	defer ldb.Close()
+
+	s := db.NewFileSet("test", fs.NewFilesystem(fs.FilesystemTypeFake, ""), ldb)
+
+	s.SetIndexID(remoteDevice0, 1)
+	s.Drop(remoteDevice0)
+	if got := s.IndexID(remoteDevice0); got != 1 {
+		t.Errorf("Expected unchanged (%v), got %v", 1, got)
+	}
+}
+
 func replace(fs *db.FileSet, device protocol.DeviceID, files []protocol.FileInfo) {
 	fs.Drop(device)
 	fs.Update(device, files)


### PR DESCRIPTION
This reverts commit 641b7aee384f9490e747abd1c61a4b987018de4a respectively PR #7135.

I created a unit test to make sure that behaviour doesn't erroneously get changed again in the future, and added a comment there why this behaviour is correct/needed:

```
// Dropping the index ID on Drop is bad, because Drop gets called when receiving
// an Index (as opposed to an IndexUpdate), and we don't want to loose the index
// ID when that happens.
```