### PR TITLE
gui: Allow setting custom path for all versioning except external

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -72,7 +72,7 @@ angular.module('syncthing.core')
             simpleKeep: 5,
             staggeredMaxAge: 365,
             staggeredCleanInterval: 3600,
-            staggeredVersionsPath: "",
+            versionsPath: "",
             externalCommand: "",
         };
 
@@ -1910,17 +1910,19 @@ angular.module('syncthing.core')
             case "trashcan":
                 $scope.currentFolder._guiVersioning.selector = "trashcan";
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "simple":
                 $scope.currentFolder._guiVersioning.selector = "simple";
                 $scope.currentFolder._guiVersioning.simpleKeep = +currentVersioning.params.keep;
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "staggered":
                 $scope.currentFolder._guiVersioning.selector = "staggered";
                 $scope.currentFolder._guiVersioning.staggeredMaxAge = Math.floor(+currentVersioning.params.maxAge / 86400);
                 $scope.currentFolder._guiVersioning.staggeredCleanInterval = +currentVersioning.params.cleanInterval;
-                $scope.currentFolder._guiVersioning.staggeredVersionsPath = currentVersioning.params.versionsPath;
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "external":
                 $scope.currentFolder._guiVersioning.selector = "external";
@@ -2049,7 +2051,8 @@ angular.module('syncthing.core')
                 folderCfg.versioning = {
                     'type': 'trashcan',
                     'params': {
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean
+                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
+                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
                     },
                     'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };
@@ -2059,7 +2062,8 @@ angular.module('syncthing.core')
                     'type': 'simple',
                     'params': {
                         'keep': '' + folderCfg._guiVersioning.simpleKeep,
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean
+                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
+                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
                     },
                     'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };
@@ -2070,7 +2074,7 @@ angular.module('syncthing.core')
                     'params': {
                         'maxAge': '' + (folderCfg._guiVersioning.staggeredMaxAge * 86400),
                         'cleanInterval': '' + folderCfg._guiVersioning.staggeredCleanInterval,
-                        'versionsPath': '' + folderCfg._guiVersioning.staggeredVersionsPath
+                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
                     },
                     'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -132,9 +132,9 @@
               <span translate ng-if="folderEditor._guiVersioning.staggeredMaxAge.$error.min && folderEditor._guiVersioning.staggeredMaxAge.$dirty">A negative number of days doesn't make sense.</span>
             </p>
           </div>
-          <div class="form-group" ng-if="currentFolder._guiVersioning.selector == 'staggered'">
-            <label translate for="staggeredVersionsPath">Versions Path</label>
-            <input name="staggeredVersionsPath" id="staggeredVersionsPath" class="form-control" type="text" ng-model="currentFolder._guiVersioning.staggeredVersionsPath" />
+          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none' && currentFolder._guiVersioning.selector != 'external'">
+            <label translate for="versionsPath">Versions Path</label>
+            <input name="versionsPath" id="versionsPath" class="form-control" type="text" ng-model="currentFolder._guiVersioning.versionsPath" />
             <p translate class="help-block">Path where versions should be stored (leave empty for the default .stversions directory in the shared folder).</p>
           </div>
           <div class="form-group" ng-if="currentFolder._guiVersioning.selector=='external'" ng-class="{'has-error': folderEditor.externalCommand.$invalid && folderEditor.externalCommand.$dirty}">

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -72,7 +72,7 @@ angular.module('syncthing.core')
             simpleKeep: 5,
             staggeredMaxAge: 365,
             staggeredCleanInterval: 3600,
-            staggeredVersionsPath: "",
+            versionsPath: "",
             externalCommand: "",
         };
 
@@ -1941,17 +1941,19 @@ angular.module('syncthing.core')
             case "trashcan":
                 $scope.currentFolder._guiVersioning.selector = "trashcan";
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "simple":
                 $scope.currentFolder._guiVersioning.selector = "simple";
                 $scope.currentFolder._guiVersioning.simpleKeep = +currentVersioning.params.keep;
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "staggered":
                 $scope.currentFolder._guiVersioning.selector = "staggered";
                 $scope.currentFolder._guiVersioning.staggeredMaxAge = Math.floor(+currentVersioning.params.maxAge / 86400);
                 $scope.currentFolder._guiVersioning.staggeredCleanInterval = +currentVersioning.params.cleanInterval;
-                $scope.currentFolder._guiVersioning.staggeredVersionsPath = currentVersioning.params.versionsPath;
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "external":
                 $scope.currentFolder._guiVersioning.selector = "external";
@@ -2089,7 +2091,8 @@ angular.module('syncthing.core')
                 folderCfg.versioning = {
                     'type': 'trashcan',
                     'params': {
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean
+                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
+                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
                     },
                     'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };
@@ -2099,7 +2102,8 @@ angular.module('syncthing.core')
                     'type': 'simple',
                     'params': {
                         'keep': '' + folderCfg._guiVersioning.simpleKeep,
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean
+                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
+                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
                     },
                     'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };
@@ -2110,7 +2114,7 @@ angular.module('syncthing.core')
                     'params': {
                         'maxAge': '' + (folderCfg._guiVersioning.staggeredMaxAge * 86400),
                         'cleanInterval': '' + folderCfg._guiVersioning.staggeredCleanInterval,
-                        'versionsPath': '' + folderCfg._guiVersioning.staggeredVersionsPath
+                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
                     },
                     'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };

--- a/gui/default/untrusted/syncthing/folder/editFolderModalView.html
+++ b/gui/default/untrusted/syncthing/folder/editFolderModalView.html
@@ -120,9 +120,9 @@
               <span translate ng-if="folderEditor._guiVersioning.staggeredMaxAge.$error.min && folderEditor._guiVersioning.staggeredMaxAge.$dirty">A negative number of days doesn't make sense.</span>
             </p>
           </div>
-          <div class="form-group" ng-if="currentFolder._guiVersioning.selector == 'staggered'">
-            <label translate for="staggeredVersionsPath">Versions Path</label>
-            <input name="staggeredVersionsPath" id="staggeredVersionsPath" class="form-control" type="text" ng-model="currentFolder._guiVersioning.staggeredVersionsPath" />
+          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none' && currentFolder._guiVersioning.selector != 'external'">
+            <label translate for="versionsPath">Versions Path</label>
+            <input name="versionsPath" id="versionsPath" class="form-control" type="text" ng-model="currentFolder._guiVersioning.versionsPath" />
             <p translate class="help-block">Path where versions should be stored (leave empty for the default .stversions directory in the shared folder).</p>
           </div>
           <div class="form-group" ng-if="currentFolder._guiVersioning.selector=='external'" ng-class="{'has-error': folderEditor.externalCommand.$invalid && folderEditor.externalCommand.$dirty}">


### PR DESCRIPTION
Setting a custom path is already possible through config.xml, but using
the Edit Folder modal in the GUI resets it, unless Staggered Versioning
is being used. This commit removes this restriction, allowing custom
versioning paths for all types of versioning, except for external.

Ref: https://forum.syncthing.net/t/16357

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
