### PR TITLE
gui: Fix typo in new tooltip.

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -95,7 +95,7 @@
    "Discovery": "Discovery",
    "Discovery Failures": "Discovery Failures",
    "Dismiss": "Dismiss",
-   "Do not add it to the ignore list, so this notification may recurr.": "Do not add it to the ignore list, so this notification may recurr.",
+   "Do not add it to the ignore list, so this notification may recur.": "Do not add it to the ignore list, so this notification may recur.",
    "Do not restore": "Do not restore",
    "Do not restore all": "Do not restore all",
    "Do you want to enable watching for changes for all your folders?": "Do you want to enable watching for changes for all your folders?",


### PR DESCRIPTION
Fixes a typo introduced in #7712.  That happened after the last release, but has been included in the `-rc.1` version and propagated to transifex.