### PR TITLE
gui: Fix folder path validation (fixes #7379)

### DIFF
--- a/gui/default/syncthing/core/pathIsSubDirDirective.js
+++ b/gui/default/syncthing/core/pathIsSubDirDirective.js
@@ -3,7 +3,7 @@ angular.module('syncthing.core')
         return {
             require: 'ngModel',
             link: function (scope, elm, attrs, ctrl) {
-                ctrl.$parsers.unshift(function (viewValue) {
+                ctrl.$validators.folderPathErrors = function (viewValue) {
                     // This function checks whether ydir is a subdirectory of xdir,
                     // e.g. it would return true if xdir = "/home/a", ydir = "/home/a/b".
                     function isSubDir(xdir, ydir) {
@@ -25,6 +25,9 @@ angular.module('syncthing.core')
                     scope.folderPathErrors.otherID = "";
                     scope.folderPathErrors.otherLabel = "";
                     for (var folderID in scope.folders) {
+                        if (folderID === scope.currentFolder.id) {
+                            continue;
+                        }
                         if (isSubDir(scope.folders[folderID].path, viewValue)) {
                             scope.folderPathErrors.otherID = folderID;
                             scope.folderPathErrors.otherLabel = scope.folders[folderID].label;
@@ -39,8 +42,8 @@ angular.module('syncthing.core')
                             break;
                         }
                     }
-                    return viewValue;
-                });
+                    return true;
+                };
             }
         };
     });


### PR DESCRIPTION
Parses are only used when the input field is changed, thus not when we update the value from javascript. Change it to be a validator, which is used whenever the value changes.