### PR TITLE
gui: Fix log-tailing behavior when scrolled to top (fixes #7267)

### DIFF
--- a/gui/default/syncthing/core/logViewerModalView.html
+++ b/gui/default/syncthing/core/logViewerModalView.html
@@ -29,7 +29,7 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-default btn-sm" ng-click="logging.close()">
+    <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">
       <span class="fas fa-times"></span>&nbsp;<span translate>Close</span>
     </button>
   </div>

--- a/gui/default/syncthing/core/logViewerModalView.html
+++ b/gui/default/syncthing/core/logViewerModalView.html
@@ -29,7 +29,7 @@
     </div>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">
+    <button type="button" class="btn btn-default btn-sm" ng-click="logging.close()">
       <span class="fas fa-times"></span>&nbsp;<span translate>Close</span>
     </button>
   </div>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1212,6 +1212,10 @@ angular.module('syncthing.core')
                     $scope.logging.entries = [];
                 });
             },
+            close: function () {
+                $('#logViewer').modal('hide');
+                $scope.logging.paused = false;
+            },
             onFacilityChange: function (facility) {
                 var enabled = $scope.logging.facilities[facility].enabled;
                 // Disable checkboxes while we're in flight.

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1198,6 +1198,7 @@ angular.module('syncthing.core')
                 }).error($scope.emitHTTPError);
             },
             show: function () {
+                $scope.logging.paused = false;
                 $scope.logging.refreshFacilities();
                 $scope.logging.timer = $timeout($scope.logging.fetch);
                 var textArea = $('#logViewerText');
@@ -1211,10 +1212,6 @@ angular.module('syncthing.core')
                     $scope.logging.timer = null;
                     $scope.logging.entries = [];
                 });
-            },
-            close: function () {
-                $('#logViewer').modal('hide');
-                $scope.logging.paused = false;
             },
             onFacilityChange: function (facility) {
                 var enabled = $scope.logging.facilities[facility].enabled;


### PR DESCRIPTION
### Purpose

Fixes reported issue #7267

### Testing

1) Open logging modal
2) Scroll to top to stop log-tailing
3) Close modal
4) Reopen modal and see log-tailing resumes and displays log instead of blank textarea as shown in issue repoort