### PR TITLE
cmd/syncthing: Correct name of HiddenConsole flag (fixes #7446)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -139,6 +139,7 @@ var entrypoint struct {
 
 // serveOptions are the options for the `syncthing serve` command.
 type serveOptions struct {
+	buildServeOptions
 	AllowNewerConfig bool   `help:"Allow loading newer than current config version"`
 	Audit            bool   `help:"Write events to audit file"`
 	AuditFile        string `name:"auditfile" placeholder:"PATH" help:"Specify audit file (use \"-\" for stdout, \"--\" for stderr)"`
@@ -149,7 +150,6 @@ type serveOptions struct {
 	GenerateDir      string `name:"generate" placeholder:"PATH" help:"Generate key and config in specified dir, then exit"`
 	GUIAddress       string `name:"gui-address" placeholder:"URL" help:"Override GUI address (e.g. \"http://192.0.2.42:8443\")"`
 	GUIAPIKey        string `name:"gui-apikey" placeholder:"API-KEY" help:"Override GUI API key"`
-	HideConsole      bool   `help:"Hide console window (Windows only)"`
 	HomeDir          string `name:"home" placeholder:"PATH" help:"Set configuration and data directory"`
 	LogFile          string `name:"logfile" default:"${logFile}" placeholder:"PATH" help:"Log file name (see below)"`
 	LogFlags         int    `name:"logflags" default:"${logFlags}" placeholder:"BITS" help:"Select information in log line prefix (see below)"`

--- a/cmd/syncthing/options_others.go
+++ b/cmd/syncthing/options_others.go
@@ -1,0 +1,13 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// +build !windows
+
+package main
+
+type buildServeOptions struct {
+	HideConsole bool `hidden:""`
+}

--- a/cmd/syncthing/options_windows.go
+++ b/cmd/syncthing/options_windows.go
@@ -1,0 +1,11 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+type buildServeOptions struct {
+	HideConsole bool `name:"no-console" help:"Hide console window"`
+}


### PR DESCRIPTION
This fixes #7446 by adding the `name:"no-console"` tag. I also moved it into a separate file with build tags, such that it only shows up on windows as before, because why not.