### PR TITLE
cmd/syncthing: Fix help for cli subcommands

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -249,8 +249,10 @@ func main() {
 
 func helpHandler(options kong.HelpOptions, ctx *kong.Context) error {
 	// If we're looking for CLI help, pass the arguments down to the CLI library to print it's own help.
-	if ctx.Command() == "cli" {
-		return ctx.Run()
+	for node := ctx.Selected(); node != nil; node = node.Parent {
+		if node.Name == "cli" {
+			return ctx.Run()
+		}
 	}
 	if err := kong.DefaultHelpPrinter(options, ctx); err != nil {
 		return err


### PR DESCRIPTION
Fixes part one of the issues brought up in #7454: Help for `cli` subcommands doesn't work.

I used a slightly modified fix of what @AudriusButkevicius proposed in https://github.com/syncthing/syncthing/pull/7454#issuecomment-796943025:

> Changing that line I was referring to (https://github.com/syncthing/syncthing/blob/main/cmd/syncthing/main.go#L252), to read:
> 
> ```
> 	if ctx.Command() == "cli" || ctx.Command() == "cli <args>" {
> 		return ctx.Run()
> 	}
> ```
> 
> Fixes the `syncthing cli subcommand --help` not working.

I didn't see any reference to `<args>` in the kong docs. Instead I am now iterating over all parent `*Node` to look for the `cli` command.