### PR TITLE
lib/fs: Consider options in case-fs caching (fixes #7371)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -51,7 +51,7 @@ func (f FolderConfiguration) Filesystem() fs.Filesystem {
 	}
 	filesystem := fs.NewFilesystem(f.FilesystemType, f.Path, opts...)
 	if !f.CaseSensitiveFS {
-		filesystem = fs.NewCaseFilesystem(filesystem)
+		filesystem = fs.NewCaseFilesystem(filesystem, opts...)
 	}
 	return filesystem
 }

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -27,12 +27,15 @@ var (
 )
 
 func WithJunctionsAsDirs() Option {
-	return func(fs Filesystem) {
-		if basic, ok := fs.(*BasicFilesystem); !ok {
-			l.Warnln("WithJunctionsAsDirs must only be used with FilesystemTypeBasic")
-		} else {
-			basic.junctionsAsDirs = true
-		}
+	return Option{
+		apply: func(fs Filesystem) {
+			if basic, ok := fs.(*BasicFilesystem); !ok {
+				l.Warnln("WithJunctionsAsDirs must only be used with FilesystemTypeBasic")
+			} else {
+				basic.junctionsAsDirs = true
+			}
+		},
+		id: "junctionsAsDirs=true",
 	}
 }
 
@@ -82,7 +85,7 @@ func newBasicFilesystem(root string, opts ...Option) *BasicFilesystem {
 		root: root,
 	}
 	for _, opt := range opts {
-		opt(fs)
+		opt.apply(fs)
 	}
 	return fs
 }

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -35,7 +35,7 @@ func WithJunctionsAsDirs() Option {
 				basic.junctionsAsDirs = true
 			}
 		},
-		id: "junctionsAsDirs=true",
+		id: "junctionsAsDirs",
 	}
 }
 

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -178,7 +178,10 @@ var IsPermission = os.IsPermission
 // IsPathSeparator is the equivalent of os.IsPathSeparator
 var IsPathSeparator = os.IsPathSeparator
 
-type Option func(Filesystem)
+type Option struct {
+	apply func(Filesystem)
+	id    string
+}
 
 func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem {
 	var fs Filesystem


### PR DESCRIPTION
This adds an url query like `id` internal member to `fs.Options`. The case-fs then creates a query-like options-string and uses that for caching in addition to the path.