### PR TITLE
lib/model: Don't use empty folder cfg for index sender (fixes #7649)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -587,6 +587,18 @@ func (db *Lowlevel) dropFolderIndexIDs(folder []byte) error {
 	return t.Commit()
 }
 
+func (db *Lowlevel) dropIndexIDs() error {
+	t, err := db.newReadWriteTransaction()
+	if err != nil {
+		return err
+	}
+	defer t.close()
+	if err := t.deleteKeyPrefix([]byte{KeyTypeIndexID}); err != nil {
+		return err
+	}
+	return t.Commit()
+}
+
 func (db *Lowlevel) dropMtimes(folder []byte) error {
 	key, err := db.keyer.GenerateMtimesKey(nil, folder)
 	if err != nil {

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -20,7 +20,7 @@ import (
 // do not put restrictions on downgrades (e.g. for repairs after a bugfix).
 const (
 	dbVersion             = 14
-	dbMigrationVersion    = 17
+	dbMigrationVersion    = 18
 	dbMinSyncthingVersion = "v1.9.0"
 )
 
@@ -102,6 +102,7 @@ func (db *schemaUpdater) updateSchema() error {
 		{14, 14, "v1.9.0", db.updateSchemaTo14},
 		{14, 16, "v1.9.0", db.checkRepairMigration},
 		{14, 17, "v1.9.0", db.migration17},
+		{14, 18, "v1.9.0", db.dropIndexIDsMigration},
 	}
 
 	for _, m := range migrations {
@@ -829,6 +830,10 @@ func (db *schemaUpdater) migration17(prev int) error {
 		}
 	}
 	return nil
+}
+
+func (db *schemaUpdater) dropIndexIDsMigration(_ int) error {
+	return db.dropIndexIDs()
 }
 
 func (db *schemaUpdater) rewriteGlobals(t readWriteTransaction) error {

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -451,19 +451,10 @@ func DropDeltaIndexIDs(db *Lowlevel) {
 	}
 	opStr := "DropDeltaIndexIDs"
 	l.Debugf(opStr)
-	dbi, err := db.NewPrefixIterator([]byte{KeyTypeIndexID})
+	err := db.dropIndexIDs()
 	if backend.IsClosed(err) {
 		return
 	} else if err != nil {
-		fatalError(err, opStr, db)
-	}
-	defer dbi.Release()
-	for dbi.Next() {
-		if err := db.Delete(dbi.Key()); err != nil && !backend.IsClosed(err) {
-			fatalError(err, opStr, db)
-		}
-	}
-	if err := dbi.Error(); err != nil && !backend.IsClosed(err) {
 		fatalError(err, opStr, db)
 	}
 }

--- a/lib/model/indexsender.go
+++ b/lib/model/indexsender.go
@@ -337,17 +337,17 @@ func (r *indexSenderRegistry) addLocked(folder config.FolderConfiguration, fset 
 // addPending stores the given info to start an index sender once resume is called
 // for this folder.
 // If an index sender is already running, it will be stopped.
-func (r *indexSenderRegistry) addPending(folder config.FolderConfiguration, startInfo *indexSenderStartInfo) {
+func (r *indexSenderRegistry) addPending(folder string, startInfo *indexSenderStartInfo) {
 	r.mut.Lock()
 	defer r.mut.Unlock()
 
-	if is, ok := r.indexSenders[folder.ID]; ok {
+	if is, ok := r.indexSenders[folder]; ok {
 		r.sup.RemoveAndWait(is.token, 0)
-		delete(r.indexSenders, folder.ID)
-		l.Debugf("Removed index sender for device %v and folder %v due to added pending", r.deviceID.Short(), folder.ID)
+		delete(r.indexSenders, folder)
+		l.Debugf("Removed index sender for device %v and folder %v due to added pending", r.deviceID.Short(), folder)
 	}
-	r.startInfos[folder.ID] = startInfo
-	l.Debugf("Pending index sender for device %v and folder %v", r.deviceID.Short(), folder.ID)
+	r.startInfos[folder] = startInfo
+	l.Debugf("Pending index sender for device %v and folder %v", r.deviceID.Short(), folder)
 }
 
 // remove stops a running index sender or removes one pending to be started.

--- a/lib/model/indexsender.go
+++ b/lib/model/indexsender.go
@@ -247,7 +247,7 @@ func newIndexSenderRegistry(conn protocol.Connection, closed chan struct{}, sup 
 func (r *indexSenderRegistry) add(folder config.FolderConfiguration, fset *db.FileSet, startInfo *indexSenderStartInfo) {
 	r.mut.Lock()
 	r.addLocked(folder, fset, startInfo)
-	l.Debugf("Started index sender for device %v and folder %v", r.deviceID.Short(), folder)
+	l.Debugf("Started index sender for device %v and folder %v", r.deviceID.Short(), folder.ID)
 	r.mut.Unlock()
 }
 
@@ -344,6 +344,7 @@ func (r *indexSenderRegistry) addPending(folder config.FolderConfiguration, star
 	if is, ok := r.indexSenders[folder.ID]; ok {
 		r.sup.RemoveAndWait(is.token, 0)
 		delete(r.indexSenders, folder.ID)
+		l.Debugf("Removed index sender for device %v and folder %v due to added pending", r.deviceID.Short(), folder.ID)
 	}
 	r.startInfos[folder.ID] = startInfo
 	l.Debugf("Pending index sender for device %v and folder %v", r.deviceID.Short(), folder.ID)
@@ -411,16 +412,16 @@ func (r *indexSenderRegistry) resume(folder config.FolderConfiguration, fset *db
 		if isOk {
 			r.sup.RemoveAndWait(is.token, 0)
 			delete(r.indexSenders, folder.ID)
-			l.Debugf("Removed index sender for device %v and folder %v in resume", r.deviceID.Short(), folder)
+			l.Debugf("Removed index sender for device %v and folder %v in resume", r.deviceID.Short(), folder.ID)
 		}
 		r.addLocked(folder, fset, info)
 		delete(r.startInfos, folder.ID)
-		l.Debugf("Started index sender for device %v and folder %v in resume", r.deviceID.Short(), folder)
+		l.Debugf("Started index sender for device %v and folder %v in resume", r.deviceID.Short(), folder.ID)
 	} else if isOk {
 		is.resume(fset)
-		l.Debugf("Resume index sender for device %v and folder %v", r.deviceID.Short(), folder)
+		l.Debugf("Resume index sender for device %v and folder %v", r.deviceID.Short(), folder.ID)
 	} else {
-		l.Debugf("Not resuming index sender for device %v and folder %v as none is paused and there is no start info", r.deviceID.Short(), folder)
+		l.Debugf("Not resuming index sender for device %v and folder %v as none is paused and there is no start info", r.deviceID.Short(), folder.ID)
 	}
 }
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1341,7 +1341,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 			if err := m.db.AddOrUpdatePendingFolder(folder.ID, of, deviceID); err != nil {
 				l.Warnf("Failed to persist pending folder entry to database: %v", err)
 			}
-			indexSenders.addPending(cfg, ccDeviceInfos[folder.ID])
+			indexSenders.addPending(folder.ID, ccDeviceInfos[folder.ID])
 			updatedPending = append(updatedPending, updatedPendingFolder{
 				FolderID:         folder.ID,
 				FolderLabel:      folder.Label,
@@ -1365,7 +1365,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 		}
 
 		if cfg.Paused {
-			indexSenders.addPending(cfg, ccDeviceInfos[folder.ID])
+			indexSenders.addPending(folder.ID, ccDeviceInfos[folder.ID])
 			continue
 		}
 
@@ -1410,7 +1410,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 			// Shouldn't happen because !cfg.Paused, but might happen
 			// if the folder is about to be unpaused, but not yet.
 			l.Debugln("ccH: no fset", folder.ID)
-			indexSenders.addPending(cfg, ccDeviceInfos[folder.ID])
+			indexSenders.addPending(folder.ID, ccDeviceInfos[folder.ID])
 			continue
 		}
 


### PR DESCRIPTION
~~Adds more debugging to analyse https://github.com/syncthing/syncthing/issues/7649~~

Still contains the debugging, but mainly now a fix for #7649.

The diff has too little content to see what the problem is, so here is a larger section:

```diff
 		cfg, ok := m.cfg.Folder(folder.ID)
 		if ok {
 			folderDevice, ok = cfg.Device(deviceID)
 		}
 		if !ok {
 			indexSenders.remove(folder.ID)
 			if deviceCfg.IgnoredFolder(folder.ID) {
 				l.Infof("Ignoring folder %s from device %s since we are configured to", folder.Description(), deviceID)
 				continue
 			}
 			delete(expiredPending, folder.ID)
 			of.Label = folder.Label
 			of.ReceiveEncrypted = len(ccDeviceInfos[folder.ID].local.EncryptionPasswordToken) > 0
 			if err := m.db.AddOrUpdatePendingFolder(folder.ID, of, deviceID); err != nil {
 				l.Warnf("Failed to persist pending folder entry to database: %v", err)
 			}
-			indexSenders.addPending(cfg, ccDeviceInfos[folder.ID])
+			indexSenders.addPending(folder.ID, ccDeviceInfos[folder.ID])
```

The `cfg` at this point is just an empty/default object. Thus in `addPending` when using `cfg.ID`, that's an empty string.