### PR TITLE
lib/connections: Fully dial resumed devices

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -792,11 +792,10 @@ func (s *service) checkAndSignalConnectLoopOnUpdatedDevices(from, to config.Conf
 		if dev.Paused {
 			continue
 		}
-		oldDev, ok := oldDevices[dev.DeviceID]
-		if !ok || oldDev.Paused || !util.EqualStrings(oldDev.Addresses, dev.Addresses) {
-			if !ok || oldDev.Paused {
-				s.dialNowDevices[dev.DeviceID] = struct{}{}
-			}
+		if oldDev, ok := oldDevices[dev.DeviceID]; !ok || oldDev.Paused {
+			s.dialNowDevices[dev.DeviceID] = struct{}{}
+			dial = true
+		} else if !util.EqualStrings(oldDev.Addresses, dev.Addresses) {
 			dial = true
 		}
 	}


### PR DESCRIPTION
This improves/extends the mechanism to dial changed devices introduced in https://github.com/syncthing/syncthing/pull/7604: So far it covers newly added devices and addresses. It does not cover resumed devices, as they are still subject redial delays (e.g. when quickly pausing/unpausing a device to trigger a reconnect). Now new or previously paused are added to `dialNowDevices`, thus not subject to any delays.