### PR TITLE
lib: Do not set ModifiedBy on meta only changes

### DIFF
--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -748,7 +748,7 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 				continue
 			}
 
-			fi.SetMustRescan(protocol.LocalDeviceID.Short())
+			fi.SetMustRescan()
 			if err = t.putFile(it.Key(), fi); err != nil {
 				return err
 			}

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -1354,7 +1354,7 @@ func TestNeedAfterUnignore(t *testing.T) {
 
 	// Initial state: Devices in sync, locally ignored
 	local := protocol.FileInfo{Name: file, Version: protocol.Vector{Counters: []protocol.Counter{{ID: remID, Value: 1}, {ID: myID, Value: 1}}}, ModifiedS: 10}
-	local.SetIgnored(myID)
+	local.SetIgnored()
 	remote := protocol.FileInfo{Name: file, Version: protocol.Vector{Counters: []protocol.Counter{{ID: remID, Value: 1}, {ID: myID, Value: 1}}}, ModifiedS: 10}
 	s.Update(protocol.LocalDeviceID, fileList{local})
 	s.Update(remoteDevice0, fileList{remote})

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -125,9 +125,9 @@ func (f FileInfoTruncated) FileModifiedBy() protocol.ShortID {
 	return f.ModifiedBy
 }
 
-func (f FileInfoTruncated) ConvertToIgnoredFileInfo(by protocol.ShortID) protocol.FileInfo {
+func (f FileInfoTruncated) ConvertToIgnoredFileInfo() protocol.FileInfo {
 	file := f.copyToFileInfo()
-	file.SetIgnored(by)
+	file.SetIgnored()
 	return file
 }
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -652,7 +652,7 @@ func (f *folder) scanSubdirsDeletedAndIgnored(subDirs []string, batch *fileInfoB
 			if ignoredParent != "" && !fs.IsParent(file.Name, ignoredParent) {
 				for _, file := range toIgnore {
 					l.Debugln("marking file as ignored", file)
-					nf := file.ConvertToIgnoredFileInfo(f.shortID)
+					nf := file.ConvertToIgnoredFileInfo()
 					if batchAppend(nf, snap) {
 						changes++
 					}
@@ -682,7 +682,7 @@ func (f *folder) scanSubdirsDeletedAndIgnored(subDirs []string, batch *fileInfoB
 				}
 
 				l.Debugln("marking file as ignored", file)
-				nf := file.ConvertToIgnoredFileInfo(f.shortID)
+				nf := file.ConvertToIgnoredFileInfo()
 				if batchAppend(nf, snap) {
 					changes++
 				}
@@ -745,7 +745,7 @@ func (f *folder) scanSubdirsDeletedAndIgnored(subDirs []string, batch *fileInfoB
 		if iterError == nil && len(toIgnore) > 0 {
 			for _, file := range toIgnore {
 				l.Debugln("marking file as ignored", f)
-				nf := file.ConvertToIgnoredFileInfo(f.shortID)
+				nf := file.ConvertToIgnoredFileInfo()
 				if batchAppend(nf, snap) {
 					changes++
 				}
@@ -1192,7 +1192,7 @@ func (f *folder) handleForcedRescans() {
 		if !ok {
 			continue
 		}
-		fi.SetMustRescan(f.shortID)
+		fi.SetMustRescan()
 		batch.append(fi)
 	}
 

--- a/lib/model/folder_sendonly.go
+++ b/lib/model/folder_sendonly.go
@@ -51,7 +51,7 @@ func (f *sendOnlyFolder) pull() bool {
 
 		if f.ignores.ShouldIgnore(intf.FileName()) {
 			file := intf.(protocol.FileInfo)
-			file.SetIgnored(f.shortID)
+			file.SetIgnored()
 			batch = append(batch, file)
 			batchSizeBytes += file.ProtoSize()
 			l.Debugln(f, "Handling ignored file", file)

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -331,7 +331,7 @@ func (f *sendReceiveFolder) processNeeded(snap *db.Snapshot, dbUpdateChan chan<-
 
 		switch {
 		case f.ignores.ShouldIgnore(file.Name):
-			file.SetIgnored(f.shortID)
+			file.SetIgnored()
 			l.Debugln(f, "Handling ignored file", file)
 			dbUpdateChan <- dbUpdateJob{file, dbUpdateInvalidate}
 
@@ -390,7 +390,7 @@ func (f *sendReceiveFolder) processNeeded(snap *db.Snapshot, dbUpdateChan chan<-
 				f.newPullError(file.Name, fmt.Errorf("handling unsupported symlink: %w", err))
 				break
 			}
-			file.SetUnsupported(f.shortID)
+			file.SetUnsupported()
 			l.Debugln(f, "Invalidating symlink (unsupported)", file.Name)
 			dbUpdateChan <- dbUpdateJob{file, dbUpdateInvalidate}
 

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -297,16 +297,16 @@ func blocksEqual(a, b []BlockInfo) bool {
 	return true
 }
 
-func (f *FileInfo) SetMustRescan(by ShortID) {
-	f.setLocalFlags(by, FlagLocalMustRescan)
+func (f *FileInfo) SetMustRescan() {
+	f.setLocalFlags(FlagLocalMustRescan)
 }
 
-func (f *FileInfo) SetIgnored(by ShortID) {
-	f.setLocalFlags(by, FlagLocalIgnored)
+func (f *FileInfo) SetIgnored() {
+	f.setLocalFlags(FlagLocalIgnored)
 }
 
-func (f *FileInfo) SetUnsupported(by ShortID) {
-	f.setLocalFlags(by, FlagLocalUnsupported)
+func (f *FileInfo) SetUnsupported() {
+	f.setLocalFlags(FlagLocalUnsupported)
 }
 
 func (f *FileInfo) SetDeleted(by ShortID) {
@@ -317,10 +317,9 @@ func (f *FileInfo) SetDeleted(by ShortID) {
 	f.setNoContent()
 }
 
-func (f *FileInfo) setLocalFlags(by ShortID, flags uint32) {
+func (f *FileInfo) setLocalFlags(flags uint32) {
 	f.RawInvalid = false
 	f.LocalFlags = flags
-	f.ModifiedBy = by
 	f.setNoContent()
 }
 

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -635,17 +635,17 @@ func TestLocalFlagBits(t *testing.T) {
 		t.Error("file should have no weird bits set by default")
 	}
 
-	f.SetIgnored(42)
+	f.SetIgnored()
 	if !f.IsIgnored() || f.MustRescan() || !f.IsInvalid() {
 		t.Error("file should be ignored and invalid")
 	}
 
-	f.SetMustRescan(42)
+	f.SetMustRescan()
 	if f.IsIgnored() || !f.MustRescan() || !f.IsInvalid() {
 		t.Error("file should be must-rescan and invalid")
 	}
 
-	f.SetUnsupported(42)
+	f.SetUnsupported()
 	if f.IsIgnored() || f.MustRescan() || !f.IsInvalid() {
 		t.Error("file should be invalid")
 	}


### PR DESCRIPTION
Setting `ModifiedBy` when marking a file as ignored, unsupported or must be rescanned is confusing (and wrong).