### PR TITLE
all: Truncate some timestamps (fixes #7457)

### DIFF
--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/syncthing/syncthing/lib/protocol"
 	"io"
 	"io/ioutil"
 	"log"
@@ -22,6 +21,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/syncthing/syncthing/lib/protocol"
 
 	"github.com/golang/groupcache/lru"
 	"github.com/oschwald/geoip2-golang"
@@ -475,7 +476,7 @@ func handleRelayTest(request request) {
 		updateMetrics(request.relay.uri.Host, *stats, location)
 	}
 	request.relay.Stats = stats
-	request.relay.StatsRetrieved = time.Now()
+	request.relay.StatsRetrieved = time.Now().Truncate(time.Second)
 	request.relay.Location = location
 
 	timer, ok := evictionTimers[request.relay.uri.Host]

--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -89,7 +89,7 @@ func newInternalConn(tc tlsConn, connType connType, priority int) internalConn {
 		tlsConn:       tc,
 		connType:      connType,
 		priority:      priority,
-		establishedAt: time.Now(),
+		establishedAt: time.Now().Truncate(time.Second),
 	}
 }
 

--- a/lib/db/observed.go
+++ b/lib/db/observed.go
@@ -15,7 +15,7 @@ import (
 func (db *Lowlevel) AddOrUpdatePendingDevice(device protocol.DeviceID, name, address string) error {
 	key := db.keyer.GeneratePendingDeviceKey(nil, device[:])
 	od := ObservedDevice{
-		Time:    time.Now().Round(time.Second),
+		Time:    time.Now().Truncate(time.Second),
 		Name:    name,
 		Address: address,
 	}
@@ -72,7 +72,7 @@ func (db *Lowlevel) AddOrUpdatePendingFolder(id, label string, device protocol.D
 		return err
 	}
 	of := ObservedFolder{
-		Time:             time.Now().Round(time.Second),
+		Time:             time.Now().Truncate(time.Second),
 		Label:            label,
 		ReceiveEncrypted: receiveEncrypted,
 	}

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -317,7 +317,7 @@ loop:
 
 func (l *logger) Log(t EventType, data interface{}) {
 	l.events <- Event{
-		Time: time.Now(),
+		Time: time.Now(), // intentionally high precision
 		Type: t,
 		Data: data,
 		// SubscriptionID and GlobalID are set in sendEvent

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -337,7 +337,7 @@ func (r *recorder) Clear() {
 
 func (r *recorder) append(l LogLevel, msg string) {
 	line := Line{
-		When:    time.Now(),
+		When:    time.Now(), // intentionally high precision
 		Message: msg,
 		Level:   l,
 	}

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -100,7 +100,7 @@ func (s *stateTracker) setState(newState folderState) {
 	}
 
 	s.current = newState
-	s.changed = time.Now()
+	s.changed = time.Now().Truncate(time.Second)
 
 	s.evLogger.Log(events.StateChanged, eventData)
 }
@@ -139,7 +139,7 @@ func (s *stateTracker) setError(err error) {
 	}
 
 	s.err = err
-	s.changed = time.Now()
+	s.changed = time.Now().Truncate(time.Second)
 
 	s.evLogger.Log(events.StateChanged, eventData)
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -769,7 +769,7 @@ func (m *model) ConnectionStats() map[string]interface{} {
 	in, out := protocol.TotalInOut()
 	res["total"] = ConnectionInfo{
 		Statistics: protocol.Statistics{
-			At:            time.Now(),
+			At:            time.Now().Truncate(time.Second),
 			InBytesTotal:  in,
 			OutBytesTotal: out,
 		},

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -296,7 +296,7 @@ func (c *rawConnection) Start() {
 		c.pingReceiver()
 		c.loopWG.Done()
 	}()
-	c.startTime = time.Now()
+	c.startTime = time.Now().Truncate(time.Second)
 }
 
 func (c *rawConnection) ID() DeviceID {
@@ -1040,7 +1040,7 @@ type Statistics struct {
 
 func (c *rawConnection) Statistics() Statistics {
 	return Statistics{
-		At:            time.Now(),
+		At:            time.Now().Truncate(time.Second),
 		InBytesTotal:  c.cr.Tot(),
 		OutBytesTotal: c.cw.Tot(),
 		StartedAt:     c.startTime,

--- a/lib/stats/device.go
+++ b/lib/stats/device.go
@@ -62,7 +62,7 @@ func (s *DeviceStatisticsReference) GetLastConnectionDuration() (time.Duration, 
 
 func (s *DeviceStatisticsReference) WasSeen() error {
 	l.Debugln("stats.DeviceStatisticsReference.WasSeen:", s.device)
-	return s.ns.PutTime(lastSeenKey, time.Now())
+	return s.ns.PutTime(lastSeenKey, time.Now().Truncate(time.Second))
 }
 
 func (s *DeviceStatisticsReference) LastConnectionDuration(d time.Duration) error {

--- a/lib/stats/folder.go
+++ b/lib/stats/folder.go
@@ -61,7 +61,7 @@ func (s *FolderStatisticsReference) GetLastFile() (LastFile, error) {
 
 func (s *FolderStatisticsReference) ReceivedFile(file string, deleted bool) error {
 	l.Debugln("stats.FolderStatisticsReference.ReceivedFile:", s.folder, file)
-	if err := s.ns.PutTime("lastFileAt", time.Now()); err != nil {
+	if err := s.ns.PutTime("lastFileAt", time.Now().Truncate(time.Second)); err != nil {
 		return err
 	}
 	if err := s.ns.PutString("lastFileName", file); err != nil {
@@ -74,7 +74,7 @@ func (s *FolderStatisticsReference) ReceivedFile(file string, deleted bool) erro
 }
 
 func (s *FolderStatisticsReference) ScanCompleted() error {
-	return s.ns.PutTime("lastScan", time.Now())
+	return s.ns.PutTime("lastScan", time.Now().Truncate(time.Second))
 }
 
 func (s *FolderStatisticsReference) GetLastScanTime() (time.Time, error) {

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -36,7 +36,7 @@ import (
 // are prompted for acceptance of the new report.
 const Version = 3
 
-var StartTime = time.Now()
+var StartTime = time.Now().Truncate(time.Second)
 
 type Service struct {
 	cfg                config.Wrapper


### PR DESCRIPTION
This truncates times meant for API consumption to second precision,
where fractions won't typically matter or add any value. Exception to
this is timestamps on logs and events, and of course I'm not touching
things like file metadata.

I'm not 100% certain this is an exhaustive change, but it's the things I
found by grepping and following the breadcrumbs from lib/api...

I also considered general-but-ugly solutions, like having the API
serializer itself do reflection magic or even regexp magic on returned
objects, but decided against it because aurgh...
