### PR TITLE
gui: Move the QR code button next to device ID in editDevice modal.

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -443,3 +443,9 @@ ul.three-columns li, ul.two-columns li {
     background-color: #eeeeee;
     opacity: 1;
 }
+
+/* Make a "well" look more like a readonly text input when grouped with a button */
+.input-group .well-sm {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -11,7 +11,14 @@
           <div ng-if="!editingDefaults" class="form-group" ng-class="{'has-error': deviceEditor.deviceID.$invalid && deviceEditor.deviceID.$dirty}" ng-init="loadFormIntoScope(deviceEditor)">
             <label translate for="deviceID">Device ID</label>
             <div ng-if="!editingExisting">
-              <input name="deviceID" id="deviceID" class="form-control text-monospace" type="text" ng-model="currentDevice.deviceID" required="" valid-deviceid list="discovery-list" aria-required="true" />
+              <div class="input-group">
+                <input name="deviceID" id="deviceID" class="form-control text-monospace" type="text" ng-model="currentDevice.deviceID" required="" valid-deviceid list="discovery-list" aria-required="true" />
+                <div class="input-group-btn">
+                  <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#idqr" ng-disabled="!deviceEditor.deviceID.$valid">
+                    <span class="fas fa-qrcode"></span>&nbsp;<span translate>Show QR</span>
+                  </button>
+                </div>
+              </div>
               <datalist id="discovery-list">
                 <option ng-repeat="id in discovery" value="{{id}}" />
               </datalist>
@@ -29,7 +36,14 @@
                 <span translate ng-if="deviceEditor.deviceID.$error.unique && deviceEditor.deviceID.$dirty">A device with that ID is already added.</span>
               </p>
             </div>
-            <div ng-if="editingExisting" class="well well-sm text-monospace" select-on-click>{{currentDevice.deviceID}}</div>
+            <div ng-if="editingExisting" class="input-group">
+              <div class="well well-sm text-monospace form-control" style="height: auto;" select-on-click>{{currentDevice.deviceID}}</div>
+              <div class="input-group-btn">
+                <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#idqr">
+                  <span class="fas fa-qrcode"></span>&nbsp;<span translate>Show QR</span>
+                </button>
+              </div>
+            </div>
           </div>
           <div class="form-group">
             <label translate for="name">Device Name</label>
@@ -150,9 +164,6 @@
   <div class="modal-footer">
     <button type="button" class="btn btn-primary btn-sm" ng-click="saveDevice()" ng-disabled="deviceEditor.$invalid">
       <span class="fas fa-check"></span>&nbsp;<span translate>Save</span>
-    </button>
-    <button ng-if="!editingDefaults" type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#idqr" ng-if="editingExisting || deviceEditor.deviceID.$valid">
-      <span class="fas fa-qrcode"></span>&nbsp;<span translate>Show QR</span>
     </button>
     <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">
       <span class="fas fa-times"></span>&nbsp;<span translate>Close</span>

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -14,7 +14,7 @@
               <div class="input-group">
                 <input name="deviceID" id="deviceID" class="form-control text-monospace" type="text" ng-model="currentDevice.deviceID" required="" valid-deviceid list="discovery-list" aria-required="true" />
                 <div class="input-group-btn">
-                  <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#idqr" ng-disabled="!deviceEditor.deviceID.$valid">
+                  <button type="button" class="btn btn-default" data-toggle="modal" data-target="#idqr" ng-disabled="!deviceEditor.deviceID.$valid">
                     <span class="fas fa-qrcode"></span>&nbsp;<span translate>Show QR</span>
                   </button>
                 </div>
@@ -39,7 +39,7 @@
             <div ng-if="editingExisting" class="input-group">
               <div class="well well-sm text-monospace form-control" style="height: auto;" select-on-click>{{currentDevice.deviceID}}</div>
               <div class="input-group-btn">
-                <button type="button" class="btn btn-default btn-sm" data-toggle="modal" data-target="#idqr">
+                <button type="button" class="btn btn-default" data-toggle="modal" data-target="#idqr">
                   <span class="fas fa-qrcode"></span>&nbsp;<span translate>Show QR</span>
                 </button>
               </div>

--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -29,7 +29,7 @@
                 </ul>
               </p>
               <p class="help-block">
-                <span translate ng-if="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">The device ID to enter here can be found in the "Actions > Show ID" dialog on the other device. Spaces and dashes are optional (ignored).</span>
+                <span translate ng-if="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">The device ID to enter here can be found in the "Actions &gt; Show ID" dialog on the other device. Spaces and dashes are optional (ignored).</span>
                 <span translate ng-show="deviceEditor.deviceID.$valid || deviceEditor.deviceID.$pristine">When adding a new device, keep in mind that this device must be added on the other side too.</span>
                 <span translate ng-if="deviceEditor.deviceID.$error.required && deviceEditor.deviceID.$dirty">The device ID cannot be blank.</span>
                 <span translate ng-if="deviceEditor.deviceID.$error.validDeviceid && deviceEditor.deviceID.$dirty">The entered device ID does not look valid. It should be a 52 or 56 character string consisting of letters and numbers, with spaces and dashes being optional.</span>


### PR DESCRIPTION
### Purpose

Trying to avoid one source of confusion when using QR codes to mutually add devices, where the local ID / QR code is needed but the user ended up with the remote device's ([forum link](https://forum.syncthing.net/t/great-technology-bad-user-interface/16781/4?u=acolomb)).

The "Show QR" button shows a different representation of the device ID input field contents, so move it right next to that one.  There are now two possible incarnations because in the `editingExisting` case, the read-only device ID is not actually an HTML input.  Treat both cases as Bootstrap input groups with attached button.

Note this removes access to the "Show QR" function when any other tab than "General" is active.  That is intentional to better guide the user about which device ID will be shown (not the local one).

### Testing

Tested in Firefox: Button is shown and works both when adding and editing a device.  Does not show up when editing device default config.  Resizing the window results in sane wrapping of long device IDs, as seen in the second screenshot.

### Screenshots

![Screenshot_2021-05-09 devtest Syncthing_addDevice2](https://user-images.githubusercontent.com/6996887/117587002-f9e99400-b11b-11eb-8ac9-82f596962595.png)
![Screenshot_2021-05-09 devtest Syncthing_editDevice2](https://user-images.githubusercontent.com/6996887/117587000-f5bd7680-b11b-11eb-9a09-fa49ad3aa2d1.png)

### Documentation

The button is not mentioned in the docs, but can be seen in [some screenshots](https://docs.syncthing.net/intro/getting-started.html).  Is there a preferred way / setup to update those?