### PR TITLE
gui: Unset current folder on modal close (fixes #7584)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1893,6 +1893,7 @@ angular.module('syncthing.core')
             }).one('hidden.bs.modal', function () {
                 $('.nav-tabs a[href="#folder-general"]').tab('show');
                 window.location.hash = "";
+                $scope.currentFolder = {};
             });
         };
 


### PR DESCRIPTION
We watch folder label to update the path if it hasn't been modified yet. However if the same folder is opened again, the folder label doesn't change and thus the watch isn't triggered. Now `$scope.currentFolder` is cleared when the modal is closed, thus the watch gets trigered.