### PR TITLE
lib/protocol: Optimize encrypted filename handling + make it more strict

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -368,7 +368,10 @@ func encryptName(name string, key *[keySize]byte) string {
 
 // decryptName decrypts a string from encryptName
 func decryptName(name string, key *[keySize]byte) (string, error) {
-	name = deslashify(name)
+	name, err := deslashify(name)
+	if err != nil {
+		return "", err
+	}
 	bs, err := base32Hex.DecodeString(name)
 	if err != nil {
 		return "", err
@@ -525,9 +528,12 @@ func slashify(s string) string {
 
 // deslashify removes slashes and encrypted file extensions from the string.
 // This is the inverse of slashify().
-func deslashify(s string) string {
-	s = strings.ReplaceAll(s, encryptedDirExtension, "")
-	return strings.ReplaceAll(s, "/", "")
+func deslashify(s string) (string, error) {
+	if len(s) == 0 || !strings.HasPrefix(s[1:], encryptedDirExtension) {
+		return "", fmt.Errorf("invalid encrypted path: %q", s)
+	}
+	s = s[:1] + s[1+len(encryptedDirExtension):]
+	return strings.ReplaceAll(s, "/", ""), nil
 }
 
 type rawResponse struct {

--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -356,19 +356,20 @@ func DecryptFileInfo(fi FileInfo, folderKey *[keySize]byte) (FileInfo, error) {
 	return decFI, nil
 }
 
+var base32Hex = base32.HexEncoding.WithPadding(base32.NoPadding)
+
 // encryptName encrypts the given string in a deterministic manner (the
 // result is always the same for any given string) and encodes it in a
 // filesystem-friendly manner.
 func encryptName(name string, key *[keySize]byte) string {
 	enc := encryptDeterministic([]byte(name), key, nil)
-	b32enc := base32.HexEncoding.WithPadding(base32.NoPadding).EncodeToString(enc)
-	return slashify(b32enc)
+	return slashify(base32Hex.EncodeToString(enc))
 }
 
 // decryptName decrypts a string from encryptName
 func decryptName(name string, key *[keySize]byte) (string, error) {
 	name = deslashify(name)
-	bs, err := base32.HexEncoding.WithPadding(base32.NoPadding).DecodeString(name)
+	bs, err := base32Hex.DecodeString(name)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Here's three minor changes for the encrypted filename handling in lib/protocol:

* The base32.Encoding object that encryptName and decryptName use is allocated once, instead of in every call. This also counts as DRY, since both functions necessarily use the same encoding.
* deslashify now does some light input validation. It used to strip out any occurrences of ".syncthing-enc", without requiring that string to even occur. It now checks for that string in the exact place where it should appear, and removes it only there.
* The tests cover more cases and more extensively check encryptName output.

I don't believe any of these changes address any existing issues; they just protect against potential future mistakes.