### PR TITLE
lib/model: Don't remove non-empty .stfolder

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -475,8 +475,13 @@ func (m *model) removeFolder(cfg config.FolderConfiguration) {
 		}
 	}
 	if isPathUnique {
-		// Delete syncthing specific files
-		cfg.Filesystem().RemoveAll(config.DefaultMarkerName)
+		// Remove (if empty and removable) or move away (if non-empty or
+		// otherwise not removable) Syncthing-specific marker files.
+		fs := cfg.Filesystem()
+		if err := fs.Remove(config.DefaultMarkerName); err != nil {
+			moved := config.DefaultMarkerName + time.Now().Format(".removed-20060102-150405")
+			_ = fs.Rename(config.DefaultMarkerName, moved)
+		}
 	}
 
 	m.cleanupFolderLocked(cfg)


### PR DESCRIPTION
When a folder is removed we remove the marker. But there may be things
stored in it that have usefulness past the lifetime of the folder in
Syncthing, in particularly the folder ID marker for encrypted folders.

This changes the behavior to remove empty markers (or if the marker's a
file...) but otherwise rename it to `.stfolder.removed-$timestamp` so
that it's out of the way but the contents aren't lost.
