### PR TITLE
lib/scanner: Pass on errors while hashing

### DIFF
--- a/lib/scanner/blockqueue.go
+++ b/lib/scanner/blockqueue.go
@@ -104,7 +104,7 @@ func (ph *parallelHasher) hashFiles(ctx context.Context) {
 
 			blocks, err := HashFile(ctx, ph.fs, f.Name, f.BlockSize(), ph.counter, true)
 			if err != nil {
-				l.Debugln("hash error:", f.Name, err)
+				handleError(ctx, "hashing", f.Name, err, ph.outbox)
 				continue
 			}
 

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -253,7 +253,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 		}
 
 		if !utf8.ValidString(path) {
-			w.handleError(ctx, "scan", path, errUTF8Invalid, finishedChan)
+			handleError(ctx, "scan", path, errUTF8Invalid, finishedChan)
 			return skip
 		}
 
@@ -285,7 +285,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 		}
 
 		if err != nil {
-			w.handleError(ctx, "scan", path, err, finishedChan)
+			handleError(ctx, "scan", path, err, finishedChan)
 			return skip
 		}
 
@@ -316,7 +316,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 			info, err = w.Filesystem.Lstat(ignoredParent)
 			// An error here would be weird as we've already gotten to this point, but act on it nonetheless
 			if err != nil {
-				w.handleError(ctx, "scan", ignoredParent, err, finishedChan)
+				handleError(ctx, "scan", ignoredParent, err, finishedChan)
 				return skip
 			}
 			if err = w.handleItem(ctx, ignoredParent, info, toHashChan, finishedChan, skip); err != nil {
@@ -333,7 +333,7 @@ func (w *walker) handleItem(ctx context.Context, path string, info fs.FileInfo, 
 	oldPath := path
 	path, err := w.normalizePath(path, info)
 	if err != nil {
-		w.handleError(ctx, "normalizing path", oldPath, err, finishedChan)
+		handleError(ctx, "normalizing path", oldPath, err, finishedChan)
 		return skip
 	}
 
@@ -451,7 +451,7 @@ func (w *walker) walkSymlink(ctx context.Context, relPath string, info fs.FileIn
 
 	f, err := CreateFileInfo(info, relPath, w.Filesystem)
 	if err != nil {
-		w.handleError(ctx, "reading link:", relPath, err, finishedChan)
+		handleError(ctx, "reading link:", relPath, err, finishedChan)
 		return nil
 	}
 
@@ -556,7 +556,7 @@ func (w *walker) updateFileInfo(file, curFile protocol.FileInfo) protocol.FileIn
 	return file
 }
 
-func (w *walker) handleError(ctx context.Context, context, path string, err error, finishedChan chan<- ScanResult) {
+func handleError(ctx context.Context, context, path string, err error, finishedChan chan<- ScanResult) {
 	// Ignore missing items, as deletions are not handled by the scanner.
 	if fs.IsNotExist(err) {
 		return


### PR DESCRIPTION
A user reported that files failed to be scanned, however there was no errors in the web ui. Turns out Syncthing is able to stat the files, but not to open them for hashing. And errors while hashing aren't passed on to the model and thus do not turn up in the web UI. With this PR they now are passed on.

Came up in https://forum.syncthing.net/t/not-all-files-getting-scannned-synced/16365/8)