### PR TITLE
gui: Fix versioning date filter popup position (fixes #4755)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2378,12 +2378,13 @@ angular.module('syncthing.core')
                             });
 
                             $("#restoreVersionDateRange").daterangepicker({
+                                parentEl: '#restoreVersions',
                                 timePicker: true,
                                 timePicker24Hour: true,
                                 timePickerSeconds: true,
                                 autoUpdateInput: true,
                                 opens: "left",
-                                drops: "up",
+                                drops: "down",
                                 startDate: minDate,
                                 endDate: maxDate,
                                 minDate: minDate,

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -2418,12 +2418,13 @@ angular.module('syncthing.core')
                             });
 
                             $("#restoreVersionDateRange").daterangepicker({
+                                parentEl: '#restoreVersions',
                                 timePicker: true,
                                 timePicker24Hour: true,
                                 timePickerSeconds: true,
                                 autoUpdateInput: true,
                                 opens: "left",
-                                drops: "up",
+                                drops: "down",
                                 startDate: minDate,
                                 endDate: maxDate,
                                 minDate: minDate,


### PR DESCRIPTION
Change the position and the parent element of the calendar popup, so
that it spawns inside the Restore Versions modal. This way, even on
small phone screens it is possible to scroll down to view the whole
calendar.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>