### PR TITLE
gui: Split folders into two categories on the sharing tab for devices.

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1432,7 +1432,11 @@ angular.module('syncthing.core')
             initShareEditing('device');
             $scope.currentSharing.selected = {};
             $scope.deviceFolders($scope.currentDevice).forEach(function (folder) {
+                $scope.currentSharing.shared.push($scope.folders[folder]);
                 $scope.currentSharing.selected[folder] = true;
+            });
+            $scope.currentSharing.unrelated = $scope.folderList().filter(function (n) {
+                return !$scope.currentSharing.selected[n.id];
             });
             $scope.deviceEditor.$setPristine();
             $('#editDevice').modal();
@@ -1478,6 +1482,7 @@ angular.module('syncthing.core')
                     };
                     $scope.editingExisting = false;
                     initShareEditing('device');
+                    $scope.currentSharing.unrelated = $scope.folderList();
                     $scope.deviceEditor.$setPristine();
                     $('#editDevice').modal();
                 });

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1439,16 +1439,16 @@ angular.module('syncthing.core')
         };
 
         $scope.selectAllSharedFolders = function (state) {
-            var devices = $scope.currentSharing.shared;
-            for (var i = 0; i < devices.length; i++) {
-                $scope.currentSharing.selected[devices[i].deviceID] = !!state;
+            var folders = $scope.currentSharing.shared;
+            for (var i = 0; i < folders.length; i++) {
+                $scope.currentSharing.selected[folders[i].id] = !!state;
             }
         };
 
         $scope.selectAllUnrelatedFolders = function (state) {
-            var devices = $scope.currentSharing.unrelated;
-            for (var i = 0; i < devices.length; i++) {
-                $scope.currentSharing.selected[devices[i].deviceID] = !!state;
+            var folders = $scope.currentSharing.unrelated;
+            for (var i = 0; i < folders.length; i++) {
+                $scope.currentSharing.selected[folders[i].id] = !!state;
             }
         };
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1430,10 +1430,9 @@ angular.module('syncthing.core')
             }
             $scope.currentDevice._addressesStr = deviceCfg.addresses.join(', ');
             initShareEditing('device');
-            $scope.currentSharing.selected = {};
-            $scope.deviceFolders($scope.currentDevice).forEach(function (folder) {
-                $scope.currentSharing.shared.push($scope.folders[folder]);
-                $scope.currentSharing.selected[folder] = true;
+            $scope.deviceFolders($scope.currentDevice).forEach(function (folderID) {
+                $scope.currentSharing.shared.push($scope.folders[folderID]);
+                $scope.currentSharing.selected[folderID] = true;
             });
             $scope.currentSharing.unrelated = $scope.folderList().filter(function (n) {
                 return !$scope.currentSharing.selected[n.id];

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1530,17 +1530,22 @@ angular.module('syncthing.core')
                     }
 
                     if (!found) {
+                        // Add device to folder
                         $scope.folders[id].devices.push({
                             deviceID: deviceCfg.deviceID
                         });
                     }
                 } else {
+                    // Remove device from folder
                     $scope.folders[id].devices = $scope.folders[id].devices.filter(function (n) {
                         return n.deviceID !== deviceCfg.deviceID;
                     });
                 }
             }
 
+            delete $scope.currentSharing;
+
+            $scope.config.folders = folderList($scope.folders);
             $scope.saveConfig();
         };
 

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -66,7 +66,7 @@
           <div class="row">
             <div class="col-md-12">
               <div class="form-group" ng-if="currentSharing.shared.length">
-                <label translate for="folders">Currently Shared Folders for Device</label>
+                <label translate for="folders">Shared Folders</label>
                 <p class="help-block">
                   <span translate>Deselect folders to stop sharing with this device.</span>&emsp;
                   <small><a href="#" ng-click="selectAllSharedFolders(true)" translate>Select All</a>&emsp;

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -68,7 +68,7 @@
               <div class="form-group" ng-if="currentSharing.shared.length">
                 <label translate for="folders">Currently Shared Folders for Device</label>
                 <p class="help-block">
-		  <span translate>Deselect folders to stop sharing with this device.</span>&emsp;
+                  <span translate>Deselect folders to stop sharing with this device.</span>&emsp;
                   <small><a href="#" ng-click="selectAllSharedFolders(true)" translate>Select All</a>&emsp;
                     <a href="#" ng-click="selectAllSharedFolders(false)" translate>Deselect All</a></small>
                 </p>
@@ -92,9 +92,9 @@
                   <small><a href="#" ng-click="selectAllUnrelatedFolders(true)" translate>Select All</a>&emsp;
                     <a href="#" ng-click="selectAllUnrelatedFolders(false)" translate>Deselect All</a></small>
                 </p>
-		<p class="help-block" ng-if="folderList().length == 0">
-		  <span translate>There are no folders to share with this device.</span>
-		</p>
+                <p class="help-block" ng-if="folderList().length == 0">
+                  <span translate>There are no folders to share with this device.</span>
+                </p>
                 <div class="row">
                   <div class="col-md-4" ng-repeat="folder in currentSharing.unrelated">
                     <div class="checkbox">

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -65,15 +65,38 @@
           </div>
           <div class="row">
             <div class="col-md-12">
-              <div class="form-group">
-                <label translate for="folders">Share Folders With Device</label>
+              <div class="form-group" ng-if="currentSharing.shared.length">
+                <label translate for="folders">Currently Shared Folders for Device</label>
                 <p class="help-block">
-                  <span translate>Select the folders to share with this device.</span>&emsp;
-                  <small><a href="#" ng-click="selectAllFolders()" translate>Select All</a>&emsp;
-                    <a href="#" ng-click="deSelectAllFolders()" translate>Deselect All</a></small>
+		  <span translate>Deselect folders to stop sharing with this device.</span>&emsp;
+                  <small><a href="#" ng-click="selectAllSharedFolders(true)" translate>Select All</a>&emsp;
+                    <a href="#" ng-click="selectAllSharedFolders(false)" translate>Deselect All</a></small>
                 </p>
                 <div class="row">
-                  <div class="col-md-4" ng-repeat="folder in folderList()">
+                  <div class="col-md-4" ng-repeat="folder in currentSharing.shared">
+                    <div class="checkbox">
+                      <label ng-if="folder.label.length == 0">
+                        <input type="checkbox" ng-model="currentSharing.selected[folder.id]" />&nbsp;{{folder.id}}
+                      </label>
+                      <label ng-if="folder.label.length != 0">
+                        <input type="checkbox" ng-model="currentSharing.selected[folder.id]" />&nbsp; <span tooltip data-original-title="{{folder.id}}">{{folder.label}}</span>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="form-group" ng-if="currentSharing.unrelated.length || folderList().length == 0">
+                <label translate for="folders">Unshared Folders</label>
+                <p class="help-block" ng-if="folderList().length > 0">
+                  <span translate>Select additional folders to share with this device.</span>&emsp;
+                  <small><a href="#" ng-click="selectAllUnrelatedFolders(true)" translate>Select All</a>&emsp;
+                    <a href="#" ng-click="selectAllUnrelatedFolders(false)" translate>Deselect All</a></small>
+                </p>
+		<p class="help-block" ng-if="folderList().length == 0">
+		  <span translate>There are no folders to share with this device.</span>
+		</p>
+                <div class="row">
+                  <div class="col-md-4" ng-repeat="folder in currentSharing.unrelated">
                     <div class="checkbox">
                       <label ng-if="folder.label.length == 0">
                         <input type="checkbox" ng-model="currentSharing.selected[folder.id]">&nbsp;{{folder.id}}

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1457,16 +1457,16 @@ angular.module('syncthing.core')
         };
 
         $scope.selectAllSharedFolders = function (state) {
-            var devices = $scope.currentSharing.shared;
-            for (var i = 0; i < devices.length; i++) {
-                $scope.currentSharing.selected[devices[i].deviceID] = !!state;
+            var folders = $scope.currentSharing.shared;
+            for (var i = 0; i < folders.length; i++) {
+                $scope.currentSharing.selected[folders[i].id] = !!state;
             }
         };
 
         $scope.selectAllUnrelatedFolders = function (state) {
-            var devices = $scope.currentSharing.unrelated;
-            for (var i = 0; i < devices.length; i++) {
-                $scope.currentSharing.selected[devices[i].deviceID] = !!state;
+            var folders = $scope.currentSharing.unrelated;
+            for (var i = 0; i < folders.length; i++) {
+                $scope.currentSharing.selected[folders[i].id] = !!state;
             }
         };
 
@@ -1496,6 +1496,7 @@ angular.module('syncthing.core')
                     };
                     $scope.editingExisting = false;
                     initShareEditing('device');
+                    $scope.currentSharing.unrelated = $scope.folderList();
                     $scope.deviceEditor.$setPristine();
                     $('#editDevice').modal();
                 });
