### PR TITLE
lib/ur: Prevent panic when blocksResult is nil (ref #7495)

### DIFF
--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -426,12 +426,12 @@ func CpuBench(ctx context.Context, iterations int, duration time.Duration, useWe
 			perf = v
 		}
 	}
-	if blocksResult == nil {
-		// not looking at the blocksResult makes it unused from a static
-		// analysis / compiler standpoint...
-		panic("blocksResult should have been set by benchmark loop")
+	// not looking at the blocksResult makes it unused from a static
+	// analysis / compiler standpoint...
+	// blocksResult may be nil at this point if the context is cancelled
+	if blocksResult != nil {
+		blocksResult = nil
 	}
-	blocksResult = nil
 	return perf
 }
 


### PR DESCRIPTION
`blocksResult` can be `nil` at this point, e.g. due to already canceled context:

https://sentry.syncthing.net/share/issue/dea5883d4a654749a818d19ccbdf3448/

I assume the if check around setting it to nil will also satisfy the static analysis.