### PR TITLE
gui: Fix blank device name under recent changes.

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1094,7 +1094,7 @@ angular.module('syncthing.core')
             if (matches.length !== 1) {
                 return shortID;
             }
-            return matches[0].name;
+            return $scope.friendlyNameFromID(matches[0]);
         };
 
         $scope.friendlyNameFromID = function (deviceID) {

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1098,7 +1098,7 @@ angular.module('syncthing.core')
             if (matches.length !== 1) {
                 return shortID;
             }
-            return matches[0].name;
+            return $scope.friendlyNameFromID(matches[0]);
         };
 
         $scope.friendlyNameFromID = function (deviceID) {


### PR DESCRIPTION
### Purpose

Fixes the device showing up as blank under recent changes if the friendly name is known. This also appears to have been mentioned in the [forum](https://forum.syncthing.net/t/device-name-is-blank-in-recent-changes/15970).

If the friendly name is unknown, eg if the remote device is removed after making a change, the short ID is still shown properly both before and after this change.