@@ -1562,7 +1563,6 @@ angular.module('syncthing.core')
             delete $scope.currentSharing;
 
             $scope.config.folders = folderList($scope.folders);
-
             $scope.saveConfig();
         };
 
@@ -1981,8 +1981,8 @@ angular.module('syncthing.core')
             // Bump time
             pendingFolder.time = (new Date()).toISOString();
 
-            if (id in $scope.devices) {
-                $scope.devices[id].ignoredFolders.push(pendingFolder);
+            if (device in $scope.devices) {
+                $scope.devices[device].ignoredFolders.push(pendingFolder);
                 $scope.saveConfig();
             }
         };

--- a/gui/default/untrusted/syncthing/device/editDeviceModalView.html
+++ b/gui/default/untrusted/syncthing/device/editDeviceModalView.html
@@ -65,7 +65,7 @@
           </div>
           <div class="form-group">
             <div class="form-horizontal" ng-if="currentSharing.shared.length">
-              <label translate for="folders">Currently Shared Folders for Device</label>
+              <label translate for="folders">Shared Folders</label>
               <p class="help-block">
                 <span translate>Deselect folders to stop sharing with this device.</span>&emsp;
                 <small><a href="#" ng-click="selectAllSharedFolders(true)" translate>Select All</a>&emsp;

