### PR TITLE
lib: Return error from db.FileSet.Snapshot (fixes #7419, ref #5907)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/lucas-clemente/quic-go v0.19.3
 	github.com/maruel/panicparse v1.5.1
 	github.com/mattn/go-isatty v0.0.12
+	github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0 // indirect
 	github.com/minio/sha256-simd v0.1.1
 	github.com/miscreant/miscreant.go v0.0.0-20200214223636-26d376326b75
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
@@ -49,6 +50,7 @@ require (
 	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
 	golang.org/x/text v0.3.4
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
+	golang.org/x/tools v0.1.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0 h1:8E6DrFvII6QR4eJ3PkFvV+lc03P+2qwqTPLm1ax7694=
+github.com/maxbrunsfeld/counterfeiter/v6 v6.3.0/go.mod h1:fcEyUyXZXoV4Abw8DX0t7wyL8mCDxXyU4iAFZfT3IHw=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.1/go.mod h1:hsXNsILzKxV+sX77C5b8FSuKF00vh2OMYv+xgHpAMF4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -380,6 +382,7 @@ github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
 github.com/sasha-s/go-deadlock v0.2.0 h1:lMqc+fUb7RrFS3gQLtoQsJ7/6TV/pAIFvBsqX73DK8Y=
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
+github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil/v3 v3.20.11 h1:NeVf1K0cgxsWz+N3671ojRptdgzvp7BXL3KV21R0JnA=
@@ -446,6 +449,7 @@ github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMI
 github.com/vitrun/qart v0.0.0-20160531060029-bf64b92db6b0 h1:okhMind4q9H1OxF44gNegWkiP4H/gsTFLalHFa4OOUI=
 github.com/vitrun/qart v0.0.0-20160531060029-bf64b92db6b0/go.mod h1:TTbGUfE+cXXceWtbTHq6lqcTvYPBKLNejBEbnUsQJtU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
+github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=
@@ -483,6 +487,8 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
+golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
+golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -507,6 +513,8 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201026091529-146b70c837a4/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102 h1:42cLlJJdEh+ySyeUUbEQ5bsTiq8voBeTuweGVkY6Puw=
 golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -520,6 +528,7 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -582,7 +591,11 @@ golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20201023174141-c8cfbd0f21e6/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
+golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -600,7 +600,13 @@ angular.module('syncthing.core')
                 }
                 $scope.completion[device][folder] = data;
                 recalcCompletion(device);
-            }).error($scope.emitHTTPError);
+            }).error(function(data, status, headers, config) {
+                if (status === 404) {
+                    console.log("refreshCompletion:", data);
+                } else {
+                    $scope.emitHTTPError(data, status, headers, config);
+                }
+            });
         }
 
         function refreshConnectionStats() {

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -600,7 +600,13 @@ angular.module('syncthing.core')
                 }
                 $scope.completion[device][folder] = data;
                 recalcCompletion(device);
