### PR TITLE
gui: Allow to resize command in External Versioning

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -140,7 +140,7 @@
           <div class="form-group" ng-if="currentFolder._guiVersioning.selector=='external'" ng-class="{'has-error': folderEditor.externalCommand.$invalid && folderEditor.externalCommand.$dirty}">
             <p translate class="help-block">An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.</p>
             <label translate for="externalCommand">Command</label>
-            <input name="externalCommand" id="externalCommand" class="form-control" type="text" ng-model="currentFolder._guiVersioning.externalCommand" required="" aria-required="true" />
+            <textarea name="externalCommand" id="externalCommand" class="form-control" rows="1" ng-model="currentFolder._guiVersioning.externalCommand" required="" aria-required="true" />
             <p class="help-block">
               <span translate ng-if="folderEditor.externalCommand.$valid || folderEditor.externalCommand.$pristine">See external versioning help for supported templated command line parameters.</span>
               <span translate ng-if="folderEditor.externalCommand.$error.required && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>

--- a/gui/default/untrusted/syncthing/folder/editFolderModalView.html
+++ b/gui/default/untrusted/syncthing/folder/editFolderModalView.html
@@ -128,7 +128,7 @@
           <div class="form-group" ng-if="currentFolder._guiVersioning.selector=='external'" ng-class="{'has-error': folderEditor.externalCommand.$invalid && folderEditor.externalCommand.$dirty}">
             <p translate class="help-block">An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.</p>
             <label translate for="externalCommand">Command</label>
-            <input name="externalCommand" id="externalCommand" class="form-control" type="text" ng-model="currentFolder._guiVersioning.externalCommand" required="" aria-required="true" />
+            <textarea name="externalCommand" id="externalCommand" class="form-control" rows="1" ng-model="currentFolder._guiVersioning.externalCommand" required="" aria-required="true" />
             <p class="help-block">
               <span translate ng-if="folderEditor.externalCommand.$valid || folderEditor.externalCommand.$pristine">See external versioning help for supported templated command line parameters.</span>
               <span translate ng-if="folderEditor.externalCommand.$error.required && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>


### PR DESCRIPTION
Use textarea instead of input in the command field for the External File
Versioning. This way, it is possible to resize it at will, so that we
can input and view even a very long command in full, without it being
cut off and forcing us to scroll horizontally.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Testing

Tested in IE 11, Chromium 88, and Firefox ESR 78.7.1.

### Screenshots

Before:
![1](https://user-images.githubusercontent.com/5626656/109294100-1b064c80-7870-11eb-9e5e-3165c7b7924b.png)

After:
![1](https://user-images.githubusercontent.com/5626656/109368727-673ba600-78dd-11eb-99fc-882a858199e8.png)
