### PR TITLE
etc: Fix start-limit parameters location in systemd units (ref #7439)

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -2,14 +2,14 @@
 Description=Syncthing - Open Source Continuous File Synchronization for %I
 Documentation=man:syncthing(1)
 After=network.target
+StartLimitIntervalSec=60
+StartLimitBurst=4
 
 [Service]
 User=%i
 ExecStart=/usr/bin/syncthing serve --no-browser --no-restart --logflags=0
 Restart=on-failure
 RestartSec=1
-StartLimitIntervalSec=60
-StartLimitBurst=4
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -1,13 +1,13 @@
 [Unit]
 Description=Syncthing - Open Source Continuous File Synchronization
 Documentation=man:syncthing(1)
+StartLimitIntervalSec=60
+StartLimitBurst=4
 
 [Service]
 ExecStart=/usr/bin/syncthing serve --no-browser --no-restart --logflags=0
 Restart=on-failure
 RestartSec=1
-StartLimitIntervalSec=60
-StartLimitBurst=4
 SuccessExitStatus=3 4
 RestartForceExitStatus=3 4
 


### PR DESCRIPTION
### Purpose

https://github.com/syncthing/syncthing/commit/587c89d9798df451d1dced957196d9491a442e2f introduced a systemd unit based restart burst limit, but the directives have been added to the wrong section. StartLimitIntervalSec and StartLimitBurst need to be located in the `[Unit]` section of the systemd unit to be effective: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#StartLimitIntervalSec=interval

### Testing

To be true, I didn't test it, but the fact is trivial and well documented in the systemd documentation (see above), and it is a pretty common mistake as it's not intuitive with other restart-related directives being located in the `[Service]` section. Also it has changed with systemd v230, `StartLimitInterval` being renamed to `StartLimitIntervalSec` and both moved from `[Service]` to `[Unit]`.

## Authorship

Signed-off-by: MichaIng <micha@dietpi.com>