### PR TITLE
Package sysctl configuration to raise UDP buffer size on Linux

### DIFF
--- a/build.go
+++ b/build.go
@@ -115,6 +115,7 @@ var targets = map[string]target{
 			{src: "etc/linux-systemd/system/syncthing@.service", dst: "deb/lib/systemd/system/syncthing@.service", perm: 0644},
 			{src: "etc/linux-systemd/system/syncthing-resume.service", dst: "deb/lib/systemd/system/syncthing-resume.service", perm: 0644},
 			{src: "etc/linux-systemd/user/syncthing.service", dst: "deb/usr/lib/systemd/user/syncthing.service", perm: 0644},
+			{src: "etc/linux-sysctl/30-syncthing.conf", dst: "deb/usr/lib/sysctl.d/30-syncthing.conf", perm: 0644},
 			{src: "etc/firewall-ufw/syncthing", dst: "deb/etc/ufw/applications.d/syncthing", perm: 0644},
 			{src: "etc/linux-desktop/syncthing-start.desktop", dst: "deb/usr/share/applications/syncthing-start.desktop", perm: 0644},
 			{src: "etc/linux-desktop/syncthing-ui.desktop", dst: "deb/usr/share/applications/syncthing-ui.desktop", perm: 0644},

--- a/etc/linux-sysctl/30-syncthing.conf
+++ b/etc/linux-sysctl/30-syncthing.conf
@@ -1,0 +1,3 @@
+# Increase maximum receive socket buffer size to 2MiB for QUIC connections
+# see https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size
+net.core.rmem_max = 2097152

--- a/etc/linux-sysctl/README.md
+++ b/etc/linux-sysctl/README.md
@@ -1,0 +1,21 @@
+sysctl configuration to raise UDP buffer size
+===================
+Installation
+-----------
+**Please note:** When you installed syncthing using the official deb package, you can skip the copying.
+
+Copy the file `30-syncthing.conf` to `/etc/sysctl.d/` (root permissions required).
+
+In a terminal run
+```
+sudo sysctl -q --system
+```
+to apply the sysctl changes.
+
+
+Verification
+----------
+You can verify that the new limit is active using
+```
+sysctl net.core.rmem_max
+```

--- a/script/post-upgrade
+++ b/script/post-upgrade
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+deb-systemd-invoke restart procps.service
 pkill -HUP -x syncthing || true

--- a/script/post-upgrade
+++ b/script/post-upgrade
@@ -1,4 +1,8 @@
 #!/bin/sh
 
-deb-systemd-invoke restart procps.service
+if command -v deb-systemd-invoke > /dev/null; then
+	deb-systemd-invoke restart procps.service
+else
+	sysctl -q --system
+fi
 pkill -HUP -x syncthing || true


### PR DESCRIPTION
### Purpose

This PR provides a sysctl configuration to increase the maximum receive socket buffer on Linux as suggest by https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size

The configuration gets placed in `/usr/lib/sysctl.d` according to [sysctl.d(5)](https://manpages.ubuntu.com/manpages/focal/en/man5/sysctl.d.5.html). The prefix `30-` causes the file to be applied early as the processing is done in lexicographic order. This should be low enough that configuration files of other packages can still overwrite this value.

I picked the `30-` prefix so that the file can be also used for manual installs in `/etc/sysctl.d` according to the older naming schema in Ubuntu Bionic:

>  Other packages install their files in the 30-*.conf range, to override system defaults.

I also modified the `post-upgrade` script to call `deb-systemd-invoke restart procps.service`

See also #7146

