### PR TITLE
lib/model: Reset conn when enc token is missing (fixes #7198)

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -428,7 +428,8 @@ func TestClusterConfig(t *testing.T) {
 	m.ServeBackground()
 	defer cleanupModel(m)
 
-	cm, _ := m.generateClusterConfig(device2)
+	cm, _, err := m.generateClusterConfig(device2)
+	must(t, err)
 
 	if l := len(cm.Folders); l != 2 {
 		t.Fatalf("Incorrect number of folders %d != 2", l)
@@ -853,7 +854,8 @@ func TestIssue4897(t *testing.T) {
 	defer cleanupModel(m)
 	cancel()
 
-	cm, _ := m.generateClusterConfig(device1)
+	cm, _, err := m.generateClusterConfig(device1)
+	must(t, err)
 	if l := len(cm.Folders); l != 1 {
 		t.Errorf("Cluster config contains %v folders, expected 1", l)
 	}
@@ -4142,7 +4144,8 @@ func TestCCFolderNotRunning(t *testing.T) {
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	// A connection can happen before all the folders are started.
-	cc, _ := m.generateClusterConfig(device1)
+	cc, _, err := m.generateClusterConfig(device1)
+	must(t, err)
 	if l := len(cc.Folders); l != 1 {
 		t.Fatalf("Expected 1 folder in CC, got %v", l)
 	}


### PR DESCRIPTION
When a receive-only folder is added, we don't have the folder token yet. However that is required to ensure a correct (consistent when there's more than 1 device) password. Thus we need to drop and reestablish the connection to ensure the remote sends the cluster-config with the token.