### PR TITLE
lib: Consistently set suture logging

### DIFF
--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -119,7 +119,7 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 	defer os.Remove(token)
 	srv.started = make(chan string)
 
-	sup := suture.New("test", util.Spec(func(e suture.Event) { l.Debugln(e) }))
+	sup := suture.New("test", util.SpecWithDebugLogger(l))
 	sup.Add(srv)
 	ctx, cancel := context.WithCancel(context.Background())
 	sup.ServeBackground(ctx)

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -119,7 +119,7 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 	defer os.Remove(token)
 	srv.started = make(chan string)
 
-	sup := suture.New("test", util.Spec())
+	sup := suture.New("test", util.Spec(func(e suture.Event) { l.Debugln(e) }))
 	sup.Add(srv)
 	ctx, cancel := context.WithCancel(context.Background())
 	sup.ServeBackground(ctx)

--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -45,7 +45,7 @@ type cast struct {
 // methods to get a functional implementation of Interface.
 func newCast(name string) *cast {
 	// Only log restarts in debug mode.
-	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
+	spec := util.SpecWithDebugLogger(l)
 	// Don't retry too frenetically: an error to open a socket or
 	// whatever is usually something that is either permanent or takes
 	// a while to get solved...

--- a/lib/beacon/beacon.go
+++ b/lib/beacon/beacon.go
@@ -44,16 +44,13 @@ type cast struct {
 // caller needs to set reader and writer with the addReader and addWriter
 // methods to get a functional implementation of Interface.
 func newCast(name string) *cast {
-	spec := util.Spec()
+	// Only log restarts in debug mode.
+	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
 	// Don't retry too frenetically: an error to open a socket or
 	// whatever is usually something that is either permanent or takes
 	// a while to get solved...
 	spec.FailureThreshold = 2
 	spec.FailureBackoff = 60 * time.Second
-	// Only log restarts in debug mode.
-	spec.EventHook = func(e suture.Event) {
-		l.Debugln(e)
-	}
 	c := &cast{
 		Supervisor: suture.New(name, spec),
 		name:       name,

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -139,7 +139,7 @@ type service struct {
 }
 
 func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *tls.Config, discoverer discover.Finder, bepProtocolName string, tlsDefaultCommonName string, evLogger events.Logger) Service {
-	spec := util.Spec(func(e suture.Event) { l.Infoln(e) })
+	spec := util.SpecWithInfoLogger(l)
 	service := &service{
 		Supervisor:              suture.New("connections.Service", spec),
 		connectionStatusHandler: newConnectionStatusHandler(),

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -139,10 +139,7 @@ type service struct {
 }
 
 func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *tls.Config, discoverer discover.Finder, bepProtocolName string, tlsDefaultCommonName string, evLogger events.Logger) Service {
-	spec := util.Spec()
-	spec.EventHook = func(e suture.Event) {
-		l.Infoln(e)
-	}
+	spec := util.Spec(func(e suture.Event) { l.Infoln(e) })
 	service := &service{
 		Supervisor:              suture.New("connections.Service", spec),
 		connectionStatusHandler: newConnectionStatusHandler(),

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -68,11 +68,8 @@ type Lowlevel struct {
 }
 
 func NewLowlevel(backend backend.Backend, opts ...Option) *Lowlevel {
-	spec := util.Spec()
 	// Only log restarts in debug mode.
-	spec.EventHook = func(e suture.Event) {
-		l.Debugln(e)
-	}
+	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
 	db := &Lowlevel{
 		Supervisor:         suture.New("db.Lowlevel", spec),
 		Backend:            backend,

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -69,7 +69,7 @@ type Lowlevel struct {
 
 func NewLowlevel(backend backend.Backend, opts ...Option) *Lowlevel {
 	// Only log restarts in debug mode.
-	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
+	spec := util.SpecWithDebugLogger(l)
 	db := &Lowlevel{
 		Supervisor:         suture.New("db.Lowlevel", spec),
 		Backend:            backend,

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -52,7 +52,7 @@ const (
 
 func NewLocal(id protocol.DeviceID, addr string, addrList AddressLister, evLogger events.Logger) (FinderService, error) {
 	c := &localClient{
-		Supervisor:      suture.New("local", util.Spec()),
+		Supervisor:      suture.New("local", util.Spec(func(e suture.Event) { l.Debugln(e) })),
 		myID:            id,
 		addrList:        addrList,
 		evLogger:        evLogger,

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -52,7 +52,7 @@ const (
 
 func NewLocal(id protocol.DeviceID, addr string, addrList AddressLister, evLogger events.Logger) (FinderService, error) {
 	c := &localClient{
-		Supervisor:      suture.New("local", util.Spec(func(e suture.Event) { l.Debugln(e) })),
+		Supervisor:      suture.New("local", util.SpecWithDebugLogger(l)),
 		myID:            id,
 		addrList:        addrList,
 		evLogger:        evLogger,

--- a/lib/discover/manager.go
+++ b/lib/discover/manager.go
@@ -47,7 +47,7 @@ type manager struct {
 
 func NewManager(myID protocol.DeviceID, cfg config.Wrapper, cert tls.Certificate, evLogger events.Logger, lister AddressLister) Manager {
 	m := &manager{
-		Supervisor:    suture.New("discover.Manager", util.Spec(func(e suture.Event) { l.Debugln(e) })),
+		Supervisor:    suture.New("discover.Manager", util.SpecWithDebugLogger(l)),
 		myID:          myID,
 		cfg:           cfg,
 		cert:          cert,

--- a/lib/discover/manager.go
+++ b/lib/discover/manager.go
@@ -47,7 +47,7 @@ type manager struct {
 
 func NewManager(myID protocol.DeviceID, cfg config.Wrapper, cert tls.Certificate, evLogger events.Logger, lister AddressLister) Manager {
 	m := &manager{
-		Supervisor:    suture.New("discover.Manager", util.Spec()),
+		Supervisor:    suture.New("discover.Manager", util.Spec(func(e suture.Event) { l.Debugln(e) })),
 		myID:          myID,
 		cfg:           cfg,
 		cert:          cert,

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -52,7 +52,7 @@ type folderSummaryService struct {
 
 func NewFolderSummaryService(cfg config.Wrapper, m Model, id protocol.DeviceID, evLogger events.Logger) FolderSummaryService {
 	service := &folderSummaryService{
-		Supervisor:      suture.New("folderSummaryService", util.Spec()),
+		Supervisor:      suture.New("folderSummaryService", util.Spec(func(e suture.Event) { l.Debugln(e) })),
 		cfg:             cfg,
 		model:           m,
 		id:              id,

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -52,7 +52,7 @@ type folderSummaryService struct {
 
 func NewFolderSummaryService(cfg config.Wrapper, m Model, id protocol.DeviceID, evLogger events.Logger) FolderSummaryService {
 	service := &folderSummaryService{
-		Supervisor:      suture.New("folderSummaryService", util.Spec(func(e suture.Event) { l.Debugln(e) })),
+		Supervisor:      suture.New("folderSummaryService", util.SpecWithDebugLogger(l)),
 		cfg:             cfg,
 		model:           m,
 		id:              id,

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -195,10 +195,7 @@ var (
 // where it sends index information to connected peers and responds to requests
 // for file data without altering the local folder in any way.
 func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersion string, ldb *db.Lowlevel, protectedFiles []string, evLogger events.Logger) Model {
-	spec := util.Spec()
-	spec.EventHook = func(e suture.Event) {
-		l.Debugln(e)
-	}
+	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
 	m := &model{
 		Supervisor: suture.New("model", spec),
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -195,7 +195,7 @@ var (
 // where it sends index information to connected peers and responds to requests
 // for file data without altering the local folder in any way.
 func NewModel(cfg config.Wrapper, id protocol.DeviceID, clientName, clientVersion string, ldb *db.Lowlevel, protectedFiles []string, evLogger events.Logger) Model {
-	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
+	spec := util.SpecWithDebugLogger(l)
 	m := &model{
 		Supervisor: suture.New("model", spec),
 

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -99,10 +99,7 @@ func New(cfg config.Wrapper, dbBackend backend.Backend, evLogger events.Logger, 
 func (a *App) Start() error {
 	// Create a main service manager. We'll add things to this as we go along.
 	// We want any logging it does to go through our log system.
-	spec := util.Spec()
-	spec.EventHook = func(e suture.Event) {
-		l.Debugln(e)
-	}
+	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
 	a.mainService = suture.New("main", spec)
 
 	// Start the supervisor and wait for it to stop to handle cleanup.

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -99,7 +99,7 @@ func New(cfg config.Wrapper, dbBackend backend.Backend, evLogger events.Logger, 
 func (a *App) Start() error {
 	// Create a main service manager. We'll add things to this as we go along.
 	// We want any logging it does to go through our log system.
-	spec := util.Spec(func(e suture.Event) { l.Debugln(e) })
+	spec := util.SpecWithDebugLogger(l)
 	a.mainService = suture.New("main", spec)
 
 	// Start the supervisor and wait for it to stop to handle cleanup.

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/syncthing/syncthing/lib/logger"
 	"github.com/syncthing/syncthing/lib/sync"
 
 	"github.com/thejerf/suture/v4"
@@ -390,7 +391,15 @@ func OnSupervisorDone(sup *suture.Supervisor, fn func()) {
 	sup.Add(&doneService{fn})
 }
 
-func Spec(eventHook suture.EventHook) suture.Spec {
+func SpecWithDebugLogger(l logger.Logger) suture.Spec {
+	return spec(func(e suture.Event) { l.Debugln(e) })
+}
+
+func SpecWithInfoLogger(l logger.Logger) suture.Spec {
+	return spec(func(e suture.Event) { l.Infoln(e) })
+}
+
+func spec(eventHook suture.EventHook) suture.Spec {
 	return suture.Spec{
 		EventHook:                eventHook,
 		PassThroughPanics:        true,

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -390,8 +390,9 @@ func OnSupervisorDone(sup *suture.Supervisor, fn func()) {
 	sup.Add(&doneService{fn})
 }
 
-func Spec() suture.Spec {
+func Spec(eventHook suture.EventHook) suture.Spec {
 	return suture.Spec{
+		EventHook:                eventHook,
 		PassThroughPanics:        true,
 		DontPropagateTermination: false,
 	}


### PR DESCRIPTION
I got some log lines like this in my testing logs:

```
2020/12/16 11:57:51 broadcastBeacon: Failed service 'Service@0xc000046500 created by broadcastBeacon@0xc000272460/reader' (1.000000 failures of 2.000000), restarting: true, error: listen udp4 :21027: bind: address already in use
```

The supervisor for local discovery didn't set the suture event (log) hook, thus it got logged to stdout via `log`.

To prevent that oversight I added an `eventHook` argument to our `util.Spec` convenience function.