### PR TITLE
lib/model: Fix addFakeConn and other test improvements

### DIFF
--- a/lib/model/fakeconns_test.go
+++ b/lib/model/fakeconns_test.go
@@ -154,17 +154,17 @@ func (f *fakeConnection) sendIndexUpdate() {
 	f.model.IndexUpdate(f.id, f.folder, toSend)
 }
 
-func addFakeConn(m *testModel, dev protocol.DeviceID) *fakeConnection {
+func addFakeConn(m *testModel, dev protocol.DeviceID, folderID string) *fakeConnection {
 	fc := newFakeConnection(dev, m)
 	m.AddConnection(fc, protocol.Hello{})
 
 	m.ClusterConfig(dev, protocol.ClusterConfig{
 		Folders: []protocol.Folder{
 			{
-				ID: "default",
+				ID: folderID,
 				Devices: []protocol.Device{
 					{ID: myID},
-					{ID: device1},
+					{ID: dev},
 				},
 			},
 		},

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -43,7 +43,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 
 	// Send and index update for the known stuff
 
-	m.Index(device1, "ro", knownFiles)
+	must(t, m.Index(device1, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	size := globalSize(t, m, "ro")
@@ -119,7 +119,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 
 	// Send and index update for the known stuff
 
-	m.Index(device1, "ro", knownFiles)
+	must(t, m.Index(device1, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -208,7 +208,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 
 	// Send an index update for the known stuff
 
-	m.Index(device1, "ro", knownFiles)
+	must(t, m.Index(device1, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -277,7 +277,7 @@ func TestRecvOnlyDeletedRemoteDrop(t *testing.T) {
 
 	// Send an index update for the known stuff
 
-	m.Index(device1, "ro", knownFiles)
+	must(t, m.Index(device1, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -341,7 +341,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 
 	// Send an index update for the known stuff
 
-	m.Index(device1, "ro", knownFiles)
+	must(t, m.Index(device1, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -396,7 +396,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 		return true
 	})
 	snap.Release()
-	m.IndexUpdate(device1, "ro", files)
+	must(t, m.IndexUpdate(device1, "ro", files))
 
 	// Ensure the pull to resolve conflicts (content identical) happened
 	must(t, f.doInSync(func() error {

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -1297,7 +1297,7 @@ func TestPullSymlinkOverExistingWindows(t *testing.T) {
 	if !ok {
 		t.Fatal("file missing")
 	}
-	m.Index(device1, f.ID, []protocol.FileInfo{{Name: name, Type: protocol.FileInfoTypeSymlink, Version: file.Version.Update(device1.Short())}})
+	must(t, m.Index(device1, f.ID, []protocol.FileInfo{{Name: name, Type: protocol.FileInfoTypeSymlink, Version: file.Version.Update(device1.Short())}}))
 
 	scanChan := make(chan string)
 

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -126,7 +126,7 @@ func setupModelWithConnectionFromWrapper(t testing.TB, w config.Wrapper) (*testM
 	t.Helper()
 	m := setupModel(t, w)
 
-	fc := addFakeConn(m, device1)
+	fc := addFakeConn(m, device1, "default")
 	fc.folder = "default"
 
 	_ = m.ScanFolder("default")


### PR DESCRIPTION
There's one test bugfix on `addFakeConn`, where `device1` was hardcoded in the cluster-config instead of using the argument `dev`. The rest is adding `folderID` arg to `addFakeConn` to use instead of the hardcoded `"default"`, wrapping `Index`/`IndexUpdate` in `must` to see the test-failure cause immediately and a few other minor test improvements.

Apparently none of the current tests is affected by this, but one on a local branch is. And this change would add a lot of clutter to that diff, and is useful/correct in general - thus filing it separately here.