### PR TITLE
lib/model: Fix passwords on receive-enc needing token (ref #7518)

### DIFF
--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -428,8 +428,7 @@ func TestClusterConfig(t *testing.T) {
 	m.ServeBackground()
 	defer cleanupModel(m)
 
-	cm, _, err := m.generateClusterConfig(device2)
-	must(t, err)
+	cm, _ := m.generateClusterConfig(device2)
 
 	if l := len(cm.Folders); l != 2 {
 		t.Fatalf("Incorrect number of folders %d != 2", l)
@@ -854,8 +853,7 @@ func TestIssue4897(t *testing.T) {
 	defer cleanupModel(m)
 	cancel()
 
-	cm, _, err := m.generateClusterConfig(device1)
-	must(t, err)
+	cm, _ := m.generateClusterConfig(device1)
 	if l := len(cm.Folders); l != 1 {
 		t.Errorf("Cluster config contains %v folders, expected 1", l)
 	}
@@ -4144,8 +4142,7 @@ func TestCCFolderNotRunning(t *testing.T) {
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	// A connection can happen before all the folders are started.
-	cc, _, err := m.generateClusterConfig(device1)
-	must(t, err)
+	cc, _ := m.generateClusterConfig(device1)
 	if l := len(cc.Folders); l != 1 {
 		t.Fatalf("Expected 1 folder in CC, got %v", l)
 	}


### PR DESCRIPTION
I was testing some encryption related UI changes (not this PR) when suddenly all hell broke loose: The trusted side treated received encrypted file indexes like normal files. Reason is that the change in #7198 is just plain broken, luckily it only matters if you have encrypted folders both ways (folder1: A untrusted <-> B, folder2: A <-> B untrusted). That is uncommon enough that no-one seems to have run into it yet - yeii for not cleaning up old test folders on test setups.

The completely broken part is returning early from `generateClusterConfig` with `passwords == nil`, and then ignoring that error in `AddConnection`, thus going ahead and calling `Connection.SetPasswords` with a nil map.

I basically reverted #7518 and to keep #7198 fixed, I added a new check to `CommitConfiguration`: If a receive-encrypted folder changes, and it doesn't have the token yet, don't just resend a cluster config, but drop the connection (to get the token).