### PR TITLE
lib/api: Log the remote address on login attempts.

### DIFF
--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -29,10 +29,11 @@ var (
 	sessionsMut = sync.NewMutex()
 )
 
-func emitLoginAttempt(success bool, username string, evLogger events.Logger) {
+func emitLoginAttempt(success bool, username, address string, evLogger events.Logger) {
 	evLogger.Log(events.LoginAttempt, map[string]interface{}{
 		"success":  success,
 		"username": username,
+		"remoteAddress": address,
 	})
 }
 
@@ -95,7 +96,7 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 		}
 
 		if !authOk {
-			emitLoginAttempt(false, username, evLogger)
+			emitLoginAttempt(false, username, r.RemoteAddr, evLogger)
 			error()
 			return
 		}
@@ -110,7 +111,7 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 			MaxAge: 0,
 		})
 
-		emitLoginAttempt(true, username, evLogger)
+		emitLoginAttempt(true, username, r.RemoteAddr, evLogger)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -31,8 +31,8 @@ var (
 
 func emitLoginAttempt(success bool, username, address string, evLogger events.Logger) {
 	evLogger.Log(events.LoginAttempt, map[string]interface{}{
-		"success":  success,
-		"username": username,
+		"success":       success,
+		"username":      username,
 		"remoteAddress": address,
 	})
 }


### PR DESCRIPTION
### Purpose

This enables usage of the audit log to e.g. automatically block remote addresses from connecting after repeated login failures, as requested [on the forum](https://forum.syncthing.net/t/can-the-syncthing-web-gui-report-authentication-errors/16642/11).

### Testing

Manual verification of the audit log contents when the API authorization is enabled.

### Documentation

**TODO**: No docs PR prepared yet, waiting on feedback whether this is the right approach or if there are any other security implications.