### PR TITLE
Trigger connection loop on config device addition (fixes #7600)

### DIFF
--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syncthing/syncthing/lib/ur"
+	"github.com/syncthing/syncthing/lib/util"
 	"github.com/thejerf/suture/v4"
 )
 
@@ -126,6 +127,7 @@ func TestStopAfterBrokenConfig(t *testing.T) {
 
 	srv := New(protocol.LocalDeviceID, w, "", "syncthing", nil, nil, nil, events.NoopLogger, nil, nil, nil, nil, nil, nil, false).(*service)
 	defer os.Remove(token)
+
 	srv.started = make(chan string)
 
 	sup := suture.New("test", svcutil.SpecWithDebugLogger(l))
@@ -1178,7 +1180,7 @@ func TestBrowse(t *testing.T) {
 
 	for _, tc := range cases {
 		ret := browseFiles(tc.current, fs.FilesystemTypeBasic)
-		if !equalStrings(ret, tc.returns) {
+		if !util.EqualStrings(ret, tc.returns) {
 			t.Errorf("browseFiles(%q) => %q, expected %q", tc.current, ret, tc.returns)
 		}
 	}
@@ -1387,18 +1389,6 @@ func TestSanitizedHostname(t *testing.T) {
 			t.Errorf("%q => %q, expected %q", tc.in, res, tc.out)
 		}
 	}
-}
-
-func equalStrings(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }
 
 // runningInContainer returns true if we are inside Docker or LXC. It might

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -15,7 +15,6 @@ import (
 	"math"
 	"net"
 	"net/url"
-	"reflect"
 	"sort"
 	"strings"
 	stdsync "sync"
@@ -747,7 +746,7 @@ func (s *service) checkAndSignalConnectLoopOnUpdatedDevices(from, to config.Conf
 
 	for _, dev := range to.Devices {
 		oldDev, ok := oldDevices[dev.DeviceID]
-		if !ok || !reflect.DeepEqual(oldDev.Addresses, dev.Addresses) {
+		if !ok || !util.EqualStrings(oldDev.Addresses, dev.Addresses) {
 			s.deviceAddressesChanged <- struct{}{}
 			break
 		}

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -739,7 +739,7 @@ func (s *service) CommitConfiguration(from, to config.Configuration) bool {
 }
 
 func (s *service) checkAndSignalConnectLoopOnUpdatedDevices(from, to config.Configuration) {
-	oldDevices := make(map[protocol.DeviceID]config.DeviceConfiguration, len(to.Devices))
+	oldDevices := make(map[protocol.DeviceID]config.DeviceConfiguration, len(from.Devices))
 	for _, dev := range from.Devices {
 		oldDevices[dev.DeviceID] = dev
 	}

--- a/lib/util/utils.go
+++ b/lib/util/utils.go
@@ -280,3 +280,15 @@ func NiceDurationString(d time.Duration) string {
 	}
 	return d.String()
 }
+
+func EqualStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
### Purpose
In order to fix issue #7600, we use the existing config commit listener in the connections service to check for new devices. If any exist, we signal on a new channel for the connection loop to stop sleeping.

There is technically a small edge case between the channel check and the config copy where if the config is updated during that time we would end up with two dialDevices immediately following each other. This is extremely low probability, so not addressed currently.

### Testing
1) Run syncthing in the background
2) Use api to add new device (POST to `/rest/config/devices`)
3) See from GUI that device is immediately connected to.

I'd be happy to make any changes needed. Thanks!