### PR TITLE
lib/connections: Missed map init in nextDialAt (ref #7753)

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -1085,6 +1085,7 @@ func (r nextDialRegistry) redialDevice(device protocol.DeviceID, now time.Time) 
 	dev, ok := r[device]
 	if !ok {
 		r[device] = nextDialDevice{
+			nextDial:              make(map[string]time.Time),
 			coolDownIntervalStart: now,
 			attempts:              1,
 		}


### PR DESCRIPTION
https://sentry.syncthing.net/organizations/syncthing/issues/11957

Mistake made in #7753: Map isn't initialized.