### PR TITLE
cmd/stevents: Add command line argument for event type filtering.

### DIFF
--- a/cmd/stevents/main.go
+++ b/cmd/stevents/main.go
@@ -28,16 +28,21 @@ func main() {
 	log.SetFlags(0)
 
 	target := flag.String("target", "localhost:8384", "Target Syncthing instance")
+	types := flag.String("types", "", "Filter for specific event types (comma-separated)")
 	apikey := flag.String("apikey", "", "Syncthing API key")
 	flag.Parse()
 
 	if *apikey == "" {
 		log.Fatal("Must give -apikey argument")
 	}
+	var eventsArg string
+	if len(*types) > 0 {
+		eventsArg = "&events=" + *types
+	}
 
 	since := 0
 	for {
-		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/rest/events?since=%d", *target, since), nil)
+		req, err := http.NewRequest("GET", fmt.Sprintf("http://%s/rest/events?since=%d%s", *target, since, eventsArg), nil)
 		if err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
Add a `-types` flag which can be set to a comma-separated list of event
types.  The contents will be included verbatim in the URL parameter
`events`.

### Testing

Tested against a devopment instance of Syncthing running locally, with two event types specified.