### PR TITLE
gui: cut off long remote device names (fixes #7592)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -713,7 +713,7 @@
                     <span ng-switch-when="disconnected"><span class="hidden-xs" translate>Disconnected</span><span class="visible-xs" aria-label="{{'Disconnected' | translate}}"><i class="fas fa-fw fa-power-off"></i></span></span>
                     <span ng-switch-when="unused-disconnected"><span class="hidden-xs" translate>Disconnected (Unused)</span><span class="visible-xs" aria-label="{{'Disconnected (Unused)' | translate}}"><i class="fas fa-fw fa-unlink"></i></span></span>
                   </span>
-                  <span>{{deviceName(deviceCfg)}}</span>
+                  <div class="panel-title-text">{{deviceName(deviceCfg)}}</div>
                 </h4>
               </button>
               <div id="device-{{$index}}" class="panel-collapse collapse">


### PR DESCRIPTION
### Purpose

The Remote Devices names now get cut off as folder names and This Device already do, if they don't fit inside the header.

### Screenshots

![grafik](https://user-images.githubusercontent.com/1026763/116431175-d1be8300-a847-11eb-8f04-ee04de02839f.png)
