### PR TITLE
lib/fs: Fix TestChmodDir depending on umask (fixes #6551)

### DIFF
--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -121,6 +121,10 @@ func TestChmodDir(t *testing.T) {
 	if err := os.Mkdir(path, mode); err != nil {
 		t.Error(err)
 	}
+	// On UNIX, Mkdir will subtract the umask, so force desired mode explicitly
+	if err := os.Chmod(path, mode); err != nil {
+		t.Error(err)
+	}
 
 	if stat, err := os.Stat(path); err != nil || stat.Mode()&os.ModePerm != mode {
 		t.Errorf("wrong perm: %t %#o", err == nil, stat.Mode()&os.ModePerm)


### PR DESCRIPTION
The test would fail if the umask on UNIX is greater than 0022, because
the OS transparently subtracts it from the mode passed to Mkdir(), as
the Go documentation confirms.

Our goal here is not to test os.Mkdir(), so just make sure the desired
mode is actually set by forcing it afterwards.