### PR TITLE
gui: Fix invalid HTML syntax.

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -474,7 +474,7 @@
                               <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Failed to setup, retrying</span>
                             </span>
                           </div>
-                          <div ng-if="0 >= folder.rescanIntervalS">
+                          <div ng-if="folder.rescanIntervalS <= 0">
                             <span ng-if="!folder.fsWatcherEnabled" tooltip data-original-title="{{'Disabled periodic scanning and disabled watching for changes' | translate}}">
                               <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
                               <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Disabled</span>
@@ -517,7 +517,7 @@
                       <tr ng-if="folderStats[folder.id].lastScan">
                         <th><span class="far fa-fw fa-clock"></span>&nbsp;<span translate>Last Scan</span></th>
                         <td translate ng-if="folderStats[folder.id].lastScanDays >= 365" class="text-right">Never</td>
-                        <td ng-if="365 > folderStats[folder.id].lastScanDays" class="text-right">
+                        <td ng-if="folderStats[folder.id].lastScanDays < 365" class="text-right">
                           <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
                         </td>
                       </tr>
@@ -551,7 +551,7 @@
                     <button type="button" class="btn btn-default btn-sm" ng-click="restoreVersions.show(folder.id)" ng-if="folder.versioning.type">
                       <span class="fas fa-undo"></span>&nbsp;<span translate>Versions</span>
                     </button>
-                    <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-disabled="0 > ['idle', 'stopped', 'unshared', 'outofsync', 'faileditems', 'localadditions'].indexOf(folderStatus(folder))">
+                    <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-disabled="['idle', 'stopped', 'unshared', 'outofsync', 'faileditems', 'localadditions'].indexOf(folderStatus(folder)) < 0">
                       <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan</span>
                     </button>
                     <button type="button" class="btn btn-sm btn-default" ng-click="editFolder(folder)">
@@ -796,7 +796,7 @@
                       <tr ng-if="!connections[deviceCfg.deviceID].connected">
                         <th><span class="fas fa-fw fa-eye"></span>&nbsp;<span translate>Last seen</span></th>
                         <td translate ng-if="!deviceStats[deviceCfg.deviceID].lastSeenDays || deviceStats[deviceCfg.deviceID].lastSeenDays >= 365" class="text-right">Never</td>
-                        <td ng-if="365 > deviceStats[deviceCfg.deviceID].lastSeenDays" class="text-right">{{deviceStats[deviceCfg.deviceID].lastSeen | date:"yyyy-MM-dd HH:mm:ss"}}</td>
+                        <td ng-if="deviceStats[deviceCfg.deviceID].lastSeenDays < 365" class="text-right">{{deviceStats[deviceCfg.deviceID].lastSeen | date:"yyyy-MM-dd HH:mm:ss"}}</td>
                       </tr>
                       <tr ng-if="deviceFolders(deviceCfg).length > 0">
                         <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folders</span></th>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -474,7 +474,7 @@
                               <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Failed to setup, retrying</span>
                             </span>
                           </div>
-                          <div ng-if="folder.rescanIntervalS <= 0">
+                          <div ng-if="0 >= folder.rescanIntervalS">
                             <span ng-if="!folder.fsWatcherEnabled" tooltip data-original-title="{{'Disabled periodic scanning and disabled watching for changes' | translate}}">
                               <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
                               <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Disabled</span>
@@ -517,7 +517,7 @@
                       <tr ng-if="folderStats[folder.id].lastScan">
                         <th><span class="far fa-fw fa-clock"></span>&nbsp;<span translate>Last Scan</span></th>
                         <td translate ng-if="folderStats[folder.id].lastScanDays >= 365" class="text-right">Never</td>
-                        <td ng-if="folderStats[folder.id].lastScanDays < 365" class="text-right">
+                        <td ng-if="365 > folderStats[folder.id].lastScanDays" class="text-right">
                           <span>{{folderStats[folder.id].lastScan | date:'yyyy-MM-dd HH:mm:ss'}}</span>
                         </td>
                       </tr>
