### PR TITLE
lib/protocol: Set invalid flag on encrypted file infos (fixes #7466)

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -314,6 +314,7 @@ func encryptFileInfo(fi FileInfo, folderKey *[keySize]byte) FileInfo {
 		Permissions:  0644,
 		ModifiedS:    1234567890, // Sat Feb 14 00:31:30 CET 2009
 		Deleted:      fi.Deleted,
+		RawInvalid:   fi.IsInvalid(),
 		Version:      version,
 		Sequence:     fi.Sequence,
 		RawBlockSize: fi.RawBlockSize + blockOverhead,

--- a/lib/protocol/encryption_test.go
+++ b/lib/protocol/encryption_test.go
@@ -113,9 +113,8 @@ func TestEnDecryptBytes(t *testing.T) {
 	}
 }
 
-func TestEnDecryptFileInfo(t *testing.T) {
-	var key [32]byte
-	fi := FileInfo{
+func encFileInfo() FileInfo {
+	return FileInfo{
 		Name:        "hello",
 		Size:        45,
 		Permissions: 0755,
@@ -133,6 +132,11 @@ func TestEnDecryptFileInfo(t *testing.T) {
 			},
 		},
 	}
+}
+
+func TestEnDecryptFileInfo(t *testing.T) {
+	var key [32]byte
+	fi := encFileInfo()
 
 	enc := encryptFileInfo(fi, &key)
 	if bytes.Equal(enc.Blocks[0].Hash, enc.Blocks[1].Hash) {
@@ -152,6 +156,21 @@ func TestEnDecryptFileInfo(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fi, dec) {
 		t.Error("mismatch after decryption")
+	}
+}
+
+func TestEncryptedFileInfoConsistency(t *testing.T) {
+	var key [32]byte
+	files := []FileInfo{
+		encFileInfo(),
+		encFileInfo(),
+	}
+	files[1].SetIgnored()
+	for i, f := range files {
+		enc := encryptFileInfo(f, &key)
+		if err := checkFileInfoConsistency(enc); err != nil {
+			t.Errorf("%v: %v", i, err)
+		}
 	}
 }
 


### PR DESCRIPTION
Without the invalid bit the untrusted device will complain that it gets a valid file without blocks.

Considering information available to the untrusted party: I consider it as a meta flag like `Deleted` that's necessary for syncing, thus ok to share.

I added a small unit test.