### PR TITLE
lib/connections: Handle QUIC not being available

### DIFF
--- a/lib/connections/deprecated.go
+++ b/lib/connections/deprecated.go
@@ -15,6 +15,10 @@ type invalidListener struct {
 }
 
 func (i invalidListener) Valid(_ config.Configuration) error {
+	if i.err == nil {
+		// fallback so we don't accidentally return nil
+		return errUnsupported
+	}
 	return i.err
 }
 
@@ -25,6 +29,10 @@ type invalidDialer struct {
 }
 
 func (i invalidDialer) Valid(_ config.Configuration) error {
+	if i.err == nil {
+		// fallback so we don't accidentally return nil
+		return errUnsupported
+	}
 	return i.err
 }
 

--- a/lib/connections/deprecated.go
+++ b/lib/connections/deprecated.go
@@ -8,29 +8,31 @@ package connections
 
 import "github.com/syncthing/syncthing/lib/config"
 
-// deprecatedListener is never valid
-type deprecatedListener struct {
+// invalidListener is never valid
+type invalidListener struct {
 	listenerFactory
+	err error
 }
 
-func (deprecatedListener) Valid(_ config.Configuration) error {
-	return errDeprecated
+func (i invalidListener) Valid(_ config.Configuration) error {
+	return i.err
 }
 
-// deprecatedDialer is never valid
-type deprecatedDialer struct {
+// invalidDialer is never valid
+type invalidDialer struct {
 	dialerFactory
+	err error
 }
 
-func (deprecatedDialer) Valid(_ config.Configuration) error {
-	return errDeprecated
+func (i invalidDialer) Valid(_ config.Configuration) error {
+	return i.err
 }
 
 func init() {
-	listeners["kcp"] = deprecatedListener{}
-	listeners["kcp4"] = deprecatedListener{}
-	listeners["kcp6"] = deprecatedListener{}
-	dialers["kcp"] = deprecatedDialer{}
-	dialers["kcp4"] = deprecatedDialer{}
-	dialers["kcp6"] = deprecatedDialer{}
+	listeners["kcp"] = invalidListener{err: errDeprecated}
+	listeners["kcp4"] = invalidListener{err: errDeprecated}
+	listeners["kcp6"] = invalidListener{err: errDeprecated}
+	dialers["kcp"] = invalidDialer{err: errDeprecated}
+	dialers["kcp4"] = invalidDialer{err: errDeprecated}
+	dialers["kcp6"] = invalidDialer{err: errDeprecated}
 }

--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// +build go1.12,!noquic,!go1.16
+// +build go1.14,!noquic,!go1.16
 
 package connections
 

--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// +build go1.12,!noquic
+// +build go1.12,!noquic,!go1.16
 
 package connections
 

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build go1.12,!noquic,!go1.16
+// +build go1.14,!noquic,!go1.16
 
 package connections
 

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build go1.12,!noquic
+// +build go1.12,!noquic,!go1.16
 
 package connections
 

--- a/lib/connections/quic_misc.go
+++ b/lib/connections/quic_misc.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build go1.12,!noquic,!go1.16
+// +build go1.14,!noquic,!go1.16
 
 package connections
 

--- a/lib/connections/quic_misc.go
+++ b/lib/connections/quic_misc.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build go1.12,!noquic
+// +build go1.12,!noquic,!go1.16
 
 package connections
 

--- a/lib/connections/quic_unsupported.go
+++ b/lib/connections/quic_unsupported.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build noquic go1.16
+// +build noquic !go1.14 go1.16
 
 package connections
 

--- a/lib/connections/quic_unsupported.go
+++ b/lib/connections/quic_unsupported.go
@@ -1,0 +1,68 @@
+// Copyright (C) 2020 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at http://mozilla.org/MPL/2.0/.
+
+// +build noquic go1.16
+
+package connections
+
+import (
+	"crypto/tls"
+	"net/url"
+
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/nat"
+)
+
+func init() {
+	factory := &quicUnsupportedListenerFactory{}
+	for _, scheme := range []string{"quic", "quic4", "quic6"} {
+		listeners[scheme] = factory
+	}
+}
+
+type quicUnsupportedListenerFactory struct{}
+
+func (quicUnsupportedListenerFactory) Valid(config.Configuration) error {
+	return errNotIncluded
+}
+
+func (quicUnsupportedListenerFactory) New(_ *url.URL, _ config.Wrapper, _ *tls.Config, _ chan internalConn, _ *nat.Service) genericListener {
+	panic("should never be called")
+}
+
+func (quicUnsupportedListenerFactory) Enabled(_ config.Configuration) bool {
+	return false
+}
+
+func init() {
+	factory := &quicUnsupportedDialerFactory{}
+	for _, scheme := range []string{"quic", "quic4", "quic6"} {
+		dialers[scheme] = factory
+	}
+}
+
+type quicUnsupportedDialerFactory struct {
+}
+
+func (quicUnsupportedDialerFactory) New(_ config.OptionsConfiguration, _ *tls.Config) genericDialer {
+	panic("should never be called")
+}
+
+func (quicUnsupportedDialerFactory) Priority() int {
+	return 0
+}
+
+func (quicUnsupportedDialerFactory) AlwaysWAN() bool {
+	return false
+}
+
+func (quicUnsupportedDialerFactory) Valid(_ config.Configuration) error {
+	return errNotIncluded
+}
+
+func (quicUnsupportedDialerFactory) String() string {
+	return "QUIC Dialer"
+}

--- a/lib/connections/quic_unsupported.go
+++ b/lib/connections/quic_unsupported.go
@@ -10,7 +10,7 @@ package connections
 
 func init() {
 	for _, scheme := range []string{"quic", "quic4", "quic6"} {
-		listeners[scheme] = invalidListener{err: errUnsupported}
-		dialers[scheme] = invalidDialer{err: errUnsupported}
+		listeners[scheme] = invalidListener{err: errNotInBuild}
+		dialers[scheme] = invalidDialer{err: errNotInBuild}
 	}
 }

--- a/lib/connections/quic_unsupported.go
+++ b/lib/connections/quic_unsupported.go
@@ -8,61 +8,9 @@
 
 package connections
 
-import (
-	"crypto/tls"
-	"net/url"
-
-	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/nat"
-)
-
 func init() {
-	factory := &quicUnsupportedListenerFactory{}
 	for _, scheme := range []string{"quic", "quic4", "quic6"} {
-		listeners[scheme] = factory
+		listeners[scheme] = invalidListener{err: errUnsupported}
+		dialers[scheme] = invalidDialer{err: errUnsupported}
 	}
-}
-
-type quicUnsupportedListenerFactory struct{}
-
-func (quicUnsupportedListenerFactory) Valid(config.Configuration) error {
-	return errNotIncluded
-}
-
-func (quicUnsupportedListenerFactory) New(_ *url.URL, _ config.Wrapper, _ *tls.Config, _ chan internalConn, _ *nat.Service) genericListener {
-	panic("should never be called")
-}
-
-func (quicUnsupportedListenerFactory) Enabled(_ config.Configuration) bool {
-	return false
-}
-
-func init() {
-	factory := &quicUnsupportedDialerFactory{}
-	for _, scheme := range []string{"quic", "quic4", "quic6"} {
-		dialers[scheme] = factory
-	}
-}
-
-type quicUnsupportedDialerFactory struct {
-}
-
-func (quicUnsupportedDialerFactory) New(_ config.OptionsConfiguration, _ *tls.Config) genericDialer {
-	panic("should never be called")
-}
-
-func (quicUnsupportedDialerFactory) Priority() int {
-	return 0
-}
-
-func (quicUnsupportedDialerFactory) AlwaysWAN() bool {
-	return false
-}
-
-func (quicUnsupportedDialerFactory) Valid(_ config.Configuration) error {
-	return errNotIncluded
-}
-
-func (quicUnsupportedDialerFactory) String() string {
-	return "QUIC Dialer"
 }

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -41,8 +41,9 @@ var (
 )
 
 var (
-	errDisabled   = errors.New("disabled by configuration")
-	errDeprecated = errors.New("deprecated protocol")
+	errDisabled    = errors.New("disabled by configuration")
+	errDeprecated  = errors.New("deprecated protocol")
+	errNotIncluded = errors.New("not included in this build")
 )
 
 const (
@@ -449,6 +450,9 @@ func (s *service) connect(ctx context.Context) error {
 					continue
 				case errDeprecated:
 					l.Debugln("Dialer for", uri, "is deprecated")
+					continue
+				case errNotIncluded:
+					l.Debugln("Dialer for", uri, "is not included in this build")
 					continue
 				default:
 					l.Infof("Dialer for %v: %v", uri, err)


### PR DESCRIPTION
This does two things:

- Exclude QUIC from go1.16 builds, automatically, for now, since it
  doesn't work and just panics.

- Provide some fake listeners and dialers when QUIC is disabled.

These fake listeners and dialers indicate that they are disabled and
unsupported, which silences "Dialing $address: unknown address scheme:
quic" type of stuff which is not super helpful to the user.
