### PR TITLE
lib/db: Don't panic debugging an inexistent file

### DIFF
--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -312,7 +312,7 @@ func (s *Snapshot) DebugGlobalVersions(file string) VersionList {
 	opStr := fmt.Sprintf("%s DebugGlobalVersions(%v)", s.folder, file)
 	l.Debugf(opStr)
 	vl, err := s.t.getGlobalVersions(nil, []byte(s.folder), []byte(osutil.NormalizedFilename(file)))
-	if backend.IsClosed(err) {
+	if backend.IsClosed(err) || backend.IsNotFound(err) {
 		return VersionList{}
 	} else if err != nil {
 		s.fatalError(err, opStr)


### PR DESCRIPTION
Less bad, because it can only be triggered using `/rest/debug/file` and no-one uses that (except if I tell them to :| ).