### PR TITLE
lib/protocol: Write uncompressible messages uncompressed

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -523,7 +523,7 @@ func (c *rawConnection) readMessageAfterHeader(hdr Header, fourByteBuf []byte) (
 		// Nothing
 
 	case MessageCompressionLZ4:
-		decomp, err := c.lz4Decompress(buf)
+		decomp, err := lz4Decompress(buf)
 		BufferPool.Put(buf)
 		if err != nil {
 			return nil, errors.Wrap(err, "decompressing message")
@@ -754,7 +754,7 @@ func (c *rawConnection) writeCompressedMessage(msg message) error {
 		return errors.Wrap(err, "marshalling message")
 	}
 
-	compressed, err := c.lz4Compress(buf)
+	compressed, err := lz4Compress(buf)
 	if err != nil {
 		BufferPool.Put(buf)
 		return errors.Wrap(err, "compressing message")
@@ -1018,7 +1018,7 @@ func (c *rawConnection) Statistics() Statistics {
 	}
 }
 
-func (c *rawConnection) lz4Compress(src []byte) ([]byte, error) {
+func lz4Compress(src []byte) ([]byte, error) {
 	var err error
 	buf := BufferPool.Get(lz4.CompressBound(len(src)))
 	compressed, err := lz4.Encode(buf, src)
@@ -1034,7 +1034,7 @@ func (c *rawConnection) lz4Compress(src []byte) ([]byte, error) {
 	return compressed, nil
 }
 
-func (c *rawConnection) lz4Decompress(src []byte) ([]byte, error) {
+func lz4Decompress(src []byte) ([]byte, error) {
 	size := binary.BigEndian.Uint32(src)
 	binary.LittleEndian.PutUint32(src, size)
 	var err error

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -440,8 +440,6 @@ func testMarshal(t *testing.T, prefix string, m1, m2 message) bool {
 }
 
 func TestLZ4Compression(t *testing.T) {
-	c := new(rawConnection)
-
 	for i := 0; i < 10; i++ {
 		dataLen := 150 + rand.Intn(150)
 		data := make([]byte, dataLen)
@@ -449,13 +447,13 @@ func TestLZ4Compression(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		comp, err := c.lz4Compress(data)
+		comp, err := lz4Compress(data)
 		if err != nil {
 			t.Errorf("compressing %d bytes: %v", dataLen, err)
 			continue
 		}
 
-		res, err := c.lz4Decompress(comp)
+		res, err := lz4Decompress(comp)
 		if err != nil {
 			t.Errorf("decompressing %d bytes to %d: %v", len(comp), dataLen, err)
 			continue
@@ -471,7 +469,6 @@ func TestLZ4Compression(t *testing.T) {
 }
 
 func TestStressLZ4CompressGrows(t *testing.T) {
-	c := new(rawConnection)
 	success := 0
 	for i := 0; i < 100; i++ {
 		// Create a slize that is precisely one min block size, fill it with
@@ -482,7 +479,7 @@ func TestStressLZ4CompressGrows(t *testing.T) {
 			t.Fatal("randomness failure")
 		}
 
-		comp, err := c.lz4Compress(data)
+		comp, err := lz4Compress(data)
 		if err != nil {
 			t.Fatal("unexpected compression error: ", err)
 		}


### PR DESCRIPTION
When a message becomes bigger after compression, the uncompressed version can be sent instead to not waste bandwidth and receiver CPU time. I've been keeping track of compressed message sizes and I've found it extremely common that metadata messages become larger from compression; it's only the longer ones that actually benefit (so maybe the threshold should be increased too).

I've merged the various send*Message methods so that there's less copying of compressed messages and less reallocation when compression fails. The cost of that is having to serialize the header of the uncompressed version unconditionally.