### PR TITLE
gui: Restore Select / Deselect All buttons in device sharing tab.

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1438,6 +1438,18 @@ angular.module('syncthing.core')
             $('#editDevice').modal();
         };
 
+        $scope.selectAllFolders = function () {
+            angular.forEach($scope.folders, function (_, id) {
+                $scope.currentSharing.selected[id] = true;
+            });
+        };
+
+        $scope.deSelectAllFolders = function () {
+            angular.forEach($scope.folders, function (_, id) {
+                $scope.currentSharing.selected[id] = false;
+            });
+        };
+
         $scope.selectAllSharedFolders = function (state) {
             var devices = $scope.currentSharing.shared;
             for (var i = 0; i < devices.length; i++) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1439,9 +1439,10 @@ angular.module('syncthing.core')
         };
 
         $scope.selectAllFolders = function (state) {
-            angular.forEach($scope.folders, function (_, id) {
+            var folders = $scope.folders;
+            for (var id in folders) {
                 $scope.currentSharing.selected[id] = !!state;
-            });
+            };
         };
 
         $scope.selectAllSharedFolders = function (state) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1438,15 +1438,9 @@ angular.module('syncthing.core')
             $('#editDevice').modal();
         };
 
-        $scope.selectAllFolders = function () {
+        $scope.selectAllFolders = function (state) {
             angular.forEach($scope.folders, function (_, id) {
-                $scope.currentSharing.selected[id] = true;
-            });
-        };
-
-        $scope.deSelectAllFolders = function () {
-            angular.forEach($scope.folders, function (_, id) {
-                $scope.currentSharing.selected[id] = false;
+                $scope.currentSharing.selected[id] = !!state;
             });
         };
 

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -69,8 +69,8 @@
                 <label translate for="folders">Share Folders With Device</label>
                 <p class="help-block">
                   <span translate>Select the folders to share with this device.</span>&emsp;
-                  <small><a href="#" ng-click="selectAllFolders()" translate>Select All</a>&emsp;
-                    <a href="#" ng-click="deSelectAllFolders()" translate>Deselect All</a></small>
+                  <small><a href="#" ng-click="selectAllFolders(true)" translate>Select All</a>&emsp;
+                    <a href="#" ng-click="selectAllFolders(false)" translate>Deselect All</a></small>
                 </p>
                 <div class="row">
                   <div class="col-md-4" ng-repeat="folder in folderList()">


### PR DESCRIPTION
### Purpose

Refactoring in #7049 broke the "Select All" and "Deselect All" buttons under the Sharing tab for editing devices.  It was supposed to work just like for the folder editing modal, but the distinction between already shared and not shared is not made in the edit device modal yet.

Fixing that properly (by splitting just like it is done in the edit folder modal) will come in a separate PR, but I wanted to get this one out as a quick regression fix.

### Testing

Both buttons confirmed working when editing an existing device.
