### PR TITLE
lib: Revert needing invalid files (fixes #7608, ref #7476)

### DIFF
--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -472,7 +472,6 @@ func TestNeedWithInvalid(t *testing.T) {
 		remote0Have[0],
 		remote1Have[0],
 		remote0Have[2],
-		remote1Have[2],
 	}
 
 	replace(s, protocol.LocalDeviceID, localHave)

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -774,8 +774,10 @@ func (t readWriteTransaction) updateLocalNeed(keyBuf, folder, name []byte, add b
 }
 
 func Need(global FileVersion, haveLocal bool, localVersion protocol.Vector) bool {
-	// We never need a file without a valid version.
-	if global.Version.IsEmpty() {
+	// We never need an invalid file or a file without a valid version (just
+	// another way of expressing "invalid", really, until we fix that
+	// part...).
+	if global.IsInvalid() || global.Version.IsEmpty() {
 		return false
 	}
 	// We don't need a deleted file if we don't have it.

--- a/lib/db/util.go
+++ b/lib/db/util.go
@@ -1,0 +1,70 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package db
+
+import "github.com/syncthing/syncthing/lib/protocol"
+
+// How many files to send in each Index/IndexUpdate message.
+const (
+	MaxBatchSizeBytes = 250 * 1024 // Aim for making index messages no larger than 250 KiB (uncompressed)
+	MaxBatchSizeFiles = 1000       // Either way, don't include more files than this
+)
+
+// FileInfoBatch is a utility to do file operations on the database in suitably
+// sized batches.
+type FileInfoBatch struct {
+	infos   []protocol.FileInfo
+	size    int
+	flushFn func([]protocol.FileInfo) error
+}
+
+func NewFileInfoBatch(fn func([]protocol.FileInfo) error) *FileInfoBatch {
+	return &FileInfoBatch{
+		infos:   make([]protocol.FileInfo, 0, MaxBatchSizeFiles),
+		flushFn: fn,
+	}
+}
+
+func (b *FileInfoBatch) SetFlushFunc(fn func([]protocol.FileInfo) error) {
+	b.flushFn = fn
+}
+
+func (b *FileInfoBatch) Append(f protocol.FileInfo) {
+	b.infos = append(b.infos, f)
+	b.size += f.ProtoSize()
+}
+
+func (b *FileInfoBatch) Full() bool {
+	return len(b.infos) >= MaxBatchSizeFiles || b.size >= MaxBatchSizeBytes
+}
+
+func (b *FileInfoBatch) FlushIfFull() error {
+	if b.Full() {
+		return b.Flush()
+	}
+	return nil
+}
+
+func (b *FileInfoBatch) Flush() error {
+	if len(b.infos) == 0 {
+		return nil
+	}
+	if err := b.flushFn(b.infos); err != nil {
+		return err
+	}
+	b.Reset()
+	return nil
+}
+
+func (b *FileInfoBatch) Reset() {
+	b.infos = b.infos[:0]
+	b.size = 0
+}
+
+func (b *FileInfoBatch) Size() int {
+	return b.size
+}

--- a/lib/model/folder_recvenc.go
+++ b/lib/model/folder_recvenc.go
@@ -41,7 +41,7 @@ func (f *receiveEncryptedFolder) revert() error {
 	f.setState(FolderScanning)
 	defer f.setState(FolderIdle)
 
-	batch := newFileInfoBatch(func(fs []protocol.FileInfo) error {
+	batch := db.NewFileInfoBatch(func(fs []protocol.FileInfo) error {
 		f.updateLocalsFromScanning(fs)
 		return nil
 	})
@@ -54,7 +54,7 @@ func (f *receiveEncryptedFolder) revert() error {
 	var iterErr error
 	var dirs []string
 	snap.WithHaveTruncated(protocol.LocalDeviceID, func(intf protocol.FileIntf) bool {
-		if iterErr = batch.flushIfFull(); iterErr != nil {
+		if iterErr = batch.FlushIfFull(); iterErr != nil {
 			return false
 		}
 
@@ -81,7 +81,7 @@ func (f *receiveEncryptedFolder) revert() error {
 		// item should still not be sent in index updates. However being
 		// deleted, it will not show up as an unexpected file in the UI
 		// anymore.
-		batch.append(fi)
+		batch.Append(fi)
 
 		return true
 	})
@@ -91,7 +91,7 @@ func (f *receiveEncryptedFolder) revert() error {
 	if iterErr != nil {
 		return iterErr
 	}
-	return batch.flush()
+	return batch.Flush()
 }
 
 func (f *receiveEncryptedFolder) revertHandleDirs(dirs []string, snap *db.Snapshot) {


### PR DESCRIPTION
Unfortunately the solution for #7474 implemented in #7476 created a new, more severe problem: Files that should be synced, aren't: #7608. I couldn't come up with a way to fix #7474 without introducing this regression that doesn't add a lot of complexity. Thus I reverted that change and thus re-introduce #7474. As that is only a "presentation issue" that's clearly the more desirable issue to have.

Most of the diff here is due to the migration needed to resolve issues for users already affected by #7608. As I needed a file info batch in this migration, I moved the `fileInfoBatch` from model to db.

### Testing

I introduced a new unit test reproducing #7608 and removed the test for #7474.