### PR TITLE
lib/db: Handle indirection error repairing sequences (fixes #7026)

### DIFF
--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -516,7 +516,7 @@ func TestCheckGlobals(t *testing.T) {
 	}
 
 	// Clean up global entry of the now missing file
-	if repaired, err := db.checkGlobals([]byte(fs.folder)); err != nil {
+	if repaired, err := db.checkGlobals(fs.folder); err != nil {
 		t.Fatal(err)
 	} else if repaired != 1 {
 		t.Error("Expected 1 repaired global item, got", repaired)

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -1040,6 +1040,15 @@ func (db *Lowlevel) repairSequenceGCLocked(folderStr string, meta *metadataTrack
 				if err != nil {
 					return 0, err
 				}
+				name := []byte(intf.FileName())
+				gk, err := t.keyer.GenerateGlobalVersionKey(nil, folder, name)
+				if err != nil {
+					return 0, err
+				}
+				_, err = t.removeFromGlobal(gk, nil, folder, protocol.LocalDeviceID[:], name, nil)
+				if err != nil {
+					return 0, err
+				}
 				sk, err = db.keyer.GenerateSequenceKey(sk, folder, intf.SequenceNo())
 				if err != nil {
 					return 0, err

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -100,7 +100,6 @@ func (db *schemaUpdater) updateSchema() error {
 		{11, 11, "v1.6.0", db.updateSchemaTo11},
 		{13, 13, "v1.7.0", db.updateSchemaTo13},
 		{14, 14, "v1.9.0", db.updateSchemaTo14},
-		{14, 15, "v1.9.0", db.migration15},
 		{14, 16, "v1.9.0", db.checkRepairMigration},
 	}
 
@@ -771,15 +770,6 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 		t.close()
 	}
 
-	return nil
-}
-
-func (db *schemaUpdater) migration15(_ int) error {
-	for _, folder := range db.ListFolders() {
-		if _, err := db.recalcMeta(folder); err != nil {
-			return err
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
#7026 is about unspecific `key not found` errors on sentry. The only one that still gets events is https://sentry.syncthing.net/share/issue/270bbc681e3943f7a121268553e6f2e5/, and that's what I am addressing here:

`panic: repairing sequences: filling Blocks: key not found`

When repairing sequences all local files are deserialized, and apparently sometimes the blocks are indirected (or look like it), but theirs no entry for the hash. Instead of failing db repair and thus making the db entirely broken, the defective file info is now removed from the db - to be rescanned later.

Some related changes: I moved checking/repairing globals out of `recalcMeta` into `getMetaAndCheck`. Having that happen as a side effect of recalculating metadata is plain confusing (and I probably wrote that code :) ).  
And the db migration 15 (which uses `recalcMeta`), is redundant with 16 (the meta just gets recalculated twice) - thus removed.