### PR TITLE
cmd/syncthing: Provide early startup for config service (ref #7188)

### DIFF
--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -121,10 +121,6 @@ func (a *App) Start() error {
 }
 
 func (a *App) startup() error {
-	if cfgService, ok := a.cfg.(suture.Service); ok {
-		a.mainService.Add(cfgService)
-	}
-
 	a.mainService.Add(ur.NewFailureHandler(a.cfg, a.evLogger))
 
 	a.mainService.Add(a.ll)


### PR DESCRIPTION
Don't hang on startup.

(We should push a new nightly after merging...)