### PR TITLE
gui: Fix missing sharing device when adding pending folder.

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1781,7 +1781,7 @@ angular.module('syncthing.core')
                 $scope.currentSharing.selected[n.deviceID] = true;
             });
             $scope.currentSharing.unrelated = $scope.deviceList().filter(function (n) {
-                return n.deviceID !== $scope.myID && !$scope.currentSharing.selected[n.deviceID]
+                return n.deviceID !== $scope.myID && !$scope.currentSharing.selected[n.deviceID];
             });
             if ($scope.currentFolder.versioning && $scope.currentFolder.versioning.type === "trashcan") {
                 $scope.currentFolder.trashcanFileVersioning = true;
@@ -1879,7 +1879,7 @@ angular.module('syncthing.core')
             initShareEditing('folder');
             $scope.currentSharing.selected[device] = true;
             $scope.currentSharing.unrelated = $scope.deviceList().filter(function (n) {
-                return n.deviceID !== $scope.myID && !$scope.currentSharing.selected[n.deviceID]
+                return n.deviceID !== $scope.myID;
             });
             $scope.ignores.text = '';
             $scope.ignores.error = null;

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1798,7 +1798,7 @@ angular.module('syncthing.core')
                 $scope.currentSharing.selected[n.deviceID] = true;
             });
             $scope.currentSharing.unrelated = $scope.deviceList().filter(function (n) {
-                return n.deviceID !== $scope.myID && !$scope.currentSharing.selected[n.deviceID]
+                return n.deviceID !== $scope.myID && !$scope.currentSharing.selected[n.deviceID];
             });
             if ($scope.currentFolder.versioning && $scope.currentFolder.versioning.type === "trashcan") {
                 $scope.currentFolder.trashcanFileVersioning = true;
@@ -1896,7 +1896,7 @@ angular.module('syncthing.core')
             initShareEditing('folder');
             $scope.currentSharing.selected[device] = true;
             $scope.currentSharing.unrelated = $scope.deviceList().filter(function (n) {
-                return n.deviceID !== $scope.myID && !$scope.currentSharing.selected[n.deviceID]
+                return n.deviceID !== $scope.myID;
             });
             $scope.ignores.text = '';
             $scope.ignores.error = null;


### PR DESCRIPTION
When adding a folder from the pending folder from another device
through the Add button on the "New Folder" notification panel, the
offering device should be preselected for sharing with.  The selection
works, but the checkmark for that device is not shown at all.

Do not filter out the preselected device ID when building the
currentSharing.unrelated member in addFolderAndShare() to actually
show all devices under the "Unshared Devices" heading.

### Testing

Tested with local development instance where several folders are pending from other devices.  Offering device appears again, with the checkmark pre-selected.  Also verified on the "untrusted" GUI variant.