### PR TITLE
lib/stun: Close connection from defer, not goroutine

### DIFF
--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -109,9 +109,8 @@ func (s *Service) Serve(ctx context.Context) error {
 	defer func() {
 		s.setNATType(NATUnknown)
 		s.setExternalAddress(nil, "")
+		_ = s.stunConn.Close()
 	}()
-
-	util.OnDone(ctx, func() { _ = s.stunConn.Close() })
 
 	timer := time.NewTimer(time.Millisecond)
 

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -264,14 +264,6 @@ func (s ExitStatus) AsInt() int {
 	return int(s)
 }
 
-// OnDone calls fn when ctx is cancelled.
-func OnDone(ctx context.Context, fn func()) {
-	go func() {
-		<-ctx.Done()
-		fn()
-	}()
-}
-
 func CallWithContext(ctx context.Context, fn func() error) error {
 	var err error
 	done := make(chan struct{})


### PR DESCRIPTION
The goroutine waited for the context to be done, but that is exactly Serve's exit condition. The only behavioral change, in the absence of panics, should be that Serve now waits for the connection to be closed before it returns.