### PR TITLE
lib/model: Fix reverting when version has only our own ID (fixes #7708)

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -414,7 +414,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 func TestRecvOnlyRevertOwnID(t *testing.T) {
 	// If the folder was receive-only in the past, the global item might have
 	// only our id in the version vector and be valid. There was a bug based on
-	// the incorrect assumpation that this can never happen.
+	// the incorrect assumption that this can never happen.
 
 	// Get us a model up and running
 


### PR DESCRIPTION
This condition based on only our own ID being in the version vector of our own, locally changed item is flawed. Not only if the folder type changes, but also in general: We might just never have had the global item (with other IDs), and directly have scanned our own file. Now we get the global file, check if that is locally changed, then indeed the file only exists here, if not check if what we have is equivalent to the global file to shortcut and otherwise just proceed normally (reset our version vector to make pulling resolve everything).

I added a unit test reproducing #7708