### PR TITLE
lib/fs: Check both old and new path when renaming (fixes #7426)

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -226,6 +226,9 @@ func (f *caseFilesystem) Rename(oldpath, newpath string) error {
 	if err := f.checkCase(oldpath); err != nil {
 		return err
 	}
+	if err := f.checkCase(newpath); err != nil {
+		return err
+	}
 	if err := f.Filesystem.Rename(oldpath, newpath); err != nil {
 		return err
 	}

--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -227,7 +227,11 @@ func (f *caseFilesystem) Rename(oldpath, newpath string) error {
 		return err
 	}
 	if err := f.checkCase(newpath); err != nil {
-		return err
+		// Case-only rename is ok
+		e := &ErrCaseConflict{}
+		if !errors.As(err, &e) || e.Real != oldpath {
+			return err
+		}
 	}
 	if err := f.Filesystem.Rename(oldpath, newpath); err != nil {
 		return err


### PR DESCRIPTION
I can't think of any reason why we shouldn't test both the source and target path for case-conflicts, so I assume that was an oversight. It's not problematic in our usage, because in the puller we always check both source and target files against db (i.e. stat them) before renaming, but it still seems like the right/save thing to do.