### PR TITLE
gui: Handle info labels that are longer than available space (fixes #944)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -120,7 +120,8 @@ table.table-dynamic {
     word-break: break-all;
 }
 
-table.table-condensed td {
+table.table-condensed td,
+table.table-condensed th {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -363,7 +364,8 @@ ul.three-columns li, ul.two-columns li {
         overflow-y: scroll;
     }
 
-    table.table-condensed td {
+    table.table-condensed td,
+    table.table-condensed th {
         /* for mobile phones to allow linebreaks in long repro folder/shared with
         * columns. */
         white-space: normal;


### PR DESCRIPTION
Apply to table headers the same code as already used for table data.
This way, the headers will be either pushed to the next line, or cut
with an ellipsis if the single word is too long.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>