@@ -551,7 +551,7 @@
                     <button type="button" class="btn btn-default btn-sm" ng-click="restoreVersions.show(folder.id)" ng-if="folder.versioning.type">
                       <span class="fas fa-undo"></span>&nbsp;<span translate>Versions</span>
                     </button>
-                    <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-disabled="['idle', 'stopped', 'unshared', 'outofsync', 'faileditems', 'localadditions'].indexOf(folderStatus(folder)) < 0">
+                    <button type="button" class="btn btn-sm btn-default" ng-click="rescanFolder(folder.id)" ng-disabled="0 > ['idle', 'stopped', 'unshared', 'outofsync', 'faileditems', 'localadditions'].indexOf(folderStatus(folder))">
                       <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan</span>
                     </button>
                     <button type="button" class="btn btn-sm btn-default" ng-click="editFolder(folder)">
@@ -796,7 +796,7 @@
                       <tr ng-if="!connections[deviceCfg.deviceID].connected">
                         <th><span class="fas fa-fw fa-eye"></span>&nbsp;<span translate>Last seen</span></th>
                         <td translate ng-if="!deviceStats[deviceCfg.deviceID].lastSeenDays || deviceStats[deviceCfg.deviceID].lastSeenDays >= 365" class="text-right">Never</td>
-                        <td ng-if="deviceStats[deviceCfg.deviceID].lastSeenDays < 365" class="text-right">{{deviceStats[deviceCfg.deviceID].lastSeen | date:"yyyy-MM-dd HH:mm:ss"}}</td>
+                        <td ng-if="365 > deviceStats[deviceCfg.deviceID].lastSeenDays" class="text-right">{{deviceStats[deviceCfg.deviceID].lastSeen | date:"yyyy-MM-dd HH:mm:ss"}}</td>
                       </tr>
                       <tr ng-if="deviceFolders(deviceCfg).length > 0">
                         <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folders</span></th>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -755,12 +755,12 @@
                         </td>
                         <td ng-if="!connections[deviceCfg.deviceID].connected" class="text-right">
                           <span ng-repeat="addr in deviceCfg.addresses">
-                              <span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br>
-                              <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
+                              <span tooltip data-original-title="{{'Configured' | translate}}">{{addr}}</span><br />
+                              <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br /></small>
                           </span>
                           <span ng-repeat="addr in discoveryCache[deviceCfg.deviceID].addresses">
-                            <span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br>
-                            <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br></small>
+                            <span tooltip data-original-title="{{'Discovered' | translate}}">{{addr}}</span><br />
+                            <small ng-if="system.lastDialStatus[addr].error" tooltip data-original-title="{{system.lastDialStatus[addr].error}}" class="text-danger">{{abbreviatedError(addr)}}<br /></small>
                           </span>
                         </td>
                       </tr>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -45,7 +45,7 @@
           <div class="panel panel-danger">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <div class="panel-icon">
+                <div class="panel-icon"><!--FIXME-->
                   <span class="fas fa-exclamation-circle"></span>
                 </div>
                 Warning!
@@ -133,7 +133,7 @@
           <div class="panel panel-danger">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <div class="panel-icon">
+                <div class="panel-icon"><!--FIXME-->
                   <span class="fas fa-exclamation-circle"></span>
                 </div>
                 <span translate>Danger!</span>
@@ -228,7 +228,7 @@
               <div class="panel panel-warning">
                 <div class="panel-heading">
                   <h3 class="panel-title">
-                    <div class="panel-icon">
+                    <div class="panel-icon"><!--FIXME-->
                       <span class="fas fa-folder"></span>
                     </div>
                     <span translate ng-if="!folders[pendingFolder.id]">New Folder</span>
@@ -275,7 +275,7 @@
           <div class="panel panel-warning">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <div class="panel-icon">
+                <div class="panel-icon"><!--FIXME-->
                   <span class="fas fa-exclamation-circle"></span>
                 </div>
                 <span translate>Notice</span>
@@ -304,7 +304,7 @@
           <div class="panel panel-warning">
             <div class="panel-heading">
               <h3 class="panel-title">
-                <div class="panel-icon">
+                <div class="panel-icon"><!--FIXME-->
                   <span class="fas fa-exclamation-circle"></span>
                 </div>
                 <span translate>Filesystem Watcher Errors</span>
