### PR TITLE
lib/api: Returns tags in version as list

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -643,7 +643,7 @@ func (s *service) getSystemVersion(w http.ResponseWriter, r *http.Request) {
 		"isCandidate": build.IsCandidate,
 		"isRelease":   build.IsRelease,
 		"date":        build.Date,
-		"tags":        build.Tags,
+		"tags":        build.TagsList(),
 		"stamp":       build.Stamp,
 		"user":        build.User,
 	})

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -87,18 +87,25 @@ func LongVersionFor(program string) string {
 	date := Date.UTC().Format("2006-01-02 15:04:05 MST")
 	v := fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
 
+	if tags := TagsList(); len(tags) > 0 {
+		sort.Strings(tags)
+		v = fmt.Sprintf("%s [%s]", v, strings.Join(tags, ", "))
+	}
+	return v
+}
+
+func TagsList() []string {
 	tags := strings.Split(Tags, ",")
 	if len(tags) == 1 && tags[0] == "" {
 		tags = tags[:0]
 	}
+
 	for _, envVar := range envTags {
 		if os.Getenv(envVar) != "" {
 			tags = append(tags, strings.ToLower(envVar))
 		}
 	}
-	if len(tags) > 0 {
-		sort.Strings(tags)
-		v = fmt.Sprintf("%s [%s]", v, strings.Join(tags, ", "))
-	}
-	return v
+
+	sort.Strings(tags)
+	return tags
 }

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -88,7 +88,6 @@ func LongVersionFor(program string) string {
 	v := fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
 
 	if tags := TagsList(); len(tags) > 0 {
-		sort.Strings(tags)
 		v = fmt.Sprintf("%s [%s]", v, strings.Join(tags, ", "))
 	}
 	return v
@@ -99,7 +98,6 @@ func TagsList() []string {
 	if len(tags) == 1 && tags[0] == "" {
 		tags = tags[:0]
 	}
-
 	for _, envVar := range envTags {
 		if os.Getenv(envVar) != "" {
 			tags = append(tags, strings.ToLower(envVar))


### PR DESCRIPTION
The GUI expected the version.tags field to be a list of current build
tags, but the thing the API sent was actually the comma separated string
set by the build script. (This was broken in d53a2567a.) First of all
this is the wrong format, secondly it doesn't include all the things we
actually consider tags. This fixes that.

Technically it's a breaking API change. I don't think anyone cares; it's
a bugfix of the previous unintentional API change.
