### PR TITLE
gui: Fix hidden Ignore Patterns tab for folder editing (fixes #7429)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1933,6 +1933,7 @@ angular.module('syncthing.core')
 
         $scope.editFolderExisting = function(folderCfg) {
             $scope.editingExisting = true;
+            $scope.editingDefaults = false;
             $scope.currentFolder = angular.copy(folderCfg);
 
             $scope.ignores.text = 'Loading...';


### PR DESCRIPTION
After editing the folder default config, the tab was still hidden when
editing regular folder.