### PR TITLE
api: Log warnings on API authorization failures.

### DIFF
--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -35,6 +35,9 @@ func emitLoginAttempt(success bool, username, address string, evLogger events.Lo
 		"username":      username,
 		"remoteAddress": address,
 	})
+	if !success {
+		l.Infof("Wrong credentials supplied during API authorization from %s", address)
+	}
 }
 
 func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfiguration, ldapCfg config.LDAPConfiguration, next http.Handler, evLogger events.Logger) http.Handler {
@@ -97,7 +100,6 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 
 		if !authOk {
 			emitLoginAttempt(false, username, r.RemoteAddr, evLogger)
-			l.Infof("Wrong credentials supplied during API authorization from %s", r.RemoteAddr)
 			error()
 			return
 		}

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -97,7 +97,7 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 
 		if !authOk {
 			emitLoginAttempt(false, username, r.RemoteAddr, evLogger)
-			l.Infoln("Wrong credentials supplied during API authorization")
+			l.Infof("Wrong credentials supplied during API authorization from %s", r.RemoteAddr)
 			error()
 			return
 		}


### PR DESCRIPTION
This is intended as an enhancement for #7560, to make failed login attempts more easily visible even when the audit log is disabled.  Inspired by [this forum discussion](https://forum.syncthing.net/t/can-the-syncthing-web-gui-report-authentication-errors/16642).  The log level is kept to Info to avoid message panels in an already connected GUI.