### PR TITLE
lib/model: Fix indexhandling for new folders paused on remote

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1306,7 +1306,9 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 			if err := m.db.AddOrUpdatePendingFolder(folder.ID, of, deviceID); err != nil {
 				l.Warnf("Failed to persist pending folder entry to database: %v", err)
 			}
-			indexHandlers.AddIndexInfo(folder.ID, ccDeviceInfos[folder.ID])
+			if !folder.Paused {
+				indexHandlers.AddIndexInfo(folder.ID, ccDeviceInfos[folder.ID])
+			}
 			updatedPending = append(updatedPending, updatedPendingFolder{
 				FolderID:         folder.ID,
 				FolderLabel:      folder.Label,


### PR DESCRIPTION
When a unknown/new folder is later accepted in the UI, and that folder is paused on the remote, we start sending indexes. The remote then drops the connection, because they don't like getting indexes for a paused folder. Solution: Don't add the index info to the index handler when the folder is paused (same as for regular, already known folders).