### PR TITLE
lib/fs, lib/model: Reduce lock contention on NewCaseFilesystem (fixes #7268)

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -48,25 +48,35 @@ type fskey struct {
 // their cache every now and then.
 type caseFilesystemRegistry struct {
 	fss          map[fskey]*caseFilesystem
-	mut          sync.Mutex
+	mut          sync.RWMutex
 	startCleaner sync.Once
 }
 
 func (r *caseFilesystemRegistry) get(fs Filesystem) Filesystem {
-	r.mut.Lock()
-	defer r.mut.Unlock()
-
 	k := fskey{fs.Type(), fs.URI()}
+
+	// Use double locking when getting a caseFs. In the common case it will
+	// already exist and we take the read lock fast path. If it doesn't, we
+	// take a write lock and try again.
+
+	r.mut.RLock()
 	caseFs, ok := r.fss[k]
+	r.mut.RUnlock()
+
 	if !ok {
-		caseFs = &caseFilesystem{
-			Filesystem: fs,
-			realCaser:  newDefaultRealCaser(fs),
+		r.mut.Lock()
+		caseFs, ok = r.fss[k]
+		if !ok {
+			caseFs = &caseFilesystem{
+				Filesystem: fs,
+				realCaser:  newDefaultRealCaser(fs),
+			}
+			r.fss[k] = caseFs
+			r.startCleaner.Do(func() {
+				go r.cleaner()
+			})
 		}
-		r.fss[k] = caseFs
-		r.startCleaner.Do(func() {
-			go r.cleaner()
-		})
+		r.mut.Unlock()
 	}
 
 	return caseFs
@@ -74,11 +84,11 @@ func (r *caseFilesystemRegistry) get(fs Filesystem) Filesystem {
 
 func (r *caseFilesystemRegistry) cleaner() {
 	for range time.NewTicker(time.Minute).C {
-		r.mut.Lock()
+		r.mut.RLock()
 		for _, caseFs := range r.fss {
 			caseFs.dropCache()
 		}
-		r.mut.Unlock()
+		r.mut.RUnlock()
 	}
 }
 


### PR DESCRIPTION
This makes it faster to get a caseFs when it's already cached, which it almost always is. It also moves the filesystem touching things in the request path to until after we've passed the limiter, so that we block there instead on the casefs lock.