### PR TITLE
lib/ur: Reset timer when there's nothing to report

### DIFF
--- a/cmd/stcrashreceiver/main.go
+++ b/cmd/stcrashreceiver/main.go
@@ -74,6 +74,7 @@ func handleFailureFn(dsn string) func(w http.ResponseWriter, req *http.Request) 
 		}
 		if len(reports) == 0 {
 			// Shouldn't happen
+			log.Printf("Got zero failure reports")
 			return
 		}
 
@@ -91,7 +92,9 @@ func handleFailureFn(dsn string) func(w http.ResponseWriter, req *http.Request) 
 			pkt.Fingerprint = []string{r.Description}
 
 			if err := sendReport(dsn, pkt, userIDFor(req)); err != nil {
-				log.Println("Failed to send  crash report:", err)
+				log.Println("Failed to send failure report:", err)
+			} else {
+				log.Println("Sent failure report:", r.Description)
 			}
 		}
 	}

--- a/cmd/stcrashreceiver/stcrashreceiver.go
+++ b/cmd/stcrashreceiver/stcrashreceiver.go
@@ -130,7 +130,7 @@ func (r *crashReceiver) servePut(reportID, fullPath string, w http.ResponseWrite
 				return
 			}
 			if err := sendReport(r.dsn, pkt, user); err != nil {
-				log.Println("Failed to send  crash report:", err)
+				log.Println("Failed to send crash report:", err)
 			}
 		}()
 	}

--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -133,6 +133,8 @@ outer:
 					case <-ctx.Done():
 					}
 				}()
+			} else {
+				timer.Reset(minDelay)
 			}
 		case <-resetTimer:
 			timer.Reset(minDelay)


### PR DESCRIPTION
Failure reporting is broken because the timer is never reset when there's nothing to report. I also added/improved some logging on `stcrashreceiver`.

I tested failure reporting by running `stcrashreceiver` locally and triggering a "failure report testing" event - it works: https://sentry.syncthing.net/syncthing/syncthing/issues/5741/?query=test