### PR TITLE
all: Refactor relay invitations

### DIFF
--- a/cmd/strelaysrv/testutil/main.go
+++ b/cmd/strelaysrv/testutil/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	if join {
 		log.Println("Creating client")
-		relay, err := client.NewClient(uri, []tls.Certificate{cert}, nil, 10*time.Second)
+		relay, err := client.NewClient(uri, []tls.Certificate{cert}, 10*time.Second)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -98,7 +98,12 @@ func (c *staticClient) serve(ctx context.Context) error {
 				if len(ip) == 0 || ip.IsUnspecified() {
 					msg.Address = remoteIPBytes(c.conn)
 				}
-				c.invitations <- msg
+				select {
+				case c.invitations <- msg:
+				case <-ctx.Done():
+					l.Debugln(c, "stopping")
+					return ctx.Err()
+				}
 
 			case protocol.RelayFull:
 				l.Infof("Disconnected from relay %s due to it becoming full.", c.uri)


### PR DESCRIPTION
While investigating and changing stuff related to how relay failures are handled and logged, I noticed that the invitations channel is handled badly on service restart: When creating a relay client, one might or might not provide the invitation channel. If one is not provided, it is closed when the service exits. That means the service can't be restarted, while the suture service model requires services to be restartable.

I removed the invitations channel from `NewClient`, as the ambiguity of providing one or not needlessly creates the opportunity to close the channel in the wrong place. Now it's clear that invitations belong to the `lib/relay/client` package and no-one ought to close it from outside.

Two related changes I made:
 - Refactor the relay listener service loop to directly get the error from the relay clients `Serve` method.
 - Wrap sending to the invitations channel in the relay client into a `select` with `ctx.Done()` to unblock if it's shut down.