### PR TITLE
gui: Hide the Rescan All button when no folders exist

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -570,7 +570,7 @@
             <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
               <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
             </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
+            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-if="isAtleastOneFolderPausedStateSetTo(true) || isAtleastOneFolderPausedStateSetTo(false)" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
               <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -570,7 +570,7 @@
             <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
               <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
             </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-if="isAtleastOneFolderPausedStateSetTo(true) || isAtleastOneFolderPausedStateSetTo(false)" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
+            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-if="folderList().length > 0" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
               <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">

--- a/gui/default/untrusted/index.html
+++ b/gui/default/untrusted/index.html
@@ -582,7 +582,7 @@
             <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
               <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
             </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-if="isAtleastOneFolderPausedStateSetTo(true) || isAtleastOneFolderPausedStateSetTo(false)" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
+            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-if="folderList().length > 0" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
               <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">

--- a/gui/default/untrusted/index.html
+++ b/gui/default/untrusted/index.html
@@ -582,7 +582,7 @@
             <button type="button" class="btn btn-sm btn-default" ng-click="setAllFoldersPause(false)" ng-if="isAtleastOneFolderPausedStateSetTo(true)">
               <span class="fas fa-play"></span>&nbsp;<span translate>Resume All</span>
             </button>
-            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
+            <button type="button" class="btn btn-sm btn-default" ng-click="rescanAllFolders()" ng-if="isAtleastOneFolderPausedStateSetTo(true) || isAtleastOneFolderPausedStateSetTo(false)" ng-disabled="!isAtleastOneFolderPausedStateSetTo(false)">
               <span class="fas fa-refresh"></span>&nbsp;<span translate>Rescan All</span>
             </button>
             <button type="button" class="btn btn-sm btn-default" ng-click="addFolder()">


### PR DESCRIPTION
If there are no folders present, show only the "Add Folder" button, and
hide the "Rescan All" button. Only show the latter when at least one
folder exists.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>