### PR TITLE
cmd/stcrashreceiver: Add tag for report type (crash/failure)

### DIFF
--- a/cmd/stcrashreceiver/main.go
+++ b/cmd/stcrashreceiver/main.go
@@ -84,7 +84,7 @@ func handleFailureFn(dsn string) func(w http.ResponseWriter, req *http.Request) 
 			return
 		}
 		for _, r := range reports {
-			pkt := packet(version)
+			pkt := packet(version, "failure")
 			pkt.Message = r.Description
 			pkt.Extra = raven.Extra{
 				"count": r.Count,

--- a/cmd/stcrashreceiver/sentry.go
+++ b/cmd/stcrashreceiver/sentry.go
@@ -122,7 +122,7 @@ func parseCrashReport(path string, report []byte) (*raven.Packet, error) {
 		}
 	}
 
-	pkt := packet(version)
+	pkt := packet(version, "crash")
 	pkt.Message = string(subjectLine)
 	pkt.Extra = raven.Extra{
 		"url": reportServer + path,
@@ -229,7 +229,7 @@ func parseVersion(line string) (version, error) {
 	return v, nil
 }
 
-func packet(version version) *raven.Packet {
+func packet(version version, reportType string) *raven.Packet {
 	pkt := &raven.Packet{
 		Platform:    "go",
 		Release:     version.tag,
@@ -242,6 +242,7 @@ func packet(version version) *raven.Packet {
 			raven.Tag{Key: "goos", Value: version.goos},
 			raven.Tag{Key: "goarch", Value: version.goarch},
 			raven.Tag{Key: "builder", Value: version.builder},
+			raven.Tag{Key: "report_type", Value: reportType},
 		},
 	}
 	if version.commit != "" {


### PR DESCRIPTION
Adds a new tag to distinguish panics from failures (events) in sentry. There's a lot of noise in sentry (also signal), and I'd like to have a way to see all failure events at a glance.