### PR TITLE
gui: Ignore own device when pausing/resuming all devices (ref #7359)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1732,21 +1732,21 @@ angular.module('syncthing.core')
         };
 
         $scope.setAllDevicesPause = function (pause) {
-            for (var id in $scope.otherDevices()) {
-                $scope.otherDevices()[id].paused = pause;
-            };
+            $scope.otherDevices().forEach(function (device) {
+                device.paused = pause;
+            });
             $scope.config.devices = deviceList($scope.otherDevices());
             $scope.saveConfig();
         }
 
         $scope.isAtleastOneDevicePausedStateSetTo = function (pause) {
-            for (var id in $scope.otherDevices()) {
-                if ($scope.otherDevices()[id].paused == pause) {
-                    return true;
+            var paused = false;
+            $scope.otherDevices().forEach(function (device) {
+                if (device.paused == pause) {
+                    paused = true;
                 }
-            }
-
-            return false
+            });
+            return paused;
         }
 
         $scope.errorList = function () {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1732,16 +1732,16 @@ angular.module('syncthing.core')
         };
 
         $scope.setAllDevicesPause = function (pause) {
-            for (var id in $scope.devices) {
-                $scope.devices[id].paused = pause;
+            for (var id in $scope.otherDevices()) {
+                $scope.otherDevices()[id].paused = pause;
             };
-            $scope.config.devices = deviceList($scope.devices);
+            $scope.config.devices = deviceList($scope.otherDevices());
             $scope.saveConfig();
         }
 
         $scope.isAtleastOneDevicePausedStateSetTo = function (pause) {
-            for (var id in $scope.devices) {
-                if ($scope.devices[id].paused == pause) {
+            for (var id in $scope.otherDevices()) {
+                if ($scope.otherDevices()[id].paused == pause) {
                     return true;
                 }
             }

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1735,7 +1735,7 @@ angular.module('syncthing.core')
             $scope.otherDevices().forEach(function (device) {
                 device.paused = pause;
             });
-            $scope.config.devices = deviceList($scope.otherDevices());
+            $scope.config.devices = deviceList($scope.devices);
             $scope.saveConfig();
         }
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1733,7 +1733,7 @@ angular.module('syncthing.core')
 
         $scope.setAllDevicesPause = function (pause) {
             $scope.otherDevices().forEach(function (device) {
-                device.paused = pause;
+                $scope.devices[device.deviceID].paused = pause;
             });
             $scope.config.devices = deviceList($scope.devices);
             $scope.saveConfig();
@@ -1742,7 +1742,7 @@ angular.module('syncthing.core')
         $scope.isAtleastOneDevicePausedStateSetTo = function (pause) {
             var paused = false;
             $scope.otherDevices().forEach(function (device) {
-                if (device.paused == pause) {
+                if ($scope.devices[device.deviceID].paused == pause) {
                     paused = true;
                 }
             });

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1749,21 +1749,21 @@ angular.module('syncthing.core')
         };
 
         $scope.setAllDevicesPause = function (pause) {
-            for (var id in $scope.otherDevices()) {
-                $scope.otherDevices()[id].paused = pause;
-            };
+            $scope.otherDevices().forEach(function (device) {
+                device.paused = pause;
+            });
             $scope.config.devices = deviceList($scope.otherDevices());
             $scope.saveConfig();
         }
 
         $scope.isAtleastOneDevicePausedStateSetTo = function (pause) {
-            for (var id in $scope.otherDevices()) {
-                if ($scope.otherDevices()[id].paused == pause) {
-                    return true;
+            var paused = false;
+            $scope.otherDevices().forEach(function (device) {
+                if (device.paused == pause) {
+                    paused = true;
                 }
-            }
-
-            return false
+            });
+            return paused;
         }
 
         $scope.errorList = function () {

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1750,7 +1750,7 @@ angular.module('syncthing.core')
 
         $scope.setAllDevicesPause = function (pause) {
             $scope.otherDevices().forEach(function (device) {
-                device.paused = pause;
+                $scope.devices[device.deviceID].paused = pause;
             });
             $scope.config.devices = deviceList($scope.devices);
             $scope.saveConfig();
@@ -1759,7 +1759,7 @@ angular.module('syncthing.core')
         $scope.isAtleastOneDevicePausedStateSetTo = function (pause) {
             var paused = false;
             $scope.otherDevices().forEach(function (device) {
-                if (device.paused == pause) {
+                if ($scope.devices[device.deviceID].paused == pause) {
                     paused = true;
                 }
             });

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1749,16 +1749,16 @@ angular.module('syncthing.core')
         };
 
         $scope.setAllDevicesPause = function (pause) {
-            for (var id in $scope.devices) {
-                $scope.devices[id].paused = pause;
+            for (var id in $scope.otherDevices()) {
+                $scope.otherDevices()[id].paused = pause;
             };
-            $scope.config.devices = deviceList($scope.devices);
+            $scope.config.devices = deviceList($scope.otherDevices());
             $scope.saveConfig();
         }
 
         $scope.isAtleastOneDevicePausedStateSetTo = function (pause) {
-            for (var id in $scope.devices) {
-                if ($scope.devices[id].paused == pause) {
+            for (var id in $scope.otherDevices()) {
+                if ($scope.otherDevices()[id].paused == pause) {
                     return true;
                 }
             }

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -1752,7 +1752,7 @@ angular.module('syncthing.core')
             $scope.otherDevices().forEach(function (device) {
                 device.paused = pause;
             });
-            $scope.config.devices = deviceList($scope.otherDevices());
+            $scope.config.devices = deviceList($scope.devices);
             $scope.saveConfig();
         }
 


### PR DESCRIPTION
Do not change the state of the current device when using the "Pause All"
and "Resume All" buttons. Also, ignore the state of the current device
when checking whether all devices are paused, so that the two buttons
appear and disappear properly, depending only the state of remote
devices.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>