### PR TITLE
all: Fix Microsoft documentation links in code comments

### DIFF
--- a/lib/fs/basicfs_copy_range_duplicateextents.go
+++ b/lib/fs/basicfs_copy_range_duplicateextents.go
@@ -121,7 +121,7 @@ func wrapError(err error) error {
 }
 
 // call FSCTL_DUPLICATE_EXTENTS_TO_FILE IOCTL
-// see https://docs.microsoft.com/en-us/windows/win32/api/winioctl/ni-winioctl-fsctl_duplicate_extents_to_file
+// see https://docs.microsoft.com/windows/win32/api/winioctl/ni-winioctl-fsctl_duplicate_extents_to_file
 //
 // memo: Overflow (cloneRegionSize is greater than file ends) is safe and just ignored by windows.
 func callDuplicateExtentsToFile(src, dst uintptr, srcOffset, dstOffset int64, cloneRegionSize int64) error {

--- a/lib/fs/basicfs_lstat_windows.go
+++ b/lib/fs/basicfs_lstat_windows.go
@@ -29,7 +29,7 @@ func isDirectoryJunction(path string) (bool, error) {
 	}
 	defer syscall.CloseHandle(h)
 
-	//https://docs.microsoft.com/en-us/windows/win32/api/winbase/ns-winbase-file_attribute_tag_info
+	//https://docs.microsoft.com/windows/win32/api/winbase/ns-winbase-file_attribute_tag_info
 	const fileAttributeTagInfo = 9
 	type FILE_ATTRIBUTE_TAG_INFO struct {
 		FileAttributes uint32

--- a/lib/fs/debug_symlink_windows.go
+++ b/lib/fs/debug_symlink_windows.go
@@ -66,7 +66,7 @@ func DebugSymlinkForTestsOnly(oldFs, newFS Filesystem, oldname, newname string) 
 // or contains .. elements), or is short enough, fixLongPath returns
 // path unmodified.
 //
-// See https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx#maxpath
+// See https://docs.microsoft.com/windows/win32/fileio/naming-a-file#maximum-path-length-limitation
 func fixLongPath(path string) string {
 	// Do nothing (and don't allocate) if the path is "short".
 	// Empirically (at least on the Windows Server 2013 builder),
@@ -77,7 +77,7 @@ func fixLongPath(path string) string {
 	// name (that is, the directory name cannot exceed MAX_PATH
 	// minus 12)." Since MAX_PATH is 260, 260 - 12 = 248.
 	//
-	// The MSDN docs appear to say that a normal path that is 248 bytes long
+	// The MS docs appear to say that a normal path that is 248 bytes long
 	// will work; empirically the path must be less than 248 bytes long.
 	if len(path) < 248 {
 		// Don't fix. (This is how Go 1.7 and earlier worked,

--- a/lib/fs/util.go
+++ b/lib/fs/util.go
@@ -63,7 +63,7 @@ func WindowsInvalidFilename(name string) error {
 	// None of the path components should end in space or period, or be a
 	// reserved name. COM0 and LPT0 are missing from the Microsoft docs,
 	// but Windows Explorer treats them as invalid too.
-	// (https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file)
+	// (https://docs.microsoft.com/windows/win32/fileio/naming-a-file)
 	for _, part := range strings.Split(name, `\`) {
 		if len(part) == 0 {
 			continue

--- a/lib/osutil/lowprio_windows.go
+++ b/lib/osutil/lowprio_windows.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms686219(v=vs.85).aspx
+	// https://docs.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass
 	aboveNormalPriorityClass   = 0x00008000
 	belowNormalPriorityClass   = 0x00004000
 	highPriorityClass          = 0x00000080

--- a/lib/syncthing/superuser_windows.go
+++ b/lib/syncthing/superuser_windows.go
@@ -8,7 +8,7 @@ package syncthing
 
 import "syscall"
 
-// https://msdn.microsoft.com/en-us/library/windows/desktop/aa379649(v=vs.85).aspx
+// https://docs.microsoft.com/windows/win32/secauthz/well-known-sids
 const securityLocalSystemRID = "S-1-5-18"
 
 func isSuperUser() bool {


### PR DESCRIPTION
Replace the old MSDN links with their counterparts on the Microsoft
Docs, and remove the hardcoded language codes to make the other ones
language-agnostic.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>