### PR TITLE
lib/osutil: Fix raising max FDs on macOS

### DIFF
--- a/lib/osutil/rlimit_unix.go
+++ b/lib/osutil/rlimit_unix.go
@@ -36,7 +36,7 @@ func MaximizeOpenFileLimit() (int, error) {
 	// macOS doesn't like a soft limit greater then OPEN_MAX
 	// See also: man setrlimit
 	if runtime.GOOS == "darwin" && lim.Max > darwinOpenMax {
-		lim.Cur = darwinOpenMax
+		lim.Max = darwinOpenMax
 	}
 
 	// Try to increase the limit to the max.


### PR DESCRIPTION
There was a logic mistake, so the limit in question wasn't used. On my
macOS this doesn't seem to matter, the hard limit returned is 2^63-1 and
setting the soft limit to that works. However I presume that's not
the case for older macOSes since it was so nicely documented, so we
should still have this working. (10240 FDs should be enough for
anybody.)
