### PR TITLE
lib/connections: Trigger dialer when connection gets closed

### DIFF
--- a/lib/connections/connections_test.go
+++ b/lib/connections/connections_test.go
@@ -234,9 +234,9 @@ func TestConnectionStatus(t *testing.T) {
 func TestNextDialRegistryCleanup(t *testing.T) {
 	now := time.Now()
 	firsts := []time.Time{
-		now.Add(time.Second),
-		now.Add(time.Second + dialCoolDownInterval),
-		now.Add(time.Second + dialCoolDownDelay),
+		now.Add(-dialCoolDownInterval + time.Second),
+		now.Add(-dialCoolDownDelay + time.Second),
+		now.Add(-2 * dialCoolDownDelay),
 	}
 
 	r := make(nextDialRegistry)

--- a/lib/model/fakeconns_test.go
+++ b/lib/model/fakeconns_test.go
@@ -27,14 +27,16 @@ func newFakeConnection(id protocol.DeviceID, model Model) *fakeConnection {
 		Connection: new(protocolmocks.Connection),
 		id:         id,
 		model:      model,
+		closed:     make(chan struct{}),
 	}
 	f.RequestCalls(func(ctx context.Context, folder, name string, blockNo int, offset int64, size int, hash []byte, weakHash uint32, fromTemporary bool) ([]byte, error) {
 		return f.fileData[name], nil
 	})
 	f.IDReturns(id)
 	f.CloseCalls(func(err error) {
+		close(f.closed)
 		model.Closed(id, err)
-		f.ClosedReturns(true)
+		f.ClosedReturns(f.closed)
 	})
 	return f
 }
@@ -47,6 +49,7 @@ type fakeConnection struct {
 	fileData                 map[string][]byte
 	folder                   string
 	model                    Model
+	closed                   chan struct{}
 	mut                      sync.Mutex
 }
 

--- a/lib/model/fakeconns_test.go
+++ b/lib/model/fakeconns_test.go
@@ -28,7 +28,6 @@ func newFakeConnection(id protocol.DeviceID, model Model) *fakeConnection {
 		id:         id,
 		model:      model,
 		closed:     make(chan struct{}),
-		closeOnce:  sync.Once{},
 	}
 	f.RequestCalls(func(ctx context.Context, folder, name string, blockNo int, offset int64, size int, hash []byte, weakHash uint32, fromTemporary bool) ([]byte, error) {
 		return f.fileData[name], nil

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -2245,8 +2245,10 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		t.Error("not shared with device2")
 	}
 
-	if conn2.Closed() {
+	select {
+	case <-conn2.Closed():
 		t.Error("conn already closed")
+	default:
 	}
 
 	if _, err := wcfg.RemoveDevice(device2); err != nil {
@@ -2271,7 +2273,9 @@ func TestSharedWithClearedOnDisconnect(t *testing.T) {
 		}
 	}
 
-	if !conn2.Closed() {
+	select {
+	case <-conn2.Closed():
+	default:
 		t.Error("connection not closed")
 	}
 

--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -224,7 +224,7 @@ func (e encryptedConnection) Close(err error) {
 	e.conn.Close(err)
 }
 
-func (e encryptedConnection) Closed() bool {
+func (e encryptedConnection) Closed() <-chan struct{} {
 	return e.conn.Closed()
 }
 

--- a/lib/protocol/mocks/connection.go
+++ b/lib/protocol/mocks/connection.go
@@ -16,15 +16,15 @@ type Connection struct {
 	closeArgsForCall []struct {
 		arg1 error
 	}
-	ClosedStub        func() bool
+	ClosedStub        func() <-chan struct{}
 	closedMutex       sync.RWMutex
 	closedArgsForCall []struct {
 	}
 	closedReturns struct {
-		result1 bool
+		result1 <-chan struct{}
 	}
 	closedReturnsOnCall map[int]struct {
-		result1 bool
+		result1 <-chan struct{}
 	}
 	ClusterConfigStub        func(protocol.ClusterConfig)
 	clusterConfigMutex       sync.RWMutex
@@ -220,7 +220,7 @@ func (fake *Connection) CloseArgsForCall(i int) error {
 	return argsForCall.arg1
 }
 
-func (fake *Connection) Closed() bool {
+func (fake *Connection) Closed() <-chan struct{} {
 	fake.closedMutex.Lock()
 	ret, specificReturn := fake.closedReturnsOnCall[len(fake.closedArgsForCall)]
 	fake.closedArgsForCall = append(fake.closedArgsForCall, struct {
@@ -244,32 +244,32 @@ func (fake *Connection) ClosedCallCount() int {
 	return len(fake.closedArgsForCall)
 }
 
-func (fake *Connection) ClosedCalls(stub func() bool) {
+func (fake *Connection) ClosedCalls(stub func() <-chan struct{}) {
 	fake.closedMutex.Lock()
 	defer fake.closedMutex.Unlock()
 	fake.ClosedStub = stub
 }
 
-func (fake *Connection) ClosedReturns(result1 bool) {
+func (fake *Connection) ClosedReturns(result1 <-chan struct{}) {
 	fake.closedMutex.Lock()
 	defer fake.closedMutex.Unlock()
 	fake.ClosedStub = nil
 	fake.closedReturns = struct {
-		result1 bool
+		result1 <-chan struct{}
 	}{result1}
 }
 
-func (fake *Connection) ClosedReturnsOnCall(i int, result1 bool) {
+func (fake *Connection) ClosedReturnsOnCall(i int, result1 <-chan struct{}) {
 	fake.closedMutex.Lock()
 	defer fake.closedMutex.Unlock()
 	fake.ClosedStub = nil
 	if fake.closedReturnsOnCall == nil {
 		fake.closedReturnsOnCall = make(map[int]struct {
-			result1 bool
+			result1 <-chan struct{}
 		})
 	}
 	fake.closedReturnsOnCall[i] = struct {
-		result1 bool
+		result1 <-chan struct{}
 	}{result1}
 }
 

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -151,7 +151,7 @@ type Connection interface {
 	ClusterConfig(config ClusterConfig)
 	DownloadProgress(ctx context.Context, folder string, updates []FileDownloadProgressUpdate)
 	Statistics() Statistics
-	Closed() bool
+	Closed() <-chan struct{}
 	ConnectionInfo
 }
 
@@ -380,13 +380,8 @@ func (c *rawConnection) ClusterConfig(config ClusterConfig) {
 	}
 }
 
-func (c *rawConnection) Closed() bool {
-	select {
-	case <-c.closed:
-		return true
-	default:
-		return false
-	}
+func (c *rawConnection) Closed() <-chan struct{} {
+	return c.closed
 }
 
 // DownloadProgress sends the progress updates for the files that are currently being downloaded.


### PR DESCRIPTION
When a connection is closed (config change, pausing/resuming, error, ...) it may take a while for a connection to be re-established (up to a minute by default). When just running unsupervised that's fine, but when setting something up in the UI or debugging it's annoying. Now the connection service tracks the lifetime of established connections and triggers dialling when it's closed.

That requires removing all keys in `nextDialAt` for a device. To simplify that, I refactored it to have a (typed) double map instead of a composed `*deviceID*/*addr*` string key.