### PR TITLE
cmd/syncthing: Discard default logger output (ref #7146)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -47,6 +47,13 @@ import (
 	"github.com/pkg/errors"
 )
 
+func init() {
+	// Temporary (hopefully) workaround due to QUIC writing unconditionally
+	// to the default logger.
+	// https://github.com/syncthing/syncthing/issues/7146
+	log.SetOutput(ioutil.Discard)
+}
+
 const (
 	tlsDefaultCommonName   = "syncthing"
 	deviceCertLifetimeDays = 20 * 365

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -68,6 +68,13 @@ type logger struct {
 // DefaultLogger logs to standard output with a time prefix.
 var DefaultLogger = New()
 
+func init() {
+	// Temporary (hopefully) workaround due to QUIC writing unconditionally
+	// to the default logger.
+	// https://github.com/syncthing/syncthing/issues/7146
+	log.SetOutput(ioutil.Discard)
+}
+
 func New() Logger {
 	if os.Getenv("LOGGER_DISCARD") != "" {
 		// Hack to completely disable logging, for example when running

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -68,13 +68,6 @@ type logger struct {
 // DefaultLogger logs to standard output with a time prefix.
 var DefaultLogger = New()
 
-func init() {
-	// Temporary (hopefully) workaround due to QUIC writing unconditionally
-	// to the default logger.
-	// https://github.com/syncthing/syncthing/issues/7146
-	log.SetOutput(ioutil.Discard)
-}
-
 func New() Logger {
 	if os.Getenv("LOGGER_DISCARD") != "" {
 		// Hack to completely disable logging, for example when running


### PR DESCRIPTION
The logs on my nightly devices get filled with this quic stuff that they write directly to the default logger of the `log` package (#7146). I hope they will reconsider that practice, but until then lets discard it to not drown relevant logging. Alternatively we could redirect it to a new debug logging facility (e.g. `logger` or `external`) but that seems pointless as noone will ever remember it exists or notice when debugging, given how generic it would be.