### PR TITLE
lib/connections: Add SyscallConn() to quic conn (fixes #7551)

### DIFF
--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/lucas-clemente/quic-go"
@@ -223,7 +224,12 @@ type stunConnQUICWrapper struct {
 	underlying *net.UDPConn
 }
 
-// SetReadBuffer is required by QUIC.
+// SetReadBuffer is required by QUIC < v0.20.0
 func (s *stunConnQUICWrapper) SetReadBuffer(size int) error {
 	return s.underlying.SetReadBuffer(size)
+}
+
+// SyscallConn is required by QUIC
+func (s *stunConnQUICWrapper) SyscallConn() (syscall.RawConn, error) {
+	return s.underlying.SyscallConn()
 }


### PR DESCRIPTION
Fixes https://github.com/syncthing/syncthing/issues/7551

Probably another dependency triggered us building with the new quic, which apparently uses a new interface now. This change adds the method required for that to the stun wrapper conn. 