### PR TITLE
gui: Handle empty path in validation (ref #7379)

### DIFF
--- a/gui/default/syncthing/core/pathIsSubDirDirective.js
+++ b/gui/default/syncthing/core/pathIsSubDirDirective.js
@@ -24,6 +24,9 @@ angular.module('syncthing.core')
                     scope.folderPathErrors.isParent = false;
                     scope.folderPathErrors.otherID = "";
                     scope.folderPathErrors.otherLabel = "";
+                    if (!viewValue) {
+                        return true;
+                    }
                     for (var folderID in scope.folders) {
                         if (folderID === scope.currentFolder.id) {
                             continue;


### PR DESCRIPTION
The validation now can also kick in when the path is empty, which produced a JS error.