### PR TITLE
lib/api: Rename config insync endpoint to restart-required

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -297,7 +297,8 @@ func (s *service) Serve(ctx context.Context) error {
 	}
 
 	configBuilder.registerConfig("/rest/config")
-	configBuilder.registerConfigInsync("/rest/config/insync")
+	configBuilder.registerConfigInsync("/rest/config/insync") // deprecated
+	configBuilder.registerConfigInsync("/rest/config/restart-required")
 	configBuilder.registerFolders("/rest/config/folders")
 	configBuilder.registerDevices("/rest/config/devices")
 	configBuilder.registerFolder("/rest/config/folders/:id")


### PR DESCRIPTION
`insync` isn't a very descriptive name, thus proposing to change it to `restart-required` as brought up in https://github.com/syncthing/docs/pull/616. The currently incorrect docs can then be switched to reference `restart-required`.