### PR TITLE
cmd/syncthing, etc: Consistent failure restart backoff

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -7,7 +7,9 @@ After=network.target
 User=%i
 ExecStart=/usr/bin/syncthing serve --no-browser --no-restart --logflags=0
 Restart=on-failure
-RestartSec=5
+RestartSec=1
+StartLimitIntervalSec=60
+StartLimitBurst=4
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -5,7 +5,9 @@ Documentation=man:syncthing(1)
 [Service]
 ExecStart=/usr/bin/syncthing serve --no-browser --no-restart --logflags=0
 Restart=on-failure
-RestartSec=5
+RestartSec=1
+StartLimitIntervalSec=60
+StartLimitBurst=4
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 


### PR DESCRIPTION
There are timing parameters to catch frequent failure restarts in our monitor, and exit with an error. Systemd units also have such a mechanism by default, but with much less strict parameters that often allow infinite restart loops in case of DB problems. One example is this report, where a single user sent 3.5k events in a few hours: https://sentry.syncthing.net/syncthing/syncthing/issues/8679

Now the same restart parameters are used in the monitor as in the systemd service.