### PR TITLE
lib/relay, lib/svcutil: Improve service logging (fixes #7580)

### DIFF
--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -93,7 +93,8 @@ func (c *dynamicClient) serve(ctx context.Context) error {
 			c.client = client
 			c.mut.Unlock()
 
-			c.client.Serve(ctx)
+			err = c.client.Serve(ctx)
+			l.Debugf("Disconnected from %s://%s: %v", c.client.URI().Scheme, c.client.URI().Host, err)
 
 			c.mut.Lock()
 			c.client = nil


### PR DESCRIPTION
Sutures logging provides a lot of info, but is not very user friendly. I thus created a custom events hook that prints user-friendly messages when a service fails and prints everything else at debug level.

And when playing around with loosing connection while relaying is enabled, I got flooded with info logging from the dynamic relay client: It tried to connect to every known relay and printed the same error about not being able to connect over and over again. I changed all of that to debug logging. A failed relay will still print one info level line due to the service terminating.