@@ -338,12 +338,12 @@
                 <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id) | percent}}"></div>
                 <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id) | percent}}"></div>
                 <h4 class="panel-title">
-                  <div class="panel-icon hidden-xs">
+                  <div class="panel-icon hidden-xs"><!--FIXME-->
                     <span ng-if="folder.type == 'sendreceive'" class="fas fa-fw fa-folder"></span>
                     <span ng-if="folder.type == 'sendonly'" class="fas fa-fw fa-upload"></span>
                     <span ng-if="folder.type == 'receiveonly'" class="fas fa-fw fa-download"></span>
                   </div>
-                  <div class="panel-status pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)">
+                  <div class="panel-status pull-right text-{{folderClass(folder)}}" ng-switch="folderStatus(folder)"><!--FIXME-->
                     <span ng-switch-when="paused"><span class="hidden-xs" translate>Paused</span><span class="visible-xs" aria-label="{{'Paused' | translate}}"><i class="fas fa-fw fa-pause"></i></span></span>
                     <span ng-switch-when="unknown"><span class="hidden-xs" translate>Unknown</span><span class="visible-xs" aria-label="{{'Unknown' | translate}}"><i class="fas fa-fw fa-question-circle"></i></span></span>
                     <span ng-switch-when="unshared"><span class="hidden-xs" translate>Unshared</span><span class="visible-xs" aria-label="{{'Unshared' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
@@ -375,7 +375,7 @@
                     <span ng-switch-when="outofsync"><span class="hidden-xs" translate>Out of Sync</span><span class="visible-xs" aria-label="{{'Out of Sync' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
                     <span ng-switch-when="faileditems"><span class="hidden-xs" translate>Failed Items</span><span class="visible-xs" aria-label="{{'Failed Items' | translate}}"><i class="fas fa-fw fa-exclamation-circle"></i></span></span>
                   </div>
-                  <div class="panel-title-text">
+                  <div class="panel-title-text"><!--FIXME-->
                     <span tooltip data-original-title="{{folder.label.length != 0 ? folder.id : ''}}">{{folder.label.length != 0 ? folder.label : folder.id}}</span>
                   </div>
                 </h4>
@@ -483,7 +483,7 @@
                               <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
                               <span class="fas fa-eye"></span>&nbsp;<span translate>Enabled</span>
                             </span>
-                            <span ng-if="folder.fsWatcherEnabled && !folder.paused && folderStatus(folder) !== 'stopped' && model[folder.id].watchError" tooltip data-original-title="{{'Disabled periodic scanning and failed setting up watching for changes, retrying every 1m:' | translate}}<br/>{{model[folder.id].watchError}}">
+                            <span ng-if="folder.fsWatcherEnabled && !folder.paused && folderStatus(folder) !== 'stopped' && model[folder.id].watchError" tooltip data-original-title="{{'Disabled periodic scanning and failed setting up watching for changes, retrying every 1m:' | translate}}<br/>{{model[folder.id].watchError}}"><!--FIXME-->
                               <span class="far fa-clock"></span>&nbsp;<span translate>Disabled</span>&ensp;
                               <span class="fas fa-eye-slash"></span>&nbsp;<span translate>Failed to setup, retrying</span>
                             </span>
@@ -647,7 +647,7 @@
                           <span>{{listenersTotal}}/{{listenersTotal}}</span>
                         </span>
                         <span ng-if="listenersFailed.length != 0" class="data" ng-class="{'text-danger': listenersFailed.length == listenersTotal}">
-                          <span popover data-trigger="hover" data-placement="bottom" data-html="true" data-content="{{listenersFailed.join('<br>\n')}}">
+                          <span popover data-trigger="hover" data-placement="bottom" data-html="true" data-content="{{listenersFailed.join('<br>\n')}}"><!--FIXME-->
                             {{listenersTotal-listenersFailed.length}}/{{listenersTotal}}
                           </span>
                         </span>

--- a/gui/default/syncthing/core/logViewerModalView.html
+++ b/gui/default/syncthing/core/logViewerModalView.html
@@ -18,7 +18,7 @@
           <tbody>
             <tr ng-repeat="(name, data) in logging.facilities">
               <td>
