### PR TITLE
gui: fix device config not saving after changes

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1636,7 +1636,7 @@ angular.module('syncthing.core')
         };
 
         function setDeviceConfig() {
-            var currentID = $scope.currentDevice.DeviceID;
+            var currentID = $scope.currentDevice.deviceID;
             $scope.devices[currentID] = $scope.currentDevice;
             $scope.config.devices = deviceList($scope.devices);
 


### PR DESCRIPTION
### Purpose

#7131 included a typo, reading `DeviceID` from `$scope.currentDevice` instead of `deviceID`. Then currentDevice is added to `$scope.devices` with key undefined. I'm not sure how exactly the undefined entry appears in the PUT /rest/config body, but the effect is some device attributes are not saved. For example: changing the selected Shared Folders.

There is also an error reported from angular when it tries to render a duplicate device, since currentDevice now appears with key undefined and its own device ID key.

### Testing

Edit a device's shared folders, save, ensure changes are persisted.