### PR TITLE
lib/config: Remove deprecated pending entries from config (ref #6443)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	OldestHandledVersion = 10
-	CurrentVersion       = 32
+	CurrentVersion       = 33
 	MaxRescanIntervalS   = 365 * 24 * 60 * 60
 )
 

--- a/lib/config/migrations.go
+++ b/lib/config/migrations.go
@@ -27,6 +27,7 @@ import (
 // put the newest on top for readability.
 var (
 	migrations = migrationSet{
+		{33, migrateToConfigV33},
 		{32, migrateToConfigV32},
 		{31, migrateToConfigV31},
 		{30, migrateToConfigV30},
@@ -91,15 +92,22 @@ func (m migration) apply(cfg *Configuration) {
 	cfg.Version = m.targetVersion
 }
 
-func migrateToConfigV31(cfg *Configuration) {
-	// Show a notification about setting User and Password
-	cfg.Options.UnackedNotificationIDs = append(cfg.Options.UnackedNotificationIDs, "authenticationUserAndPassword")
+func migrateToConfigV33(cfg *Configuration) {
+	for i := range cfg.Devices {
+		cfg.Devices[i].DeprecatedPendingFolders = nil
+	}
+	cfg.DeprecatedPendingDevices = nil
 }
 
 func migrateToConfigV32(cfg *Configuration) {
 	for i := range cfg.Folders {
 		cfg.Folders[i].JunctionsAsDirs = true
 	}
+}
+
+func migrateToConfigV31(cfg *Configuration) {
+	// Show a notification about setting User and Password
+	cfg.Options.UnackedNotificationIDs = append(cfg.Options.UnackedNotificationIDs, "authenticationUserAndPassword")
 }
 
 func migrateToConfigV30(cfg *Configuration) {


### PR DESCRIPTION
Removes the pending entries in config, which live in db since #6443.  
We discussed that there's no need to transfer existing pending entries in config over to db as that's low-value info and will get reintroduced on next connect (and would also be hard to do due to package dependency issues), but they still should be erased.