### PR TITLE
lib/model: Improve encryption cluster-config errors

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -4068,14 +4068,14 @@ func TestCcCheckEncryption(t *testing.T) {
 			tokenLocal:        nil,
 			isEncryptedRemote: true,
 			isEncryptedLocal:  false,
-			expectedErr:       errEncryptionNotEncryptedRemote,
+			expectedErr:       errEncryptionPlainForRemoteEncrypted,
 		},
 		{
 			tokenRemote:       nil,
 			tokenLocal:        nil,
 			isEncryptedRemote: false,
 			isEncryptedLocal:  true,
-			expectedErr:       errEncryptionNotEncryptedRemote,
+			expectedErr:       errEncryptionPlainForReceiveEncrypted,
 		},
 		{
 			tokenRemote:       nil,


### PR DESCRIPTION
An attempt at making the errors about encryption mis-configuration more understandable, i.e. the goal is that the user is more likely to understand what is wrong and what they can/need to change to get it working.