### PR TITLE
gui: Folder versioning editing cleanup

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -68,7 +68,7 @@ angular.module('syncthing.core')
         $scope.versioningDefaults = {
             selector: "none",
             trashcanClean: 0,
-            versioningCleanupIntervalS: 3600,
+            cleanupIntervalS: 3600,
             simpleKeep: 5,
             staggeredMaxAge: 365,
             staggeredCleanInterval: 3600,
@@ -1894,38 +1894,42 @@ angular.module('syncthing.core')
             editFolderModal();
         }
 
+        $scope.internalVersioningEnabled = function(guiVersioning) {
+            if (!$scope.currentFolder._guiVersioning) {
+                return false;
+            }
+            return ['none', 'external'].indexOf($scope.currentFolder._guiVersioning.selector) === -1;
+        };
+
         function initVersioningEditing() {
             $scope.currentFolder._guiVersioning = angular.copy($scope.versioningDefaults);
 
-            if (!$scope.currentFolder.versioning) {
+            var currentVersioning = $scope.currentFolder.versioning;
+
+            if (!currentVersioning || !currentVersioning.type || currentVersioning.type === 'none') {
                 return;
             }
 
-            var currentVersioning = $scope.currentFolder.versioning;
-
             $scope.currentFolder._guiVersioning.cleanupIntervalS = +currentVersioning.cleanupIntervalS;
+            $scope.currentFolder._guiVersioning.selector = currentVersioning.type;
+            if (currentVersioning.type !== 'external') {
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
+            }
 
             // Apply parameters currently in use
             switch (currentVersioning.type) {
             case "trashcan":
-                $scope.currentFolder._guiVersioning.selector = "trashcan";
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
-                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "simple":
-                $scope.currentFolder._guiVersioning.selector = "simple";
                 $scope.currentFolder._guiVersioning.simpleKeep = +currentVersioning.params.keep;
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
-                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "staggered":
-                $scope.currentFolder._guiVersioning.selector = "staggered";
                 $scope.currentFolder._guiVersioning.staggeredMaxAge = Math.floor(+currentVersioning.params.maxAge / 86400);
                 $scope.currentFolder._guiVersioning.staggeredCleanInterval = +currentVersioning.params.cleanInterval;
-                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "external":
-                $scope.currentFolder._guiVersioning.selector = "external";
                 $scope.currentFolder._guiVersioning.externalCommand = currentVersioning.params.command;
                 break;
             }
@@ -2046,46 +2050,25 @@ angular.module('syncthing.core')
             folderCfg.devices = newDevices;
             delete $scope.currentSharing;
 
+            folderCfg.versioning.type = folderCfg._guiVersioning.selector;
+            if ($scope.internalVersioningEnabled()) {
+                folderCfg.versioning.cleanupIntervalS = folderCfg._guiVersioning.cleanupIntervalS;
+                folderCfg.versioning.versionsPath = folderCfg._guiVersioning.versionsPath;
+            }
             switch (folderCfg._guiVersioning.selector) {
             case "trashcan":
-                folderCfg.versioning = {
-                    'type': 'trashcan',
-                    'params': {
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
-                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
-                    },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
-                };
+                folderCfg.versioning.params.cleanoutDays = '' + folderCfg._guiVersioning.trashcanClean;
                 break;
             case "simple":
-                folderCfg.versioning = {
-                    'type': 'simple',
-                    'params': {
-                        'keep': '' + folderCfg._guiVersioning.simpleKeep,
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
-                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
-                    },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
-                };
+                folderCfg.versioning.params.keep = '' + folderCfg._guiVersioning.simpleKeep,
+                folderCfg.versioning.params.cleanoutDays = '' + folderCfg._guiVersioning.trashcanClean;
                 break;
             case "staggered":
-                folderCfg.versioning = {
-                    'type': 'staggered',
-                    'params': {
-                        'maxAge': '' + (folderCfg._guiVersioning.staggeredMaxAge * 86400),
-                        'cleanInterval': '' + folderCfg._guiVersioning.staggeredCleanInterval,
-                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
-                    },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
-                };
+                folderCfg.versioning.params.maxAge = '' + (folderCfg._guiVersioning.staggeredMaxAge * 86400);
+                folderCfg.versioning.params.cleanInterval = '' + folderCfg._guiVersioning.staggeredCleanInterval;
                 break;
             case "external":
-                folderCfg.versioning = {
-                    'type': 'external',
-                    'params': {
-                        'command': '' + folderCfg._guiVersioning.externalCommand
-                    },
-                };
+                folderCfg.versioning.params.command = '' + folderCfg._guiVersioning.externalCommand;
                 break;
             default:
                 delete folderCfg.versioning;

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -132,7 +132,7 @@
               <span translate ng-if="folderEditor._guiVersioning.staggeredMaxAge.$error.min && folderEditor._guiVersioning.staggeredMaxAge.$dirty">A negative number of days doesn't make sense.</span>
             </p>
           </div>
-          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none' && currentFolder._guiVersioning.selector != 'external'">
+          <div class="form-group" ng-if="internalVersioningEnabled()">
             <label translate for="versionsPath">Versions Path</label>
             <input name="versionsPath" id="versionsPath" class="form-control" type="text" ng-model="currentFolder._guiVersioning.versionsPath" />
             <p translate class="help-block">Path where versions should be stored (leave empty for the default .stversions directory in the shared folder).</p>
@@ -146,7 +146,7 @@
               <span translate ng-if="folderEditor.externalCommand.$error.required && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>
             </p>
           </div>
-          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none' && currentFolder._guiVersioning.selector != 'external'" ng-class="{'has-error': folderEditor._guiVersioning.cleanupIntervalS.$invalid && folderEditor._guiVersioning.cleanupIntervalS.$dirty}">
+          <div class="form-group" ng-if="internalVersioningEnabled()" ng-class="{'has-error': folderEditor._guiVersioning.cleanupIntervalS.$invalid && folderEditor._guiVersioning.cleanupIntervalS.$dirty}">
             <label translate for="versioningCleanupIntervalS">Cleanup Interval</label>
             <div class="input-group">
               <input name="versioningCleanupIntervalS" id="versioningCleanupIntervalS" class="form-control text-right" type="number" ng-model="currentFolder._guiVersioning.cleanupIntervalS" required="" min="0" max="31536000" aria-required="true" />

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -68,7 +68,7 @@ angular.module('syncthing.core')
         $scope.versioningDefaults = {
             selector: "none",
             trashcanClean: 0,
-            versioningCleanupIntervalS: 3600,
+            cleanupIntervalS: 3600,
             simpleKeep: 5,
             staggeredMaxAge: 365,
             staggeredCleanInterval: 3600,
@@ -1925,38 +1925,42 @@ angular.module('syncthing.core')
             editFolderModal();
         }
 
+        $scope.internalVersioningEnabled = function(guiVersioning) {
+            if (!$scope.currentFolder._guiVersioning) {
+                return false;
+            }
+            return ['none', 'external'].indexOf($scope.currentFolder._guiVersioning.selector) === -1;
+        };
+
         function initVersioningEditing() {
             $scope.currentFolder._guiVersioning = angular.copy($scope.versioningDefaults);
 
-            if (!$scope.currentFolder.versioning) {
+            var currentVersioning = $scope.currentFolder.versioning;
+
+            if (!currentVersioning || !currentVersioning.type || currentVersioning.type === 'none') {
                 return;
             }
 
-            var currentVersioning = $scope.currentFolder.versioning;
-
             $scope.currentFolder._guiVersioning.cleanupIntervalS = +currentVersioning.cleanupIntervalS;
+            $scope.currentFolder._guiVersioning.selector = currentVersioning.type;
+            if (currentVersioning.type !== 'external') {
+                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
+            }
 
             // Apply parameters currently in use
             switch (currentVersioning.type) {
             case "trashcan":
-                $scope.currentFolder._guiVersioning.selector = "trashcan";
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
-                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "simple":
-                $scope.currentFolder._guiVersioning.selector = "simple";
                 $scope.currentFolder._guiVersioning.simpleKeep = +currentVersioning.params.keep;
                 $scope.currentFolder._guiVersioning.trashcanClean = +currentVersioning.params.cleanoutDays;
-                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "staggered":
-                $scope.currentFolder._guiVersioning.selector = "staggered";
                 $scope.currentFolder._guiVersioning.staggeredMaxAge = Math.floor(+currentVersioning.params.maxAge / 86400);
                 $scope.currentFolder._guiVersioning.staggeredCleanInterval = +currentVersioning.params.cleanInterval;
-                $scope.currentFolder._guiVersioning.versionsPath = currentVersioning.params.versionsPath;
                 break;
             case "external":
-                $scope.currentFolder._guiVersioning.selector = "external";
                 $scope.currentFolder._guiVersioning.externalCommand = currentVersioning.params.command;
                 break;
             }
@@ -2086,46 +2090,25 @@ angular.module('syncthing.core')
             folderCfg.devices = newDevices;
             delete $scope.currentSharing;
 
+            folderCfg.versioning.type = folderCfg._guiVersioning.selector;
+            if ($scope.internalVersioningEnabled()) {
+                folderCfg.versioning.cleanupIntervalS = folderCfg._guiVersioning.cleanupIntervalS;
+                folderCfg.versioning.versionsPath = folderCfg._guiVersioning.versionsPath;
+            }
             switch (folderCfg._guiVersioning.selector) {
             case "trashcan":
-                folderCfg.versioning = {
-                    'type': 'trashcan',
-                    'params': {
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
-                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
-                    },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
-                };
+                folderCfg.versioning.params.cleanoutDays = '' + folderCfg._guiVersioning.trashcanClean;
                 break;
             case "simple":
-                folderCfg.versioning = {
-                    'type': 'simple',
-                    'params': {
-                        'keep': '' + folderCfg._guiVersioning.simpleKeep,
-                        'cleanoutDays': '' + folderCfg._guiVersioning.trashcanClean,
-                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
-                    },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
-                };
+                folderCfg.versioning.params.keep = '' + folderCfg._guiVersioning.simpleKeep,
+                folderCfg.versioning.params.cleanoutDays = '' + folderCfg._guiVersioning.trashcanClean;
                 break;
             case "staggered":
-                folderCfg.versioning = {
-                    'type': 'staggered',
-                    'params': {
-                        'maxAge': '' + (folderCfg._guiVersioning.staggeredMaxAge * 86400),
-                        'cleanInterval': '' + folderCfg._guiVersioning.staggeredCleanInterval,
-                        'versionsPath': '' + folderCfg._guiVersioning.versionsPath
-                    },
-                    'cleanupIntervalS': folderCfg._guiVersioning.cleanupIntervalS
-                };
+                folderCfg.versioning.params.maxAge = '' + (folderCfg._guiVersioning.staggeredMaxAge * 86400);
+                folderCfg.versioning.params.cleanInterval = '' + folderCfg._guiVersioning.staggeredCleanInterval;
                 break;
             case "external":
-                folderCfg.versioning = {
-                    'type': 'external',
-                    'params': {
-                        'command': '' + folderCfg._guiVersioning.externalCommand
-                    },
-                };
+                folderCfg.versioning.params.command = '' + folderCfg._guiVersioning.externalCommand;
                 break;
             default:
                 delete folderCfg.versioning;

--- a/gui/default/untrusted/syncthing/folder/editFolderModalView.html
+++ b/gui/default/untrusted/syncthing/folder/editFolderModalView.html
@@ -120,7 +120,7 @@
               <span translate ng-if="folderEditor._guiVersioning.staggeredMaxAge.$error.min && folderEditor._guiVersioning.staggeredMaxAge.$dirty">A negative number of days doesn't make sense.</span>
             </p>
           </div>
-          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none' && currentFolder._guiVersioning.selector != 'external'">
+          <div class="form-group" ng-if="internalVersioningEnabled()">
             <label translate for="versionsPath">Versions Path</label>
             <input name="versionsPath" id="versionsPath" class="form-control" type="text" ng-model="currentFolder._guiVersioning.versionsPath" />
             <p translate class="help-block">Path where versions should be stored (leave empty for the default .stversions directory in the shared folder).</p>
@@ -134,7 +134,7 @@
               <span translate ng-if="folderEditor.externalCommand.$error.required && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>
             </p>
           </div>
-          <div class="form-group" ng-if="currentFolder._guiVersioning.selector != 'none' && currentFolder._guiVersioning.selector != 'external'" ng-class="{'has-error': folderEditor._guiVersioning.cleanupIntervalS.$invalid && folderEditor._guiVersioning.cleanupIntervalS.$dirty}">
+          <div class="form-group" ng-if="internalVersioningEnabled()" ng-class="{'has-error': folderEditor._guiVersioning.cleanupIntervalS.$invalid && folderEditor._guiVersioning.cleanupIntervalS.$dirty}">
             <label translate for="versioningCleanupIntervalS">Cleanup Interval</label>
             <div class="input-group">
               <input name="versioningCleanupIntervalS" id="versioningCleanupIntervalS" class="form-control text-right" type="number" ng-model="currentFolder._guiVersioning.cleanupIntervalS" required="" min="0" max="31536000" aria-required="true" />


### PR DESCRIPTION
Main purpose: Less javascript - as in fewer or shorter lines :)

Secondary purpose: Don't clobber versioning parameters in case there's any that do not exist in the web UI, but do exist in the config.

Accidentally found a bug too: An incorrect default versioning parameter name.