-                <input type="checkbox" ng-model="data.enabled" ng-change="logging.onFacilityChange(name)" ng-disabled="data.enabled == null"> <span>{{ name }}</span>
+                <input type="checkbox" ng-model="data.enabled" ng-change="logging.onFacilityChange(name)" ng-disabled="data.enabled == null" /> <span>{{ name }}</span>
               </td>
               <td>{{ data.description }}</td>
             </tr>

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -44,7 +44,7 @@
               <div class="form-group">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" ng-model="currentDevice.introducer">
+                    <input type="checkbox" ng-model="currentDevice.introducer" />
                     <span translate>Introducer</span>
                     <p translate class="help-block">Add devices from the introducer to our device list, for mutually shared folders.</p>
                   </label>
@@ -55,7 +55,7 @@
               <div class="form-group">
                 <div class="checkbox">
                   <label>
-                    <input type="checkbox" ng-model="currentDevice.autoAcceptFolders">
+                    <input type="checkbox" ng-model="currentDevice.autoAcceptFolders" />
                     <span translate>Auto Accept</span>
                     <p translate class="help-block">Automatically create or share folders that this device advertises at the default path.</p>
                   </label>
@@ -76,10 +76,10 @@
                   <div class="col-md-4" ng-repeat="folder in folderList()">
                     <div class="checkbox">
                       <label ng-if="folder.label.length == 0">
-                        <input type="checkbox" ng-model="currentSharing.selected[folder.id]">&nbsp;{{folder.id}}
+                        <input type="checkbox" ng-model="currentSharing.selected[folder.id]" />&nbsp;{{folder.id}}
                       </label>
                       <label ng-if="folder.label.length != 0">
-                        <input type="checkbox" ng-model="currentSharing.selected[folder.id]">&nbsp; <span tooltip data-original-title="{{folder.id}}">{{folder.label}}</span>
+                        <input type="checkbox" ng-model="currentSharing.selected[folder.id]" />&nbsp; <span tooltip data-original-title="{{folder.id}}">{{folder.label}}</span>
                       </label>
                     </div>
                   </div>

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -22,7 +22,7 @@
                 </ul>
               </p>
               <p class="help-block">
-                <span translate ng-if="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">The device ID to enter here can be found in the "Actions > Show ID" dialog on the other device. Spaces and dashes are optional (ignored).</span>
+                <span translate ng-if="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">The device ID to enter here can be found in the "Actions &gt; Show ID" dialog on the other device. Spaces and dashes are optional (ignored).</span>
                 <span translate ng-show="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">When adding a new device, keep in mind that this device must be added on the other side too.</span>
                 <span translate ng-if="deviceEditor.deviceID.$error.required && deviceEditor.deviceID.$dirty">The device ID cannot be blank.</span>
                 <span translate ng-if="deviceEditor.deviceID.$error.validDeviceid && deviceEditor.deviceID.$dirty">The entered device ID does not look valid. It should be a 52 or 56 character string consisting of letters and numbers, with spaces and dashes being optional.</span>

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -35,7 +35,7 @@
               <option ng-repeat="directory in directoryList" value="{{ directory }}" />
             </datalist>
             <p class="help-block">
-              <span ng-if="folderEditor.folderPath.$valid || folderEditor.folderPath.$pristine"><span translate>Path to the folder on the local computer. Will be created if it does not exist. The tilde character (~) can be used as a shortcut for</span> <code>{{system.tilde}}</code>.</br></span>
+              <span ng-if="folderEditor.folderPath.$valid || folderEditor.folderPath.$pristine"><span translate>Path to the folder on the local computer. Will be created if it does not exist. The tilde character (~) can be used as a shortcut for</span> <code>{{system.tilde}}</code>.<br /></span>
               <span translate ng-if="folderEditor.folderPath.$error.required && folderEditor.folderPath.$dirty">The folder path cannot be blank.</span>
               <span class="text-danger" translate translate-value-other-folder="{{folderPathErrors.otherID}}" ng-if="folderPathErrors.isSub && folderPathErrors.otherLabel.length == 0">Warning, this path is a subdirectory of an existing folder "{%otherFolder%}".</span>
               <span class="text-danger" translate translate-value-other-folder="{{folderPathErrors.otherID}}" translate-value-other-folder-label="{{folderPathErrors.otherLabel}}" ng-if="folderPathErrors.isSub && folderPathErrors.otherLabel.length != 0">Warning, this path is a subdirectory of an existing folder "{%otherFolderLabel%}" ({%otherFolder%}).</span>
