### PR TITLE
docker: Raise UDP buffer size in example

### DIFF
--- a/README-Docker.md
+++ b/README-Docker.md
@@ -13,7 +13,8 @@ altered with the ``PUID`` and ``PGID`` environment variables.
 
 ```
 $ docker pull syncthing/syncthing
-$ docker run -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp \
+$ docker run --sysctl net.core.rmem_max=2097152 \
+    -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp \
     -v /wherever/st-sync:/var/syncthing \
     syncthing/syncthing:latest
 ```


### PR DESCRIPTION
### Purpose

Raises the UDP buffer size limit similar to #7417 for docker deployments if the host network isn't used.

### Testing

I did not test it but it is explicitly stated in the docker documentation:

https://docs.docker.com/engine/reference/commandline/run/#configure-namespaced-kernel-parameters-sysctls-at-runtime
