### PR TITLE
cmd/syncthing: Don't fail early on api setup error (fixes 7558)

### DIFF
--- a/cmd/syncthing/cli/config.go
+++ b/cmd/syncthing/cli/config.go
@@ -46,13 +46,24 @@ func getConfigCommand(f *apiClientFactory) (cli.Command, error) {
 		HideHelp:    true,
 		Usage:       "Configuration modification command group",
 		Subcommands: commands,
+		Before:      h.configBefore,
 		After:       h.configAfter,
 	}, nil
 }
 
+func (h *configHandler) configBefore(c *cli.Context) error {
+	for _, arg := range c.Args() {
+		if arg == "--help" || arg == "-h" {
+			return nil
+		}
+	}
+	return h.err
+}
+
 func (h *configHandler) configAfter(c *cli.Context) error {
 	if h.err != nil {
-		return h.err
+		// Error was already returned in configBefore
+		return nil
 	}
 	if reflect.DeepEqual(h.cfg, h.original) {
 		return nil

--- a/cmd/syncthing/cli/config.go
+++ b/cmd/syncthing/cli/config.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/AudriusButkevicius/recli"
+	"github.com/pkg/errors"
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/urfave/cli"
+)
+
+type configHandler struct {
+	original, cfg config.Configuration
+	client        APIClient
+	err           error
+}
+
+func getConfigCommand(f *apiClientFactory) (cli.Command, error) {
+	h := new(configHandler)
+	h.client, h.err = f.getClient()
+	if h.err == nil {
+		h.cfg, h.err = getConfig(h.client)
+	}
+	h.original = h.cfg.Copy()
+
+	// Copy the config and set the default flags
+	recliCfg := recli.DefaultConfig
+	recliCfg.IDTag.Name = "xml"
+	recliCfg.SkipTag.Name = "json"
+
+	commands, err := recli.New(recliCfg).Construct(&h.cfg)
+	if err != nil {
+		return cli.Command{}, fmt.Errorf("config reflect: %w", err)
+	}
+
+	return cli.Command{
+		Name:        "config",
+		HideHelp:    true,
+		Usage:       "Configuration modification command group",
+		Subcommands: commands,
+		After:       h.configAfter,
+	}, nil
+}
+
+func (h *configHandler) configAfter(c *cli.Context) error {
+	if h.err != nil {
+		return h.err
+	}
+	if reflect.DeepEqual(h.cfg, h.original) {
+		return nil
+	}
+	body, err := json.MarshalIndent(h.cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	resp, err := h.client.Post("system/config", string(body))
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != 200 {
+		body, err := responseToBArray(resp)
+		if err != nil {
+			return err
+		}
+		return errors.New(string(body))
+	}
+	return nil
+}

--- a/cmd/syncthing/cli/errors.go
+++ b/cmd/syncthing/cli/errors.go
@@ -39,7 +39,7 @@ var errorsCommand = cli.Command{
 }
 
 func errorsPush(c *cli.Context) error {
-	client := c.App.Metadata["client"].(*APIClient)
+	client := c.App.Metadata["client"].(APIClient)
 	errStr := strings.Join(c.Args(), " ")
 	response, err := client.Post("system/error", strings.TrimSpace(errStr))
 	if err != nil {

--- a/cmd/syncthing/cli/operations.go
+++ b/cmd/syncthing/cli/operations.go
@@ -42,7 +42,10 @@ var operationCommand = cli.Command{
 }
 
 func foldersOverride(c *cli.Context) error {
-	client := c.App.Metadata["client"].(APIClient)
+	client, err := getClientFactory(c).getClient()
+	if err != nil {
+		return err
+	}
 	cfg, err := getConfig(client)
 	if err != nil {
 		return err

--- a/cmd/syncthing/cli/operations.go
+++ b/cmd/syncthing/cli/operations.go
@@ -42,7 +42,7 @@ var operationCommand = cli.Command{
 }
 
 func foldersOverride(c *cli.Context) error {
-	client := c.App.Metadata["client"].(*APIClient)
+	client := c.App.Metadata["client"].(APIClient)
 	cfg, err := getConfig(client)
 	if err != nil {
 		return err

--- a/cmd/syncthing/cli/utils.go
+++ b/cmd/syncthing/cli/utils.go
@@ -32,7 +32,10 @@ func responseToBArray(response *http.Response) ([]byte, error) {
 
 func emptyPost(url string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		client := c.App.Metadata["client"].(APIClient)
+		client, err := getClientFactory(c).getClient()
+		if err != nil {
+			return err
+		}
 		_, err := client.Post(url, "")
 		return err
 	}
@@ -40,7 +43,10 @@ func emptyPost(url string) cli.ActionFunc {
 
 func indexDumpOutput(url string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		client := c.App.Metadata["client"].(APIClient)
+		client, err := getClientFactory(c).getClient()
+		if err != nil {
+			return err
+		}
 		response, err := client.Get(url)
 		if err != nil {
 			return err
@@ -51,7 +57,10 @@ func indexDumpOutput(url string) cli.ActionFunc {
 
 func saveToFile(url string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		client := c.App.Metadata["client"].(APIClient)
+		client, err := getClientFactory(c).getClient()
+		if err != nil {
+			return err
+		}
 		response, err := client.Get(url)
 		if err != nil {
 			return err
@@ -146,6 +155,10 @@ func nulString(bs []byte) string {
 
 func normalizePath(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func setClientFactory(c *cli.Context, f *apiClientFactory) {
+	c.App.Metadata["clientFactory"] = f
 }
 
 func getClientFactory(c *cli.Context) *apiClientFactory {

--- a/cmd/syncthing/cli/utils.go
+++ b/cmd/syncthing/cli/utils.go
@@ -36,7 +36,7 @@ func emptyPost(url string) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		_, err := client.Post(url, "")
+		_, err = client.Post(url, "")
 		return err
 	}
 }
@@ -155,10 +155,6 @@ func nulString(bs []byte) string {
 
 func normalizePath(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
-}
-
-func setClientFactory(c *cli.Context, f *apiClientFactory) {
-	c.App.Metadata["clientFactory"] = f
 }
 
 func getClientFactory(c *cli.Context) *apiClientFactory {

--- a/cmd/syncthing/cli/utils.go
+++ b/cmd/syncthing/cli/utils.go
@@ -32,7 +32,7 @@ func responseToBArray(response *http.Response) ([]byte, error) {
 
 func emptyPost(url string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		client := c.App.Metadata["client"].(*APIClient)
+		client := c.App.Metadata["client"].(APIClient)
 		_, err := client.Post(url, "")
 		return err
 	}
@@ -40,7 +40,7 @@ func emptyPost(url string) cli.ActionFunc {
 
 func indexDumpOutput(url string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		client := c.App.Metadata["client"].(*APIClient)
+		client := c.App.Metadata["client"].(APIClient)
 		response, err := client.Get(url)
 		if err != nil {
 			return err
@@ -51,7 +51,7 @@ func indexDumpOutput(url string) cli.ActionFunc {
 
 func saveToFile(url string) cli.ActionFunc {
 	return func(c *cli.Context) error {
-		client := c.App.Metadata["client"].(*APIClient)
+		client := c.App.Metadata["client"].(APIClient)
 		response, err := client.Get(url)
 		if err != nil {
 			return err
@@ -82,7 +82,7 @@ func saveToFile(url string) cli.ActionFunc {
 	}
 }
 
-func getConfig(c *APIClient) (config.Configuration, error) {
+func getConfig(c APIClient) (config.Configuration, error) {
 	cfg := config.Configuration{}
 	response, err := c.Get("system/config")
 	if err != nil {

--- a/cmd/syncthing/cli/utils.go
+++ b/cmd/syncthing/cli/utils.go
@@ -147,3 +147,7 @@ func nulString(bs []byte) string {
 func normalizePath(path string) string {
 	return filepath.ToSlash(filepath.Clean(path))
 }
+
+func getClientFactory(c *cli.Context) *apiClientFactory {
+	return c.App.Metadata["clientFactory"].(*apiClientFactory)
+}


### PR DESCRIPTION
Instead of immediately exiting when encountering an error setting up the API client, the error is stored and returned if the api client is used. That ensures that the error does not come up if no operation involving the API is happening (like just querying `--help`).

To do so I added an interface for the api client and an `errorAPIClient` type that returns the error from setup when on all of it's methods.