### PR TITLE
lib/protocol: Improve messages when an error occurs receiving (ref #7466)

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -1058,29 +1058,12 @@ func (c *rawConnection) lz4Decompress(src []byte) ([]byte, error) {
 	return decoded, nil
 }
 
-type unwrapError interface {
-	error
-	Unwrap() error
+func newProtocolError(err error, msgContext string) error {
+	return fmt.Errorf("protocol error on %v: %w", msgContext, err)
 }
 
-type ProtocolError struct {
-	unwrapError
-}
-
-func newProtocolError(err error, msgContext string) *ProtocolError {
-	return &ProtocolError{
-		unwrapError: fmt.Errorf("protocol error on %v: %w", msgContext, err).(unwrapError),
-	}
-}
-
-type HandleError struct {
-	unwrapError
-}
-
-func newHandleError(err error, msgContext string) *HandleError {
-	return &HandleError{
-		unwrapError: fmt.Errorf("handling %v: %w", msgContext, err).(unwrapError),
-	}
+func newHandleError(err error, msgContext string) error {
+	return fmt.Errorf("handling %v: %w", msgContext, err)
 }
 
 func messageContext(msg message) (string, error) {


### PR DESCRIPTION
The error messages have no info on which folders are affected, see e.g. #7466 

>  [J47TR] 13:37:50 INFO: Connection to BWYS6XV-XXXXXXXXXXXXXXXXXXXXXXX-RP6EJAB at 141.xxx.xxx.xxx:22000-xxx.xxx.xxx.xxx:5068/tcp-client/TLS1.3-TLS_CHACHA20_POLY1305_SHA256 closed: protocol error: index update: "9.syncthing-enc/45/F31BH51JPLO2N7T7MJ03AQ56Q0IIM1CTNE9A38NRNAOIU19NB5LGKF093B6M6D4U6SP5LKTN5NFA9GHN1PK4SK8LFD0K1R9R9S0CQKQQ86T1D7P1HG415P20JD299GNPTJPD54QSP0DKMF9T9D4SRO116INLTOC7DMIKUN1F6AED4D2P27NG": file with empty block list

And they aren't consistent in whether they include "receiving" and "message". I always added the former (the same method names exist for sending) and removed the latter.