### PR TITLE
lib/model: Send failure report on CC encryption check error

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1369,7 +1369,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 			} else {
 				l.Warnln(msg)
 			}
-
+			m.evLogger.Log(events.Failure, err.Error())
 			return tempIndexFolders, paused, err
 		}
 		if devErrs, ok := m.folderEncryptionFailures[folder.ID]; ok {


### PR DESCRIPTION
Adds a failure report if we drop a connection because of misconfigured encrypted folders (e.g. remote sends encrypt, local folder is not receive-encrypted, ...). Good to know whether that occurs often, i.e. if UX is bad.