### PR TITLE
lib/db: Prevent IndexID creation race

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -65,6 +65,7 @@ type Lowlevel struct {
 	gcKeyCount         int
 	indirectGCInterval time.Duration
 	recheckInterval    time.Duration
+	oneFileSetCreated  chan struct{}
 }
 
 func NewLowlevel(backend backend.Backend, opts ...Option) *Lowlevel {
@@ -81,6 +82,7 @@ func NewLowlevel(backend backend.Backend, opts ...Option) *Lowlevel {
 		gcMut:              sync.NewRWMutex(),
 		indirectGCInterval: indirectGCDefaultInterval,
 		recheckInterval:    recheckDefaultInterval,
+		oneFileSetCreated:  make(chan struct{}),
 	}
 	for _, opt := range opts {
 		opt(db)

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -39,13 +39,27 @@ type FileSet struct {
 type Iterator func(f protocol.FileIntf) bool
 
 func NewFileSet(folder string, fs fs.Filesystem, db *Lowlevel) *FileSet {
-	return &FileSet{
+	select {
+	case <-db.oneFileSetCreated:
+	default:
+		close(db.oneFileSetCreated)
+	}
+	s := &FileSet{
 		folder:      folder,
 		fs:          fs,
 		db:          db,
 		meta:        db.loadMetadataTracker(folder),
 		updateMutex: sync.NewMutex(),
 	}
+	if id := s.IndexID(protocol.LocalDeviceID); id == 0 {
+		// No index ID set yet. We create one now.
+		id = protocol.NewIndexID()
+		err := s.db.setIndexID(protocol.LocalDeviceID[:], []byte(s.folder), id)
+		if err != nil && !backend.IsClosed(err) {
+			fatalError(err, fmt.Sprintf("%s Creating new IndexID", s.folder), s.db)
+		}
+	}
+	return s
 }
 
 func (s *FileSet) Drop(device protocol.DeviceID) {
@@ -357,16 +371,6 @@ func (s *FileSet) IndexID(device protocol.DeviceID) protocol.IndexID {
 	} else if err != nil {
 		fatalError(err, opStr, s.db)
 	}
-	if id == 0 && device == protocol.LocalDeviceID {
-		// No index ID set yet. We create one now.
-		id = protocol.NewIndexID()
-		err := s.db.setIndexID(device[:], []byte(s.folder), id)
-		if backend.IsClosed(err) {
-			return 0
-		} else if err != nil {
-			fatalError(err, opStr, s.db)
-		}
-	}
 	return id
 }
 
@@ -432,7 +436,14 @@ func DropFolder(db *Lowlevel, folder string) {
 
 // DropDeltaIndexIDs removes all delta index IDs from the database.
 // This will cause a full index transmission on the next connection.
+// Must be called before using FileSets, i.e. before NewFileSet is called for
+// the first time.
 func DropDeltaIndexIDs(db *Lowlevel) {
+	select {
+	case <-db.oneFileSetCreated:
+		panic("DropDeltaIndexIDs must not be called after NewFileSet for the same Lowlevel")
+	default:
+	}
 	opStr := "DropDeltaIndexIDs"
 	l.Debugf(opStr)
 	dbi, err := db.NewPrefixIterator([]byte{KeyTypeIndexID})


### PR DESCRIPTION
### Purpose

When anyone calls `FileSet.IndexID` and the local one is zero, we create a new one. Thus two goroutines calling it concurrently may return two different IDs, and the later one will be persisted. I realised this because of logs connected to https://forum.syncthing.net/t/mismatching-index-id-for-us-on-almost-every-restart-again/16036/8:
```
129:[RTF25] 14:24:38 INFO: Device DWJVRMJ-... folder "A" (a) has mismatching index ID for us (0xA0175C8807ED7CBB != 0x42C01C3C03087F58)
[...]
566:[RTF25] 15:10:32 INFO: Device DWJVRMJ-... folder "A" (a) has mismatching index ID for us (0x42C01C3C03087F58 != 0x6F4E1206A392035F)
```

However it still seems quite improbable: The race would be between any incoming and any outgoing CC (both call `IndexID`). Then again, there's quite a few devices and folders in that log, so why not.

### Testing

New unit test of questionable style. Before this PR it consistently failed the first time for me, so it does work at least.