### PR TITLE
lib/model: Unflake TestIgnoreDeleteUnignore

### DIFF
--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -1029,6 +1029,7 @@ func TestIgnoreDeleteUnignore(t *testing.T) {
 	defer cleanupModelAndRemoveDir(m, tmpDir)
 
 	folderIgnoresAlwaysReload(m, fcfg)
+	m.ScanFolders()
 
 	fc := addFakeConn(m, device1)
 	fc.folder = "default"


### PR DESCRIPTION
Finally a flaky test that I can trigger :)

`folderIgnoresAlwaysReload` causes a folder restart, thus an initial scan. And writing a test file is a two step procedure: 1. write contents. 2. chmod. If that initial scan falls in between those two operations, the test fails :D 