### PR TITLE
lib/model: Fix wrongly hardcoded arguments in test helper

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -139,7 +139,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	if size.Files != 1 || size.Directories != 1 {
 		t.Fatalf("Local: expected 1 file and 1 directory: %+v", size)
 	}
-	size = needSize(t, m, "ro")
+	size = needSizeLocal(t, m, "ro")
 	if size.Files+size.Directories > 0 {
 		t.Fatalf("Need: expected nothing: %+v", size)
 	}
@@ -168,7 +168,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	if size.Files != 1 || size.Bytes != sizeOfDir+int64(len(newData)) {
 		t.Fatalf("Local: expected the new file to be reflected: %+v", size)
 	}
-	size = needSize(t, m, "ro")
+	size = needSizeLocal(t, m, "ro")
 	if size.Files+size.Directories > 0 {
 		t.Fatalf("Need: expected nothing: %+v", size)
 	}
@@ -189,7 +189,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	if size.Files != 1 || size.Bytes != sizeOfDir+int64(len(newData)) {
 		t.Fatalf("Local: expected the local size to remain: %+v", size)
 	}
-	size = needSize(t, m, "ro")
+	size = needSizeLocal(t, m, "ro")
 	if size.Files != 1 || size.Bytes != int64(len(oldData)) {
 		t.Fatalf("Local: expected to need the old file data: %+v", size)
 	}
@@ -229,7 +229,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	if size.Files != 1 || size.Directories != 1 {
 		t.Fatalf("Local: expected 1 file and 1 directory: %+v", size)
 	}
-	size = needSize(t, m, "ro")
+	size = needSizeLocal(t, m, "ro")
 	if size.Files+size.Directories > 0 {
 		t.Fatalf("Need: expected nothing: %+v", size)
 	}
@@ -299,7 +299,7 @@ func TestRecvOnlyDeletedRemoteDrop(t *testing.T) {
 	if size.Files != 1 || size.Directories != 1 {
 		t.Fatalf("Local: expected 1 file and 1 directory: %+v", size)
 	}
-	size = needSize(t, m, "ro")
+	size = needSizeLocal(t, m, "ro")
 	if size.Files+size.Directories > 0 {
 		t.Fatalf("Need: expected nothing: %+v", size)
 	}
@@ -364,7 +364,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 	if size.Files != 1 || size.Directories != 1 {
 		t.Fatalf("Local: expected 1 file and 1 directory: %+v", size)
 	}
-	size = needSize(t, m, "ro")
+	size = needSizeLocal(t, m, "ro")
 	if size.Files+size.Directories > 0 {
 		t.Fatalf("Need: expected nothing: %+v", size)
 	}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2358,7 +2358,7 @@ func TestIssue3496(t *testing.T) {
 	t.Log(comp)
 
 	// Check that NeedSize does the correct thing
-	need := needSize(t, m, "default")
+	need := needSizeLocal(t, m, "default")
 	if need.Files != 1 || need.Bytes != 1234 {
 		// The one we added synthetically above
 		t.Errorf("Incorrect need size; %d, %d != 1, 1234", need.Files, need.Bytes)

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -194,7 +194,7 @@ func (m *testModel) testCurrentFolderFile(folder string, file string) (protocol.
 }
 
 func (m *testModel) testCompletion(device protocol.DeviceID, folder string) FolderCompletion {
-	comp, err := m.Completion(protocol.LocalDeviceID, "default")
+	comp, err := m.Completion(device, folder)
 	must(m.t, err)
 	return comp
 }
@@ -276,7 +276,7 @@ func receiveOnlyChangedSize(t *testing.T, m Model, folder string) db.Counts {
 	return snap.ReceiveOnlyChangedSize()
 }
 
-func needSize(t *testing.T, m Model, folder string) db.Counts {
+func needSizeLocal(t *testing.T, m Model, folder string) db.Counts {
 	t.Helper()
 	snap := dbSnapshot(t, m, folder)
 	defer snap.Release()


### PR DESCRIPTION
`TestNeedMetaAfterIndexReset` failed pretty consistently on the coverage test and adding a bit of sleep in the test that's reproducible. Turns out the the test is only racy, because it doesn't do what it is supposed to, due to a fault test helper: `testCompletion` uses hardcoded values instead of the arguments. I had a quick look if there's more such blunders and didn't find any, however renamed `needSize` to `needSizeLocal` to make the name more closely represent what it does.