### PR TITLE
lib/protocol: Optimize FileKey

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -8,7 +8,6 @@ package protocol
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base32"
 	"encoding/binary"
 	"errors"
@@ -20,6 +19,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	"github.com/miscreant/miscreant.go"
 	"github.com/syncthing/syncthing/lib/rand"
+	"github.com/syncthing/syncthing/lib/sha256"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/hkdf"
 	"golang.org/x/crypto/scrypt"
@@ -487,8 +487,10 @@ func KeyFromPassword(folderID, password string) *[keySize]byte {
 	return &key
 }
 
+var hkdfSalt = []byte("syncthing")
+
 func FileKey(filename string, folderKey *[keySize]byte) *[keySize]byte {
-	kdf := hkdf.New(sha256.New, append(folderKey[:], filename...), []byte("syncthing"), nil)
+	kdf := hkdf.New(sha256.New, append(folderKey[:], filename...), hkdfSalt, nil)
 	var fileKey [keySize]byte
 	n, err := io.ReadFull(kdf, fileKey[:])
 	if err != nil || n != keySize {


### PR DESCRIPTION
Use lib/sha256 to get the fast Minio hash, allocate the salt at init time. Benchmark results on Linux/amd64 with STHASHING=minio:

```
name       old time/op    new time/op    delta
FileKey-8    6.27µs ± 3%    4.58µs ± 3%  -26.91%  (p=0.000 n=20+19)

name       old alloc/op   new alloc/op   delta
FileKey-8    1.47kB ± 0%    1.17kB ± 0%  -20.58%  (p=0.000 n=20+20)

name       old allocs/op  new allocs/op  delta
FileKey-8      19.0 ± 0%      16.0 ± 0%  -15.79%  (p=0.000 n=20+20)
```