### PR TITLE
gui: Use grey background for disabled options in form-control

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -437,3 +437,9 @@ ul.three-columns li, ul.two-columns li {
 .form-horizontal {
     margin-bottom: 10px;
 }
+
+/* Use the same style as Bootstrap uses for disabled <select>. */
+.form-control option[disabled] {
+    background-color: #eeeeee;
+    opacity: 1;
+}


### PR DESCRIPTION
Disabled options are currently barely distinguishable from enabled
ones. This changes their background to grey, following the Bootstrap
defaults already used for disabled \<select\>.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

Before:
![1](https://user-images.githubusercontent.com/5626656/111035244-d5937300-845c-11eb-8e36-0c70b0efa6f5.png)

After:
![2](https://user-images.githubusercontent.com/5626656/111035246-d75d3680-845c-11eb-8549-ffde0deedb29.png)
