### PR TITLE
lib/scanner: Remove unused field, move WaitGroup.Add out of loop

### DIFF
--- a/lib/scanner/blockqueue.go
+++ b/lib/scanner/blockqueue.go
@@ -63,7 +63,6 @@ func HashFile(ctx context.Context, fs fs.Filesystem, path string, blockSize int,
 // is closed and all items handled.
 type parallelHasher struct {
 	fs      fs.Filesystem
-	workers int
 	outbox  chan<- ScanResult
 	inbox   <-chan protocol.FileInfo
 	counter Counter
@@ -74,7 +73,6 @@ type parallelHasher struct {
 func newParallelHasher(ctx context.Context, fs fs.Filesystem, workers int, outbox chan<- ScanResult, inbox <-chan protocol.FileInfo, counter Counter, done chan<- struct{}) {
 	ph := &parallelHasher{
 		fs:      fs,
-		workers: workers,
 		outbox:  outbox,
 		inbox:   inbox,
 		counter: counter,
@@ -82,8 +80,8 @@ func newParallelHasher(ctx context.Context, fs fs.Filesystem, workers int, outbo
 		wg:      sync.NewWaitGroup(),
 	}
 
+	ph.wg.Add(workers)
 	for i := 0; i < workers; i++ {
-		ph.wg.Add(1)
 		go ph.hashFiles(ctx)
 	}
 


### PR DESCRIPTION
This removes an unused field and applies a very minor optimization.