### PR TITLE
lib/connections: Allow QUIC with Go 1.16

### DIFF
--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// +build go1.14,!noquic,!go1.16
+// +build go1.14,!noquic,!go1.17
 
 package connections
 

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build go1.14,!noquic,!go1.16
+// +build go1.14,!noquic,!go1.17
 
 package connections
 

--- a/lib/connections/quic_misc.go
+++ b/lib/connections/quic_misc.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build go1.14,!noquic,!go1.16
+// +build go1.14,!noquic,!go1.17
 
 package connections
 

--- a/lib/connections/quic_unsupported.go
+++ b/lib/connections/quic_unsupported.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-// +build noquic !go1.14 go1.16
+// +build noquic !go1.14 go1.17
 
 package connections
 


### PR DESCRIPTION
This appears to work for me locally, even though there isn't a newer released version of quic-go yet, and the master branch of quic-go has references to a qtls package for 1.16 that is not pulled in here...