### PR TITLE
lib/ur: Plug file descriptor leak in Linux memorySize

### DIFF
--- a/lib/ur/memsize_linux.go
+++ b/lib/ur/memsize_linux.go
@@ -18,6 +18,7 @@ func memorySize() int64 {
 	if err != nil {
 		return 0
 	}
+	defer f.Close()
 
 	s := bufio.NewScanner(f)
 	if !s.Scan() {


### PR DESCRIPTION
On Linux, memorySize in lib/ur would open /proc/meminfo but never close it.