### PR TITLE
lib/stun: Inline util.OnDone, comment on its purpose

### DIFF
--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -111,7 +111,12 @@ func (s *Service) Serve(ctx context.Context) error {
 		s.setExternalAddress(nil, "")
 	}()
 
-	util.OnDone(ctx, func() { _ = s.stunConn.Close() })
+	// Closing s.stunConn unblocks operations that use the connection
+	// (Discover, Keepalive) and might otherwise block us from returning.
+	go func() {
+		<-ctx.Done()
+		_ = s.stunConn.Close()
+	}()
 
 	timer := time.NewTimer(time.Millisecond)
 

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -250,14 +250,6 @@ func AddressUnspecifiedLess(a, b net.Addr) bool {
 	return aIsUnspecified
 }
 
-// OnDone calls fn when ctx is cancelled.
-func OnDone(ctx context.Context, fn func()) {
-	go func() {
-		<-ctx.Done()
-		fn()
-	}()
-}
-
 func CallWithContext(ctx context.Context, fn func() error) error {
 	var err error
 	done := make(chan struct{})


### PR DESCRIPTION
This is an alternative to #7304: it inlines util.OnDone at its only call site and replaces its comment by one that explains why the separate goroutine is necessary.

I didn't add the second CallWithContext as I didn't find the resulting code much clearer than this version. In fact, I'm wondering if the CallWithContext around Discover cannot be removed instead?

Closes #7304.