### PR TITLE
Allow validation of relay join requests by certificate

### DIFF
--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -6,9 +6,11 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"github.com/syncthing/syncthing/lib/protocol"
 	"io"
 	"io/ioutil"
 	"log"
@@ -208,6 +210,7 @@ func main() {
 		tlsCfg := &tls.Config{
 			Certificates: []tls.Certificate{cert},
 			MinVersion:   tls.VersionTLS10, // No SSLv3
+			ClientAuth:   tls.RequestClientCert,
 			CipherSuites: []uint16{
 				// No RC4
 				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
@@ -338,6 +341,12 @@ func handleGetRequest(rw http.ResponseWriter, r *http.Request) {
 }
 
 func handlePostRequest(w http.ResponseWriter, r *http.Request) {
+	var relayCert *x509.Certificate
+	if r.TLS != nil && len(r.TLS.PeerCertificates) > 0 {
+		relayCert = r.TLS.PeerCertificates[0]
+		log.Printf("Got TLS cert from relay server")
+	}
+
 	var newRelay relay
 	err := json.NewDecoder(r.Body).Decode(&newRelay)
 	r.Body.Close()
@@ -357,6 +366,16 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
+	}
+
+	if relayCert != nil {
+		advertisedId := uri.Query().Get("id")
+		idFromCert := protocol.NewDeviceID(relayCert.Raw).String()
+		if advertisedId != idFromCert {
+			log.Println("Warning: Relay server requested to join with an ID different from the join request, rejecting")
+			http.Error(w, "mismatched advertised id and join request cert", http.StatusBadRequest)
+			return
+		}
 	}
 
 	host, port, err := net.SplitHostPort(uri.Host)
@@ -379,7 +398,7 @@ func handlePostRequest(w http.ResponseWriter, r *http.Request) {
 	if ip == nil || ip.IsUnspecified() {
 		uri.Host = net.JoinHostPort(rhost, port)
 		newRelay.URL = uri.String()
-	} else if host != rhost {
+	} else if host != rhost && relayCert == nil {
 		if debug {
 			log.Println("IP address advertised does not match client IP address", r.RemoteAddr, uri)
 		}

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -247,7 +247,7 @@ func main() {
 	for _, pool := range pools {
 		pool = strings.TrimSpace(pool)
 		if len(pool) > 0 {
-			go poolHandler(pool, uri, mapping)
+			go poolHandler(pool, uri, mapping, cert)
 		}
 	}
 

--- a/cmd/strelaysrv/pool.go
+++ b/cmd/strelaysrv/pool.go
@@ -32,12 +32,21 @@ func poolHandler(pool string, uri *url.URL, mapping mapping, ownCert tls.Certifi
 			uriCopy.String(),
 		})
 
-		client := http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					Certificates: []tls.Certificate{ownCert},
+		poolUrl, err := url.Parse(pool)
+		if err != nil {
+			log.Printf("Could not parse pool url '%s': %v", pool, err)
+		}
+
+		client := http.DefaultClient
+		if poolUrl.Scheme == "https" {
+			// Sent our certificate in join request
+			client = &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{
+						Certificates: []tls.Certificate{ownCert},
+					},
 				},
-			},
+			}
 		}
 
 		resp, err := client.Post(pool, "application/json", &b)


### PR DESCRIPTION
### Purpose

As discussed in #7196, there might be some scenarios where a relay server might want to advertise itself from a different IP address from which it is actually listening on. This is currently not possible, as the relay pool server rejects join requests whose advertised remote address does not match the address used to make the join request.

This PR enables relay servers to send their TLS certificate in the join requests, provided the pool is contacted via https. The relay pool server will capture this certificate, generate the Device ID from it, and compare it to the advertised device ID. If they do not match, the request is rejected straight away.

This ensures that the agent sending the join request is indeed in possession of the key corresponding to the advertised device ID. This advertised device ID is later checked to be the same as the one behind the advertised IP address as a part of the original connection test by `performHandshakeAndValidation` on: https://github.com/syncthing/syncthing/blob/d904dfa1918ae09a7af38c75945903ba494fd21f/lib/relay/client/static.go#L240-L242

While this check is only triggered if `uri.Query().Get("id") != ""`, this is ensured by the mismatch check mentioned earlier.

### Testing

Very basic tested was performed locally by building a relay server and a pool server with the changes, and checking that they were able to exchange and validate the certificates. Please comment if you think more testing (automated or not) is desired for this.

### Screenshots

N/A

### Documentation

> If this is a user visible change (including API and protocol changes), add a link here to the corresponding pull request on https://github.com/syncthing/docs or describe the documentation changes necessary.

None done yet, please tell me if this is necessary.

---

Closes #7196
