### PR TITLE
lib/model: Don't share with introduced device if encrypted (fixes #7724)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1616,6 +1616,11 @@ func (m *model) handleIntroductions(introducerCfg config.DeviceConfiguration, cm
 				continue
 			}
 
+			if fcfg.Type != config.FolderTypeReceiveEncrypted && device.EncryptionPasswordToken != nil {
+				l.Infof("Cannot share folder %s with %v because the introducer %v encrypts data, which requires a password", folder.Description(), device.ID, introducerCfg.DeviceID)
+				continue
+			}
+
 			// We don't yet share this folder with this device. Add the device
 			// to sharing list of the folder.
 			l.Infof("Sharing folder %s with %v (vouched for by introducer %v)", folder.Description(), device.ID, introducerCfg.DeviceID)

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -516,11 +516,17 @@ func TestIntroducer(t *testing.T) {
 			},
 		},
 	})
-	cc := basicClusterConfig(myID, device1, "folder1")
+	cc := basicClusterConfig(myID, device1, "folder1", "folder2")
 	cc.Folders[0].Devices = append(cc.Folders[0].Devices, protocol.Device{
 		ID:                       device2,
 		Introducer:               true,
 		SkipIntroductionRemovals: true,
+	})
+	cc.Folders[1].Devices = append(cc.Folders[1].Devices, protocol.Device{
+		ID:                       device2,
+		Introducer:               true,
+		SkipIntroductionRemovals: true,
+		EncryptionPasswordToken:  []byte("faketoken"),
 	})
 	m.ClusterConfig(device1, cc)
 
@@ -530,6 +536,12 @@ func TestIntroducer(t *testing.T) {
 
 	if !contains(m.cfg.Folders()["folder1"], device2, device1) {
 		t.Error("expected folder 1 to have device2 introduced by device 1")
+	}
+
+	for _, devCfg := range m.cfg.Folders()["folder2"].Devices {
+		if devCfg.DeviceID == device2 {
+			t.Error("Device was added even though it's untrusted")
+		}
 	}
 
 	cleanupModel(m)


### PR DESCRIPTION
Checks if the introducing device encrypts data to the introduced device, and if it does, don't share the folder. The user must enter the password to encrypt the data as well.

I extended an introducer test to cover this scenario.