### PR TITLE
lib/model: Return correct error in puller-iteration (ref #7424)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -307,7 +307,7 @@ func (f *sendReceiveFolder) pullerIteration(scanChan chan<- string) (int, error)
 
 	f.queue.Reset()
 
-	return changed, nil
+	return changed, err
 }
 
 func (f *sendReceiveFolder) processNeeded(snap *db.Snapshot, dbUpdateChan chan<- dbUpdateJob, copyChan chan<- copyBlocksState, scanChan chan<- string) (int, map[string]protocol.FileInfo, []protocol.FileInfo, error) {


### PR DESCRIPTION
The error at the end of `pullerIteration` isn't necessarily `nil`. The mistake isn't actually bad (i.e. no immediate release needed), because the only error that can occur there is a cancelled context, which will also be caught by the caller if the error is nil.