### PR TITLE
lib/api: Fix body of renamed config/restart-required endpoint (ref #7402)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -298,7 +298,7 @@ func (s *service) Serve(ctx context.Context) error {
 
 	configBuilder.registerConfig("/rest/config")
 	configBuilder.registerConfigInsync("/rest/config/insync") // deprecated
-	configBuilder.registerConfigInsync("/rest/config/restart-required")
+	configBuilder.registerConfigRequiresRestart("/rest/config/restart-required")
 	configBuilder.registerFolders("/rest/config/folders")
 	configBuilder.registerDevices("/rest/config/devices")
 	configBuilder.registerFolder("/rest/config/folders/:id")

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -51,6 +51,12 @@ func (c *configMuxBuilder) registerConfigInsync(path string) {
 	})
 }
 
+func (c *configMuxBuilder) registerConfigRequiresRestart(path string) {
+	c.HandlerFunc(http.MethodGet, path, func(w http.ResponseWriter, _ *http.Request) {
+		sendJSON(w, map[string]bool{"config-requires-restart": c.cfg.RequiresRestart()})
+	})
+}
+
 func (c *configMuxBuilder) registerFolders(path string) {
 	c.HandlerFunc(http.MethodGet, path, func(w http.ResponseWriter, _ *http.Request) {
 		sendJSON(w, c.cfg.FolderList())

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -53,7 +53,7 @@ func (c *configMuxBuilder) registerConfigInsync(path string) {
 
 func (c *configMuxBuilder) registerConfigRequiresRestart(path string) {
 	c.HandlerFunc(http.MethodGet, path, func(w http.ResponseWriter, _ *http.Request) {
-		sendJSON(w, map[string]bool{"config-requires-restart": c.cfg.RequiresRestart()})
+		sendJSON(w, map[string]bool{"requiresRestart": c.cfg.RequiresRestart()})
 	})
 }
 


### PR DESCRIPTION
Just renaming the endpoint (#7402) isn't enough: The body also needs to change, both in key (`configInSync`) and reversing the value.