@@ -151,7 +151,7 @@
               <div class="input-group-addon" translate>seconds</div>
             </div>
             <p class="help-block">
-              <span translate ng-if="folderEditor.versioningCleanupIntervalS.$valid || folderEditor.versioningCleanupIntervalS.$pristine"class="help-block">The interval, in seconds, for running cleanup in the versions directory. Zero to disable periodic cleaning.</span>
+              <span translate ng-if="folderEditor.versioningCleanupIntervalS.$valid || folderEditor.versioningCleanupIntervalS.$pristine" class="help-block">The interval, in seconds, for running cleanup in the versions directory. Zero to disable periodic cleaning.</span>
               <span translate ng-if="folderEditor.versioningCleanupIntervalS.$error.required && folderEditor.versioningCleanupIntervalS.$dirty">The cleanup interval cannot be blank.</span>
               <span translate ng-if="folderEditor.versioningCleanupIntervalS.$error.min && folderEditor.versioningCleanupIntervalS.$dirty">The interval must be a positive number of seconds.</span>
             </p>
@@ -191,12 +191,12 @@
           <div class="row form-group" ng-class="{'has-error': folderEditor.rescanIntervalS.$invalid && folderEditor.rescanIntervalS.$dirty}">
             <div class="col-md-12">
               <label translate>Scanning</label>
-              &nbsp;<a href="https://docs.syncthing.net/users/syncing.html#scanning" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a></br>
+              &nbsp;<a href="https://docs.syncthing.net/users/syncing.html#scanning" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a><br />
 
               <div class="row">
                 <div class="col-md-6">
                   <label>
-                    <input type="checkbox" ng-model="currentFolder.fsWatcherEnabled" ng-change="fsWatcherToggled()" tooltip data-original-title="{{'Use notifications from the filesystem to detect changed items.' | translate }}">&nbsp;<span translate>Watch for Changes</span>
+                    <input type="checkbox" ng-model="currentFolder.fsWatcherEnabled" ng-change="fsWatcherToggled()" tooltip data-original-title="{{'Use notifications from the filesystem to detect changed items.' | translate }}" />&nbsp;<span translate>Watch for Changes</span>
                   </label>
                   <p translate class="help-block">Watching for changes discovers most changes without periodic scanning.</p>
                 </div>

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -63,14 +63,14 @@
               </div>
             </div>
           </div>
-          <div class="form-group" ng-if="currentSharing.unrelated.length || otherDevices().length <= 0">
+          <div class="form-group" ng-if="currentSharing.unrelated.length || otherDevices().length == 0">
             <label translate>Unshared Devices</label>
             <p class="help-block" ng-if="otherDevices().length > 0">
               <span translate>Select additional devices to share this folder with.</span>&emsp;
               <small><a href="#" ng-click="selectAllUnrelatedDevices(true)" translate>Select All</a>&emsp;
                 <a href="#" ng-click="selectAllUnrelatedDevices(false)" translate>Deselect All</a></small>
             </p>
-            <p class="help-block" ng-if="otherDevices().length <= 0">
+            <p class="help-block" ng-if="otherDevices().length == 0">
               <span translate>There are no devices to share this folder with.</span>
             </p>
             <div class="row">

--- a/gui/default/syncthing/folder/restoreVersionsModalView.html
+++ b/gui/default/syncthing/folder/restoreVersionsModalView.html
@@ -16,14 +16,14 @@
       <div class="row form-inline">
         <div class="col-md-6">
           <div class="form-group">
