### PR TITLE
gui: Sort folders and devices in advanced config modal (fixes #6985)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2332,6 +2332,8 @@ angular.module('syncthing.core')
 
         $scope.advanced = function () {
             $scope.advancedConfig = angular.copy($scope.config);
+            $scope.advancedConfig.devices.sort(deviceCompare);
+            $scope.advancedConfig.folders.sort(folderCompare);
             $('#advanced').modal('show');
         };
 


### PR DESCRIPTION
Use alphabetical order for the name / label instead of ID, just like in the main page listings.

### Testing

Manual verification in the GUI.