### PR TITLE
lib/protocol: Handle slashified paths in IsEncryptedParent (fixes #7184)

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -538,9 +538,8 @@ func IsEncryptedParent(path string) bool {
 }
 
 func isEncryptedParentFromComponents(pathComponents []string) bool {
-	if l := len(pathComponents); l > 2 {
-		return false
-	} else if l == 2 && len(pathComponents[1]) != 2 {
+	l := len(pathComponents)
+	if l == 2 && len(pathComponents[1]) != 2 {
 		return false
 	} else if l == 0 {
 		return false
@@ -548,5 +547,16 @@ func isEncryptedParentFromComponents(pathComponents []string) bool {
 	if len(pathComponents[0]) == 0 {
 		return false
 	}
-	return pathComponents[0][1:] == encryptedDirExtension
+	if pathComponents[0][1:] != encryptedDirExtension {
+		return false
+	}
+	if l < 2 {
+		return true
+	}
+	for _, comp := range pathComponents[2:] {
+		if len(comp) != maxPathComponent {
+			return false
+		}
+	}
+	return true
 }

--- a/lib/protocol/encryption_test.go
+++ b/lib/protocol/encryption_test.go
@@ -11,6 +11,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/syncthing/syncthing/lib/rand"
 )
 
 func TestEnDecryptName(t *testing.T) {
@@ -97,6 +99,7 @@ func TestEnDecryptFileInfo(t *testing.T) {
 }
 
 func TestIsEncryptedParent(t *testing.T) {
+	comp := rand.String(maxPathComponent)
 	cases := []struct {
 		path string
 		is   bool
@@ -111,6 +114,10 @@ func TestIsEncryptedParent(t *testing.T) {
 		{"1" + encryptedDirExtension + "/bcd", false},
 		{"1" + encryptedDirExtension + "/bc/foo", false},
 		{"1.12/22", false},
+		{"1" + encryptedDirExtension + "/bc/" + comp, true},
+		{"1" + encryptedDirExtension + "/bc/" + comp + "/" + comp, true},
+		{"1" + encryptedDirExtension + "/bc/" + comp + "a", false},
+		{"1" + encryptedDirExtension + "/bc/" + comp + "/a/" + comp, false},
 	}
 	for _, tc := range cases {
 		if res := IsEncryptedParent(tc.path); res != tc.is {


### PR DESCRIPTION
This PR just adds awareness of slashified paths to existing methods that check if a given path could have been auto-generated by our encryption code (of course it's still possible to create an extraneous dir that looks like an encrypted one to sneak past this detection, that's not an issue though, we'll just ignore it (or delete if empty)). This does not address the point brought up in #7184 that it might be better to just not care about extraneous stuff in encrypted folders at all, it just fixes the behaviour as it is.