-            <label translate for="restoreVersionSearch">Filter by name</label>:&nbsp
-            <input id="restoreVersionSearch" class="form-control" type="text" ng-model="restoreVersions.filters.text">
+            <label translate for="restoreVersionSearch">Filter by name</label>:&nbsp;
+            <input id="restoreVersionSearch" class="form-control" type="text" ng-model="restoreVersions.filters.text" />
           </div>
         </div>
         <div class="col-md-6">
           <div class="form-group">
-            <label translate for="restoreVersionDate">Filter by date</label>:&nbsp
-            <input id="restoreVersionDateRange" class="form-control">
+            <label translate for="restoreVersionDate">Filter by date</label>:&nbsp;
+            <input id="restoreVersionDateRange" class="form-control" />
           </div>
         </div>
       </div>

--- a/gui/default/syncthing/folder/restoreVersionsModalView.html
+++ b/gui/default/syncthing/folder/restoreVersionsModalView.html
@@ -41,7 +41,7 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#restore-versions-confirmation" ng-if="restoreVersions.versions" ng-disabled="restoreVersions.selectionCount() < 1">
+    <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#restore-versions-confirmation" ng-if="restoreVersions.versions" ng-disabled="1 > restoreVersions.selectionCount()">
       <span class="fas fa-check"></span>&nbsp;<span translate>Restore</span>
     </button>
     <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">

--- a/gui/default/syncthing/folder/restoreVersionsModalView.html
+++ b/gui/default/syncthing/folder/restoreVersionsModalView.html
@@ -41,7 +41,7 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#restore-versions-confirmation" ng-if="restoreVersions.versions" ng-disabled="1 > restoreVersions.selectionCount()">
+    <button type="button" class="btn btn-primary btn-sm" data-toggle="modal" data-target="#restore-versions-confirmation" ng-if="restoreVersions.versions" ng-disabled="restoreVersions.selectionCount() < 1">
       <span class="fas fa-check"></span>&nbsp;<span translate>Restore</span>
     </button>
     <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -78,7 +78,7 @@
                     <option value="-1" translate>Disabled</option>
                   </select>
                 </div>
-                <p class="help-block" ng-if="tmpOptions.upgrades == 'candidate' || version.isCandidate"">
+                <p class="help-block" ng-if="tmpOptions.upgrades == 'candidate' || version.isCandidate">
                   <span translate>Usage reporting is always enabled for candidate releases.</span>
                 </p>
               </div>
@@ -94,7 +94,7 @@
                 <p class="help-block" ng-if="!upgradeInfo">
                   <span translate>Unavailable/Disabled by administrator or maintainer</span>
                 </p>
-                <p class="help-block" ng-if="version.isCandidate && upgradeInfo"">
+                <p class="help-block" ng-if="version.isCandidate && upgradeInfo">
                   <span translate>Automatic upgrades are always enabled for candidate releases.</span>
                 </p>
               </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -166,7 +166,7 @@
                     {{ themeName(theme) }}
                   </option>
                 </select>
-                <p class="help-block" ng-if="2 > themes.length">
+                <p class="help-block" ng-if="themes.length < 2">
                   <span translate>Unavailable</span>
                 </p>
               </div>

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -166,7 +166,7 @@
                     {{ themeName(theme) }}
                   </option>
                 </select>
-                <p class="help-block" ng-if="themes.length < 2">
+                <p class="help-block" ng-if="2 > themes.length">
                   <span translate>Unavailable</span>
                 </p>
               </div>

--- a/gui/default/syncthing/usagereport/usageReportModalView.html
+++ b/gui/default/syncthing/usagereport/usageReportModalView.html
@@ -1,9 +1,9 @@
 <modal id="ur" status="info" icon="fas fa-question-circle" heading="{{'Allow Anonymous Usage Reporting?' | translate}}" large="yes" closeable="no">
   <div class="modal-body">
-    <div ng-if="config.options.urAccepted > 0 && system.urVersionMax > config.options.urAccepted">
+    <div ng-if="config.options.urAccepted > 0 && config.options.urAccepted < system.urVersionMax">
       <p translate>Anonymous usage report format has changed. Would you like to move to the new format?</p>
     </div>
