### PR TITLE
lib/db: Remove index ids when dropping folder

### DIFF
--- a/lib/db/keyer.go
+++ b/lib/db/keyer.go
@@ -96,6 +96,7 @@ type keyer interface {
 
 	// index IDs
 	GenerateIndexIDKey(key, device, folder []byte) (indexIDKey, error)
+	FolderFromIndexIDKey(key []byte) ([]byte, bool)
 
 	// Mtimes
 	GenerateMtimesKey(key, folder []byte) (mtimesKey, error)
@@ -287,6 +288,10 @@ func (k defaultKeyer) GenerateIndexIDKey(key, device, folder []byte) (indexIDKey
 	binary.BigEndian.PutUint32(key[keyPrefixLen:], deviceID)
 	binary.BigEndian.PutUint32(key[keyPrefixLen+keyDeviceLen:], folderID)
 	return key, nil
+}
+
+func (k defaultKeyer) FolderFromIndexIDKey(key []byte) ([]byte, bool) {
+	return k.folderIdx.Val(binary.BigEndian.Uint32(key[keyPrefixLen+keyDeviceLen:]))
 }
 
 type mtimesKey []byte

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -556,6 +556,26 @@ func (db *Lowlevel) setIndexID(device, folder []byte, id protocol.IndexID) error
 	return db.Put(key, bs)
 }
 
+func (db *Lowlevel) dropFolderIndexIDs(folder []byte) error {
+	t, err := db.newReadWriteTransaction()
+	if err != nil {
+		return err
+	}
+	defer t.close()
+
+	if err := t.deleteKeyPrefixMatching([]byte{KeyTypeIndexID}, func(key []byte) bool {
+		keyFolder, ok := t.keyer.FolderFromIndexIDKey(key)
+		if !ok {
+			l.Debugf("Deleting IndexID with missing FolderIdx: %v", key)
+			return true
+		}
+		return bytes.Equal(keyFolder, folder)
+	}); err != nil {
+		return err
+	}
+	return t.Commit()
+}
+
 func (db *Lowlevel) dropMtimes(folder []byte) error {
 	key, err := db.keyer.GenerateMtimesKey(nil, folder)
 	if err != nil {

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -419,6 +419,7 @@ func DropFolder(db *Lowlevel, folder string) {
 		db.dropFolder,
 		db.dropMtimes,
 		db.dropFolderMeta,
+		db.dropFolderIndexIDs,
 		db.folderIdx.Delete,
 	}
 	for _, drop := range droppers {

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -889,12 +889,19 @@ func (t readWriteTransaction) removeFromGlobal(gk, keyBuf, folder, device, file 
 }
 
 func (t readWriteTransaction) deleteKeyPrefix(prefix []byte) error {
+	return t.deleteKeyPrefixMatching(prefix, func([]byte) bool { return true })
+}
+
+func (t readWriteTransaction) deleteKeyPrefixMatching(prefix []byte, match func(key []byte) bool) error {
 	dbi, err := t.NewPrefixIterator(prefix)
 	if err != nil {
 		return err
 	}
 	defer dbi.Release()
 	for dbi.Next() {
+		if !match(dbi.Key()) {
+			continue
+		}
 		if err := t.Delete(dbi.Key()); err != nil {
 			return err
 		}


### PR DESCRIPTION
We don't remove index-id entries from the database when removing a folder. I initially thought this is the culprit for https://github.com/syncthing/syncthing/issues/7198, however it is not: We do remove the folder index, thus we cannot reach the existing indexid, even though it still exists, and a new one is created. So all this PR does is clean up those unreachable index ids.