### PR TITLE
Allow QUIC traffic

### DIFF
--- a/etc/firewall-ufw/syncthing
+++ b/etc/firewall-ufw/syncthing
@@ -1,7 +1,7 @@
 [syncthing]
 title=Syncthing
 description=Syncthing file synchronisation
-ports=22000/tcp|21027/udp
+ports=22000|21027/udp
 
 [syncthing-gui]
 title=Syncthing-GUI


### PR DESCRIPTION
### Purpose

The current ufw template only allows 22000/tcp and therefore blocks UDP based QUIC.