### PR TITLE
Added firewalld service files

### DIFF
--- a/etc/firewall-firewalld/README.md
+++ b/etc/firewall-firewalld/README.md
@@ -1,0 +1,25 @@
+Firewalld services
+==================
+Installation
+------------
+Copy the files`syncthing.xml` and `syncthing-gui.xml`  to your firewalld services directory usually located at `/etc/firewalld/services/` (root permissions required).
+
+To allow the syncthing ports, run
+```
+sudo firewall-cmd --add-service=syncthing
+sudo firewall-cmd --add-service=syncthing --permanent
+```
+If you want to access the web gui from anywhere (not only from localhost), you can also allow the gui port.
+This is step is **not** necessary for a "normal" installation!
+```
+sudo firewall-cmd --add-service=syncthing-gui
+sudo firewall-cmd --add-service=syncthing-gui --permanent
+```
+
+
+Verification
+------------
+You can verify the enabled services by running
+```
+sudo firewall-cmd --list-all
+```

--- a/etc/firewall-firewalld/syncthing-gui.xml
+++ b/etc/firewall-firewalld/syncthing-gui.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Syncthing-GUI</short>
+  <description>Syncthing web gui</description>
+  <port protocol="tcp" port="8384"/>
+</service>
+

--- a/etc/firewall-firewalld/syncthing.xml
+++ b/etc/firewall-firewalld/syncthing.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>Syncthing</short>
+  <description>Syncthing file synchronization</description>
+  <port protocol="udp" port="22000"/>
+  <port protocol="udp" port="21027"/>
+</service>
+


### PR DESCRIPTION
### Purpose

Provide firewalld service files for users using Syncthing on systems with the firewalld service running.
These files are the firewalld equivalent of the UFW application presets already provided in this repo.

### Testing

N/A

### Screenshots

N/A

### Documentation

N/A
