### PR TITLE
all: Failure reporting fixes

### DIFF
--- a/cmd/stcrashreceiver/main.go
+++ b/cmd/stcrashreceiver/main.go
@@ -47,7 +47,7 @@ func main() {
 	mux.Handle("/", cr)
 
 	if *dsn != "" {
-		mux.HandleFunc("/failure", handleFailureFn(*dsn))
+		mux.HandleFunc("/newcrash/failure", handleFailureFn(*dsn))
 	}
 
 	log.SetOutput(os.Stdout)

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -1202,7 +1202,7 @@ func unchanged(nf, ef protocol.FileIntf) bool {
 func (db *Lowlevel) handleFailure(err error) {
 	db.checkErrorForRepair(err)
 	if shouldReportFailure(err) {
-		db.evLogger.Log(events.Failure, err)
+		db.evLogger.Log(events.Failure, err.Error())
 	}
 }
 

--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -194,7 +194,7 @@ func sendFailureReports(ctx context.Context, reports []FailureReport, url string
 
 	reqCtx, reqCancel := context.WithTimeout(ctx, sendTimeout)
 	defer reqCancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodPut, url, &b)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, &b)
 	if err != nil {
 		l.Infoln("Failed to send failure report:", err)
 		return

--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -123,13 +123,15 @@ func (h *failureHandler) Serve(ctx context.Context) error {
 
 	if sub != nil {
 		sub.Unsubscribe()
-		reports := make([]FailureReport, 0, len(h.buf))
-		for descr, stat := range h.buf {
-			reports = append(reports, newFailureReport(descr, stat.count))
+		if len(h.buf) > 0 {
+			reports := make([]FailureReport, 0, len(h.buf))
+			for descr, stat := range h.buf {
+				reports = append(reports, newFailureReport(descr, stat.count))
+			}
+			timeout, cancel := context.WithTimeout(context.Background(), finalSendTimeout)
+			defer cancel()
+			sendFailureReports(timeout, reports, url)
 		}
-		timeout, cancel := context.WithTimeout(context.Background(), finalSendTimeout)
-		defer cancel()
-		sendFailureReports(timeout, reports, url)
 	}
 	return err
 }
@@ -192,7 +194,7 @@ func sendFailureReports(ctx context.Context, reports []FailureReport, url string
 
 	reqCtx, reqCancel := context.WithTimeout(ctx, sendTimeout)
 	defer reqCancel()
-	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, &b)
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPut, url, &b)
 	if err != nil {
 		l.Infoln("Failed to send failure report:", err)
 		return


### PR DESCRIPTION
Failure reports should be arriving on sentry, but didn't: Forgot the crash reporting url has a path already, `newcrash`.

Also empty failure reports are sent on shutdown. And `GET` used for sending failure reports - which works as we don't care, but is still weird. And finally: There's lots of "failure report is not a string" failure reports, because errors from the db have not been stringified.