### PR TITLE
gui: Check if versioning object exists (fixes #7449)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2053,6 +2053,9 @@ angular.module('syncthing.core')
             folderCfg.devices = newDevices;
             delete $scope.currentSharing;
 
+            if (!folderCfg.versioning) {
+                folderCfg.versioning = {params: {}};
+            }
             folderCfg.versioning.type = folderCfg._guiVersioning.selector;
             if ($scope.internalVersioningEnabled()) {
                 folderCfg.versioning.cleanupIntervalS = folderCfg._guiVersioning.cleanupIntervalS;

--- a/gui/default/untrusted/syncthing/core/syncthingController.js
+++ b/gui/default/untrusted/syncthing/core/syncthingController.js
@@ -2093,6 +2093,9 @@ angular.module('syncthing.core')
             folderCfg.devices = newDevices;
             delete $scope.currentSharing;
 
+            if (!folderCfg.versioning) {
+                folderCfg.versioning = {params: {}};
+            }
             folderCfg.versioning.type = folderCfg._guiVersioning.selector;
             if ($scope.internalVersioningEnabled()) {
                 folderCfg.versioning.cleanupIntervalS = folderCfg._guiVersioning.cleanupIntervalS;


### PR DESCRIPTION
Regression introduced in #7384: Previously we always created a new versioning object. That was changed on purpose to not clobber existing values, however the case that there's no existing object wasn't dealt with.