### PR TITLE
gui: Tweak the Restore Versions modal for better usability

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -304,6 +304,73 @@ ul.three-columns li, ul.two-columns li {
     z-index: 980;
 }
 
+/**
+ * Fancytree tweaks
+ */
+
+table.fancytree-ext-table {
+  width: 100%
+}
+
+span.fancytree-expander,
+span.fancytree-icon {
+    vertical-align: middle;
+}
+
+/* Break long names not to push the restore buttons off the screen. */
+span.fancytree-title {
+    word-break: break-all;
+}
+
+/**
+ * Restore Versions modal tweaks
+ */
+
+/* Contain the file list in a fix-sized box with a scrollbar. By
+   default, display 5.5 items at once (depends on the browser, font, and
+   DPI). The container can be resized by the user at will. */
+#restoreTree-container {
+    height: auto;
+    overflow-y: auto;
+    resize: both;
+    /* Size of a single item, 39px + 12px (.form-control padding). */
+    min-height: 51px;
+    /* Size of 5.5 items, (39px * 5.5) + 6px (.form-control padding). */
+    max-height: 220.5px;
+}
+
+/* Disable the max-height limit set above when resized manually. */
+#restoreTree-container[style*="height"] {
+    max-height: none;
+}
+
+/* The outline is ugly and serves no purpose here. */
+#restoreTree {
+    outline: none;
+}
+
+/* Hide the empty table head, so that it takes no vertical space. */
+#restoreTree > thead {
+    display: none;
+}
+
+/* Reduce the space between the restore button and menu on mobile. */
+#restoreTree .dropdown-toggle {
+    margin-bottom: 0;
+}
+
+/* Move the button to the left, so that it is visible on mobile. */
+#restoreTree .dropdown-menu {
+    left: auto;
+    right: 0;
+}
+
+/* Widen the filter inputs to fit more text, esp. the date range. */
+#restoreVersions .form-group,
+#restoreVersions .form-control {
+    width: 100%;
+}
+
 /** Footer nav on small devices **/
 @media (max-width: 1199px) {
     /* Stay at the end of the page, with space reserved for the footer
@@ -395,10 +462,6 @@ ul.three-columns li, ul.two-columns li {
 
 .tab-content {
     padding-top: 10px;
-}
-
-.fancytree-ext-table {
-    width: 100% !important;
 }
 
 @media (max-width: 419px) {

--- a/gui/default/syncthing/folder/restoreVersionsModalView.html
+++ b/gui/default/syncthing/folder/restoreVersionsModalView.html
@@ -2,27 +2,29 @@
   <div class="modal-body">
     <span translate ng-if="!restoreVersions.versions && !restoreVersions.errors">Loading data...</span>
     <div ng-if="restoreVersions.versions">
-      <table id="restoreTree">
-        <thead>
-          <tr>
-            <th></th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-        </tbody>
-      </table>
+      <div id="restoreTree-container" class="form-control">
+        <table id="restoreTree">
+          <thead>
+            <tr>
+              <th></th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+          </tbody>
+        </table>
+      </div>
       <hr />
       <div class="row form-inline">
         <div class="col-md-6">
           <div class="form-group">
-            <label translate for="restoreVersionSearch">Filter by name</label>:&nbsp
+            <label for="restoreVersionSearch"><span translate>Filter by name</span>:&nbsp</label>
             <input id="restoreVersionSearch" class="form-control" type="text" ng-model="restoreVersions.filters.text">
           </div>
         </div>
         <div class="col-md-6">
           <div class="form-group">
-            <label translate for="restoreVersionDate">Filter by date</label>:&nbsp
+            <label for="restoreVersionDate"><span translate>Filter by date</span>:&nbsp</label>
             <input id="restoreVersionDateRange" class="form-control">
           </div>
         </div>


### PR DESCRIPTION
Add various tweaks to the Restore Versions modal in order to make it
more usable in general, and also to prevent the content from breaking
when used with long filenames and on small resolutions.

The specific changes are as follows.

1. Contain the file list in a resizable box, so that only 5.5 items are
   visible initially, while the rest is available through scrolling.
   This prevents the whole body from being pushed down by the list, and
   also keeps the filter and confirmation buttons visible on the screen.
2. Forcefully break long filenames with no spaces, so that they always
   fit on the screen.
3. Change the position of the restore buttons' menu popup to the left,
   so that it does not go out of the screen on small resolutions.
4. Widen the filter input fields, so that there is more space for the
   text, and especially the data range fits without being cut off.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Testing

Tested in Chromium, Firefox, and IE11*.

\* The browser does not support `resize: both`, so the container is not user-resizable, but it is still usable nevertheless.

### Screenshots

Before:

![1](https://user-images.githubusercontent.com/5626656/108678533-8b3e6680-752e-11eb-9f82-b819b6865b85.png)
![4](https://user-images.githubusercontent.com/5626656/108678541-8e395700-752e-11eb-84e0-5baffefef202.png)

After:

![2](https://user-images.githubusercontent.com/5626656/108678561-9396a180-752e-11eb-85d4-7fcbf472c068.png)
![3](https://user-images.githubusercontent.com/5626656/108678564-94c7ce80-752e-11eb-864f-a54e79a596a6.png)
