### PR TITLE
lib/fs: Expose fs option on interface (fixes #7385, ref #7381)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -45,13 +45,13 @@ func (f FolderConfiguration) Copy() FolderConfiguration {
 func (f FolderConfiguration) Filesystem() fs.Filesystem {
 	// This is intentionally not a pointer method, because things like
 	// cfg.Folders["default"].Filesystem() should be valid.
-	var opts []fs.Option
+	var opts fs.FilesystemOptions
 	if f.FilesystemType == fs.FilesystemTypeBasic && f.JunctionsAsDirs {
-		opts = append(opts, fs.WithJunctionsAsDirs())
+		opts |= fs.OptionJunctionsAsDirs
 	}
-	filesystem := fs.NewFilesystem(f.FilesystemType, f.Path, opts...)
+	filesystem := fs.NewFilesystem(f.FilesystemType, f.Path, opts)
 	if !f.CaseSensitiveFS {
-		filesystem = fs.NewCaseFilesystem(filesystem, opts...)
+		filesystem = fs.NewCaseFilesystem(filesystem)
 	}
 	return filesystem
 }

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -45,11 +45,11 @@ func (f FolderConfiguration) Copy() FolderConfiguration {
 func (f FolderConfiguration) Filesystem() fs.Filesystem {
 	// This is intentionally not a pointer method, because things like
 	// cfg.Folders["default"].Filesystem() should be valid.
-	var opts fs.FilesystemOptions
+	var opts []fs.Option
 	if f.FilesystemType == fs.FilesystemTypeBasic && f.JunctionsAsDirs {
-		opts |= fs.OptionJunctionsAsDirs
+		opts = append(opts, new(fs.OptionJunctionsAsDirs))
 	}
-	filesystem := fs.NewFilesystem(f.FilesystemType, f.Path, opts)
+	filesystem := fs.NewFilesystem(f.FilesystemType, f.Path, opts...)
 	if !f.CaseSensitiveFS {
 		filesystem = fs.NewCaseFilesystem(filesystem)
 	}

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -40,6 +40,10 @@ func (o *OptionJunctionsAsDirs) ID() string {
 	return "junctionsAsDirs"
 }
 
+func (o *OptionJunctionsAsDirs) String() string {
+	return o.ID()
+}
+
 // The BasicFilesystem implements all aspects by delegating to package os.
 // All paths are relative to the root and cannot (should not) escape the root directory.
 type BasicFilesystem struct {

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -26,27 +26,14 @@ var (
 	errNotRelative                        = errors.New("not a relative path")
 )
 
-func WithJunctionsAsDirs() Option {
-	return Option{
-		apply: func(fs Filesystem) {
-			if basic, ok := fs.(*BasicFilesystem); !ok {
-				l.Warnln("WithJunctionsAsDirs must only be used with FilesystemTypeBasic")
-			} else {
-				basic.junctionsAsDirs = true
-			}
-		},
-		id: "junctionsAsDirs",
-	}
-}
-
 // The BasicFilesystem implements all aspects by delegating to package os.
 // All paths are relative to the root and cannot (should not) escape the root directory.
 type BasicFilesystem struct {
-	root            string
-	junctionsAsDirs bool
+	FilesystemOptions
+	root string
 }
 
-func newBasicFilesystem(root string, opts ...Option) *BasicFilesystem {
+func newBasicFilesystem(root string, opts ...FilesystemOptions) *BasicFilesystem {
 	if root == "" {
 		root = "." // Otherwise "" becomes "/" below
 	}
@@ -84,9 +71,8 @@ func newBasicFilesystem(root string, opts ...Option) *BasicFilesystem {
 	fs := &BasicFilesystem{
 		root: root,
 	}
-	for _, opt := range opts {
-		opt.apply(fs)
-	}
+	fs.FilesystemOptions.Add(opts...)
+
 	return fs
 }
 

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -36,12 +36,8 @@ func (o *OptionJunctionsAsDirs) apply(fs Filesystem) {
 	}
 }
 
-func (o *OptionJunctionsAsDirs) ID() string {
-	return "junctionsAsDirs"
-}
-
 func (o *OptionJunctionsAsDirs) String() string {
-	return o.ID()
+	return "junctionsAsDirs"
 }
 
 // The BasicFilesystem implements all aspects by delegating to package os.

--- a/lib/fs/basicfs_lstat_windows.go
+++ b/lib/fs/basicfs_lstat_windows.go
@@ -71,7 +71,7 @@ func (f *BasicFilesystem) underlyingLstat(name string) (os.FileInfo, error) {
 
 	// NTFS directory junctions can be treated as ordinary directories,
 	// see https://forum.syncthing.net/t/option-to-follow-directory-junctions-symbolic-links/14750
-	if err == nil && f.junctionsAsDirs && fi.Mode()&os.ModeSymlink != 0 {
+	if err == nil && f.Has(OptionJunctionsAsDirs) && fi.Mode()&os.ModeSymlink != 0 {
 		var isJunct bool
 		isJunct, err = isDirectoryJunction(name)
 		if err == nil && isJunct {

--- a/lib/fs/basicfs_lstat_windows.go
+++ b/lib/fs/basicfs_lstat_windows.go
@@ -71,7 +71,7 @@ func (f *BasicFilesystem) underlyingLstat(name string) (os.FileInfo, error) {
 
 	// NTFS directory junctions can be treated as ordinary directories,
 	// see https://forum.syncthing.net/t/option-to-follow-directory-junctions-symbolic-links/14750
-	if err == nil && f.Has(OptionJunctionsAsDirs) && fi.Mode()&os.ModeSymlink != 0 {
+	if err == nil && f.junctionsAsDirs && fi.Mode()&os.ModeSymlink != 0 {
 		var isJunct bool
 		isJunct, err = isDirectoryJunction(name)
 		if err == nil && isJunct {

--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -61,9 +61,9 @@ func newFSKey(fs Filesystem) fskey {
 		uri:    fs.URI(),
 	}
 	if opts := fs.Options(); len(opts) > 0 {
-		k.opts = opts[0].ID()
+		k.opts = opts[0].String()
 		for _, o := range opts[1:] {
-			k.opts += "&" + o.ID()
+			k.opts += "&" + o.String()
 		}
 	}
 	return k

--- a/lib/fs/errorfs.go
+++ b/lib/fs/errorfs.go
@@ -12,6 +12,7 @@ import (
 )
 
 type errorFilesystem struct {
+	FilesystemOptions
 	err    error
 	fsType FilesystemType
 	uri    string

--- a/lib/fs/errorfs.go
+++ b/lib/fs/errorfs.go
@@ -12,7 +12,6 @@ import (
 )
 
 type errorFilesystem struct {
-	FilesystemOptions
 	err    error
 	fsType FilesystemType
 	uri    string
@@ -46,7 +45,10 @@ func (fs *errorFilesystem) Roots() ([]string, error)                     { retur
 func (fs *errorFilesystem) Usage(name string) (Usage, error)             { return Usage{}, fs.err }
 func (fs *errorFilesystem) Type() FilesystemType                         { return fs.fsType }
 func (fs *errorFilesystem) URI() string                                  { return fs.uri }
-func (fs *errorFilesystem) SameFile(fi1, fi2 FileInfo) bool              { return false }
+func (fs *errorFilesystem) Options() []Option {
+	return nil
+}
+func (fs *errorFilesystem) SameFile(fi1, fi2 FileInfo) bool { return false }
 func (fs *errorFilesystem) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
 	return nil, nil, fs.err
 }

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -54,7 +54,6 @@ const randomBlockShift = 14 // 128k
 // - Two fakefs:s pointing at the same root path see the same files.
 //
 type fakefs struct {
-	FilesystemOptions
 	counters    fakefsCounters
 	uri         string
 	mut         sync.Mutex
@@ -86,7 +85,7 @@ var (
 	fakefsFs  = make(map[string]*fakefs)
 )
 
-func newFakeFilesystem(rootURI string, _ ...FilesystemOptions) *fakefs {
+func newFakeFilesystem(rootURI string, _ ...Option) *fakefs {
 	fakefsMut.Lock()
 	defer fakefsMut.Unlock()
 
@@ -639,6 +638,10 @@ func (fs *fakefs) Type() FilesystemType {
 
 func (fs *fakefs) URI() string {
 	return fs.uri
+}
+
+func (fs *fakefs) Options() []Option {
+	return nil
 }
 
 func (fs *fakefs) SameFile(fi1, fi2 FileInfo) bool {

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -54,6 +54,7 @@ const randomBlockShift = 14 // 128k
 // - Two fakefs:s pointing at the same root path see the same files.
 //
 type fakefs struct {
+	FilesystemOptions
 	counters    fakefsCounters
 	uri         string
 	mut         sync.Mutex
@@ -85,7 +86,7 @@ var (
 	fakefsFs  = make(map[string]*fakefs)
 )
 
-func newFakeFilesystem(rootURI string, _ ...Option) *fakefs {
+func newFakeFilesystem(rootURI string, _ ...FilesystemOptions) *fakefs {
 	fakefsMut.Lock()
 	defer fakefsMut.Unlock()
 

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -179,6 +179,12 @@ var IsPermission = os.IsPermission
 // IsPathSeparator is the equivalent of os.IsPathSeparator
 var IsPathSeparator = os.IsPathSeparator
 
+// Option modifies a filesystem at creation. An option might be specific
+// to a filesystem-type.
+//
+// ID is used to identify options with the same effect, i.e. must be different
+// for options with different effects. Meaning if an option has parameters, a
+// representation of those must be part of the returned string.
 type Option interface {
 	ID() string
 	apply(Filesystem)

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -47,7 +47,7 @@ type Filesystem interface {
 	Usage(name string) (Usage, error)
 	Type() FilesystemType
 	URI() string
-	Options() FilesystemOptions
+	Options() []Option
 	SameFile(fi1, fi2 FileInfo) bool
 }
 
@@ -179,16 +179,12 @@ var IsPermission = os.IsPermission
 // IsPathSeparator is the equivalent of os.IsPathSeparator
 var IsPathSeparator = os.IsPathSeparator
 
-type FilesystemOptions uint
+type Option interface {
+	ID() string
+	apply(Filesystem)
+}
 
-const (
-	OptionJunctionsAsDirs FilesystemOptions = 1 << iota
-)
-
-// NewFilesystem creates a filesystem of given fsType with its root at uri.
-// Options can be passed through multiple optional options. It is also possible
-// to pass a combination of FilesystemOptions in a single argument.
-func NewFilesystem(fsType FilesystemType, uri string, opts ...FilesystemOptions) Filesystem {
+func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem {
 	var fs Filesystem
 	switch fsType {
 	case FilesystemTypeBasic:
@@ -296,21 +292,5 @@ func unwrapFilesystem(fs Filesystem) Filesystem {
 		default:
 			return sfs
 		}
-	}
-}
-
-// Options is a helper function so that implementations of Filesystem can
-// just embed FilesystemOptions to implement this interface method.
-func (o FilesystemOptions) Options() FilesystemOptions {
-	return o
-}
-
-func (o FilesystemOptions) Has(other FilesystemOptions) bool {
-	return o&other != 0
-}
-
-func (o *FilesystemOptions) Add(opts ...FilesystemOptions) {
-	for _, opt := range opts {
-		*o |= opt
 	}
 }

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -47,6 +47,7 @@ type Filesystem interface {
 	Usage(name string) (Usage, error)
 	Type() FilesystemType
 	URI() string
+	Options() FilesystemOptions
 	SameFile(fi1, fi2 FileInfo) bool
 }
 
@@ -178,12 +179,16 @@ var IsPermission = os.IsPermission
 // IsPathSeparator is the equivalent of os.IsPathSeparator
 var IsPathSeparator = os.IsPathSeparator
 
-type Option struct {
-	apply func(Filesystem)
-	id    string
-}
+type FilesystemOptions uint
 
-func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem {
+const (
+	OptionJunctionsAsDirs FilesystemOptions = 1 << iota
+)
+
+// NewFilesystem creates a filesystem of given fsType with its root at uri.
+// Options can be passed through multiple optional options. It is also possible
+// to pass a combination of FilesystemOptions in a single argument.
+func NewFilesystem(fsType FilesystemType, uri string, opts ...FilesystemOptions) Filesystem {
 	var fs Filesystem
 	switch fsType {
 	case FilesystemTypeBasic:
@@ -291,5 +296,21 @@ func unwrapFilesystem(fs Filesystem) Filesystem {
 		default:
 			return sfs
 		}
+	}
+}
+
+// Options is a helper function so that implementations of Filesystem can
+// just embed FilesystemOptions to implement this interface method.
+func (o FilesystemOptions) Options() FilesystemOptions {
+	return o
+}
+
+func (o FilesystemOptions) Has(other FilesystemOptions) bool {
+	return o&other != 0
+}
+
+func (o *FilesystemOptions) Add(opts ...FilesystemOptions) {
+	for _, opt := range opts {
+		*o |= opt
 	}
 }

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -182,11 +182,11 @@ var IsPathSeparator = os.IsPathSeparator
 // Option modifies a filesystem at creation. An option might be specific
 // to a filesystem-type.
 //
-// ID is used to identify options with the same effect, i.e. must be different
+// String is used to detect options with the same effect, i.e. must be different
 // for options with different effects. Meaning if an option has parameters, a
 // representation of those must be part of the returned string.
 type Option interface {
-	ID() string
+	String() string
 	apply(Filesystem)
 }
 

--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -67,10 +67,16 @@ type walkFilesystem struct {
 }
 
 func NewWalkFilesystem(next Filesystem) Filesystem {
-	return &walkFilesystem{
-		Filesystem:             next,
-		checkInfiniteRecursion: next.Options().Has(OptionJunctionsAsDirs),
+	fs := &walkFilesystem{
+		Filesystem: next,
 	}
+	for _, opt := range next.Options() {
+		if _, ok := opt.(*OptionJunctionsAsDirs); ok {
+			fs.checkInfiniteRecursion = true
+			break
+		}
+	}
+	return fs
 }
 
 // walk recursively descends path, calling walkFn.

--- a/lib/fs/walkfs.go
+++ b/lib/fs/walkfs.go
@@ -63,10 +63,14 @@ type WalkFunc func(path string, info FileInfo, err error) error
 
 type walkFilesystem struct {
 	Filesystem
+	checkInfiniteRecursion bool
 }
 
 func NewWalkFilesystem(next Filesystem) Filesystem {
-	return &walkFilesystem{next}
+	return &walkFilesystem{
+		Filesystem:             next,
+		checkInfiniteRecursion: next.Options().Has(OptionJunctionsAsDirs),
+	}
 }
 
 // walk recursively descends path, calling walkFn.
@@ -89,11 +93,13 @@ func (f *walkFilesystem) walk(path string, info FileInfo, walkFn WalkFunc, ances
 		return nil
 	}
 
-	if !ancestors.Contains(info) {
-		ancestors.Push(info)
-		defer ancestors.Pop()
-	} else {
-		return walkFn(path, info, ErrInfiniteRecursion)
+	if f.checkInfiniteRecursion {
+		if !ancestors.Contains(info) {
+			ancestors.Push(info)
+			defer ancestors.Pop()
+		} else {
+			return walkFn(path, info, ErrInfiniteRecursion)
+		}
 	}
 
 	names, err := f.DirNames(path)
@@ -131,6 +137,9 @@ func (f *walkFilesystem) Walk(root string, walkFn WalkFunc) error {
 	if err != nil {
 		return walkFn(root, nil, err)
 	}
-	ancestors := &ancestorDirList{fs: f.Filesystem}
+	var ancestors *ancestorDirList
+	if f.checkInfiniteRecursion {
+		ancestors = &ancestorDirList{fs: f.Filesystem}
+	}
 	return f.walk(root, info, walkFn, ancestors)
 }

--- a/lib/fs/walkfs_test.go
+++ b/lib/fs/walkfs_test.go
@@ -57,7 +57,7 @@ func testWalkTraverseDirJunct(t *testing.T, fsType FilesystemType, uri string) {
 		t.Skip("Directory junctions are available and tested on windows only")
 	}
 
-	fs := NewFilesystem(fsType, uri, OptionJunctionsAsDirs)
+	fs := NewFilesystem(fsType, uri, new(OptionJunctionsAsDirs))
 
 	if err := fs.MkdirAll("target/foo", 0); err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func testWalkInfiniteRecursion(t *testing.T, fsType FilesystemType, uri string) 
 		t.Skip("Infinite recursion detection is tested on windows only")
 	}
 
-	fs := NewFilesystem(fsType, uri, OptionJunctionsAsDirs)
+	fs := NewFilesystem(fsType, uri, new(OptionJunctionsAsDirs))
 
 	if err := fs.MkdirAll("target/foo", 0); err != nil {
 		t.Fatal(err)

--- a/lib/fs/walkfs_test.go
+++ b/lib/fs/walkfs_test.go
@@ -57,7 +57,7 @@ func testWalkTraverseDirJunct(t *testing.T, fsType FilesystemType, uri string) {
 		t.Skip("Directory junctions are available and tested on windows only")
 	}
 
-	fs := NewFilesystem(fsType, uri, WithJunctionsAsDirs())
+	fs := NewFilesystem(fsType, uri, OptionJunctionsAsDirs)
 
 	if err := fs.MkdirAll("target/foo", 0); err != nil {
 		t.Fatal(err)
@@ -90,7 +90,7 @@ func testWalkInfiniteRecursion(t *testing.T, fsType FilesystemType, uri string) 
 		t.Skip("Infinite recursion detection is tested on windows only")
 	}
 
-	fs := NewFilesystem(fsType, uri, WithJunctionsAsDirs())
+	fs := NewFilesystem(fsType, uri, OptionJunctionsAsDirs)
 
 	if err := fs.MkdirAll("target/foo", 0); err != nil {
 		t.Fatal(err)

--- a/lib/scanner/virtualfs_test.go
+++ b/lib/scanner/virtualfs_test.go
@@ -97,8 +97,8 @@ func (s singleFileFS) Open(name string) (fs.File, error) {
 	return &fakeFile{s.name, s.filesize, 0}, nil
 }
 
-func (s singleFileFS) Options() fs.FilesystemOptions {
-	return 0
+func (s singleFileFS) Options() []fs.Option {
+	return nil
 }
 
 type fakeInfo struct {

--- a/lib/scanner/virtualfs_test.go
+++ b/lib/scanner/virtualfs_test.go
@@ -97,6 +97,10 @@ func (s singleFileFS) Open(name string) (fs.File, error) {
 	return &fakeFile{s.name, s.filesize, 0}, nil
 }
 
+func (s singleFileFS) Options() fs.FilesystemOptions {
+	return 0
+}
+
 type fakeInfo struct {
 	name string
 	size int64


### PR DESCRIPTION
Fixes #7385 by only checking for infinite recursion if the junctions-as-dirs option is enabled.

Passing around options like I did in #7381 is tedious/repetitive. I thus changed the way options work from passing function `With...` style arguments to const/bitmask options. This allows knowing what options are active on any given filesystem, thus we don't need to pass options to the case- and walk-fs (and the case-fs can directly use option value for the key instead of constructing some arbitrary string).

One choice I am unsure about: I kept the variable length `opts ...FilesystemOptions` argument, even though multiple options can be passed by bitwise-or-ing options. I left that such that all `NewFilesystem` calls without options don't need to be changed to have an additional `, 0` (or something like `0, fs.OptionNone`) argument.