### PR TITLE
gui: Remove cleanupIntervalS leftovers from External Versioning (ref #7360)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2081,7 +2081,6 @@ angular.module('syncthing.core')
                     'params': {
                         'command': '' + folderCfg._guiVersioning.externalCommand
                     },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };
                 break;
             default:

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -2121,7 +2121,6 @@ angular.module('syncthing.core')
                     'params': {
                         'command': '' + folderCfg._guiVersioning.externalCommand
                     },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
                 };
                 break;
             default:

--- a/gui/default/untrusted/syncthing/folder/editFolderModalView.html
+++ b/gui/default/untrusted/syncthing/folder/editFolderModalView.html
@@ -134,7 +134,7 @@
               <span translate ng-if="folderEditor.externalCommand.$error.required && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>
             </p>
           </div>
-          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none'" ng-class="{'has-error': folderEditor._guiVersioning.cleanupIntervalS.$invalid && folderEditor._guiVersioning.cleanupIntervalS.$dirty}">
+          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none' && currentFolder._guiVersioning.selector != 'external'" ng-class="{'has-error': folderEditor._guiVersioning.cleanupIntervalS.$invalid && folderEditor._guiVersioning.cleanupIntervalS.$dirty}">
             <label translate for="versioningCleanupIntervalS">Cleanup Interval</label>
             <div class="input-group">
               <input name="versioningCleanupIntervalS" id="versioningCleanupIntervalS" class="form-control text-right" type="number" ng-model="currentFolder._guiVersioning.cleanupIntervalS" required="" min="0" max="31536000" aria-required="true" />


### PR DESCRIPTION
Remove the redundant cleanupIntervalS code related to the External
Versioning, which does not use this functionality at all. Also, the
commit 5e9c7bc022040555d56860148352e5862737889f did not hide the
relevant GUI part for Untrusted GUI, so let us do it here too.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>