### PR TITLE
lib/protocol: Deterministic encrypted version (fixes #7533)

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -15,7 +15,6 @@ import (
 	"io"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/miscreant/miscreant.go"
@@ -254,20 +253,25 @@ func encryptFileInfo(fi FileInfo, folderKey *[keySize]byte) FileInfo {
 	encryptedFI := encryptBytes(bs, fileKey)
 
 	// The vector is set to something that is higher than any other version sent
-	// previously, assuming people's clocks are correct. We do this because
+	// previously. We do this because
 	// there is no way for the insecure device on the other end to do proper
 	// conflict resolution, so they will simply accept and keep whatever is the
 	// latest version they see. The secure devices will decrypt the real
 	// FileInfo, see the real Version, and act appropriately regardless of what
 	// this fake version happens to be.
+	// The vector also needs to be deterministic/the same among all trusted
+	// devices with the same vector, such that the pulling/remote completion
+	// works correctly on the untrusted device(s).
 
 	version := Vector{
 		Counters: []Counter{
 			{
-				ID:    1,
-				Value: uint64(time.Now().UnixNano()),
+				ID: 1,
 			},
 		},
+	}
+	for _, counter := range fi.Version.Counters {
+		version.Counters[0].Value += counter.Value
 	}
 
 	// Construct the fake block list. Each block will be blockOverhead bytes


### PR DESCRIPTION
Set the encrypted version counter to the sum of all real counters, instead of using `time.Now()`. Thus all trusted device agree on the version and sending an index for an already existing file-version to an untrusted device doesn't change their version, which did confuse their remote completion.