### PR TITLE
lib/db, lib/model: Allow needing invalid files (fixes #7474)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -846,6 +846,10 @@ func (db *Lowlevel) getMetaAndCheck(folder string) (*metadataTracker, error) {
 	db.gcMut.RLock()
 	defer db.gcMut.RUnlock()
 
+	return db.getMetaAndCheckGCLocked(folder)
+}
+
+func (db *Lowlevel) getMetaAndCheckGCLocked(folder string) (*metadataTracker, error) {
 	fixed, err := db.checkLocalNeed([]byte(folder))
 	if err != nil {
 		return nil, fmt.Errorf("checking local need: %w", err)

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -21,7 +21,7 @@ import (
 // do not put restrictions on downgrades (e.g. for repairs after a bugfix).
 const (
 	dbVersion             = 14
-	dbMigrationVersion    = 15
+	dbMigrationVersion    = 16
 	dbMinSyncthingVersion = "v1.9.0"
 )
 
@@ -104,6 +104,7 @@ func (db *schemaUpdater) updateSchema() error {
 		{13, 13, "v1.7.0", db.updateSchemaTo13},
 		{14, 14, "v1.9.0", db.updateSchemaTo14},
 		{14, 15, "v1.9.0", db.migration15},
+		{14, 16, "v1.9.0", db.checkRepairMigration},
 	}
 
 	for _, m := range migrations {
@@ -776,6 +777,16 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 func (db *schemaUpdater) migration15(_ int) error {
 	for _, folder := range db.ListFolders() {
 		if _, err := db.recalcMeta(folder); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *schemaUpdater) checkRepairMigration(_ int) error {
+	for _, folder := range db.ListFolders() {
+		_, err := db.getMetaAndCheckGCLocked(folder)
+		if err != nil {
 			return err
 		}
 	}

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -469,9 +469,10 @@ func TestNeedWithInvalid(t *testing.T) {
 	}
 
 	expectedNeed := fileList{
-		protocol.FileInfo{Name: "b", Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1001}}}, Blocks: genBlocks(2)},
-		protocol.FileInfo{Name: "c", Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1002}}}, Blocks: genBlocks(7)},
-		protocol.FileInfo{Name: "d", Version: protocol.Vector{Counters: []protocol.Counter{{ID: myID, Value: 1003}}}, Blocks: genBlocks(7)},
+		remote0Have[0],
+		remote1Have[0],
+		remote0Have[2],
+		remote1Have[2],
 	}
 
 	replace(s, protocol.LocalDeviceID, localHave)

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -762,10 +762,8 @@ func (t readWriteTransaction) updateLocalNeed(keyBuf, folder, name []byte, add b
 }
 
 func Need(global FileVersion, haveLocal bool, localVersion protocol.Vector) bool {
-	// We never need an invalid file or a file without a valid version (just
-	// another way of expressing "invalid", really, until we fix that
-	// part...).
-	if global.IsInvalid() || global.Version.IsEmpty() {
+	// We never need a file without a valid version.
+	if global.Version.IsEmpty() {
 		return false
 	}
 	// We don't need a deleted file if we don't have it.

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -357,6 +357,11 @@ func (f *sendReceiveFolder) processNeeded(snap *db.Snapshot, dbUpdateChan chan<-
 				changed--
 			}
 
+		case file.IsInvalid():
+			// Global invalid file just exists for need accounting
+			l.Debugln(f, "Handling global invalid item", file)
+			dbUpdateChan <- dbUpdateJob{file, dbUpdateInvalidate}
+
 		case file.IsDeleted():
 			if file.IsDirectory() {
 				// Perform directory deletions at the end, as we may have

--- a/lib/model/indexsender.go
+++ b/lib/model/indexsender.go
@@ -178,18 +178,7 @@ func (s *indexSender) sendIndexTo(ctx context.Context) error {
 			return true
 		}
 
-		// Mark the file as invalid if any of the local bad stuff flags are set.
-		f.RawInvalid = f.IsInvalid()
-		// If the file is marked LocalReceive (i.e., changed locally on a
-		// receive only folder) we do not want it to ever become the
-		// globally best version, invalid or not.
-		if f.IsReceiveOnlyChanged() {
-			f.Version = protocol.Vector{}
-		}
-
-		// never sent externally
-		f.LocalFlags = 0
-		f.VersionHash = nil
+		f = prepareFileInfoForIndex(f)
 
 		previousWasDelete = f.IsDeleted()
 
@@ -209,6 +198,21 @@ func (s *indexSender) sendIndexTo(ctx context.Context) error {
 
 	s.prevSequence = f.Sequence
 	return err
+}
+
+func prepareFileInfoForIndex(f protocol.FileInfo) protocol.FileInfo {
+	// Mark the file as invalid if any of the local bad stuff flags are set.
+	f.RawInvalid = f.IsInvalid()
+	// If the file is marked LocalReceive (i.e., changed locally on a
+	// receive only folder) we do not want it to ever become the
+	// globally best version, invalid or not.
+	if f.IsReceiveOnlyChanged() {
+		f.Version = protocol.Vector{}
+	}
+	// never sent externally
+	f.LocalFlags = 0
+	f.VersionHash = nil
+	return f
 }
 
 func (s *indexSender) String() string {


### PR DESCRIPTION
### Purpose

Scenario (https://github.com/syncthing/syncthing/issues/7474#issuecomment-798881296):

> The reason is that we have an "efficiency" measure: We do not pull items that are not present at all locally and globally invalid or deleted. B sees valid items from A, thus their global is valid. C only sees invalid items from B, thus their global is invalid and they don't pull. B doesn't know about C's global, thus shows C as out of sync. The fix here is to always pull invalid files ("pull" as in create a local invalid entry too).

I adjusted `Need` to consider invalid files needed, and added a shortcut to the puller to send invalid files directly to the db. If at some point we do create a local file, that "trumps" the invalid file as usual (bumps the version of the invalid file, uninvalidates it, ...).

I also added a db migration to trigger a repair, otherwise the changes don't take effect.

### Testing

Unit test checking that we do pull and send back an invalid file info.  
Needed to add some machinery to the fake connection to correctly send invalid files.