### PR TITLE
lib/config: Set DisableTempIndexes to true on receive-encrypted

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1343,3 +1343,30 @@ func TestInternalVersioningConfiguration(t *testing.T) {
 		}
 	}
 }
+
+func TestReceiveEncryptedFolderFixed(t *testing.T) {
+	cfg := Configuration{
+		Folders: []FolderConfiguration{
+			{
+				ID:                 "foo",
+				Path:               "testdata",
+				Type:               FolderTypeReceiveEncrypted,
+				DisableTempIndexes: false,
+				IgnorePerms:        false,
+			},
+		},
+	}
+
+	cfg.prepare(device1)
+
+	if len(cfg.Folders) != 1 {
+		t.Fatal("Expected one folder")
+	}
+	f := cfg.Folders[0]
+	if !f.DisableTempIndexes {
+		t.Error("DisableTempIndexes should be true")
+	}
+	if !f.IgnorePerms {
+		t.Error("IgnorePerms should be true")
+	}
+}

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -214,6 +214,7 @@ func (f *FolderConfiguration) prepare(myID protocol.DeviceID, existingDevices ma
 	}
 
 	if f.Type == FolderTypeReceiveEncrypted {
+		f.DisableTempIndexes = true
 		f.IgnorePerms = true
 	}
 }


### PR DESCRIPTION
We already do not send any progress updates by not registering files when pulling, but don't reflect that in the config and thus don't announce it correctly to remotes. As those are dropped in the end anyway it shouldn't be of any consequence except for a few pointless messages sent.