### PR TITLE
cmd/uraggregate: Cap memory size at a petabyte (fixes #7661)

### DIFF
--- a/cmd/uraggregate/main.go
+++ b/cmd/uraggregate/main.go
@@ -287,6 +287,8 @@ func aggregatePerformance(db *sql.DB, since time.Time) (int64, error) {
 			DATE_TRUNC('day', Received) > $1
 			AND DATE_TRUNC('day', Received) < DATE_TRUNC('day', NOW())
 			AND Report->>'version' like 'v_.%'
+			/* Some custom implementation reported bytes when we expect megabytes, cap at petabyte */
+			AND (Report->>'memorySize')::numeric < 1073741824
 		GROUP BY Day
 		);
 	`, since)


### PR DESCRIPTION
After this is merged and rolled out we should do:

`DELETE FROM performance WHERE day > '2020-08-11'` and let it re-aggregate;

Fixes #7661