### PR TITLE
gui: Default to bps for download/upload rates

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -49,7 +49,7 @@ angular.module('syncthing.core')
         $scope.scanProgress = {};
         $scope.themes = [];
         $scope.globalChangeEvents = {};
-        $scope.metricRates = false;
+        $scope.metricRates = true;
         $scope.folderPathErrors = {};
         $scope.currentSharing = {};
         $scope.currentFolder = {};


### PR DESCRIPTION
Fixes #7725 by displaying download- and upload rates with `bps` per default.

