### PR TITLE
lib/model: Fix incoming request on receive-enc (fixes #7699)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1941,7 +1941,7 @@ func (m *model) Request(deviceID protocol.DeviceID, folder, name string, blockNo
 		return nil, protocol.ErrGeneric
 	}
 
-	if len(hash) > 0 && !scanner.Validate(res.data[:n], hash, weakHash) {
+	if folderCfg.Type != config.FolderTypeReceiveEncrypted && len(hash) > 0 && !scanner.Validate(res.data[:n], hash, weakHash) {
 		m.recheckFile(deviceID, folder, name, offset, hash, weakHash)
 		l.Debugf("%v REQ(in) failed validating data: %s: %q / %q o=%d s=%d", m, deviceID, folder, name, offset, size)
 		return nil, protocol.ErrNoSuchFile


### PR DESCRIPTION
Two untrusted devices connect and send requests like normal ones, i.e. including hashes, even though those hashes are garbage. We then try to validate, which obviously fails, and thus trigger a forced rescan. That then leads to the locally changed items as seen in #7699.