### PR TITLE
lib/model: Fix test introduced in #7714 failing due to #7689

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -427,6 +427,7 @@ func TestRecvOnlyRevertOwnID(t *testing.T) {
 	defer wcfgCancel()
 	ffs := f.Filesystem()
 	defer cleanupModel(m)
+	addFakeConn(m, device1, f.ID)
 
 	// Create some test data
 


### PR DESCRIPTION
Adds the fake connection required since #7689 to the test newly introduced in #7714. This slipped through, as both were PRs at the same time and were built without the respective other one.