### PR TITLE
gui: Make device name clickable in navbar to show the ID.

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -74,11 +74,11 @@
           <img class="logo hidden visible-xs" src="assets/img/favicon-default.png" height="32" alt=""/>
         </span>
         <p class="navbar-text hidden-xs" ng-class="{'hidden-sm':upgradeInfo && upgradeInfo.newer}">
-	  <a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()" tooltip data-original-title="{{'Show ID' | translate}}" data-placement="bottom">
-	    {{thisDeviceName()}}
-	    &nbsp;<span class="fas fa-fw fa-qrcode"></span>
-	  </a>
-	</p>
+          <a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()" tooltip data-original-title="{{'Show ID' | translate}}" data-placement="bottom">
+            {{thisDeviceName()}}
+            &nbsp;<span class="fas fa-fw fa-qrcode"></span>
+          </a>
+        </p>
         <ul class="nav navbar-nav navbar-right">
           <li ng-if="upgradeInfo && upgradeInfo.newer" class="upgrade-newer">
             <button type="button" class="btn navbar-btn btn-primary btn-sm" data-toggle="modal" data-target="#upgrade">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -73,7 +73,12 @@
           <img class="logo hidden-xs" src="assets/img/logo-horizontal.svg" height="32" width="117" alt=""/>
           <img class="logo hidden visible-xs" src="assets/img/favicon-default.png" height="32" alt=""/>
         </span>
-        <p class="navbar-text hidden-xs" ng-class="{'hidden-sm':upgradeInfo && upgradeInfo.newer}">{{thisDeviceName()}}</p>
+        <p class="navbar-text hidden-xs" ng-class="{'hidden-sm':upgradeInfo && upgradeInfo.newer}">
+	  <a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()" tooltip data-original-title="{{'Show ID' | translate}}" data-placement="bottom">
+	    {{thisDeviceName()}}
+	    &nbsp;<span class="fas fa-fw fa-qrcode"></span>
+	  </a>
+	</p>
         <ul class="nav navbar-nav navbar-right">
           <li ng-if="upgradeInfo && upgradeInfo.newer" class="upgrade-newer">
             <button type="button" class="btn navbar-btn btn-primary btn-sm" data-toggle="modal" data-target="#upgrade">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -74,7 +74,7 @@
           <img class="logo hidden visible-xs" src="assets/img/favicon-default.png" height="32" alt=""/>
         </span>
         <p class="navbar-text hidden-xs" ng-class="{'hidden-sm':upgradeInfo && upgradeInfo.newer}">
-          <a href="" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()" tooltip data-original-title="{{'Show ID' | translate}}" data-placement="bottom">
+          <a href="" class="navbar-link" data-toggle="modal" data-target="#idqr" ng-click="currentDevice=thisDevice()" tooltip data-original-title="{{'Show ID' | translate}}" data-placement="bottom">
             {{thisDeviceName()}}
             &nbsp;<span class="fas fa-fw fa-qrcode"></span>
           </a>


### PR DESCRIPTION
### Purpose

Add a QR code icon next to the device name and make all that a link to show the own device's ID with QR code.  A tooltip indicates what the link does.  Inspired by [this forum thread](https://forum.syncthing.net/t/great-technology-bad-user-interface/16781/6).

This duplicates the Actions > Show ID entry but easier to discover.  That button is still kept to satisfy existing user habits.

### Screenshots

![image](https://user-images.githubusercontent.com/6996887/117768882-4bd10d80-b233-11eb-8291-2c15b3264d21.png)

### Documentation

Currently no need to adjust docs.  Only if the "Show ID" menu entry should be removed as well, the [Getting Started guide](https://docs.syncthing.net/intro/getting-started.html) would need an update.
