### PR TITLE
lib/model: Fix flaky test and add some scanning debug

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -392,6 +392,8 @@ func (f *folder) pull() (success bool) {
 }
 
 func (f *folder) scanSubdirs(subDirs []string) error {
+	l.Debugf("%v scanning", f)
+
 	oldHash := f.ignores.Hash()
 
 	err := f.getHealthErrorAndLoadIgnores()
@@ -493,6 +495,7 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 	// changes.
 	changes := 0
 	defer func() {
+		l.Debugf("%v finished scanning, detected %v changes", f, changes)
 		if changes > 0 {
 			f.SchedulePull()
 		}
@@ -508,6 +511,7 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 			case gf.IsEquivalentOptional(fi, f.modTimeWindow, false, false, protocol.FlagLocalReceiveOnly):
 				// What we have locally is equivalent to the global file.
 				fi.Version = gf.Version
+				l.Debugf("%v scanning: Merging identical locally changed item with global", f, fi)
 				fallthrough
 			case fi.IsDeleted() && (gf.IsReceiveOnlyChanged() || gf.IsDeleted()):
 				// Our item is deleted and the global item is our own
@@ -515,6 +519,7 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 				// case we can't delete file infos, so we just
 				// pretend it is a normal deleted file (nobody
 				// cares about that).
+				l.Debugf("%v scanning: Marking item as not locally changed", f, fi)
 				fi.LocalFlags &^= protocol.FlagLocalReceiveOnly
 			}
 			batch.append(fi)

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -393,9 +393,13 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 		return true
 	})
 	snap.Release()
-	m.Index(device1, "ro", files)
+	m.IndexUpdate(device1, "ro", files)
 
-	must(t, m.ScanFolder("ro"))
+	// Ensure the pull to resolve conflicts (content identical) happened
+	must(t, f.doInSync(func() error {
+		f.pull()
+		return nil
+	}))
 
 	size = receiveOnlyChangedSize(t, m, "ro")
 	if size.Files+size.Directories+size.Deleted != 0 {


### PR DESCRIPTION
Another flaky test fix:

The test checks that the locally changed items get resolved when the remote has identical files (but different version). That happens in the puller, but the test calls `ScanFolders`. In most cases a pull will happen before that, but in rare cases not.  
Solution: Do a pull from the test instead of calling `ScanFolders`.

I sneaked in some debug logging, because frankly we are super verbose all over model, but scanning is kind of a black box (concretely the lack of indication that a scan actually happens confused me looking at logs).