### PR TITLE
lib/model: Prevent folder-type change from/to encrypted (fixes #7704)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2767,6 +2767,13 @@ func (m *model) String() string {
 }
 
 func (m *model) VerifyConfiguration(from, to config.Configuration) error {
+	toFolders := to.FolderMap()
+	for _, from := range from.Folders {
+		to, ok := toFolders[from.ID]
+		if ok && from.Type != to.Type && (from.Type == config.FolderTypeReceiveEncrypted || to.Type == config.FolderTypeReceiveEncrypted) {
+			return errors.New("folder type must not be changed from/to receive-encrypted")
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
Adds a config verification step that checks that no folder type is changed from/to receive-encrypted.