### PR TITLE
lib/*/auto: Add noassets files

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,3 +8,4 @@ enabled = true
 
   [analyzers.meta]
   import_paths = ["github.com/syncthing/syncthing"]
+  build_tags = ["noassets"]

--- a/cmd/strelaypoolsrv/auto/noassets.go
+++ b/cmd/strelaypoolsrv/auto/noassets.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//+build noassets
+
+package auto
+
+import "github.com/syncthing/syncthing/lib/assets"
+
+func Assets() map[string]assets.Asset {
+	return nil
+}

--- a/lib/api/auto/noassets.go
+++ b/lib/api/auto/noassets.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//+build noassets
+
+package auto
+
+import (
+	"bytes"
+	"compress/gzip"
+
+	"github.com/syncthing/syncthing/lib/assets"
+)
+
+func Assets() map[string]assets.Asset {
+	// Return a minimal index.html and nothing else, to allow the trivial
+	// test to pass.
+
+	buf := new(bytes.Buffer)
+	gw := gzip.NewWriter(buf)
+	_, _ = gw.Write([]byte("<html></html>"))
+	_ = gw.Flush()
+	return map[string]assets.Asset{
+		"default/index.html": {
+			Gzipped: true,
+			Content: buf.String(),
+		},
+	}
+}


### PR DESCRIPTION
This adds a couple of dummy asset files protected by the "noassets"
build tag. The purpose is that it should be possible for, for example,
CI tools and static analysis things to compile and analyze the source
tree without our custom asset generation step. Also makes `go test -tags
noassets ./...` work without building assets first.
