### PR TITLE
gui: Allow to translate theme names

### DIFF
--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -164,7 +164,7 @@
               <div class="form-group">
                 <label translate>GUI Theme</label>
                 <select class="form-control" ng-model="tmpGUI.theme" ng-if="themes.length > 1">
-                  <option ng-repeat="theme in themes.sort()" value="{{ theme }}">
+                  <option translate ng-repeat="theme in themes.sort()" value="{{ theme }}">
                     {{ themeName(theme) }}
                   </option>
                 </select>


### PR DESCRIPTION
Allow to translate theme names, so that they match the GUI language
rather than being always displayed in English, as it is the case right
now.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>