-            }).error($scope.emitHTTPError);
+            }).error(function(data, status, headers, config) {
+                if (status === 404) {
+                    console.log("refreshCompletion:", data);
+                } else {
+                    $scope.emitHTTPError(data, status, headers, config);
+                }
+            })
         }
 
         function refreshConnectionStats() {

--- a/lib/db/benchmark_test.go
+++ b/lib/db/benchmark_test.go
@@ -185,7 +185,7 @@ func BenchmarkNeedHalf(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		snap := benchS.Snapshot()
+		snap := snapshot(b, benchS)
 		snap.WithNeed(protocol.LocalDeviceID, func(fi protocol.FileIntf) bool {
 			count++
 			return true
@@ -209,7 +209,7 @@ func BenchmarkNeedHalfRemote(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		snap := fset.Snapshot()
+		snap := snapshot(b, fset)
 		snap.WithNeed(remoteDevice0, func(fi protocol.FileIntf) bool {
 			count++
 			return true
@@ -230,7 +230,7 @@ func BenchmarkHave(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		snap := benchS.Snapshot()
+		snap := snapshot(b, benchS)
 		snap.WithHave(protocol.LocalDeviceID, func(fi protocol.FileIntf) bool {
 			count++
 			return true
@@ -251,7 +251,7 @@ func BenchmarkGlobal(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		snap := benchS.Snapshot()
+		snap := snapshot(b, benchS)
 		snap.WithGlobal(func(fi protocol.FileIntf) bool {
 			count++
 			return true
@@ -272,7 +272,7 @@ func BenchmarkNeedHalfTruncated(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		snap := benchS.Snapshot()
+		snap := snapshot(b, benchS)
 		snap.WithNeedTruncated(protocol.LocalDeviceID, func(fi protocol.FileIntf) bool {
 			count++
 			return true
@@ -293,7 +293,7 @@ func BenchmarkHaveTruncated(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		snap := benchS.Snapshot()
+		snap := snapshot(b, benchS)
 		snap.WithHaveTruncated(protocol.LocalDeviceID, func(fi protocol.FileIntf) bool {
 			count++
 			return true
@@ -314,7 +314,7 @@ func BenchmarkGlobalTruncated(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		snap := benchS.Snapshot()
+		snap := snapshot(b, benchS)
 		snap.WithGlobalTruncated(func(fi protocol.FileIntf) bool {
 			count++
 			return true
@@ -336,7 +336,7 @@ func BenchmarkNeedCount(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		snap := benchS.Snapshot()
+		snap := snapshot(b, benchS)
 		_ = snap.NeedSize(protocol.LocalDeviceID)
 		snap.Release()
 	}

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -77,7 +77,7 @@ func TestIgnoredFiles(t *testing.T) {
 	// Local files should have the "ignored" bit in addition to just being
 	// generally invalid if we want to look at the simulation of that bit.
 
-	snap := fs.Snapshot()
+	snap := snapshot(t, fs)
 	defer snap.Release()
 	fi, ok := snap.Get(protocol.LocalDeviceID, "foo")
 	if !ok {
@@ -866,7 +866,7 @@ func TestCheckLocalNeed(t *testing.T) {
 	fs.Update(remoteDevice0, files)
 
 	checkNeed := func() {
-		snap := fs.Snapshot()
+		snap := snapshot(t, fs)
 		defer snap.Release()
 		c := snap.NeedSize(protocol.LocalDeviceID)
 		if c.Files != 2 {
@@ -974,7 +974,7 @@ func TestNeedAfterDropGlobal(t *testing.T) {
 	fs.Update(remoteDevice1, files[1:])
 
 	// remoteDevice1 needs one file: test
-	snap := fs.Snapshot()
+	snap := snapshot(t, fs)
 	c := snap.NeedSize(remoteDevice1)
 	if c.Files != 1 {
 		t.Errorf("Expected 1 needed files initially, got %v", c.Files)
@@ -986,7 +986,7 @@ func TestNeedAfterDropGlobal(t *testing.T) {
 	fs.Drop(remoteDevice0)
 
 	// remoteDevice1 still needs test.
-	snap = fs.Snapshot()
+	snap = snapshot(t, fs)
 	c = snap.NeedSize(remoteDevice1)
 	if c.Files != 1 {
 		t.Errorf("Expected still 1 needed files, got %v", c.Files)

--- a/lib/db/meta_test.go
+++ b/lib/db/meta_test.go
@@ -117,7 +117,7 @@ func TestRecalcMeta(t *testing.T) {
 	s1.Update(protocol.LocalDeviceID, files)
 
 	// Verify local/global size
-	snap := s1.Snapshot()
+	snap := snapshot(t, s1)
 	ls := snap.LocalSize()
 	gs := snap.GlobalSize()
 	snap.Release()
@@ -149,7 +149,7 @@ func TestRecalcMeta(t *testing.T) {
 	}
 
 	// Verify that our bad data "took"
-	snap = s1.Snapshot()
+	snap = snapshot(t, s1)
 	ls = snap.LocalSize()
 	gs = snap.GlobalSize()
 	snap.Release()
@@ -164,7 +164,7 @@ func TestRecalcMeta(t *testing.T) {
 	s2 := newFileSet(t, "test", fs.NewFilesystem(fs.FilesystemTypeFake, "fake"), ldb)
 
 	// Verify local/global size
-	snap = s2.Snapshot()
+	snap = snapshot(t, s2)
 	ls = snap.LocalSize()
 	gs = snap.GlobalSize()
 	snap.Release()

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -151,12 +151,13 @@ type Snapshot struct {
 	fatalError func(error, string)
 }
 
-func (s *FileSet) Snapshot() *Snapshot {
+func (s *FileSet) Snapshot() (*Snapshot, error) {
 	opStr := fmt.Sprintf("%s Snapshot()", s.folder)
 	l.Debugf(opStr)
 	t, err := s.db.newReadOnlyTransaction()
 	if err != nil {
-		fatalError(err, opStr, s.db)
+		s.db.handleFailure(err)
+		return nil, err
 	}
 	return &Snapshot{
 		folder: s.folder,
@@ -165,7 +166,7 @@ func (s *FileSet) Snapshot() *Snapshot {
 		fatalError: func(err error, opStr string) {
 			fatalError(err, opStr, s.db)
 		},
-	}
+	}, nil
 }
 
 func (s *Snapshot) Release() {

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -45,9 +45,9 @@ func genBlocks(n int) []protocol.BlockInfo {
 	return b
 }
 
-func globalList(s *db.FileSet) []protocol.FileInfo {
+func globalList(t testing.TB, s *db.FileSet) []protocol.FileInfo {
 	var fs []protocol.FileInfo
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	snap.WithGlobal(func(fi protocol.FileIntf) bool {
 		f := fi.(protocol.FileInfo)
@@ -56,9 +56,9 @@ func globalList(s *db.FileSet) []protocol.FileInfo {
 	})
 	return fs
 }
-func globalListPrefixed(s *db.FileSet, prefix string) []db.FileInfoTruncated {
+func globalListPrefixed(t testing.TB, s *db.FileSet, prefix string) []db.FileInfoTruncated {
 	var fs []db.FileInfoTruncated
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	snap.WithPrefixedGlobalTruncated(prefix, func(fi protocol.FileIntf) bool {
 		f := fi.(db.FileInfoTruncated)
@@ -68,9 +68,9 @@ func globalListPrefixed(s *db.FileSet, prefix string) []db.FileInfoTruncated {
 	return fs
 }
 
-func haveList(s *db.FileSet, n protocol.DeviceID) []protocol.FileInfo {
+func haveList(t testing.TB, s *db.FileSet, n protocol.DeviceID) []protocol.FileInfo {
 	var fs []protocol.FileInfo
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	snap.WithHave(n, func(fi protocol.FileIntf) bool {
 		f := fi.(protocol.FileInfo)
@@ -80,9 +80,9 @@ func haveList(s *db.FileSet, n protocol.DeviceID) []protocol.FileInfo {
 	return fs
 }
 
-func haveListPrefixed(s *db.FileSet, n protocol.DeviceID, prefix string) []db.FileInfoTruncated {
+func haveListPrefixed(t testing.TB, s *db.FileSet, n protocol.DeviceID, prefix string) []db.FileInfoTruncated {
 	var fs []db.FileInfoTruncated
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	snap.WithPrefixedHaveTruncated(n, prefix, func(fi protocol.FileIntf) bool {
 		f := fi.(db.FileInfoTruncated)
@@ -92,9 +92,9 @@ func haveListPrefixed(s *db.FileSet, n protocol.DeviceID, prefix string) []db.Fi
 	return fs
 }
 
-func needList(s *db.FileSet, n protocol.DeviceID) []protocol.FileInfo {
+func needList(t testing.TB, s *db.FileSet, n protocol.DeviceID) []protocol.FileInfo {
 	var fs []protocol.FileInfo
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	snap.WithNeed(n, func(fi protocol.FileIntf) bool {
 		f := fi.(protocol.FileInfo)
@@ -221,7 +221,7 @@ func TestGlobalSet(t *testing.T) {
 	check := func() {
 		t.Helper()
 
-		g := fileList(globalList(m))
+		g := fileList(globalList(t, m))
 		sort.Sort(g)
 
 		if fmt.Sprint(g) != fmt.Sprint(expectedGlobal) {
@@ -244,7 +244,7 @@ func TestGlobalSet(t *testing.T) {
 			}
 			globalBytes += f.FileSize()
 		}
-		gs := globalSize(m)
+		gs := globalSize(t, m)
 		if gs.Files != globalFiles {
 			t.Errorf("Incorrect GlobalSize files; %d != %d", gs.Files, globalFiles)
 		}
@@ -258,7 +258,7 @@ func TestGlobalSet(t *testing.T) {
 			t.Errorf("Incorrect GlobalSize bytes; %d != %d", gs.Bytes, globalBytes)
 		}
 
-		h := fileList(haveList(m, protocol.LocalDeviceID))
+		h := fileList(haveList(t, m, protocol.LocalDeviceID))
 		sort.Sort(h)
 
 		if fmt.Sprint(h) != fmt.Sprint(localTot) {
@@ -281,7 +281,7 @@ func TestGlobalSet(t *testing.T) {
 			}
 			haveBytes += f.FileSize()
 		}
-		ls := localSize(m)
+		ls := localSize(t, m)
 		if ls.Files != haveFiles {
 			t.Errorf("Incorrect LocalSize files; %d != %d", ls.Files, haveFiles)
 		}
@@ -295,14 +295,14 @@ func TestGlobalSet(t *testing.T) {
 			t.Errorf("Incorrect LocalSize bytes; %d != %d", ls.Bytes, haveBytes)
 		}
 
-		h = fileList(haveList(m, remoteDevice0))
+		h = fileList(haveList(t, m, remoteDevice0))
 		sort.Sort(h)
 
 		if fmt.Sprint(h) != fmt.Sprint(remoteTot) {
 			t.Errorf("Have incorrect (remote);\n A: %v !=\n E: %v", h, remoteTot)
 		}
 
-		n := fileList(needList(m, protocol.LocalDeviceID))
+		n := fileList(needList(t, m, protocol.LocalDeviceID))
 		sort.Sort(n)
 
 		if fmt.Sprint(n) != fmt.Sprint(expectedLocalNeed) {
@@ -311,7 +311,7 @@ func TestGlobalSet(t *testing.T) {
 
 		checkNeed(t, m, protocol.LocalDeviceID, expectedLocalNeed)
 
-		n = fileList(needList(m, remoteDevice0))
+		n = fileList(needList(t, m, remoteDevice0))
 		sort.Sort(n)
 
 		if fmt.Sprint(n) != fmt.Sprint(expectedRemoteNeed) {
@@ -320,7 +320,7 @@ func TestGlobalSet(t *testing.T) {
 
 		checkNeed(t, m, remoteDevice0, expectedRemoteNeed)
 
-		snap := m.Snapshot()
+		snap := snapshot(t, m)
 		defer snap.Release()
 		f, ok := snap.Get(protocol.LocalDeviceID, "b")
 		if !ok {
@@ -365,7 +365,7 @@ func TestGlobalSet(t *testing.T) {
 
 	check()
 
-	snap := m.Snapshot()
+	snap := snapshot(t, m)
 
 	av := []protocol.DeviceID{protocol.LocalDeviceID, remoteDevice0}
 	a := snap.Availability("a")
@@ -431,14 +431,14 @@ func TestGlobalSet(t *testing.T) {
 
 	check()
 
-	h := fileList(haveList(m, remoteDevice1))
+	h := fileList(haveList(t, m, remoteDevice1))
 	sort.Sort(h)
 
 	if fmt.Sprint(h) != fmt.Sprint(secRemote) {
 		t.Errorf("Have incorrect (secRemote);\n A: %v !=\n E: %v", h, secRemote)
 	}
 
-	n := fileList(needList(m, remoteDevice1))
+	n := fileList(needList(t, m, remoteDevice1))
 	sort.Sort(n)
 
 	if fmt.Sprint(n) != fmt.Sprint(expectedSecRemoteNeed) {
@@ -478,7 +478,7 @@ func TestNeedWithInvalid(t *testing.T) {
 	replace(s, remoteDevice0, remote0Have)
 	replace(s, remoteDevice1, remote1Have)
 
-	need := fileList(needList(s, protocol.LocalDeviceID))
+	need := fileList(needList(t, s, protocol.LocalDeviceID))
 	sort.Sort(need)
 
 	if fmt.Sprint(need) != fmt.Sprint(expectedNeed) {
@@ -506,7 +506,7 @@ func TestUpdateToInvalid(t *testing.T) {
 
 	replace(s, protocol.LocalDeviceID, localHave)
 
-	have := fileList(haveList(s, protocol.LocalDeviceID))
+	have := fileList(haveList(t, s, protocol.LocalDeviceID))
 	sort.Sort(have)
 
 	if fmt.Sprint(have) != fmt.Sprint(localHave) {
@@ -523,7 +523,7 @@ func TestUpdateToInvalid(t *testing.T) {
 
 	s.Update(protocol.LocalDeviceID, append(fileList{}, localHave[1], localHave[4]))
 
-	have = fileList(haveList(s, protocol.LocalDeviceID))
+	have = fileList(haveList(t, s, protocol.LocalDeviceID))
 	sort.Sort(have)
 
 	if fmt.Sprint(have) != fmt.Sprint(localHave) {
@@ -567,7 +567,7 @@ func TestInvalidAvailability(t *testing.T) {
 	replace(s, remoteDevice0, remote0Have)
 	replace(s, remoteDevice1, remote1Have)
 
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 
 	if av := snap.Availability("both"); len(av) != 2 {
@@ -608,7 +608,7 @@ func TestGlobalReset(t *testing.T) {
 	}
 
 	replace(m, protocol.LocalDeviceID, local)
-	g := globalList(m)
+	g := globalList(t, m)
 	sort.Sort(fileList(g))
 
 	if diff, equal := messagediff.PrettyDiff(local, g); !equal {
@@ -618,7 +618,7 @@ func TestGlobalReset(t *testing.T) {
 	replace(m, remoteDevice0, remote)
 	replace(m, remoteDevice0, nil)
 
-	g = globalList(m)
+	g = globalList(t, m)
 	sort.Sort(fileList(g))
 
 	if diff, equal := messagediff.PrettyDiff(local, g); !equal {
@@ -655,7 +655,7 @@ func TestNeed(t *testing.T) {
 	replace(m, protocol.LocalDeviceID, local)
 	replace(m, remoteDevice0, remote)
 
-	need := needList(m, protocol.LocalDeviceID)
+	need := needList(t, m, protocol.LocalDeviceID)
 
 	sort.Sort(fileList(need))
 	sort.Sort(fileList(shouldNeed))
@@ -725,10 +725,10 @@ func TestListDropFolder(t *testing.T) {
 	if diff, equal := messagediff.PrettyDiff(expectedFolderList, actualFolderList); !equal {
 		t.Fatalf("FolderList mismatch. Diff:\n%s", diff)
 	}
-	if l := len(globalList(s0)); l != 3 {
+	if l := len(globalList(t, s0)); l != 3 {
 		t.Errorf("Incorrect global length %d != 3 for s0", l)
 	}
-	if l := len(globalList(s1)); l != 3 {
+	if l := len(globalList(t, s1)); l != 3 {
 		t.Errorf("Incorrect global length %d != 3 for s1", l)
 	}
 
@@ -741,10 +741,10 @@ func TestListDropFolder(t *testing.T) {
 	if diff, equal := messagediff.PrettyDiff(expectedFolderList, actualFolderList); !equal {
 		t.Fatalf("FolderList mismatch. Diff:\n%s", diff)
 	}
-	if l := len(globalList(s0)); l != 3 {
+	if l := len(globalList(t, s0)); l != 3 {
 		t.Errorf("Incorrect global length %d != 3 for s0", l)
 	}
-	if l := len(globalList(s1)); l != 0 {
+	if l := len(globalList(t, s1)); l != 0 {
 		t.Errorf("Incorrect global length %d != 0 for s1", l)
 	}
 }
@@ -780,13 +780,13 @@ func TestGlobalNeedWithInvalid(t *testing.T) {
 		protocol.FileInfo{Name: "d", Version: protocol.Vector{Counters: []protocol.Counter{{ID: remoteDevice0.Short(), Value: 1002}}}},
 	}
 
-	need := fileList(needList(s, protocol.LocalDeviceID))
+	need := fileList(needList(t, s, protocol.LocalDeviceID))
 	if fmt.Sprint(need) != fmt.Sprint(total) {
 		t.Errorf("Need incorrect;\n A: %v !=\n E: %v", need, total)
 	}
 	checkNeed(t, s, protocol.LocalDeviceID, total)
 
-	global := fileList(globalList(s))
+	global := fileList(globalList(t, s))
 	if fmt.Sprint(global) != fmt.Sprint(total) {
 		t.Errorf("Global incorrect;\n A: %v !=\n E: %v", global, total)
 	}
@@ -810,7 +810,7 @@ func TestLongPath(t *testing.T) {
 
 	replace(s, protocol.LocalDeviceID, local)
 
-	gf := globalList(s)
+	gf := globalList(t, s)
 	if l := len(gf); l != 1 {
 		t.Fatalf("Incorrect len %d != 1 for global list", l)
 	}
@@ -911,17 +911,17 @@ func TestDropFiles(t *testing.T) {
 
 	// Check that they're there
 
-	h := haveList(m, protocol.LocalDeviceID)
+	h := haveList(t, m, protocol.LocalDeviceID)
 	if len(h) != len(local0) {
 		t.Errorf("Incorrect number of files after update, %d != %d", len(h), len(local0))
 	}
 
-	h = haveList(m, remoteDevice0)
+	h = haveList(t, m, remoteDevice0)
 	if len(h) != len(remote0) {
 		t.Errorf("Incorrect number of files after update, %d != %d", len(h), len(local0))
 	}
 
-	g := globalList(m)
+	g := globalList(t, m)
 	if len(g) != len(local0) {
 		// local0 covers all files
 		t.Errorf("Incorrect global files after update, %d != %d", len(g), len(local0))
@@ -931,17 +931,17 @@ func TestDropFiles(t *testing.T) {
 
 	m.Drop(protocol.LocalDeviceID)
 
-	h = haveList(m, protocol.LocalDeviceID)
+	h = haveList(t, m, protocol.LocalDeviceID)
 	if len(h) != 0 {
 		t.Errorf("Incorrect number of files after drop, %d != %d", len(h), 0)
 	}
 
-	h = haveList(m, remoteDevice0)
+	h = haveList(t, m, remoteDevice0)
 	if len(h) != len(remote0) {
 		t.Errorf("Incorrect number of files after update, %d != %d", len(h), len(local0))
 	}
 
-	g = globalList(m)
+	g = globalList(t, m)
 	if len(g) != len(remote0) {
 		// the ones in remote0 remain
 		t.Errorf("Incorrect global files after update, %d != %d", len(g), len(remote0))
@@ -961,20 +961,20 @@ func TestIssue4701(t *testing.T) {
 
 	s.Update(protocol.LocalDeviceID, localHave)
 
-	if c := localSize(s); c.Files != 1 {
+	if c := localSize(t, s); c.Files != 1 {
 		t.Errorf("Expected 1 local file, got %v", c.Files)
 	}
-	if c := globalSize(s); c.Files != 1 {
+	if c := globalSize(t, s); c.Files != 1 {
 		t.Errorf("Expected 1 global file, got %v", c.Files)
 	}
 
 	localHave[1].LocalFlags = 0
 	s.Update(protocol.LocalDeviceID, localHave)
 
-	if c := localSize(s); c.Files != 2 {
+	if c := localSize(t, s); c.Files != 2 {
 		t.Errorf("Expected 2 local files, got %v", c.Files)
 	}
-	if c := globalSize(s); c.Files != 2 {
+	if c := globalSize(t, s); c.Files != 2 {
 		t.Errorf("Expected 2 global files, got %v", c.Files)
 	}
 
@@ -982,10 +982,10 @@ func TestIssue4701(t *testing.T) {
 	localHave[1].LocalFlags = protocol.FlagLocalIgnored
 	s.Update(protocol.LocalDeviceID, localHave)
 
-	if c := localSize(s); c.Files != 0 {
+	if c := localSize(t, s); c.Files != 0 {
 		t.Errorf("Expected 0 local files, got %v", c.Files)
 	}
-	if c := globalSize(s); c.Files != 0 {
+	if c := globalSize(t, s); c.Files != 0 {
 		t.Errorf("Expected 0 global files, got %v", c.Files)
 	}
 }
@@ -1009,7 +1009,7 @@ func TestWithHaveSequence(t *testing.T) {
 	replace(s, protocol.LocalDeviceID, localHave)
 
 	i := 2
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	snap.WithHaveSequence(int64(i), func(fi protocol.FileIntf) bool {
 		if f := fi.(protocol.FileInfo); !f.IsEquivalent(localHave[i-1], 0) {
@@ -1061,7 +1061,7 @@ loop:
 			break loop
 		default:
 		}
-		snap := s.Snapshot()
+		snap := snapshot(t, s)
 		snap.WithHaveSequence(prevSeq+1, func(fi protocol.FileIntf) bool {
 			if fi.SequenceNo() < prevSeq+1 {
 				t.Fatal("Skipped ", prevSeq+1, fi.SequenceNo())
@@ -1089,11 +1089,11 @@ func TestIssue4925(t *testing.T) {
 	replace(s, protocol.LocalDeviceID, localHave)
 
 	for _, prefix := range []string{"dir", "dir/"} {
-		pl := haveListPrefixed(s, protocol.LocalDeviceID, prefix)
+		pl := haveListPrefixed(t, s, protocol.LocalDeviceID, prefix)
 		if l := len(pl); l != 2 {
 			t.Errorf("Expected 2, got %v local items below %v", l, prefix)
 		}
-		pl = globalListPrefixed(s, prefix)
+		pl = globalListPrefixed(t, s, prefix)
 		if l := len(pl); l != 2 {
 			t.Errorf("Expected 2, got %v global items below %v", l, prefix)
 		}
@@ -1114,24 +1114,24 @@ func TestMoveGlobalBack(t *testing.T) {
 	s.Update(protocol.LocalDeviceID, localHave)
 	s.Update(remoteDevice0, remote0Have)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 1 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 1 {
 		t.Error("Expected 1 local need, got", need)
 	} else if !need[0].IsEquivalent(remote0Have[0], 0) {
 		t.Errorf("Local need incorrect;\n A: %v !=\n E: %v", need[0], remote0Have[0])
 	}
 	checkNeed(t, s, protocol.LocalDeviceID, remote0Have[:1])
 
-	if need := needList(s, remoteDevice0); len(need) != 0 {
+	if need := needList(t, s, remoteDevice0); len(need) != 0 {
 		t.Error("Expected no need for remote 0, got", need)
 	}
 	checkNeed(t, s, remoteDevice0, nil)
 
-	ls := localSize(s)
+	ls := localSize(t, s)
 	if haveBytes := localHave[0].Size; ls.Bytes != haveBytes {
 		t.Errorf("Incorrect LocalSize bytes; %d != %d", ls.Bytes, haveBytes)
 	}
 
-	gs := globalSize(s)
+	gs := globalSize(t, s)
 	if globalBytes := remote0Have[0].Size; gs.Bytes != globalBytes {
 		t.Errorf("Incorrect GlobalSize bytes; %d != %d", gs.Bytes, globalBytes)
 	}
@@ -1142,24 +1142,24 @@ func TestMoveGlobalBack(t *testing.T) {
 	remote0Have[0].Version = remote0Have[0].Version.Update(remoteDevice0.Short()).DropOthers(remoteDevice0.Short())
 	s.Update(remoteDevice0, remote0Have)
 
-	if need := needList(s, remoteDevice0); len(need) != 1 {
+	if need := needList(t, s, remoteDevice0); len(need) != 1 {
 		t.Error("Expected 1 need for remote 0, got", need)
 	} else if !need[0].IsEquivalent(localHave[0], 0) {
 		t.Errorf("Need for remote 0 incorrect;\n A: %v !=\n E: %v", need[0], localHave[0])
 	}
 	checkNeed(t, s, remoteDevice0, localHave[:1])
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 0 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 0 {
 		t.Error("Expected no local need, got", need)
 	}
 	checkNeed(t, s, protocol.LocalDeviceID, nil)
 
-	ls = localSize(s)
+	ls = localSize(t, s)
 	if haveBytes := localHave[0].Size; ls.Bytes != haveBytes {
 		t.Errorf("Incorrect LocalSize bytes; %d != %d", ls.Bytes, haveBytes)
 	}
 
-	gs = globalSize(s)
+	gs = globalSize(t, s)
 	if globalBytes := localHave[0].Size; gs.Bytes != globalBytes {
 		t.Errorf("Incorrect GlobalSize bytes; %d != %d", gs.Bytes, globalBytes)
 	}
@@ -1181,7 +1181,7 @@ func TestIssue5007(t *testing.T) {
 
 	s.Update(remoteDevice0, fs)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 1 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 1 {
 		t.Fatal("Expected 1 local need, got", need)
 	} else if !need[0].IsEquivalent(fs[0], 0) {
 		t.Fatalf("Local need incorrect;\n A: %v !=\n E: %v", need[0], fs[0])
@@ -1191,7 +1191,7 @@ func TestIssue5007(t *testing.T) {
 	fs[0].LocalFlags = protocol.FlagLocalIgnored
 	s.Update(protocol.LocalDeviceID, fs)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 0 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 0 {
 		t.Fatal("Expected no local need, got", need)
 	}
 	checkNeed(t, s, protocol.LocalDeviceID, nil)
@@ -1211,7 +1211,7 @@ func TestNeedDeleted(t *testing.T) {
 
 	s.Update(remoteDevice0, fs)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 0 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 0 {
 		t.Fatal("Expected no local need, got", need)
 	}
 	checkNeed(t, s, protocol.LocalDeviceID, nil)
@@ -1220,7 +1220,7 @@ func TestNeedDeleted(t *testing.T) {
 	fs[0].Version = fs[0].Version.Update(remoteDevice0.Short())
 	s.Update(remoteDevice0, fs)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 1 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 1 {
 		t.Fatal("Expected 1 local need, got", need)
 	} else if !need[0].IsEquivalent(fs[0], 0) {
 		t.Fatalf("Local need incorrect;\n A: %v !=\n E: %v", need[0], fs[0])
@@ -1231,7 +1231,7 @@ func TestNeedDeleted(t *testing.T) {
 	fs[0].Version = fs[0].Version.Update(remoteDevice0.Short())
 	s.Update(remoteDevice0, fs)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 0 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 0 {
 		t.Fatal("Expected no local need, got", need)
 	}
 	checkNeed(t, s, protocol.LocalDeviceID, nil)
@@ -1261,22 +1261,22 @@ func TestReceiveOnlyAccounting(t *testing.T) {
 	replace(s, protocol.LocalDeviceID, files)
 	replace(s, remote, files)
 
-	if n := localSize(s).Files; n != 3 {
+	if n := localSize(t, s).Files; n != 3 {
 		t.Fatal("expected 3 local files initially, not", n)
 	}
-	if n := localSize(s).Bytes; n != 30 {
+	if n := localSize(t, s).Bytes; n != 30 {
 		t.Fatal("expected 30 local bytes initially, not", n)
 	}
-	if n := globalSize(s).Files; n != 3 {
+	if n := globalSize(t, s).Files; n != 3 {
 		t.Fatal("expected 3 global files initially, not", n)
 	}
-	if n := globalSize(s).Bytes; n != 30 {
+	if n := globalSize(t, s).Bytes; n != 30 {
 		t.Fatal("expected 30 global bytes initially, not", n)
 	}
-	if n := receiveOnlyChangedSize(s).Files; n != 0 {
+	if n := receiveOnlyChangedSize(t, s).Files; n != 0 {
 		t.Fatal("expected 0 receive only changed files initially, not", n)
 	}
-	if n := receiveOnlyChangedSize(s).Bytes; n != 0 {
+	if n := receiveOnlyChangedSize(t, s).Bytes; n != 0 {
 		t.Fatal("expected 0 receive only changed bytes initially, not", n)
 	}
 
@@ -1291,22 +1291,22 @@ func TestReceiveOnlyAccounting(t *testing.T) {
 
 	// Check that we see the files
 
-	if n := localSize(s).Files; n != 3 {
+	if n := localSize(t, s).Files; n != 3 {
 		t.Fatal("expected 3 local files after local change, not", n)
 	}
-	if n := localSize(s).Bytes; n != 120 {
+	if n := localSize(t, s).Bytes; n != 120 {
 		t.Fatal("expected 120 local bytes after local change, not", n)
 	}
-	if n := globalSize(s).Files; n != 3 {
+	if n := globalSize(t, s).Files; n != 3 {
 		t.Fatal("expected 3 global files after local change, not", n)
 	}
-	if n := globalSize(s).Bytes; n != 30 {
+	if n := globalSize(t, s).Bytes; n != 30 {
 		t.Fatal("expected 30 global files after local change, not", n)
 	}
-	if n := receiveOnlyChangedSize(s).Files; n != 1 {
+	if n := receiveOnlyChangedSize(t, s).Files; n != 1 {
 		t.Fatal("expected 1 receive only changed file after local change, not", n)
 	}
-	if n := receiveOnlyChangedSize(s).Bytes; n != 100 {
+	if n := receiveOnlyChangedSize(t, s).Bytes; n != 100 {
 		t.Fatal("expected 100 receive only changed btyes after local change, not", n)
 	}
 
@@ -1322,22 +1322,22 @@ func TestReceiveOnlyAccounting(t *testing.T) {
 
 	// Check that we see the files, same data as initially
 
-	if n := localSize(s).Files; n != 3 {
+	if n := localSize(t, s).Files; n != 3 {
 		t.Fatal("expected 3 local files after revert, not", n)
 	}
-	if n := localSize(s).Bytes; n != 30 {
+	if n := localSize(t, s).Bytes; n != 30 {
 		t.Fatal("expected 30 local bytes after revert, not", n)
 	}
-	if n := globalSize(s).Files; n != 3 {
+	if n := globalSize(t, s).Files; n != 3 {
 		t.Fatal("expected 3 global files after revert, not", n)
 	}
-	if n := globalSize(s).Bytes; n != 30 {
+	if n := globalSize(t, s).Bytes; n != 30 {
 		t.Fatal("expected 30 global bytes after revert, not", n)
 	}
-	if n := receiveOnlyChangedSize(s).Files; n != 0 {
+	if n := receiveOnlyChangedSize(t, s).Files; n != 0 {
 		t.Fatal("expected 0 receive only changed files after revert, not", n)
 	}
-	if n := receiveOnlyChangedSize(s).Bytes; n != 0 {
+	if n := receiveOnlyChangedSize(t, s).Bytes; n != 0 {
 		t.Fatal("expected 0 receive only changed bytes after revert, not", n)
 	}
 }
@@ -1366,7 +1366,7 @@ func TestNeedAfterUnignore(t *testing.T) {
 	local.ModifiedS = 0
 	s.Update(protocol.LocalDeviceID, fileList{local})
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 1 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 1 {
 		t.Fatal("Expected one local need, got", need)
 	} else if !need[0].IsEquivalent(remote, 0) {
 		t.Fatalf("Got %v, expected %v", need[0], remote)
@@ -1387,7 +1387,7 @@ func TestRemoteInvalidNotAccounted(t *testing.T) {
 	}
 	s.Update(remoteDevice0, files)
 
-	global := globalSize(s)
+	global := globalSize(t, s)
 	if global.Files != 1 {
 		t.Error("Expected one file in global size, not", global.Files)
 	}
@@ -1411,7 +1411,7 @@ func TestNeedWithNewerInvalid(t *testing.T) {
 	s.Update(remoteDevice0, fileList{file})
 	s.Update(remoteDevice1, fileList{file})
 
-	need := needList(s, protocol.LocalDeviceID)
+	need := needList(t, s, protocol.LocalDeviceID)
 	if len(need) != 1 {
 		t.Fatal("Locally missing file should be needed")
 	}
@@ -1427,7 +1427,7 @@ func TestNeedWithNewerInvalid(t *testing.T) {
 	s.Update(remoteDevice1, fileList{inv})
 
 	// We still have an old file, we need the newest valid file
-	need = needList(s, protocol.LocalDeviceID)
+	need = needList(t, s, protocol.LocalDeviceID)
 	if len(need) != 1 {
 		t.Fatal("Locally missing file should be needed regardless of invalid files")
 	}
@@ -1452,13 +1452,13 @@ func TestNeedAfterDeviceRemove(t *testing.T) {
 
 	s.Update(remoteDevice0, fs)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 1 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 1 {
 		t.Fatal("Expected one local need, got", need)
 	}
 
 	s.Drop(remoteDevice0)
 
-	if need := needList(s, protocol.LocalDeviceID); len(need) != 0 {
+	if need := needList(t, s, protocol.LocalDeviceID); len(need) != 0 {
 		t.Fatal("Expected no local need, got", need)
 	}
 	checkNeed(t, s, protocol.LocalDeviceID, nil)
@@ -1481,7 +1481,7 @@ func TestCaseSensitive(t *testing.T) {
 
 	replace(s, protocol.LocalDeviceID, local)
 
-	gf := globalList(s)
+	gf := globalList(t, s)
 	if l := len(gf); l != len(local) {
 		t.Fatalf("Incorrect len %d != %d for global list", l, len(local))
 	}
@@ -1551,7 +1551,7 @@ func TestSequenceIndex(t *testing.T) {
 		// a subset of those files if we manage to run before a complete
 		// update has happened since our last iteration.
 		latest = latest[:0]
-		snap := s.Snapshot()
+		snap := snapshot(t, s)
 		snap.WithHaveSequence(seq+1, func(f protocol.FileIntf) bool {
 			seen[f.FileName()] = f
 			latest = append(latest, f)
@@ -1617,7 +1617,7 @@ func TestIgnoreAfterReceiveOnly(t *testing.T) {
 
 	s.Update(protocol.LocalDeviceID, fs)
 
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	if f, ok := snap.Get(protocol.LocalDeviceID, file); !ok {
 		t.Error("File missing in db")
@@ -1654,7 +1654,7 @@ func TestUpdateWithOneFileTwice(t *testing.T) {
 
 	s.Update(protocol.LocalDeviceID, fs)
 
-	snap := s.Snapshot()
+	snap := snapshot(t, s)
 	defer snap.Release()
 	count := 0
 	snap.WithHaveSequence(0, func(f protocol.FileIntf) bool {
@@ -1678,7 +1678,7 @@ func TestNeedRemoteOnly(t *testing.T) {
 	}
 	s.Update(remoteDevice0, remote0Have)
 
-	need := needSize(s, remoteDevice0)
+	need := needSize(t, s, remoteDevice0)
 	if !need.Equal(db.Counts{}) {
 		t.Error("Expected nothing needed, got", need)
 	}
@@ -1697,14 +1697,14 @@ func TestNeedRemoteAfterReset(t *testing.T) {
 	s.Update(protocol.LocalDeviceID, files)
 	s.Update(remoteDevice0, files)
 
-	need := needSize(s, remoteDevice0)
+	need := needSize(t, s, remoteDevice0)
 	if !need.Equal(db.Counts{}) {
 		t.Error("Expected nothing needed, got", need)
 	}
 
 	s.Drop(remoteDevice0)
 
-	need = needSize(s, remoteDevice0)
+	need = needSize(t, s, remoteDevice0)
 	if exp := (db.Counts{Files: 1}); !need.Equal(exp) {
 		t.Errorf("Expected %v, got %v", exp, need)
 	}
@@ -1723,10 +1723,10 @@ func TestIgnoreLocalChanged(t *testing.T) {
 	}
 	s.Update(protocol.LocalDeviceID, files)
 
-	if c := globalSize(s).Files; c != 0 {
+	if c := globalSize(t, s).Files; c != 0 {
 		t.Error("Expected no global file, got", c)
 	}
-	if c := localSize(s).Files; c != 1 {
+	if c := localSize(t, s).Files; c != 1 {
 		t.Error("Expected one local file, got", c)
 	}
 
@@ -1734,10 +1734,10 @@ func TestIgnoreLocalChanged(t *testing.T) {
 	files[0].LocalFlags = protocol.FlagLocalIgnored
 	s.Update(protocol.LocalDeviceID, files)
 
-	if c := globalSize(s).Files; c != 0 {
+	if c := globalSize(t, s).Files; c != 0 {
 		t.Error("Expected no global file, got", c)
 	}
-	if c := localSize(s).Files; c != 0 {
+	if c := localSize(t, s).Files; c != 0 {
 		t.Error("Expected no local file, got", c)
 	}
 }
@@ -1789,26 +1789,26 @@ func replace(fs *db.FileSet, device protocol.DeviceID, files []protocol.FileInfo
 	fs.Update(device, files)
 }
 
-func localSize(fs *db.FileSet) db.Counts {
-	snap := fs.Snapshot()
+func localSize(t testing.TB, fs *db.FileSet) db.Counts {
+	snap := snapshot(t, fs)
 	defer snap.Release()
 	return snap.LocalSize()
 }
 
-func globalSize(fs *db.FileSet) db.Counts {
-	snap := fs.Snapshot()
+func globalSize(t testing.TB, fs *db.FileSet) db.Counts {
+	snap := snapshot(t, fs)
 	defer snap.Release()
 	return snap.GlobalSize()
 }
 
-func needSize(fs *db.FileSet, id protocol.DeviceID) db.Counts {
-	snap := fs.Snapshot()
+func needSize(t testing.TB, fs *db.FileSet, id protocol.DeviceID) db.Counts {
+	snap := snapshot(t, fs)
 	defer snap.Release()
 	return snap.NeedSize(id)
 }
 
-func receiveOnlyChangedSize(fs *db.FileSet) db.Counts {
-	snap := fs.Snapshot()
+func receiveOnlyChangedSize(t testing.TB, fs *db.FileSet) db.Counts {
+	snap := snapshot(t, fs)
 	defer snap.Release()
 	return snap.ReceiveOnlyChangedSize()
 }
@@ -1833,7 +1833,7 @@ func filesToCounts(files []protocol.FileInfo) db.Counts {
 
 func checkNeed(t testing.TB, s *db.FileSet, dev protocol.DeviceID, expected []protocol.FileInfo) {
 	t.Helper()
-	counts := needSize(s, dev)
+	counts := needSize(t, s, dev)
 	if exp := filesToCounts(expected); !exp.Equal(counts) {
 		t.Errorf("Count incorrect (%v): expected %v, got %v", dev, exp, counts)
 	}
@@ -1859,4 +1859,13 @@ func newFileSet(t testing.TB, folder string, fs fs.Filesystem, ll *db.Lowlevel) 
 		t.Fatal(err)
 	}
 	return fset
+}
+
+func snapshot(t testing.TB, fset *db.FileSet) *db.Snapshot {
+	t.Helper()
+	snap, err := fset.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snap
 }

--- a/lib/db/util_test.go
+++ b/lib/db/util_test.go
@@ -92,6 +92,15 @@ func newFileSet(t testing.TB, folder string, fs fs.Filesystem, db *Lowlevel) *Fi
 	return fset
 }
 
+func snapshot(t testing.TB, fset *FileSet) *Snapshot {
+	t.Helper()
+	snap, err := fset.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snap
+}
+
 // The following commented tests were used to generate jsons files to stdout for
 // future tests and are kept here for reference (reuse).
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -178,7 +178,7 @@ func (f *folder) Serve(ctx context.Context) error {
 		case <-f.pullFailTimer.C:
 			var success bool
 			success, err = f.pull()
-			if err == nil && success && f.pullPause < 60*f.pullBasePause() {
+			if (err != nil || !success) && f.pullPause < 60*f.pullBasePause() {
 				// Back off from retrying to pull
 				f.pullPause *= 2
 			}
@@ -396,7 +396,7 @@ func (f *folder) pull() (success bool, err error) {
 
 	success, err = f.puller.pull()
 
-	if success && err != nil {
+	if success && err == nil {
 		return true, nil
 	}
 

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -384,7 +384,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 	// Do the same changes on the remote
 
 	files := make([]protocol.FileInfo, 0, 2)
-	snap := f.fset.Snapshot()
+	snap := fsetSnapshot(t, f.fset)
 	snap.WithHave(protocol.LocalDeviceID, func(fi protocol.FileIntf) bool {
 		if n := fi.FileName(); n != file && n != knownFile {
 			return true

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1490,7 +1490,7 @@ func (f *sendReceiveFolder) pullBlock(state pullBlockState, snap *db.Snapshot, o
 	}
 
 	var lastError error
-	candidates := f.model.availabilityWithInfo(f.FolderConfiguration, snap, state.file, state.block)
+	candidates := f.model.availabilityInSnapshot(f.FolderConfiguration, snap, state.file, state.block)
 	for {
 		select {
 		case <-f.ctx.Done():

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -156,7 +156,7 @@ func newSendReceiveFolder(model *model, fset *db.FileSet, ignores *ignore.Matche
 
 // pull returns true if it manages to get all needed items from peers, i.e. get
 // the device in sync with the global state.
-func (f *sendReceiveFolder) pull() bool {
+func (f *sendReceiveFolder) pull() (bool, error) {
 	l.Debugf("%v pulling", f)
 
 	scanChan := make(chan string)
@@ -173,10 +173,11 @@ func (f *sendReceiveFolder) pull() bool {
 	f.pullErrors = nil
 	f.errorsMut.Unlock()
 
+	var err error
 	for tries := 0; tries < maxPullerIterations; tries++ {
 		select {
 		case <-f.ctx.Done():
-			return false
+			return false, f.ctx.Err()
 		default:
 		}
 
@@ -184,7 +185,10 @@ func (f *sendReceiveFolder) pull() bool {
 		// it to FolderSyncing during the last iteration.
 		f.setState(FolderSyncPreparing)
 
-		changed = f.pullerIteration(scanChan)
+		changed, err = f.pullerIteration(scanChan)
+		if err != nil {
+			return false, err
+		}
 
 		l.Debugln(f, "changed", changed, "on try", tries+1)
 
@@ -219,19 +223,22 @@ func (f *sendReceiveFolder) pull() bool {
 		})
 	}
 
-	return changed == 0
+	return changed == 0, nil
 }
 
 // pullerIteration runs a single puller iteration for the given folder and
 // returns the number items that should have been synced (even those that
 // might have failed). One puller iteration handles all files currently
 // flagged as needed in the folder.
-func (f *sendReceiveFolder) pullerIteration(scanChan chan<- string) int {
+func (f *sendReceiveFolder) pullerIteration(scanChan chan<- string) (int, error) {
 	f.errorsMut.Lock()
 	f.tempPullErrors = make(map[string]string)
 	f.errorsMut.Unlock()
 
-	snap := f.fset.Snapshot()
+	snap, err := f.dbSnapshot()
+	if err != nil {
+		return 0, err
+	}
 	defer snap.Release()
 
 	pullChan := make(chan pullBlockState)
@@ -265,7 +272,7 @@ func (f *sendReceiveFolder) pullerIteration(scanChan chan<- string) int {
 	pullWg.Add(1)
 	go func() {
 		// pullerRoutine finishes when pullChan is closed
-		f.pullerRoutine(pullChan, finisherChan)
+		f.pullerRoutine(snap, pullChan, finisherChan)
 		pullWg.Done()
 	}()
 
@@ -300,7 +307,7 @@ func (f *sendReceiveFolder) pullerIteration(scanChan chan<- string) int {
 
 	f.queue.Reset()
 
-	return changed
+	return changed, nil
 }
 
 func (f *sendReceiveFolder) processNeeded(snap *db.Snapshot, dbUpdateChan chan<- dbUpdateJob, copyChan chan<- copyBlocksState, scanChan chan<- string) (int, map[string]protocol.FileInfo, []protocol.FileInfo, error) {
@@ -582,7 +589,7 @@ func (f *sendReceiveFolder) handleDir(file protocol.FileInfo, snap *db.Snapshot,
 	// that don't result in a conflict.
 	case err == nil && !info.IsDir():
 		// Check that it is what we have in the database.
-		curFile, hasCurFile := f.model.CurrentFolderFile(f.folderID, file.Name)
+		curFile, hasCurFile := snap.Get(protocol.LocalDeviceID, file.Name)
 		if err := f.scanIfItemChanged(file.Name, info, curFile, hasCurFile, scanChan); err != nil {
 			err = errors.Wrap(err, "handling dir")
 			f.newPullError(file.Name, err)
@@ -766,7 +773,7 @@ func (f *sendReceiveFolder) handleSymlinkCheckExisting(file protocol.FileInfo, s
 		return err
 	}
 	// Check that it is what we have in the database.
-	curFile, hasCurFile := f.model.CurrentFolderFile(f.folderID, file.Name)
+	curFile, hasCurFile := snap.Get(protocol.LocalDeviceID, file.Name)
 	if err := f.scanIfItemChanged(file.Name, info, curFile, hasCurFile, scanChan); err != nil {
 		return err
 	}
@@ -1427,7 +1434,7 @@ func (f *sendReceiveFolder) verifyBuffer(buf []byte, block protocol.BlockInfo) e
 	return nil
 }
 
-func (f *sendReceiveFolder) pullerRoutine(in <-chan pullBlockState, out chan<- *sharedPullerState) {
+func (f *sendReceiveFolder) pullerRoutine(snap *db.Snapshot, in <-chan pullBlockState, out chan<- *sharedPullerState) {
 	requestLimiter := newByteSemaphore(f.PullerMaxPendingKiB * 1024)
 	wg := sync.NewWaitGroup()
 
@@ -1458,13 +1465,13 @@ func (f *sendReceiveFolder) pullerRoutine(in <-chan pullBlockState, out chan<- *
 			defer wg.Done()
 			defer requestLimiter.give(bytes)
 
-			f.pullBlock(state, out)
+			f.pullBlock(state, snap, out)
 		}()
 	}
 	wg.Wait()
 }
 
-func (f *sendReceiveFolder) pullBlock(state pullBlockState, out chan<- *sharedPullerState) {
+func (f *sendReceiveFolder) pullBlock(state pullBlockState, snap *db.Snapshot, out chan<- *sharedPullerState) {
 	// Get an fd to the temporary file. Technically we don't need it until
 	// after fetching the block, but if we run into an error here there is
 	// no point in issuing the request to the network.
@@ -1483,7 +1490,7 @@ func (f *sendReceiveFolder) pullBlock(state pullBlockState, out chan<- *sharedPu
 	}
 
 	var lastError error
-	candidates := f.model.Availability(f.folderID, state.file, state.block)
+	candidates := f.model.availabilityWithInfo(f.FolderConfiguration, snap, state.file, state.block)
 	for {
 		select {
 		case <-f.ctx.Done():

--- a/lib/model/indexsender.go
+++ b/lib/model/indexsender.go
@@ -131,7 +131,10 @@ func (s *indexSender) sendIndexTo(ctx context.Context) error {
 
 	var err error
 	var f protocol.FileInfo
-	snap := s.fset.Snapshot()
+	snap, err := s.fset.Snapshot()
+	if err != nil {
+		return svcutil.AsFatalErr(err, svcutil.ExitError)
+	}
 	defer snap.Release()
 	previousWasDelete := false
 	snap.WithHaveSequence(s.prevSequence+1, func(fi protocol.FileIntf) bool {

--- a/lib/model/mocks/model.go
+++ b/lib/model/mocks/model.go
@@ -22,7 +22,7 @@ type Model struct {
 		arg1 protocol.Connection
 		arg2 protocol.Hello
 	}
-	AvailabilityStub        func(string, protocol.FileInfo, protocol.BlockInfo) []model.Availability
+	AvailabilityStub        func(string, protocol.FileInfo, protocol.BlockInfo) ([]model.Availability, error)
 	availabilityMutex       sync.RWMutex
 	availabilityArgsForCall []struct {
 		arg1 string
@@ -31,9 +31,11 @@ type Model struct {
 	}
 	availabilityReturns struct {
 		result1 []model.Availability
+		result2 error
 	}
 	availabilityReturnsOnCall map[int]struct {
 		result1 []model.Availability
+		result2 error
 	}
 	BringToFrontStub        func(string, string)
 	bringToFrontMutex       sync.RWMutex
@@ -59,7 +61,7 @@ type Model struct {
 	clusterConfigReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CompletionStub        func(protocol.DeviceID, string) model.FolderCompletion
+	CompletionStub        func(protocol.DeviceID, string) (model.FolderCompletion, error)
 	completionMutex       sync.RWMutex
 	completionArgsForCall []struct {
 		arg1 protocol.DeviceID
@@ -67,9 +69,11 @@ type Model struct {
 	}
 	completionReturns struct {
 		result1 model.FolderCompletion
+		result2 error
 	}
 	completionReturnsOnCall map[int]struct {
 		result1 model.FolderCompletion
+		result2 error
 	}
 	ConnectionStub        func(protocol.DeviceID) (protocol.Connection, bool)
 	connectionMutex       sync.RWMutex
@@ -94,7 +98,7 @@ type Model struct {
 	connectionStatsReturnsOnCall map[int]struct {
 		result1 map[string]interface{}
 	}
-	CurrentFolderFileStub        func(string, string) (protocol.FileInfo, bool)
+	CurrentFolderFileStub        func(string, string) (protocol.FileInfo, bool, error)
 	currentFolderFileMutex       sync.RWMutex
 	currentFolderFileArgsForCall []struct {
 		arg1 string
@@ -103,12 +107,14 @@ type Model struct {
 	currentFolderFileReturns struct {
 		result1 protocol.FileInfo
 		result2 bool
+		result3 error
 	}
 	currentFolderFileReturnsOnCall map[int]struct {
 		result1 protocol.FileInfo
 		result2 bool
+		result3 error
 	}
-	CurrentGlobalFileStub        func(string, string) (protocol.FileInfo, bool)
+	CurrentGlobalFileStub        func(string, string) (protocol.FileInfo, bool, error)
 	currentGlobalFileMutex       sync.RWMutex
 	currentGlobalFileArgsForCall []struct {
 		arg1 string
@@ -117,10 +123,12 @@ type Model struct {
 	currentGlobalFileReturns struct {
 		result1 protocol.FileInfo
 		result2 bool
+		result3 error
 	}
 	currentGlobalFileReturnsOnCall map[int]struct {
 		result1 protocol.FileInfo
 		result2 bool
+		result3 error
 	}
 	CurrentIgnoresStub        func(string) ([]string, []string, error)
 	currentIgnoresMutex       sync.RWMutex
@@ -577,7 +585,7 @@ func (fake *Model) AddConnectionArgsForCall(i int) (protocol.Connection, protoco
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Model) Availability(arg1 string, arg2 protocol.FileInfo, arg3 protocol.BlockInfo) []model.Availability {
+func (fake *Model) Availability(arg1 string, arg2 protocol.FileInfo, arg3 protocol.BlockInfo) ([]model.Availability, error) {
 	fake.availabilityMutex.Lock()
 	ret, specificReturn := fake.availabilityReturnsOnCall[len(fake.availabilityArgsForCall)]
 	fake.availabilityArgsForCall = append(fake.availabilityArgsForCall, struct {
@@ -593,9 +601,9 @@ func (fake *Model) Availability(arg1 string, arg2 protocol.FileInfo, arg3 protoc
 		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Model) AvailabilityCallCount() int {
@@ -604,7 +612,7 @@ func (fake *Model) AvailabilityCallCount() int {
 	return len(fake.availabilityArgsForCall)
 }
 
-func (fake *Model) AvailabilityCalls(stub func(string, protocol.FileInfo, protocol.BlockInfo) []model.Availability) {
+func (fake *Model) AvailabilityCalls(stub func(string, protocol.FileInfo, protocol.BlockInfo) ([]model.Availability, error)) {
 	fake.availabilityMutex.Lock()
 	defer fake.availabilityMutex.Unlock()
 	fake.AvailabilityStub = stub
@@ -617,27 +625,30 @@ func (fake *Model) AvailabilityArgsForCall(i int) (string, protocol.FileInfo, pr
 	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
-func (fake *Model) AvailabilityReturns(result1 []model.Availability) {
+func (fake *Model) AvailabilityReturns(result1 []model.Availability, result2 error) {
 	fake.availabilityMutex.Lock()
 	defer fake.availabilityMutex.Unlock()
 	fake.AvailabilityStub = nil
 	fake.availabilityReturns = struct {
 		result1 []model.Availability
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *Model) AvailabilityReturnsOnCall(i int, result1 []model.Availability) {
+func (fake *Model) AvailabilityReturnsOnCall(i int, result1 []model.Availability, result2 error) {
 	fake.availabilityMutex.Lock()
 	defer fake.availabilityMutex.Unlock()
 	fake.AvailabilityStub = nil
 	if fake.availabilityReturnsOnCall == nil {
 		fake.availabilityReturnsOnCall = make(map[int]struct {
 			result1 []model.Availability
+			result2 error
 		})
 	}
 	fake.availabilityReturnsOnCall[i] = struct {
 		result1 []model.Availability
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *Model) BringToFront(arg1 string, arg2 string) {
@@ -768,7 +779,7 @@ func (fake *Model) ClusterConfigReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Model) Completion(arg1 protocol.DeviceID, arg2 string) model.FolderCompletion {
+func (fake *Model) Completion(arg1 protocol.DeviceID, arg2 string) (model.FolderCompletion, error) {
 	fake.completionMutex.Lock()
 	ret, specificReturn := fake.completionReturnsOnCall[len(fake.completionArgsForCall)]
 	fake.completionArgsForCall = append(fake.completionArgsForCall, struct {
@@ -783,9 +794,9 @@ func (fake *Model) Completion(arg1 protocol.DeviceID, arg2 string) model.FolderC
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *Model) CompletionCallCount() int {
@@ -794,7 +805,7 @@ func (fake *Model) CompletionCallCount() int {
 	return len(fake.completionArgsForCall)
 }
 
-func (fake *Model) CompletionCalls(stub func(protocol.DeviceID, string) model.FolderCompletion) {
+func (fake *Model) CompletionCalls(stub func(protocol.DeviceID, string) (model.FolderCompletion, error)) {
 	fake.completionMutex.Lock()
 	defer fake.completionMutex.Unlock()
 	fake.CompletionStub = stub
@@ -807,27 +818,30 @@ func (fake *Model) CompletionArgsForCall(i int) (protocol.DeviceID, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Model) CompletionReturns(result1 model.FolderCompletion) {
+func (fake *Model) CompletionReturns(result1 model.FolderCompletion, result2 error) {
 	fake.completionMutex.Lock()
 	defer fake.completionMutex.Unlock()
 	fake.CompletionStub = nil
 	fake.completionReturns = struct {
 		result1 model.FolderCompletion
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *Model) CompletionReturnsOnCall(i int, result1 model.FolderCompletion) {
+func (fake *Model) CompletionReturnsOnCall(i int, result1 model.FolderCompletion, result2 error) {
 	fake.completionMutex.Lock()
 	defer fake.completionMutex.Unlock()
 	fake.CompletionStub = nil
 	if fake.completionReturnsOnCall == nil {
 		fake.completionReturnsOnCall = make(map[int]struct {
 			result1 model.FolderCompletion
+			result2 error
 		})
 	}
 	fake.completionReturnsOnCall[i] = struct {
 		result1 model.FolderCompletion
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *Model) Connection(arg1 protocol.DeviceID) (protocol.Connection, bool) {
@@ -947,7 +961,7 @@ func (fake *Model) ConnectionStatsReturnsOnCall(i int, result1 map[string]interf
 	}{result1}
 }
 
-func (fake *Model) CurrentFolderFile(arg1 string, arg2 string) (protocol.FileInfo, bool) {
+func (fake *Model) CurrentFolderFile(arg1 string, arg2 string) (protocol.FileInfo, bool, error) {
 	fake.currentFolderFileMutex.Lock()
 	ret, specificReturn := fake.currentFolderFileReturnsOnCall[len(fake.currentFolderFileArgsForCall)]
 	fake.currentFolderFileArgsForCall = append(fake.currentFolderFileArgsForCall, struct {
@@ -962,9 +976,9 @@ func (fake *Model) CurrentFolderFile(arg1 string, arg2 string) (protocol.FileInf
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *Model) CurrentFolderFileCallCount() int {
@@ -973,7 +987,7 @@ func (fake *Model) CurrentFolderFileCallCount() int {
 	return len(fake.currentFolderFileArgsForCall)
 }
 
-func (fake *Model) CurrentFolderFileCalls(stub func(string, string) (protocol.FileInfo, bool)) {
+func (fake *Model) CurrentFolderFileCalls(stub func(string, string) (protocol.FileInfo, bool, error)) {
 	fake.currentFolderFileMutex.Lock()
 	defer fake.currentFolderFileMutex.Unlock()
 	fake.CurrentFolderFileStub = stub
@@ -986,17 +1000,18 @@ func (fake *Model) CurrentFolderFileArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Model) CurrentFolderFileReturns(result1 protocol.FileInfo, result2 bool) {
+func (fake *Model) CurrentFolderFileReturns(result1 protocol.FileInfo, result2 bool, result3 error) {
 	fake.currentFolderFileMutex.Lock()
 	defer fake.currentFolderFileMutex.Unlock()
 	fake.CurrentFolderFileStub = nil
 	fake.currentFolderFileReturns = struct {
 		result1 protocol.FileInfo
 		result2 bool
-	}{result1, result2}
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *Model) CurrentFolderFileReturnsOnCall(i int, result1 protocol.FileInfo, result2 bool) {
+func (fake *Model) CurrentFolderFileReturnsOnCall(i int, result1 protocol.FileInfo, result2 bool, result3 error) {
 	fake.currentFolderFileMutex.Lock()
 	defer fake.currentFolderFileMutex.Unlock()
 	fake.CurrentFolderFileStub = nil
@@ -1004,15 +1019,17 @@ func (fake *Model) CurrentFolderFileReturnsOnCall(i int, result1 protocol.FileIn
 		fake.currentFolderFileReturnsOnCall = make(map[int]struct {
 			result1 protocol.FileInfo
 			result2 bool
+			result3 error
 		})
 	}
 	fake.currentFolderFileReturnsOnCall[i] = struct {
 		result1 protocol.FileInfo
 		result2 bool
-	}{result1, result2}
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *Model) CurrentGlobalFile(arg1 string, arg2 string) (protocol.FileInfo, bool) {
+func (fake *Model) CurrentGlobalFile(arg1 string, arg2 string) (protocol.FileInfo, bool, error) {
 	fake.currentGlobalFileMutex.Lock()
 	ret, specificReturn := fake.currentGlobalFileReturnsOnCall[len(fake.currentGlobalFileArgsForCall)]
 	fake.currentGlobalFileArgsForCall = append(fake.currentGlobalFileArgsForCall, struct {
@@ -1027,9 +1044,9 @@ func (fake *Model) CurrentGlobalFile(arg1 string, arg2 string) (protocol.FileInf
 		return stub(arg1, arg2)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *Model) CurrentGlobalFileCallCount() int {
@@ -1038,7 +1055,7 @@ func (fake *Model) CurrentGlobalFileCallCount() int {
 	return len(fake.currentGlobalFileArgsForCall)
 }
 
-func (fake *Model) CurrentGlobalFileCalls(stub func(string, string) (protocol.FileInfo, bool)) {
+func (fake *Model) CurrentGlobalFileCalls(stub func(string, string) (protocol.FileInfo, bool, error)) {
 	fake.currentGlobalFileMutex.Lock()
 	defer fake.currentGlobalFileMutex.Unlock()
 	fake.CurrentGlobalFileStub = stub
@@ -1051,17 +1068,18 @@ func (fake *Model) CurrentGlobalFileArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Model) CurrentGlobalFileReturns(result1 protocol.FileInfo, result2 bool) {
+func (fake *Model) CurrentGlobalFileReturns(result1 protocol.FileInfo, result2 bool, result3 error) {
 	fake.currentGlobalFileMutex.Lock()
 	defer fake.currentGlobalFileMutex.Unlock()
 	fake.CurrentGlobalFileStub = nil
 	fake.currentGlobalFileReturns = struct {
 		result1 protocol.FileInfo
 		result2 bool
-	}{result1, result2}
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *Model) CurrentGlobalFileReturnsOnCall(i int, result1 protocol.FileInfo, result2 bool) {
+func (fake *Model) CurrentGlobalFileReturnsOnCall(i int, result1 protocol.FileInfo, result2 bool, result3 error) {
 	fake.currentGlobalFileMutex.Lock()
 	defer fake.currentGlobalFileMutex.Unlock()
 	fake.CurrentGlobalFileStub = nil
@@ -1069,12 +1087,14 @@ func (fake *Model) CurrentGlobalFileReturnsOnCall(i int, result1 protocol.FileIn
 		fake.currentGlobalFileReturnsOnCall = make(map[int]struct {
 			result1 protocol.FileInfo
 			result2 bool
+			result3 error
 		})
 	}
 	fake.currentGlobalFileReturnsOnCall[i] = struct {
 		result1 protocol.FileInfo
 		result2 bool
-	}{result1, result2}
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *Model) CurrentIgnores(arg1 string) ([]string, []string, error) {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2715,10 +2715,10 @@ func (m *model) Availability(folder string, file protocol.FileInfo, block protoc
 	}
 	defer snap.Release()
 
-	return m.availabilityWithInfo(cfg, snap, file, block), nil
+	return m.availabilityInSnapshot(cfg, snap, file, block), nil
 }
 
-func (m *model) availabilityWithInfo(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
+func (m *model) availabilityInSnapshot(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
 	var availabilities []Availability
 	for _, device := range snap.Availability(file.Name) {
 		if _, ok := m.remotePausedFolders[device]; !ok {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2300,7 +2300,7 @@ func TestIssue3496(t *testing.T) {
 	fs := m.folderFiles["default"]
 	m.fmut.RUnlock()
 	var localFiles []protocol.FileInfo
-	snap := fs.Snapshot()
+	snap := fsetSnapshot(t, fs)
 	snap.WithHave(protocol.LocalDeviceID, func(i protocol.FileIntf) bool {
 		localFiles = append(localFiles, i.(protocol.FileInfo))
 		return true
@@ -2329,7 +2329,7 @@ func TestIssue3496(t *testing.T) {
 
 	// Check that the completion percentage for us makes sense
 
-	comp := m.Completion(protocol.LocalDeviceID, "default")
+	comp := m.testCompletion(protocol.LocalDeviceID, "default")
 	if comp.NeedBytes > comp.GlobalBytes {
 		t.Errorf("Need more bytes than exist, not possible: %d > %d", comp.NeedBytes, comp.GlobalBytes)
 	}
@@ -2393,7 +2393,7 @@ func TestNoRequestsFromPausedDevices(t *testing.T) {
 	files.Update(device1, []protocol.FileInfo{file})
 	files.Update(device2, []protocol.FileInfo{file})
 
-	avail := m.Availability("default", file, file.Blocks[0])
+	avail := m.testAvailability("default", file, file.Blocks[0])
 	if len(avail) != 0 {
 		t.Errorf("should not be available, no connections")
 	}
@@ -2403,7 +2403,7 @@ func TestNoRequestsFromPausedDevices(t *testing.T) {
 
 	// !!! This is not what I'd expect to happen, as we don't even know if the peer has the original index !!!
 
-	avail = m.Availability("default", file, file.Blocks[0])
+	avail = m.testAvailability("default", file, file.Blocks[0])
 	if len(avail) != 2 {
 		t.Errorf("should have two available")
 	}
@@ -2423,7 +2423,7 @@ func TestNoRequestsFromPausedDevices(t *testing.T) {
 	m.ClusterConfig(device1, cc)
 	m.ClusterConfig(device2, cc)
 
-	avail = m.Availability("default", file, file.Blocks[0])
+	avail = m.testAvailability("default", file, file.Blocks[0])
 	if len(avail) != 2 {
 		t.Errorf("should have two available")
 	}
@@ -2431,7 +2431,7 @@ func TestNoRequestsFromPausedDevices(t *testing.T) {
 	m.Closed(newFakeConnection(device1, m), errDeviceUnknown)
 	m.Closed(newFakeConnection(device2, m), errDeviceUnknown)
 
-	avail = m.Availability("default", file, file.Blocks[0])
+	avail = m.testAvailability("default", file, file.Blocks[0])
 	if len(avail) != 0 {
 		t.Errorf("should have no available")
 	}
@@ -2446,7 +2446,7 @@ func TestNoRequestsFromPausedDevices(t *testing.T) {
 	ccp.Folders[0].Paused = true
 	m.ClusterConfig(device1, ccp)
 
-	avail = m.Availability("default", file, file.Blocks[0])
+	avail = m.testAvailability("default", file, file.Blocks[0])
 	if len(avail) != 1 {
 		t.Errorf("should have one available")
 	}
@@ -2479,12 +2479,12 @@ func TestIssue2571(t *testing.T) {
 
 	m.ScanFolder("default")
 
-	if dir, ok := m.CurrentFolderFile("default", "toLink"); !ok {
+	if dir, ok := m.testCurrentFolderFile("default", "toLink"); !ok {
 		t.Fatalf("Dir missing in db")
 	} else if !dir.IsSymlink() {
 		t.Errorf("Dir wasn't changed to symlink")
 	}
-	if file, ok := m.CurrentFolderFile("default", filepath.Join("toLink", "a")); !ok {
+	if file, ok := m.testCurrentFolderFile("default", filepath.Join("toLink", "a")); !ok {
 		t.Fatalf("File missing in db")
 	} else if !file.Deleted {
 		t.Errorf("File below symlink has not been marked as deleted")
@@ -2517,7 +2517,7 @@ func TestIssue4573(t *testing.T) {
 
 	m.ScanFolder("default")
 
-	if file, ok := m.CurrentFolderFile("default", file); !ok {
+	if file, ok := m.testCurrentFolderFile("default", file); !ok {
 		t.Fatalf("File missing in db")
 	} else if file.Deleted {
 		t.Errorf("Inaccessible file has been marked as deleted.")
@@ -2577,7 +2577,7 @@ func TestInternalScan(t *testing.T) {
 	m.ScanFolder("default")
 
 	for path, cond := range testCases {
-		if f, ok := m.CurrentFolderFile("default", path); !ok {
+		if f, ok := m.testCurrentFolderFile("default", path); !ok {
 			t.Fatalf("%v missing in db", path)
 		} else if cond(f) {
 			t.Errorf("Incorrect db entry for %v", path)
@@ -2638,14 +2638,14 @@ func TestRemoveDirWithContent(t *testing.T) {
 	m := setupModel(t, defaultCfgWrapper)
 	defer cleanupModel(m)
 
-	dir, ok := m.CurrentFolderFile("default", "dirwith")
+	dir, ok := m.testCurrentFolderFile("default", "dirwith")
 	if !ok {
 		t.Fatalf("Can't get dir \"dirwith\" after initial scan")
 	}
 	dir.Deleted = true
 	dir.Version = dir.Version.Update(device1.Short()).Update(device1.Short())
 
-	file, ok := m.CurrentFolderFile("default", content)
+	file, ok := m.testCurrentFolderFile("default", content)
 	if !ok {
 		t.Fatalf("Can't get file \"%v\" after initial scan", content)
 	}
@@ -2657,11 +2657,11 @@ func TestRemoveDirWithContent(t *testing.T) {
 	// Is there something we could trigger on instead of just waiting?
 	timeout := time.NewTimer(5 * time.Second)
 	for {
-		dir, ok := m.CurrentFolderFile("default", "dirwith")
+		dir, ok := m.testCurrentFolderFile("default", "dirwith")
 		if !ok {
 			t.Fatalf("Can't get dir \"dirwith\" after index update")
 		}
-		file, ok := m.CurrentFolderFile("default", content)
+		file, ok := m.testCurrentFolderFile("default", content)
 		if !ok {
 			t.Fatalf("Can't get file \"%v\" after index update", content)
 		}
@@ -2713,11 +2713,11 @@ func TestIssue4475(t *testing.T) {
 	created := false
 	for {
 		if !created {
-			if _, ok := m.CurrentFolderFile("default", fileName); ok {
+			if _, ok := m.testCurrentFolderFile("default", fileName); ok {
 				created = true
 			}
 		} else {
-			dir, ok := m.CurrentFolderFile("default", "delDir")
+			dir, ok := m.testCurrentFolderFile("default", "delDir")
 			if !ok {
 				t.Fatalf("can't get dir from db")
 			}
@@ -2954,7 +2954,7 @@ func TestPausedFolders(t *testing.T) {
 		t.Errorf("Expected folder paused error, received: %v", err)
 	}
 
-	if err := m.ScanFolder("nonexistent"); err != errFolderMissing {
+	if err := m.ScanFolder("nonexistent"); err != ErrFolderMissing {
 		t.Errorf("Expected missing folder error, received: %v", err)
 	}
 }
@@ -3035,7 +3035,7 @@ func TestIssue5002(t *testing.T) {
 		t.Error(err)
 	}
 
-	file, ok := m.CurrentFolderFile("default", "foo")
+	file, ok := m.testCurrentFolderFile("default", "foo")
 	if !ok {
 		t.Fatal("test file should exist")
 	}
@@ -3054,7 +3054,7 @@ func TestParentOfUnignored(t *testing.T) {
 
 	m.SetIgnores("default", []string{"!quux", "*"})
 
-	if parent, ok := m.CurrentFolderFile("default", "baz"); !ok {
+	if parent, ok := m.testCurrentFolderFile("default", "baz"); !ok {
 		t.Errorf(`Directory "baz" missing in db`)
 	} else if parent.IsIgnored() {
 		t.Errorf(`Directory "baz" is ignored`)
@@ -3222,7 +3222,7 @@ func TestModTimeWindow(t *testing.T) {
 
 	// Get current version
 
-	fi, ok := m.CurrentFolderFile("default", name)
+	fi, ok := m.testCurrentFolderFile("default", name)
 	if !ok {
 		t.Fatal("File missing")
 	}
@@ -3237,7 +3237,7 @@ func TestModTimeWindow(t *testing.T) {
 
 	// No change due to within window
 
-	fi, _ = m.CurrentFolderFile("default", name)
+	fi, _ = m.testCurrentFolderFile("default", name)
 	if !fi.Version.Equal(v) {
 		t.Fatalf("Got version %v, expected %v", fi.Version, v)
 	}
@@ -3251,7 +3251,7 @@ func TestModTimeWindow(t *testing.T) {
 
 	// Version should have updated
 
-	fi, _ = m.CurrentFolderFile("default", name)
+	fi, _ = m.testCurrentFolderFile("default", name)
 	if fi.Version.Compare(v) != protocol.Greater {
 		t.Fatalf("Got result %v, expected %v", fi.Version.Compare(v), protocol.Greater)
 	}
@@ -3368,8 +3368,8 @@ func TestFolderAPIErrors(t *testing.T) {
 		if err := method(fcfg.ID); err != ErrFolderPaused {
 			t.Errorf(`Expected "%v", got "%v" (method no %v)`, ErrFolderPaused, err, i)
 		}
-		if err := method("notexisting"); err != errFolderMissing {
-			t.Errorf(`Expected "%v", got "%v" (method no %v)`, errFolderMissing, err, i)
+		if err := method("notexisting"); err != ErrFolderMissing {
+			t.Errorf(`Expected "%v", got "%v" (method no %v)`, ErrFolderMissing, err, i)
 		}
 	}
 }
@@ -3776,7 +3776,7 @@ func TestScanDeletedROChangedOnSR(t *testing.T) {
 	must(t, writeFile(ffs, name, []byte(name), 0644))
 	m.ScanFolders()
 
-	file, ok := m.CurrentFolderFile(fcfg.ID, name)
+	file, ok := m.testCurrentFolderFile(fcfg.ID, name)
 	if !ok {
 		t.Fatal("file missing in db")
 	}
@@ -3927,7 +3927,7 @@ func TestIssue6961(t *testing.T) {
 	pauseFolder(t, wcfg, fcfg.ID, true)
 	pauseFolder(t, wcfg, fcfg.ID, false)
 
-	if comp := m.Completion(device2, fcfg.ID); comp.NeedDeletes != 0 {
+	if comp := m.testCompletion(device2, fcfg.ID); comp.NeedDeletes != 0 {
 		t.Error("Expected 0 needed deletes, got", comp.NeedDeletes)
 	} else {
 		t.Log(comp)
@@ -3946,7 +3946,7 @@ func TestCompletionEmptyGlobal(t *testing.T) {
 	files[0].Deleted = true
 	files[0].Version = files[0].Version.Update(device1.Short())
 	m.IndexUpdate(device1, fcfg.ID, files)
-	comp := m.Completion(protocol.LocalDeviceID, fcfg.ID)
+	comp := m.testCompletion(protocol.LocalDeviceID, fcfg.ID)
 	if comp.CompletionPct != 95 {
 		t.Error("Expected completion of 95%, got", comp.CompletionPct)
 	}
@@ -3978,13 +3978,13 @@ func TestNeedMetaAfterIndexReset(t *testing.T) {
 	files[0].Sequence = seq
 	m.IndexUpdate(device1, fcfg.ID, files)
 
-	if comp := m.Completion(device2, fcfg.ID); comp.NeedItems != 1 {
+	if comp := m.testCompletion(device2, fcfg.ID); comp.NeedItems != 1 {
 		t.Error("Expected one needed item for device2, got", comp.NeedItems)
 	}
 
 	// Pretend we had an index reset on device 1
 	m.Index(device1, fcfg.ID, files)
-	if comp := m.Completion(device2, fcfg.ID); comp.NeedItems != 1 {
+	if comp := m.testCompletion(device2, fcfg.ID); comp.NeedItems != 1 {
 		t.Error("Expected one needed item for device2, got", comp.NeedItems)
 	}
 }

--- a/lib/svcutil/svcutil.go
+++ b/lib/svcutil/svcutil.go
@@ -38,6 +38,11 @@ func AsFatalErr(err error, status ExitStatus) *FatalErr {
 	}
 }
 
+func IsFatal(err error) bool {
+	ferr := &FatalErr{}
+	return errors.As(err, &ferr)
+}
+
 func (e *FatalErr) Error() string {
 	return e.Err.Error()
 }


### PR DESCRIPTION
### Purpose

Another step towards better database error handling (#5907), fixing #7419: Now `db.FileSet.Snapshot` returns an error instead of panicking.  
Most of the diff is boilerplate of adding error returns all over the place. One larger change regards folder error handling: Previously we did not bubble errors consistently (as in already existing errors unrelated to this PR). Now we do need errors in `Serve` to shut the service down in case of fatal errors. I thus opted to bubble "folder-level" errors (as opposed to item level errors, e.g. errors scanning/pulling an item) up to the main loop in the service. That means the folder state is set with any error that reaches that point and isn't fatal. 

### Testing

Existing unit tests pass and the UI still comes up - haven't done any manual testing beyond that.