### PR TITLE
lib/model: Scan removed dirs when reverting recv-enc (fixes #7706)

### DIFF
--- a/lib/model/folder_recvenc.go
+++ b/lib/model/folder_recvenc.go
@@ -111,5 +111,6 @@ func (f *receiveEncryptedFolder) revertHandleDirs(dirs []string, snap *db.Snapsh
 		if err := f.deleteDirOnDisk(dir, snap, scanChan); err != nil {
 			f.newScanError(dir, fmt.Errorf("deleting unexpected dir: %w", err))
 		}
+		scanChan <- dir
 	}
 }


### PR DESCRIPTION
We correctly remove the directory, but never update the db -> kick off a scan on the removed directories.