### PR TITLE
lib/model: Pull when folder leaves error state (fixes #7280)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -981,6 +981,7 @@ func (f *folder) setError(err error) {
 		}
 	} else {
 		l.Infoln("Cleared error on folder", f.Description())
+		f.SchedulePull()
 	}
 
 	if f.FSWatcherEnabled {


### PR DESCRIPTION
Schedule a pull when a folder error is cleared. Pulls are only done on demand (incoming indexes or scanned changes), which means a pull may not happen for a long time if the folder was out-of-sync while being in error state.