### PR TITLE
all: Remove crypto/md5

### DIFF
--- a/lib/fs/tempname.go
+++ b/lib/fs/tempname.go
@@ -7,11 +7,12 @@
 package fs
 
 import (
-	"crypto/md5"
 	"fmt"
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	"github.com/syncthing/syncthing/lib/sha256"
 )
 
 const (
@@ -50,9 +51,7 @@ func TempNameWithPrefix(name, prefix string) string {
 	tdir := filepath.Dir(name)
 	tbase := filepath.Base(name)
 	if len(tbase) > maxFilenameLength {
-		hash := md5.New()
-		hash.Write([]byte(name))
-		tbase = fmt.Sprintf("%x", hash.Sum(nil))
+		tbase = fmt.Sprintf("%x", sha256.Sum256([]byte(name)))
 	}
 	tname := fmt.Sprintf("%s%s.tmp", prefix, tbase)
 	return filepath.Join(tdir, tname)

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -9,7 +9,6 @@ package ignore
 import (
 	"bufio"
 	"bytes"
-	"crypto/md5"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +21,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/osutil"
+	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/sync"
 )
 
@@ -373,7 +373,7 @@ func (m *Matcher) SkipIgnoredDirs() bool {
 }
 
 func hashPatterns(patterns []Pattern) string {
-	h := md5.New()
+	h := sha256.New()
 	for _, pat := range patterns {
 		h.Write([]byte(pat.String()))
 		h.Write([]byte("\n"))

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -607,8 +607,9 @@ func TestHashOfEmpty(t *testing.T) {
 	firstHash := p1.Hash()
 
 	// Reloading with a non-existent file should empty the patterns and
-	// recalculate the hash. d41d8cd98f00b204e9800998ecf8427e is the md5 of
-	// nothing.
+	// recalculate the hash.
+	// e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855 is
+	// the sah256 of nothing.
 
 	p1.Load("file/does/not/exist")
 	secondHash := p1.Hash()
@@ -616,7 +617,7 @@ func TestHashOfEmpty(t *testing.T) {
 	if firstHash == secondHash {
 		t.Error("hash did not change")
 	}
-	if secondHash != "d41d8cd98f00b204e9800998ecf8427e" {
+	if secondHash != "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" {
 		t.Error("second hash is not hash of empty string")
 	}
 	if len(p1.patterns) != 0 {

--- a/test/util.go
+++ b/test/util.go
@@ -9,7 +9,6 @@
 package integration
 
 import (
-	"crypto/md5"
 	cr "crypto/rand"
 	"errors"
 	"fmt"
@@ -27,6 +26,7 @@ import (
 	"unicode"
 
 	"github.com/syncthing/syncthing/lib/rc"
+	"github.com/syncthing/syncthing/lib/sha256"
 )
 
 func init() {
@@ -395,7 +395,7 @@ type fileInfo struct {
 	name string
 	mode os.FileMode
 	mod  int64
-	hash [16]byte
+	hash [sha256.Size]byte
 	size int64
 }
 
@@ -442,11 +442,7 @@ func startWalker(dir string, res chan<- fileInfo, abort <-chan struct{}) chan er
 			if err != nil {
 				return err
 			}
-			h := md5.New()
-			h.Write([]byte(tgt))
-			hash := h.Sum(nil)
-
-			copy(f.hash[:], hash)
+			f.hash = sha256.Sum256([]byte(tgt))
 		} else if info.IsDir() {
 			f = fileInfo{
 				name: rn,
@@ -463,7 +459,7 @@ func startWalker(dir string, res chan<- fileInfo, abort <-chan struct{}) chan er
 				mod:  info.ModTime().Unix(),
 				size: info.Size(),
 			}
-			sum, err := md5file(path)
+			sum, err := sha256file(path)
 			if err != nil {
 				return err
 			}
@@ -490,14 +486,14 @@ func startWalker(dir string, res chan<- fileInfo, abort <-chan struct{}) chan er
 	return errc
 }
 
-func md5file(fname string) (hash [16]byte, err error) {
+func sha256file(fname string) (hash [sha256.Size]byte, err error) {
 	f, err := os.Open(fname)
 	if err != nil {
 		return
 	}
 	defer f.Close()
 
-	h := md5.New()
+	h := sha256.New()
 	io.Copy(h, f)
 	hb := h.Sum(nil)
 	copy(hash[:], hb)


### PR DESCRIPTION
This is a mostly pointless change to make security scanners and static
analysis tools happy, as they all hate seeing md5. None of our md5 uses
were security relevant, but still. Only visible effect of this change is
that our temp file names for very long file names become slightly longer
than they were previously...
