### PR TITLE
all: Encrypted fileinfo trailer needs to be in wire format

### DIFF
--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -352,8 +352,8 @@ func (s *sharedPullerState) finalizeEncrypted() error {
 	wireFile := s.file
 	wireFile.Name = osutil.NormalizedFilename(wireFile.Name)
 
-	bs := make([]byte, encryptionTrailerSize(s.file))
-	n, err := s.file.MarshalTo(bs)
+	bs := make([]byte, encryptionTrailerSize(wireFile))
+	n, err := wireFile.MarshalTo(bs)
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func (s *sharedPullerState) finalizeEncrypted() error {
 			return err
 		}
 	}
-	if _, err := s.writer.WriteAt(bs, s.file.Size); err != nil {
+	if _, err := s.writer.WriteAt(bs, wireFile.Size); err != nil {
 		return err
 	}
 

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
 )
@@ -346,6 +347,11 @@ func (s *sharedPullerState) finalClose() (bool, error) {
 // folder from encrypted data we can extract this FileInfo from the end of
 // the file and regain the original metadata.
 func (s *sharedPullerState) finalizeEncrypted() error {
+	// Here the file is in native format, while encryption happens in
+	// wire format (always slashes).
+	wireFile := s.file
+	wireFile.Name = osutil.NormalizedFilename(wireFile.Name)
+
 	bs := make([]byte, encryptionTrailerSize(s.file))
 	n, err := s.file.MarshalTo(bs)
 	if err != nil {


### PR DESCRIPTION
This issue came up in https://forum.syncthing.net/t/how-to-restore-decrypt-an-encrypted-untrusted-folder/16520/11

If the untrusted devices is running windows, the `decrypt` tool errors on decrypting metadata. Because we wrote that metadata in native format, while the protocol code expects wire format (slashes).