### PR TITLE
lib/db: Use a more concurrent GC (fixes #7722)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -857,14 +857,17 @@ func (db *Lowlevel) recordIndirectionHashesForFile(f *protocol.FileInfo) {
 }
 
 func (db *Lowlevel) recordIndirectionHashes(hs IndirectionHashesOnly) {
-	db.filtersMut.Lock()
+	// must be called with gcMut held (at least read-held)
 	if db.blockFilter != nil && len(hs.BlocksHash) > 0 {
+		db.filtersMut.Lock()
 		db.blockFilter.add(hs.BlocksHash)
+		db.filtersMut.Unlock()
 	}
 	if db.versionFilter != nil && len(hs.VersionHash) > 0 {
+		db.filtersMut.Lock()
 		db.versionFilter.add(hs.VersionHash)
+		db.filtersMut.Unlock()
 	}
-	db.filtersMut.Unlock()
 }
 
 func newBloomFilter(capacity int) *bloomFilter {


### PR DESCRIPTION
This changes the GC mechanism so that the first pass (which reads all
FileInfos to populate bloom filters with block & version hashes) can
happen concurrently with normal database operations.

The big gcMut still exists, and we grab it temporarily to block all
other modifications while we set up the bloom filters. We then release
the lock and let other things happen, with those other things also
updating the bloom filters as required. Once the first phase is done we
again grab the gcMut, knowing that we are the sole modifier of the
database, and do the cleanup.

I also removed the final compaction step.
