### PR TITLE
lib/db, lib/model: Improve error handling on pending items

### DIFF
--- a/lib/db/observed.go
+++ b/lib/db/observed.go
@@ -28,11 +28,7 @@ func (db *Lowlevel) AddOrUpdatePendingDevice(device protocol.DeviceID, name, add
 
 func (db *Lowlevel) RemovePendingDevice(device protocol.DeviceID) error {
 	key := db.keyer.GeneratePendingDeviceKey(nil, device[:])
-	if err := db.Delete(key); err != nil {
-		l.Warnf("Failed to remove pending device entry: %v", err)
-		return err
-	}
-	return nil
+	return db.Delete(key)
 }
 
 // PendingDevices enumerates all entries.  Invalid ones are dropped from the database
@@ -86,30 +82,26 @@ func (db *Lowlevel) RemovePendingFolderForDevice(id string, device protocol.Devi
 	if err != nil {
 		return err
 	}
-	if err := db.Delete(key); err != nil {
-		l.Warnf("Failed to remove pending folder entry: %v", err)
-		return err
-	}
-	return nil
+	return db.Delete(key)
 }
 
 // RemovePendingFolder removes all entries matching a specific folder ID.
 func (db *Lowlevel) RemovePendingFolder(id string) error {
 	iter, err := db.NewPrefixIterator([]byte{KeyTypePendingFolder})
 	if err != nil {
-		l.Infof("Could not iterate through pending folder entries: %v", err)
 		return err
 	}
 	defer iter.Release()
+	var iterErr error
 	for iter.Next() {
 		if id != string(db.keyer.FolderFromPendingFolderKey(iter.Key())) {
 			continue
 		}
 		if err = db.Delete(iter.Key()); err != nil {
-			l.Warnf("Failed to remove pending folder entry: %v", err)
+			iterErr = err
 		}
 	}
-	return err
+	return iterErr
 }
 
 // Consolidated information about a pending folder
@@ -122,7 +114,7 @@ func (db *Lowlevel) PendingFolders() (map[string]PendingFolder, error) {
 }
 
 // PendingFoldersForDevice enumerates only entries matching the given device ID, unless it
-// is EmptyDeviceID.  Invalid ones are dropped from the database after a warning log
+// is EmptyDeviceID.  Invalid ones are dropped from the database after a info log
 // message, as a side-effect.
 func (db *Lowlevel) PendingFoldersForDevice(device protocol.DeviceID) (map[string]PendingFolder, error) {
 	var err error

--- a/lib/db/observed.go
+++ b/lib/db/observed.go
@@ -7,6 +7,7 @@
 package db
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/syncthing/syncthing/lib/protocol"
@@ -89,7 +90,7 @@ func (db *Lowlevel) RemovePendingFolderForDevice(id string, device protocol.Devi
 func (db *Lowlevel) RemovePendingFolder(id string) error {
 	iter, err := db.NewPrefixIterator([]byte{KeyTypePendingFolder})
 	if err != nil {
-		return err
+		return fmt.Errorf("creating iterator: %w", err)
 	}
 	defer iter.Release()
 	var iterErr error
@@ -98,7 +99,11 @@ func (db *Lowlevel) RemovePendingFolder(id string) error {
 			continue
 		}
 		if err = db.Delete(iter.Key()); err != nil {
-			iterErr = err
+			if iterErr != nil {
+				l.Debugf("Repeat error removing pending folder: %v", err)
+			} else {
+				iterErr = err
+			}
 		}
 	}
 	return iterErr

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2983,7 +2983,7 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 		removeFolderForDevice:
 			if err := m.db.RemovePendingFolderForDevice(folderID, deviceID); err != nil {
 				msg := "Failed to remove pending folder-device entry"
-				l.Warnf("%v (%v, %v): %v", folderID, deviceID, msg, err)
+				l.Warnf("%v (%v, %v): %v", msg, folderID, deviceID, err)
 				m.evLogger.Log(events.Failure, msg)
 				continue
 			}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1379,7 +1379,9 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 	expiredPendingList := make([]map[string]string, 0, len(expiredPending))
 	for folder := range expiredPending {
 		if err = m.db.RemovePendingFolderForDevice(folder, deviceID); err != nil {
-			// Nothing we can fix; logged from DB already
+			msg := "Failed to remove pending folder-device entry"
+			l.Warnf("%v (%v, %v): %v", folder, deviceID, msg, err)
+			m.evLogger.Log(events.Failure, msg)
 			continue
 		}
 		expiredPendingList = append(expiredPendingList, map[string]string{
@@ -2941,7 +2943,9 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 	var removedPendingFolders []map[string]string
 	pendingFolders, err := m.db.PendingFolders()
 	if err != nil {
-		l.Infof("Could not iterate through pending folder entries for cleanup: %v", err)
+		msg := "Could not iterate through pending folder entries for cleanup"
+		l.Warnf("%v: %v", msg, err)
+		m.evLogger.Log(events.Failure, msg)
 		// Continue with pending devices below, loop is skipped.
 	}
 	for folderID, pf := range pendingFolders {
@@ -2951,7 +2955,9 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 			// at all (but might become pending again).
 			l.Debugf("Discarding pending removed folder %v from all devices", folderID)
 			if err := m.db.RemovePendingFolder(folderID); err != nil {
-				// Nothing we can fix; logged from DB already
+				msg := "Failed to remove pending folder entry"
+				l.Warnf("%v (%v): %v", folderID, msg, err)
+				m.evLogger.Log(events.Failure, msg)
 			} else {
 				removedPendingFolders = append(removedPendingFolders, map[string]string{
 					"folderID": folderID,
@@ -2976,7 +2982,9 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 			continue
 		removeFolderForDevice:
 			if err := m.db.RemovePendingFolderForDevice(folderID, deviceID); err != nil {
-				// Nothing we can fix; logged from DB already
+				msg := "Failed to remove pending folder-device entry"
+				l.Warnf("%v (%v, %v): %v", folderID, deviceID, msg, err)
+				m.evLogger.Log(events.Failure, msg)
 				continue
 			}
 			removedPendingFolders = append(removedPendingFolders, map[string]string{
@@ -2994,7 +3002,9 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 	var removedPendingDevices []map[string]string
 	pendingDevices, err := m.db.PendingDevices()
 	if err != nil {
-		l.Infof("Could not iterate through pending device entries for cleanup: %v", err)
+		msg := "Could not iterate through pending device entries for cleanup"
+		l.Warnf("%v: %v", msg, err)
+		m.evLogger.Log(events.Failure, msg)
 		return
 	}
 	for deviceID := range pendingDevices {
@@ -3009,7 +3019,9 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 		continue
 	removeDevice:
 		if err := m.db.RemovePendingDevice(deviceID); err != nil {
-			// Nothing we can fix; logged from DB already
+			msg := "Failed to remove pending device entry"
+			l.Warnf("%v: %v", msg, err)
+			m.evLogger.Log(events.Failure, msg)
 			continue
 		}
 		removedPendingDevices = append(removedPendingDevices, map[string]string{

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2956,7 +2956,7 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 			l.Debugf("Discarding pending removed folder %v from all devices", folderID)
 			if err := m.db.RemovePendingFolder(folderID); err != nil {
 				msg := "Failed to remove pending folder entry"
-				l.Warnf("%v (%v): %v", folderID, msg, err)
+				l.Warnf("%v (%v): %v", msg, folderID, err)
 				m.evLogger.Log(events.Failure, msg)
 			} else {
 				removedPendingFolders = append(removedPendingFolders, map[string]string{

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1380,7 +1380,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 	for folder := range expiredPending {
 		if err = m.db.RemovePendingFolderForDevice(folder, deviceID); err != nil {
 			msg := "Failed to remove pending folder-device entry"
-			l.Warnf("%v (%v, %v): %v", folder, deviceID, msg, err)
+			l.Warnf("%v (%v, %v): %v", msg, folder, deviceID, err)
 			m.evLogger.Log(events.Failure, msg)
 			continue
 		}


### PR DESCRIPTION
Error handling around pending entries in the db is inconsistent: Some errors are dropped, some logged at info level, some at warning level. And all errors are passed on to the caller, but still many are logged inside the method (above debug level, at debug level is always fine), while a few are logged by the caller.

I see two reasonable ways to handle this: 1. Don't ever return errors from the database. The concerned information isn't important, so reporting nothing or success when there's an error won't cause serious problems. There will just be some information missing. If the problem is serious (db corruption), some vital process will error out and produce logging/take syncthing down. 2. Do return errors, such that we can report errors on the API, but always let the caller handle the error.

I went for 2. in this PR, because I think it's nice to not lie to 3rd parties (i.e. on the API), even if the info is not important.

I also went for logging at warning level and adding failure reporting. If the cause is db corruptions, it doesn't matter: Syncthing will stop working anyway. We don't know any other failure modes, so if any still occur, we want to know about them. With warnings there's a good chance the users notices and seeks help on the forums. Info level logging would basically just be noise, that would most likely not be noticed.