### PR TITLE
lib/api: Always include usage reporting data in support bundle

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1185,7 +1185,7 @@ func (s *service) getSupportBundle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Report Data as a JSON
-	if r, err := s.urService.ReportData(context.TODO()); err != nil {
+	if r, err := s.urService.ReportDataPreview(r.Context(), ur.Version); err != nil {
 		l.Warnln("Support bundle: failed to create usage-reporting.json.txt:", err)
 	} else {
 		if usageReportingData, err := json.MarshalIndent(r, "", "  "); err != nil {


### PR DESCRIPTION
Currently it uses the "current version" which may be -1 (disabled),
resulting in blank performance data in the support bundle. The intention
was never to couple this to the anonymous usage reporting policy, it's
merely a way to get statistics about the device into the support bundle.
