### PR TITLE
gui: disable rescan all when at least one folder is not paused (fixes #7257)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -570,7 +570,7 @@
             <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
               <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
             </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()">
+            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
               <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">

--- a/gui/default/untrusted/index.html
+++ b/gui/default/untrusted/index.html
@@ -582,7 +582,7 @@
             <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
               <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
             </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()">
+            <button type="button" class="btn btn-sm btn-default"   ng-click="rescanAllFolders()" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
               <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">

--- a/gui/default/untrusted/index.html
+++ b/gui/default/untrusted/index.html
@@ -582,7 +582,7 @@
             <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
               <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
             </button>
-            <button type="button" class="btn btn-sm btn-default"   ng-click="rescanAllFolders()" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
+            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
               <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">


### PR DESCRIPTION
### Purpose

Disable rescan all when at least one folder is not paused (fixes #7257)

### Testing

1. Click on pause all
2. Confirm rescan all button is in disabled state (visually confirm greyed out and clicking does not rescan)
3. Click on resume all
4. Confirm rescan all button is in enabled state (visually confirm not greyed out and clicking does rescan)

### Screenshots

<img width="590" alt="Screen Shot 2021-01-13 at 7 57 33 PM" src="https://user-images.githubusercontent.com/1592194/104543132-b6ea3a80-55d9-11eb-8ccd-1cc8ffb6af9e.png">
<img width="598" alt="Screen Shot 2021-01-13 at 7 57 43 PM" src="https://user-images.githubusercontent.com/1592194/104543134-b782d100-55d9-11eb-9e79-ffb6061b61b0.png">

