### PR TITLE
all: Make config.Wrapper an actual suture.Service (fixes #7451)

### DIFF
--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -186,6 +186,7 @@ func main() {
 	}
 
 	wrapper := config.Wrap("config", config.New(id), id, events.NoopLogger)
+	go wrapper.Serve(context.TODO())
 	wrapper.Modify(func(cfg *config.Configuration) {
 		cfg.Options.NATLeaseM = natLease
 		cfg.Options.NATRenewalM = natRenewal

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -603,9 +603,7 @@ func syncthingMain(options serveOptions) {
 		l.Warnln("Failed to initialize config:", err)
 		os.Exit(svcutil.ExitError.AsInt())
 	}
-	if cfgService, ok := cfgWrapper.(suture.Service); ok {
-		earlyService.Add(cfgService)
-	}
+	earlyService.Add(cfgWrapper)
 
 	// Candidate builds should auto upgrade. Make sure the option is set,
 	// unless we are in a build where it's disabled or the STNOUPGRADE

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -1262,11 +1262,9 @@ func TestConfigChanges(t *testing.T) {
 	defer os.Remove(tmpFile.Name())
 	w := config.Wrap(tmpFile.Name(), cfg, protocol.LocalDeviceID, events.NoopLogger)
 	tmpFile.Close()
-	if cfgService, ok := w.(suture.Service); ok {
-		cfgCtx, cfgCancel := context.WithCancel(context.Background())
-		go cfgService.Serve(cfgCtx)
-		defer cfgCancel()
-	}
+	cfgCtx, cfgCancel := context.WithCancel(context.Background())
+	go w.Serve(cfgCtx)
+	defer cfgCancel()
 	baseURL, cancel, err := startHTTP(w)
 	if err != nil {
 		t.Fatal("Unexpected error from getting base URL:", err)

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/d4l3k/messagediff"
-	"github.com/thejerf/suture/v4"
 
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
@@ -1301,16 +1300,10 @@ func startWrapper(wrapper Wrapper) *testWrapper {
 		Wrapper: wrapper,
 		done:    make(chan struct{}),
 	}
-	s, ok := wrapper.(suture.Service)
-	if !ok {
-		tw.cancel = func() {}
-		close(tw.done)
-		return tw
-	}
 	ctx, cancel := context.WithCancel(context.Background())
 	tw.cancel = cancel
 	go func() {
-		s.Serve(ctx)
+		wrapper.Serve(ctx)
 		close(tw.done)
 	}()
 	return tw

--- a/lib/config/mocks/mocked_wrapper.go
+++ b/lib/config/mocks/mocked_wrapper.go
@@ -2,6 +2,7 @@
 package mocks
 
 import (
+	"context"
 	"sync"
 
 	"github.com/syncthing/syncthing/lib/config"
@@ -256,6 +257,17 @@ type Wrapper struct {
 		result1 error
 	}
 	saveReturnsOnCall map[int]struct {
+		result1 error
+	}
+	ServeStub        func(context.Context) error
+	serveMutex       sync.RWMutex
+	serveArgsForCall []struct {
+		arg1 context.Context
+	}
+	serveReturns struct {
+		result1 error
+	}
+	serveReturnsOnCall map[int]struct {
 		result1 error
 	}
 	SubscribeStub        func(config.Committer) config.Configuration
@@ -1577,6 +1589,67 @@ func (fake *Wrapper) SaveReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *Wrapper) Serve(arg1 context.Context) error {
+	fake.serveMutex.Lock()
+	ret, specificReturn := fake.serveReturnsOnCall[len(fake.serveArgsForCall)]
+	fake.serveArgsForCall = append(fake.serveArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.ServeStub
+	fakeReturns := fake.serveReturns
+	fake.recordInvocation("Serve", []interface{}{arg1})
+	fake.serveMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Wrapper) ServeCallCount() int {
+	fake.serveMutex.RLock()
+	defer fake.serveMutex.RUnlock()
+	return len(fake.serveArgsForCall)
+}
+
+func (fake *Wrapper) ServeCalls(stub func(context.Context) error) {
+	fake.serveMutex.Lock()
+	defer fake.serveMutex.Unlock()
+	fake.ServeStub = stub
+}
+
+func (fake *Wrapper) ServeArgsForCall(i int) context.Context {
+	fake.serveMutex.RLock()
+	defer fake.serveMutex.RUnlock()
+	argsForCall := fake.serveArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *Wrapper) ServeReturns(result1 error) {
+	fake.serveMutex.Lock()
+	defer fake.serveMutex.Unlock()
+	fake.ServeStub = nil
+	fake.serveReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *Wrapper) ServeReturnsOnCall(i int, result1 error) {
+	fake.serveMutex.Lock()
+	defer fake.serveMutex.Unlock()
+	fake.ServeStub = nil
+	if fake.serveReturnsOnCall == nil {
+		fake.serveReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.serveReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *Wrapper) Subscribe(arg1 config.Committer) config.Configuration {
 	fake.subscribeMutex.Lock()
 	ret, specificReturn := fake.subscribeReturnsOnCall[len(fake.subscribeArgsForCall)]
@@ -1719,6 +1792,8 @@ func (fake *Wrapper) Invocations() map[string][][]interface{} {
 	defer fake.requiresRestartMutex.RUnlock()
 	fake.saveMutex.RLock()
 	defer fake.saveMutex.RUnlock()
+	fake.serveMutex.RLock()
+	defer fake.serveMutex.RUnlock()
 	fake.subscribeMutex.RLock()
 	defer fake.subscribeMutex.RUnlock()
 	fake.unsubscribeMutex.RLock()

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -20,6 +20,7 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/thejerf/suture/v4"
 )
 
 const (
@@ -111,6 +112,8 @@ type Wrapper interface {
 
 	Subscribe(c Committer) Configuration
 	Unsubscribe(c Committer)
+
+	suture.Service
 }
 
 type wrapper struct {

--- a/lib/connections/limiter_test.go
+++ b/lib/connections/limiter_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
-	"github.com/thejerf/suture/v4"
 	"golang.org/x/time/rate"
 )
 
@@ -45,12 +44,8 @@ func initConfig() (config.Wrapper, context.CancelFunc) {
 	dev3Conf = newDeviceConfiguration(wrapper, device3, "device3")
 	dev4Conf = newDeviceConfiguration(wrapper, device4, "device4")
 
-	var cancel context.CancelFunc = func() {}
-	if wrapperService, ok := wrapper.(suture.Service); ok {
-		var ctx context.Context
-		ctx, cancel = context.WithCancel(context.Background())
-		go wrapperService.Serve(ctx)
-	}
+	ctx, cancel := context.WithCancel(context.Background())
+	go wrapper.Serve(ctx)
 
 	dev2Conf.MaxRecvKbps = rand.Int() % 100000
 	dev2Conf.MaxSendKbps = rand.Int() % 100000

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -13,8 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/thejerf/suture/v4"
-
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/db/backend"
@@ -84,12 +82,9 @@ func createTmpWrapper(cfg config.Configuration) (config.Wrapper, context.CancelF
 	}
 	wrapper := config.Wrap(tmpFile.Name(), cfg, myID, events.NoopLogger)
 	tmpFile.Close()
-	if cfgService, ok := wrapper.(suture.Service); ok {
-		ctx, cancel := context.WithCancel(context.Background())
-		go cfgService.Serve(ctx)
-		return wrapper, cancel
-	}
-	return wrapper, func() {}
+	ctx, cancel := context.WithCancel(context.Background())
+	go wrapper.Serve(ctx)
+	return wrapper, cancel
 }
 
 func tmpDefaultWrapper() (config.Wrapper, config.FolderConfiguration, context.CancelFunc) {


### PR DESCRIPTION
strelaysrv hung on startup because it uses the config wrapper, but the config wrapper needs to be running as a service. The comments on the constructor says this, but the returned type isn't actually a suture.Service so it's cumbersome and non-obvious to use. I fixed that by making it a service as I didn't see any reason for it being otherwise.