### PR TITLE
gui: Reduce checkboxes size in Advanced Configuration (fixes #6949)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -41,6 +41,12 @@ ul+h5 {
     float: none; /* issue #1197 */
 }
 
+#advancedAccordion input.form-control[type="checkbox"] {
+    box-shadow: none;
+    margin: 0;
+    width: auto;
+}
+
 .popover {
     max-width: none;
     min-width: 250px;


### PR DESCRIPTION
Reduce the size of checkboxes in the Advanced Configuration, so that it
matches the rest of the Web GUI.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
