### PR TITLE
Remove sysctl parameter from docker readme

### DIFF
--- a/README-Docker.md
+++ b/README-Docker.md
@@ -16,8 +16,7 @@ the name of the Syncthing instance can be optionally defined by using
 **Docker cli**
 ```
 $ docker pull syncthing/syncthing
-$ docker run --sysctl net.core.rmem_max=2097152 \
-    -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp \
+$ docker run -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp \
     -v /wherever/st-sync:/var/syncthing \
     --hostname=my-syncthing \
     syncthing/syncthing:latest
@@ -41,8 +40,6 @@ services:
       - 8384:8384
       - 22000:22000/tcp
       - 22000:22000/udp
-    sysctls:
-      - net.core.rmem_max=2097152
     restart: unless-stopped
 ```
 


### PR DESCRIPTION
Basically reverts https://github.com/syncthing/syncthing/pull/7536

Fixes #7668 

Shame on me for trusting the documentation of docker...

https://github.com/moby/moby/issues/30778