### PR TITLE
removed serve command from systemd sample configuration (fixes #7363)

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 User=%i
-ExecStart=/usr/bin/syncthing serve --no-browser --no-restart --logflags=0
+ExecStart=/usr/bin/syncthing --no-browser --no-restart --logflags=0
 Restart=on-failure
 RestartSec=1
 StartLimitIntervalSec=60

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -3,7 +3,7 @@ Description=Syncthing - Open Source Continuous File Synchronization
 Documentation=man:syncthing(1)
 
 [Service]
-ExecStart=/usr/bin/syncthing serve --no-browser --no-restart --logflags=0
+ExecStart=/usr/bin/syncthing --no-browser --no-restart --logflags=0
 Restart=on-failure
 RestartSec=1
 StartLimitIntervalSec=60


### PR DESCRIPTION
### Purpose

Docs presented [here](https://docs.syncthing.net/users/autostart.html#linux) states that in order to create systemd service, one should copy proper file from git from `Syncthing/etc/linux-systemd` directory and start it with `systemctl`. However, configuration in this files run `/usr/bin/syncthing serve --no-browser --no-restart --logflags=0` and it seems that `serve` command is no longer accepted. 

### Testing

I have successfully run service without `serve` (the same did creator of #7363).

### Documentation

I guess no docs need to be updated. I can't  `serve` option anywhere in docs.

