### PR TITLE
lib/scanner: Allocate structure for final partial block

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -30,7 +30,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 	}
 
 	hf := sha256.New()
-	hashLength := hf.Size()
+	const hashLength = sha256.Size
 
 	var weakHf hash.Hash32 = noopHash{}
 	var multiHf io.Writer = hf
@@ -48,7 +48,11 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 		// Allocate contiguous blocks for the BlockInfo structures and their
 		// hashes once and for all, and stick to the specified size.
 		r = io.LimitReader(r, sizehint)
-		numBlocks := int(sizehint / int64(blocksize))
+		numBlocks := sizehint / int64(blocksize)
+		remainder := sizehint % int64(blocksize)
+		if remainder != 0 {
+			numBlocks++
+		}
 		blocks = make([]protocol.BlockInfo, 0, numBlocks)
 		hashes = make([]byte, 0, hashLength*numBlocks)
 	}

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -551,7 +551,7 @@ func (l testfileList) String() string {
 var initOnce sync.Once
 
 const (
-	testdataSize = 17 << 20
+	testdataSize = 17<<20 + 1
 	testdataName = "_random.data"
 )
 


### PR DESCRIPTION
scanner.Blocks promises, in a comment, to allocate space "once and for all" if it knows the file size. It only did so, however, when the block size divided the file size. The pre-allocation now works as intended for files of all sizes.

Benchmark results on Linux/amd64, using updated benchmark for old and new:

```
name        old time/op    new time/op    delta
HashFile-8    88.6ms ± 1%    88.3ms ± 1%   -0.33%  (p=0.046 n=19+19)

name        old speed      new speed      delta
HashFile-8   201MB/s ± 1%   202MB/s ± 1%   +0.33%  (p=0.044 n=19+19)

name        old alloc/op   new alloc/op   delta
HashFile-8    59.4kB ± 0%    46.1kB ± 0%  -22.47%  (p=0.000 n=14+20)

name        old allocs/op  new allocs/op  delta
HashFile-8      29.0 ± 0%      27.0 ± 0%   -6.90%  (p=0.000 n=20+20)
```