--- a/gui/default/untrusted/syncthing/device/editDeviceModalView.html
+++ b/gui/default/untrusted/syncthing/device/editDeviceModalView.html
@@ -65,9 +65,9 @@
           </div>
           <div class="form-group">
             <div class="form-horizontal" ng-if="currentSharing.shared.length">
-              <label translate for="folders">Shared Folders</label>
+              <label translate for="folders">Currently Shared Folders for Device</label>
               <p class="help-block">
-                <span translate>Select the folders to share with this device.</span>&emsp;
+                <span translate>Deselect folders to stop sharing with this device.</span>&emsp;
                 <small><a href="#" ng-click="selectAllSharedFolders(true)" translate>Select All</a>&emsp;
                   <a href="#" ng-click="selectAllSharedFolders(false)" translate>Deselect All</a></small>
               </p>
@@ -76,11 +76,14 @@
               </div>
             </div>
             <div class="form-horizontal" ng-if="currentSharing.unrelated.length">
-              <label translate>Unshared Folders</label>
-              <p class="help-block">
+              <label translate for="folders">Unshared Folders</label>
+              <p class="help-block" ng-if="folderList().length > 0">
                 <span translate>Select additional folders to share with this device.</span>&emsp;
                 <small><a href="#" ng-click="selectAllUnrelatedFolders(true)" translate>Select All</a>&emsp;
                   <a href="#" ng-click="selectAllUnrelatedFolders(false)" translate>Deselect All</a></small>
+              </p>
+              <p class="help-block" ng-if="folderList().length == 0">
+                <span translate>There are no folders to share with this device.</span>
               </p>
               <div class="form-group" ng-repeat="folder in currentSharing.unrelated">
                 <share-template selected="currentSharing.selected" encryption-passwords="currentSharing.encryptionPasswords" id="{{folder.id}}" label="{{folderLabel(folder.id)}}" folder-type="{{folder.type}}" untrusted="{{currentDevice.untrusted}}" />


### PR DESCRIPTION
This is the proper fix for the problem mentioned in #7161.  While the former is meant as a hot-fix, this one actually changes the GUI layout and functionality.

When editing folders, the checkboxes have been split into two categories for some time now.  This one mirrors the same to adding / editing a device.  Also properly fixes copy-paste errors introduced with #7049.

This PR does not include replicating the changes to the `untrusted` GUI, as it is nontrivial in this case.