-    <div ng-if="!(config.options.urAccepted > 0 && system.urVersionMax > config.options.urAccepted)">
+    <div ng-if="!(config.options.urAccepted > 0 && config.options.urAccepted < system.urVersionMax)">
       <p translate>The encrypted usage report is sent daily. It is used to track common platforms, folder sizes and app versions. If the reported data set is changed you will be prompted with this dialog again.</p>
       <p translate>The aggregated statistics are publicly available at the URL below.</p>
       <p><a href="https://data.syncthing.net/" target="_blank">https://data.syncthing.net/</a></p>

--- a/gui/default/syncthing/usagereport/usageReportModalView.html
+++ b/gui/default/syncthing/usagereport/usageReportModalView.html
@@ -1,9 +1,9 @@
 <modal id="ur" status="info" icon="fas fa-question-circle" heading="{{'Allow Anonymous Usage Reporting?' | translate}}" large="yes" closeable="no">
   <div class="modal-body">
-    <div ng-if="config.options.urAccepted > 0 && config.options.urAccepted < system.urVersionMax">
+    <div ng-if="config.options.urAccepted > 0 && system.urVersionMax > config.options.urAccepted">
       <p translate>Anonymous usage report format has changed. Would you like to move to the new format?</p>
     </div>
-    <div ng-if="!(config.options.urAccepted > 0 && config.options.urAccepted < system.urVersionMax)">
+    <div ng-if="!(config.options.urAccepted > 0 && system.urVersionMax > config.options.urAccepted)">
       <p translate>The encrypted usage report is sent daily. It is used to track common platforms, folder sizes and app versions. If the reported data set is changed you will be prompted with this dialog again.</p>
       <p translate>The aggregated statistics are publicly available at the URL below.</p>
       <p><a href="https://data.syncthing.net/" target="_blank">https://data.syncthing.net/</a></p>

--- a/gui/default/syncthing/usagereport/usageReportPreviewModalView.html
+++ b/gui/default/syncthing/usagereport/usageReportPreviewModalView.html
@@ -16,11 +16,10 @@
         <span translate>Show diff with previous version</span>
       </label>
     </div>
-    <hr>
-      <form>
-	<textarea class="form-control" rows="20" ng-if="reportDataPreview">{{reportDataPreview | json}}</textarea>
-      </form>
-    </hr>
+    <hr />
+    <form>
+      <textarea class="form-control" rows="20" ng-if="reportDataPreview">{{reportDataPreview | json}}</textarea>
+    </form>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">

--- a/gui/default/syncthing/usagereport/usageReportPreviewModalView.html
+++ b/gui/default/syncthing/usagereport/usageReportPreviewModalView.html
@@ -17,9 +17,10 @@
       </label>
     </div>
     <hr>
-    <form>
-      <textarea class="form-control" rows="20" ng-if="reportDataPreview">{{reportDataPreview | json}}</textarea>
-    </form>
+      <form>
+	<textarea class="form-control" rows="20" ng-if="reportDataPreview">{{reportDataPreview | json}}</textarea>
+      </form>
+    </hr>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">

--- a/script/translate.go
+++ b/script/translate.go
@@ -94,7 +94,7 @@ func inTranslate(n *html.Node, filename string) {
 }
 
 func translation(v string) {
-	v = strings.TrimSpace(v)
+	v = strings.TrimSpace(html.UnescapeString(v))
 	if _, ok := trans[v]; !ok {
 		av := strings.Replace(v, "{%", "{{", -1)
 		av = strings.Replace(av, "%}", "}}", -1)


### PR DESCRIPTION
While starting work on some GUI code, I noticed some invalid HTML constructs.  Using Emacs' `nxml-mode`, I found some pointers to more syntax errors, across all `.html` files under `gui/default/`.  Unfortunately this can not easily be automated because some of the AngularJS constructs and `translate` attributes are not strictly XML-conformant, but correctly follow the respective package's syntax.

Some of these are arguably cosmetic, as long as no parser trips over them.  Like for the comparison operators leading to stray `<` characters, I propose a rather simple solution which should still provide the highest readability.

TODO
----
* [ ] The last commit is still in FIXME stage, as I don't know how to best solve the issue of forbidden div-elements within headings.
* [ ] This needs to be mirrored to the `untrusted` GUI when finished.