### PR TITLE
lib/fs: Correct wrapping order for meaningful log-caller

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -381,7 +381,7 @@ func (s *FileSet) SetIndexID(device protocol.DeviceID, id protocol.IndexID) {
 	}
 }
 
-func (s *FileSet) MtimeFS() *fs.MtimeFS {
+func (s *FileSet) MtimeFS() fs.Filesystem {
 	opStr := fmt.Sprintf("%s MtimeFS()", s.folder)
 	l.Debugf(opStr)
 	prefix, err := s.db.keyer.GenerateMtimesKey(nil, []byte(s.folder))

--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -98,7 +98,9 @@ type caseFilesystem struct {
 // case-sensitive one. However it will add some overhead and thus shouldn't be
 // used if the filesystem is known to already behave case-sensitively.
 func NewCaseFilesystem(fs Filesystem) Filesystem {
-	return globalCaseFilesystemRegistry.get(fs)
+	return wrapFilesystem(fs, func(ifs Filesystem) Filesystem {
+		return globalCaseFilesystemRegistry.get(ifs)
+	})
 }
 
 func (f *caseFilesystem) Chmod(name string, mode FileMode) error {

--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -52,7 +52,7 @@ type caseFilesystemRegistry struct {
 	startCleaner sync.Once
 }
 
-func (r *caseFilesystemRegistry) get(fs Filesystem) *caseFilesystem {
+func (r *caseFilesystemRegistry) get(fs Filesystem) Filesystem {
 	r.mut.Lock()
 	defer r.mut.Unlock()
 
@@ -98,9 +98,7 @@ type caseFilesystem struct {
 // case-sensitive one. However it will add some overhead and thus shouldn't be
 // used if the filesystem is known to already behave case-sensitively.
 func NewCaseFilesystem(fs Filesystem) Filesystem {
-	return wrapFilesystem(fs, func(ifs Filesystem) Filesystem {
-		return globalCaseFilesystemRegistry.get(ifs)
-	})
+	return wrapFilesystem(fs, globalCaseFilesystemRegistry.get)
 }
 
 func (f *caseFilesystem) Chmod(name string, mode FileMode) error {


### PR DESCRIPTION
With `fs` debug logging we print information about what called the fs method. However for case- and mtime-fileysstems, this information is entirely useless, as it just points at the overriding method in those wrappers (e.g. chmod just says it was called by chmod). To prevent that I added a utility function that ensures proper wrapping order:

```golang
// wrapFilesystem should always be used when wrapping a Filesystem.
// It ensures proper wrapping order, which right now means:
// `logFilesystem` needs to be the outermost wrapper for caller lookup.
func wrapFilesystem(fs Filesystem, wrapFn func(Filesystem) Filesystem) Filesystem {
```