### PR TITLE
lib/model: fix dropped test error

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -4185,6 +4185,9 @@ func TestPendingFolder(t *testing.T) {
 	}
 
 	device3, err := protocol.DeviceIDFromString("AIBAEAQ-CAIBAEC-AQCAIBA-EAQCAIA-BAEAQCA-IBAEAQC-CAIBAEA-QCAIBA7")
+	if err != nil {
+		t.Fatal(err)
+	}
 	setDevice(t, w, config.DeviceConfiguration{DeviceID: device3})
 	if err := m.db.AddOrUpdatePendingFolder(pfolder, pfolder, device3, false); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
### Purpose

This fixes a dropped error variable in the `lib/model` tests.

### Testing

I verified that unit tests still passed.


