### PR TITLE
build, lib/model: Add flag to run tests without -short and fix failure

### DIFF
--- a/build.go
+++ b/build.go
@@ -52,7 +52,7 @@ var (
 	coverage       bool
 	long           bool
 	timeout        = "120s"
-	longTimeout    = "240s"
+	longTimeout    = "600s"
 	numVersions    = 5
 	withNextGenGUI = os.Getenv("BUILD_NEXT_GEN_GUI") != ""
 )
@@ -378,8 +378,9 @@ func test(tags []string, pkgs ...string) {
 
 	tags = append(tags, "purego")
 	args := []string{"test", "-tags", strings.Join(tags, " ")}
-	if !long {
+	if long {
 		timeout = longTimeout
+	} else {
 		args = append(args, "-short")
 	}
 	args = append(args, "-timeout", timeout)

--- a/build.go
+++ b/build.go
@@ -50,7 +50,9 @@ var (
 	benchRun       string
 	debugBinary    bool
 	coverage       bool
+	long           bool
 	timeout        = "120s"
+	longTimeout    = "240s"
 	numVersions    = 5
 	withNextGenGUI = os.Getenv("BUILD_NEXT_GEN_GUI") != ""
 )
@@ -363,6 +365,7 @@ func parseFlags() {
 	flag.StringVar(&cc, "cc", os.Getenv("CC"), "Set CC environment variable for `go build`")
 	flag.BoolVar(&debugBinary, "debug-binary", debugBinary, "Create unoptimized binary to use with delve, set -gcflags='-N -l' and omit -ldflags")
 	flag.BoolVar(&coverage, "coverage", coverage, "Write coverage profile of tests to coverage.txt")
+	flag.BoolVar(&long, "long", long, "Run tests without the -short flag")
 	flag.IntVar(&numVersions, "num-versions", numVersions, "Number of versions for changelog command")
 	flag.StringVar(&run, "run", "", "Specify which tests to run")
 	flag.StringVar(&benchRun, "bench", "", "Specify which benchmarks to run")
@@ -374,7 +377,12 @@ func test(tags []string, pkgs ...string) {
 	lazyRebuildAssets()
 
 	tags = append(tags, "purego")
-	args := []string{"test", "-short", "-timeout", timeout, "-tags", strings.Join(tags, " ")}
+	args := []string{"test", "-tags", strings.Join(tags, " ")}
+	if !long {
+		timeout = longTimeout
+		args = append(args, "-short")
+	}
+	args = append(args, "-timeout", timeout)
 
 	if runtime.GOARCH == "amd64" {
 		switch runtime.GOOS {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1472,9 +1472,9 @@ func (m *model) ccCheckEncryption(fcfg config.FolderConfiguration, folderDevice 
 
 	if !(hasTokenRemote || hasTokenLocal) {
 		if isEncryptedRemote {
-			return errEncryptionPlainForReceiveEncrypted
-		} else {
 			return errEncryptionPlainForRemoteEncrypted
+		} else {
+			return errEncryptionPlainForReceiveEncrypted
 		}
 	}
 


### PR DESCRIPTION
This adds a `-long` flag to `build.go` to run all the slow test, i.e. not set `-short`.

To my surprise running with `-long` did result in a test failure, luckily just a cosmetic one: When I improved the encryption error messages, I swapped to error messages.  
We could run the coverage tests with `-long`, then it won't require much more CI time, but we at least run those tests on on platform (linux, the others being a lot slower). Long tests took 2m7s on my machine.