### PR TITLE
Expose and publish 22000/udp for the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN rm -f syncthing && go run build.go -no-upgrade build syncthing
 
 FROM alpine
 
-EXPOSE 8384 22000 21027/udp
+EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 
 VOLUME ["/var/syncthing"]
 

--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -1,7 +1,7 @@
 FROM alpine
 ARG TARGETARCH
 
-EXPOSE 8384 22000 21027/udp
+EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 
 VOLUME ["/var/syncthing"]
 

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -13,7 +13,7 @@ altered with the ``PUID`` and ``PGID`` environment variables.
 
 ```
 $ docker pull syncthing/syncthing
-$ docker run -p 8384:8384 -p 22000:22000 \
+$ docker run -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp \
     -v /wherever/st-sync:/var/syncthing \
     syncthing/syncthing:latest
 ```


### PR DESCRIPTION
### Purpose

Docker defaults to TCP for `EXPOSE` and `--publish` if no protocol is specified. This PR adds an UDP port mapping to allow QUIC transfer if host networking isn't used.

* https://docs.docker.com/engine/reference/builder/#expose
* https://docs.docker.com/config/containers/container-networking/#published-ports 

