### PR TITLE
build: Do not use --deb-systemd with fpm (fixes #7548)

### DIFF
--- a/script/deb-post-inst.template
+++ b/script/deb-post-inst.template
@@ -4,7 +4,7 @@ command -v deb-systemd-invoke > /dev/null
 has_systemd=$?
 
 if [ $has_systemd -eq 0 ]; then
-    systemctl --daemon-reload
+    systemctl daemon-reload
 fi
 
 if [ $has_systemd -eq 0 ] && [ -n "$(systemctl list-units --plain --no-legend {{.Service}})" ]; then

--- a/script/deb-post-inst.template
+++ b/script/deb-post-inst.template
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+command -v deb-systemd-invoke > /dev/null
+has_systemd=$?
+
+if [ $has_systemd -eq 0 ]; then
+	deb-systemd-invoke --daemon-reload
+fi
+
+if [ $has_systemd -eq 0 ] && [ -n "$(systemctl list-units --plain --no-legend {{.Service}})" ]; then
+	deb-systemd-invoke try-restart "{{.Service}}"
+else
+	pkill -HUP -x {{.Command}}
+fi

--- a/script/deb-post-inst.template
+++ b/script/deb-post-inst.template
@@ -4,11 +4,11 @@ command -v deb-systemd-invoke > /dev/null
 has_systemd=$?
 
 if [ $has_systemd -eq 0 ]; then
-	deb-systemd-invoke --daemon-reload
+    systemctl --daemon-reload
 fi
 
 if [ $has_systemd -eq 0 ] && [ -n "$(systemctl list-units --plain --no-legend {{.Service}})" ]; then
-	deb-systemd-invoke try-restart "{{.Service}}"
+    deb-systemd-invoke try-restart "{{.Service}}"
 else
-	pkill -HUP -x {{.Command}}
+    pkill -HUP -x {{.Command}}
 fi

--- a/script/post-upgrade
+++ b/script/post-upgrade
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-if command -v deb-systemd-invoke > /dev/null; then
-	deb-systemd-invoke restart procps.service
-else
-	sysctl -q --system
-fi
-pkill -HUP -x syncthing || true


### PR DESCRIPTION
Reuses the bits from https://github.com/syncthing/syncthing/pull/7552 that aren't related to nfpm (which requires go1.16), to fix #7548. Fixing as in not using `--deb-systemd` that was broken upstream, and doesn't get any attention, but restarting services in a script of our own. This is also a behaviour change, as `--deb-systemd` enables the service on install. I personally like that change: I dislike programs that enable their daemons automatically (thought that seems to be standard practice).

No testing yet: I was too lazy to install ruby or build/download the docker - will test after CI built something.