### PR TITLE
cmd/syncthing/cli: Remove db reset and adjust others

### DIFF
--- a/cmd/syncthing/cli/operations.go
+++ b/cmd/syncthing/cli/operations.go
@@ -28,18 +28,13 @@ var operationCommand = cli.Command{
 			Action: expects(0, emptyPost("system/shutdown")),
 		},
 		{
-			Name:   "reset",
-			Usage:  "Reset syncthing deleting all folders and devices",
-			Action: expects(0, emptyPost("system/reset")),
-		},
-		{
 			Name:   "upgrade",
 			Usage:  "Upgrade syncthing (if a newer version is available)",
 			Action: expects(0, emptyPost("system/upgrade")),
 		},
 		{
 			Name:      "folder-override",
-			Usage:     "Override changes on folder (remote for sendonly, local for receiveonly)",
+			Usage:     "Override changes on folder (remote for sendonly, local for receiveonly). WARNING: Destructive - deletes/changes your data.",
 			ArgsUsage: "[folder id]",
 			Action:    expects(1, foldersOverride),
 		},

--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -23,7 +23,7 @@ var showCommand = cli.Command{
 		{
 			Name:   "config-status",
 			Usage:  "Show configuration status, whether or not a restart is required for changes to take effect",
-			Action: expects(0, dumpOutput("system/config/insync")),
+			Action: expects(0, dumpOutput("config/restart-required")),
 		},
 		{
 			Name:   "system",


### PR DESCRIPTION
Split off from: https://github.com/syncthing/syncthing/pull/7454

> I removed the db reset operation: I don't think that should be so easily available. I also added a warning to the override operation.

And use the new/non-legacy endpoint to check if a restart is required due to config changes.