### PR TITLE
lib/db: Add failure reports to failures iterating over hashes

### DIFF
--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -398,12 +398,16 @@ func (t *readOnlyTransaction) withBlocksHash(folder, hash []byte, iterator Itera
 		f.Name = osutil.NativeFilename(f.Name)
 
 		if !bytes.Equal(f.BlocksHash, hash) {
-			l.Warnf("Mismatching block map list hashes: got %x expected %x", f.BlocksHash, hash)
+			msg := "Mismatching block map list hashes"
+			t.evLogger.Log(events.Failure, fmt.Sprintln(msg, "in withBlocksHash"))
+			l.Warnf("%v: got %x expected %x", msg, f.BlocksHash, hash)
 			continue
 		}
 
 		if f.IsDeleted() || f.IsInvalid() || f.IsDirectory() || f.IsSymlink() {
-			l.Warnf("Found something of unexpected type in block list map: %s", f)
+			msg := "Found something of unexpected type in block list map"
+			t.evLogger.Log(events.Failure, fmt.Sprintln(msg, "in withBlocksHash"))
+			l.Warnf("%v: %s", msg, f)
 			continue
 		}
 


### PR DESCRIPTION
There's been a case of those errors reported to the forum recently. Unfortunately no cause has been determined. I want to know if that happens frequently. If it does, we should consider adding mitigation/self-repair measures. Or find a cause and fix that, but until that happens mitigation would be good anyway. The only way to fix it now is removing the folder (resetting db).