### PR TITLE
lib/model: Compare all items with global on scan (fixes #7740)

### DIFF
--- a/lib/model/folder_recvenc.go
+++ b/lib/model/folder_recvenc.go
@@ -29,7 +29,9 @@ type receiveEncryptedFolder struct {
 }
 
 func newReceiveEncryptedFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, cfg config.FolderConfiguration, ver versioner.Versioner, evLogger events.Logger, ioLimiter *util.Semaphore) service {
-	return &receiveEncryptedFolder{newSendReceiveFolder(model, fset, ignores, cfg, ver, evLogger, ioLimiter).(*sendReceiveFolder)}
+	f := &receiveEncryptedFolder{newSendReceiveFolder(model, fset, ignores, cfg, ver, evLogger, ioLimiter).(*sendReceiveFolder)}
+	f.localFlags = protocol.FlagLocalReceiveOnly // gets propagated to the scanner, and set on locally changed files
+	return f
 }
 
 func (f *receiveEncryptedFolder) Revert() {


### PR DESCRIPTION
First two commits are the same as on https://github.com/syncthing/syncthing/pull/7726: Replaces the `batchAppendFunc` being passed around as a function argument with a dedicated `scanBatch` type that has an `append` method.

The main change fixing #7740 is, that we now compare every new, scanned file with the current global file. If they are equivalent, the global file info is used, thus saving the detour over syncing to resolve the conflict (that isn't actually a conflict). This also benefits initial scan scenarios, where both sides have the data: If files are scanned after the index is received from the remote, they will immediately be in sync (instead of looking out of sync until all of the scan is done and a sync happens to resolve the conflicts).