### PR TITLE
lib/db: Fix comparison of pending folder timestamps (fixes #7532)

### DIFF
--- a/lib/db/observed.go
+++ b/lib/db/observed.go
@@ -124,7 +124,7 @@ func (db *Lowlevel) RemovePendingFoldersBeforeTime(device protocol.DeviceID, old
 		return nil, err
 	}
 	defer iter.Release()
-	oldest = oldest.Round(time.Second)
+	oldest = oldest.Truncate(time.Second)
 	var res []string
 	for iter.Next() {
 		var of ObservedFolder


### PR DESCRIPTION
Regression introduced in #7459, this one instance of Round() was overlooked and not changed to Truncate().