### PR TITLE
gui: Fix nonfunctional ignore button on pending folder notification.

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1999,8 +1999,8 @@ angular.module('syncthing.core')
                 time: (new Date()).toISOString()
             }
 
-            if (id in $scope.devices) {
-                $scope.devices[id].ignoredFolders.push(ignoredFolder);
+            if (device in $scope.devices) {
+                $scope.devices[device].ignoredFolders.push(ignoredFolder);
                 $scope.saveConfig();
             }
         };

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -2018,8 +2018,8 @@ angular.module('syncthing.core')
                 time: (new Date()).toISOString()
             }
 
-            if (id in $scope.devices) {
-                $scope.devices[id].ignoredFolders.push(ignoredFolder);
+            if (device in $scope.devices) {
+                $scope.devices[device].ignoredFolders.push(ignoredFolder);
                 $scope.saveConfig();
             }
         };


### PR DESCRIPTION
The merge of #6443 apparently introduced a wrong argument name in
$scope.ignoreFolder().  This fixes the regression.