### PR TITLE
optimize zh-CN word translation: Bugs

### DIFF
--- a/gui/default/assets/lang/lang-zh-CN.json
+++ b/gui/default/assets/lang/lang-zh-CN.json
@@ -38,7 +38,7 @@
     "Automatically create or share folders that this device advertises at the default path.": "在本机默认文件夹中，自动地创建或共享这个设备共享出来的所有文件夹。",
     "Available debug logging facilities:": "可用的调试日志功能：",
     "Be careful!": "小心！",
-    "Bugs": "问题回报",
+    "Bugs": "问题反馈",
     "Changelog": "更新日志",
     "Clean out after": "在该时间后清除",
     "Cleaning Versions": "清除版本",


### PR DESCRIPTION
### Purpose

optimize zh-CN translation: 'Bugs'

> '问题回报' -> '问题反馈'

In zh-CN, '回报' means 'repay', not 'feedback', and the '反馈' is the right.

### Testing

no test

### Screenshots
from
![image](https://user-images.githubusercontent.com/9999440/105625737-2841ad00-5e66-11eb-9c5b-53a9a5ca97fc.png)
to
![image](https://user-images.githubusercontent.com/9999440/105625817-aaca6c80-5e66-11eb-83f0-371378e58a35.png)



### Documentation

no  document change

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

