### PR TITLE
cmd/ursrv: Make small numbers private by obfuscation (fixes #7787)

### DIFF
--- a/cmd/ursrv/analytics.go
+++ b/cmd/ursrv/analytics.go
@@ -16,7 +16,9 @@ import (
 type analytic struct {
 	Key        string
 	Count      int
+	CntStr     string
 	Percentage float64
+	PctStr     string
 	Items      []analytic `json:",omitempty"`
 }
 
@@ -54,7 +56,9 @@ func analyticsFor(ss []string, cutoff int) []analytic {
 		l = append(l, analytic{
 			Key:        k,
 			Count:      c,
-			Percentage: 100 * float64(c) / float64(t),
+			CntStr:     privCountString(c),
+			Percentage: privPct(c, t),
+			PctStr:     privPctString(c, t),
 		})
 	}
 
@@ -68,7 +72,9 @@ func analyticsFor(ss []string, cutoff int) []analytic {
 		l = append(l[:cutoff], analytic{
 			Key:        "Others",
 			Count:      c,
-			Percentage: 100 * float64(c) / float64(t),
+			CntStr:     privCountString(c),
+			Percentage: privPct(c, t),
+			PctStr:     privPctString(c, t),
 		})
 	}
 
@@ -110,7 +116,7 @@ func statsForInts(data []int) [4]float64 {
 	res[0] = float64(data[int(float64(len(data))*0.05)])
 	res[1] = float64(data[len(data)/2])
 	res[2] = float64(data[int(float64(len(data))*0.95)])
-	res[3] = float64(data[len(data)-1])
+	res[3] = float64(data[int(float64(len(data))*0.99)])
 	return res
 }
 
@@ -127,7 +133,7 @@ func statsForInt64s(data []int64) [4]float64 {
 	res[0] = float64(data[int(float64(len(data))*0.05)])
 	res[1] = float64(data[len(data)/2])
 	res[2] = float64(data[int(float64(len(data))*0.95)])
-	res[3] = float64(data[len(data)-1])
+	res[3] = float64(data[int(float64(len(data))*0.99)])
 	return res
 }
 
@@ -141,7 +147,7 @@ func statsForFloats(data []float64) [4]float64 {
 	res[0] = data[int(float64(len(data))*0.05)]
 	res[1] = data[len(data)/2]
 	res[2] = data[int(float64(len(data))*0.95)]
-	res[3] = data[len(data)-1]
+	res[3] = data[int(float64(len(data))*0.99)]
 	return res
 }
 
@@ -163,8 +169,10 @@ next:
 		}
 		res = append(res, analytic{
 			Key:        group,
-			Count:      a.Count,
-			Percentage: a.Percentage,
+			Count:      privCount(a.Count),
+			CntStr:     privCountString(a.Count),
+			Percentage: privPctPct(a.Percentage, isPrivate(a.Count)),
+			PctStr:     privPctPctString(a.Percentage, isPrivate(a.Count)),
 			Items:      []analytic{a},
 		})
 	}

--- a/cmd/ursrv/formatting.go
+++ b/cmd/ursrv/formatting.go
@@ -112,16 +112,17 @@ func commatize(sep, s string) string {
 	return b.String()
 }
 
-func proportion(m map[string]int, count int) float64 {
+func proportion(m map[string]intString, count int) float64 {
 	total := 0
 	isMax := true
-	for _, n := range m {
+	for _, x := range m {
+		n := x.N
 		total += n
 		if n > count {
 			isMax = false
 		}
 	}
-	pct := (100 * float64(count)) / float64(total)
+	pct := privPct(count, total)
 	// To avoid rounding errors in the template, surpassing 100% and breaking
 	// the progress bars.
 	if isMax && len(m) > 1 && count != total {

--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -453,8 +453,8 @@ type feature struct {
 }
 
 type intString struct {
-	N  int
-	S  string
+	N int
+	S string
 }
 
 type featureGroup struct {

--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -447,13 +447,20 @@ type feature struct {
 	Key     string
 	Version string
 	Count   int
+	CntStr  string
 	Pct     float64
+	PctStr  string
+}
+
+type intString struct {
+	N  int
+	S  string
 }
 
 type featureGroup struct {
 	Key     string
 	Version string
-	Counts  map[string]int
+	Counts  map[string]intString
 }
 
 // Used in the templates
@@ -869,8 +876,10 @@ func getReport(db *sql.DB) map[string]interface{} {
 				featureList = append(featureList, feature{
 					Key:     key,
 					Version: version,
-					Count:   count,
-					Pct:     (100 * float64(count)) / float64(total),
+					Count:   privCount(count),
+					CntStr:  privCountString(count),
+					Pct:     privPct(count, total),
+					PctStr:  privPctString(count, total),
 				})
 			}
 		}
@@ -886,7 +895,7 @@ func getReport(db *sql.DB) map[string]interface{} {
 				featureList = append(featureList, featureGroup{
 					Key:     key,
 					Version: version,
-					Counts:  counts,
+					Counts:  privCounts(counts),
 				})
 			}
 		}
@@ -896,9 +905,11 @@ func getReport(db *sql.DB) map[string]interface{} {
 	var countryList []feature
 	for country, count := range countries {
 		countryList = append(countryList, feature{
-			Key:   country,
-			Count: count,
-			Pct:   (100 * float64(count)) / float64(countriesTotal),
+			Key:    country,
+			Count:  privCount(count),
+			CntStr: privCountString(count),
+			Pct:    privPct(count, countriesTotal),
+			PctStr: privPctString(count, countriesTotal),
 		})
 		sort.Sort(sort.Reverse(sortableFeatureList(countryList)))
 	}

--- a/cmd/ursrv/privacy.go
+++ b/cmd/ursrv/privacy.go
@@ -63,8 +63,7 @@ func privPctString(n, total int) string {
 func privPctPctString(pct float64, private bool) string {
 	pct = privPctPct(pct, private)
 	precision := int(math.Max(0, 2-math.Max(0, math.Log10(pct))))
-	fmtPct := fmt.Sprintf("%%.0%df%%%%", precision)
-	s := fmt.Sprintf(fmtPct, pct)
+	s := fmt.Sprintf("%.*f", precision, pct)
 	if private {
 		s = "< " + s
 	}

--- a/cmd/ursrv/privacy.go
+++ b/cmd/ursrv/privacy.go
@@ -1,0 +1,72 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package main
+
+import (
+	"fmt"
+	"math"
+)
+
+var (
+	privMin = 10
+)
+
+// Helper functions for private numbers and percentages
+func isPrivate(n int) bool {
+	return n < privMin
+}
+
+func privCount(x int) int {
+	if isPrivate(x) {
+		x = privMin
+	}
+	return x
+}
+
+func privCountString(n int) string {
+	if isPrivate(n) {
+		return fmt.Sprintf("< %d", privCount(n))
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func privCounts(x map[string]int) map[string]intString {
+	fGroup := make(map[string]intString)
+	for key, counts := range x {
+		fGroup[key] = intString {
+			privCount(counts),
+			privCountString(counts),
+		}
+	}
+	return fGroup
+}
+
+func privPct(x, total int) float64 {
+	return (100 * float64(privCount(x))) / float64(total)
+}
+
+func privPctPct(x float64, private bool) float64 {
+	if private {
+		x *= 1.01
+	}
+	return x
+}
+
+func privPctString(n, total int) string {
+	pct := privPct(n, total)
+	return privPctPctString(pct, isPrivate(n))
+}
+func privPctPctString(pct float64, private bool) string {
+	pct = privPctPct(pct, private)
+	precision := int(math.Max(0, 2-math.Max(0, math.Log10(pct))))
+	fmtPct := fmt.Sprintf("%%.0%df%%%%", precision)
+	s := fmt.Sprintf(fmtPct, pct)
+	if private {
+		s = "< " + s
+	}
+	return s
+}

--- a/cmd/ursrv/privacy.go
+++ b/cmd/ursrv/privacy.go
@@ -22,7 +22,7 @@ func isPrivate(n int) bool {
 
 func privCount(x int) int {
 	if isPrivate(x) {
-		x = privMin
+		return privMin
 	}
 	return x
 }

--- a/cmd/ursrv/privacy.go
+++ b/cmd/ursrv/privacy.go
@@ -37,7 +37,7 @@ func privCountString(n int) string {
 func privCounts(x map[string]int) map[string]intString {
 	fGroup := make(map[string]intString)
 	for key, counts := range x {
-		fGroup[key] = intString {
+		fGroup[key] = intString{
 			privCount(counts),
 			privCountString(counts),
 		}

--- a/cmd/ursrv/static/index.html
+++ b/cmd/ursrv/static/index.html
@@ -318,8 +318,8 @@ found in the LICENSE file.
                       {{range .contries | slice 2 1}}
                       <tr>
                         <td style="width: 45%">{{.Key}}</td>
-                        <td style="width: 5%" class="text-right">{{if ge .Pct 10.0}}{{.Pct | printf "%.0f"}}{{else if ge .Pct 1.0}}{{.Pct | printf "%.01f"}}{{else}}{{.Pct | printf "%.02f"}}{{end}}%</td>
-                        <td style="width: 5%" class="text-right">{{.Count}}</td>
+                        <td style="width: 5%" class="text-right">{{.PctStr}}</td>
+                        <td style="width: 5%" class="text-right">{{.CntStr}}</td>
                         <td>
                             <div class="progress-bar" role="progressbar" aria-valuenow="{{.Pct | printf "%.02f"}}" aria-valuemin="0" aria-valuemax="100" style="width: {{.Pct | printf "%.02f"}}%; height:20px"></div>
                         </td>
@@ -334,8 +334,8 @@ found in the LICENSE file.
                       {{range .contries | slice 2 2}}
                       <tr>
                         <td style="width: 45%">{{.Key}}</td>
-                        <td style="width: 5%" class="text-right">{{if ge .Pct 10.0}}{{.Pct | printf "%.0f"}}{{else if ge .Pct 1.0}}{{.Pct | printf "%.01f"}}{{else}}{{.Pct | printf "%.02f"}}{{end}}%</td>
-                        <td style="width: 5%" class="text-right">{{.Count}}</td>
+												<td style="width: 5%" class="text-right">{{.PctStr}}</td>
+                        <td style="width: 5%" class="text-right">{{.CntStr}}</td>
                         <td>
                             <div class="progress-bar" role="progressbar" aria-valuenow="{{.Pct | printf "%.02f"}}" aria-valuemin="0" aria-valuemax="100" style="width: {{.Pct | printf "%.02f"}}%; height:20px"></div>
                         </td>
@@ -362,7 +362,7 @@ found in the LICENSE file.
               <th class="text-right">5%</th>
               <th class="text-right">50%</th>
               <th class="text-right">95%</th>
-              <th class="text-right">100%</th>
+              <th class="text-right">99%</th>
             </tr>
           </thead>
           <tbody>
@@ -393,15 +393,15 @@ found in the LICENSE file.
               {{if gt .Percentage 0.1}}
                 <tr class="main">
                   <td>{{.Key}}</td>
-                  <td class="text-right">{{.Count}}</td>
-                  <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                  <td class="text-right">{{.CntStr}}</td>
+                  <td class="text-right">{{.PctStr}}</td>
                 </tr>
                 {{range .Items}}
                   {{if gt .Percentage 0.1}}
                     <tr class="child">
                       <td class="first">{{.Key}}</td>
-                      <td class="text-right">{{.Count}}</td>
-                      <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                      <td class="text-right">{{.CntStr}}</td>
+                      <td class="text-right">{{.PctStr}}</td>
                     </tr>
                   {{end}}
                 {{end}}
@@ -422,7 +422,7 @@ found in the LICENSE file.
             <tr>
                 <td>{{.Count}}%</td>
                 <td>&ge; {{.Key}}</td>
-              <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+              <td class="text-right">{{.PctStr}}</td>
             </tr>
             {{end}}
           </tbody>
@@ -442,14 +442,14 @@ found in the LICENSE file.
             {{range .platforms}}
               <tr class="main">
                 <td>{{.Key}}</td>
-                <td class="text-right">{{.Count}}</td>
-                <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                <td class="text-right">{{.CntStr}}</td>
+                <td class="text-right">{{.PctStr}}</td>
               </tr>
               {{range .Items}}
                 <tr class="child">
                   <td class="first">{{.Key}}</td>
-                  <td class="text-right">{{.Count}}</td>
-                  <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                  <td class="text-right">{{.CntStr}}</td>
+                  <td class="text-right">{{.PctStr}}</td>
                 </tr>
               {{end}}
             {{end}}
@@ -473,15 +473,15 @@ found in the LICENSE file.
             {{range .compilers}}
               <tr class="main">
                 <td>{{.Key}}</td>
-                <td class="text-right">{{.Count}}</td>
-                <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                <td class="text-right">{{.CntStr}}</td>
+                <td class="text-right">{{.PctStr}}</td>
               </tr>
               {{range .Items}}
                 {{if or (gt .Percentage 0.1) (eq .Key "Others")}}
                   <tr class="child">
                     <td class="first">{{.Key}}</td>
-                    <td class="text-right">{{.Count}}</td>
-                    <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+                    <td class="text-right">{{.CntStr}}</td>
+                    <td class="text-right">{{.PctStr}}</td>
                   </tr>
                 {{end}}
               {{end}}
@@ -503,8 +503,8 @@ found in the LICENSE file.
             {{range .builders}}
             <tr>
               <td>{{.Key}}</td>
-              <td class="text-right">{{.Count}}</td>
-              <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+              <td class="text-right">{{.CntStr}}</td>
+              <td class="text-right">{{.PctStr}}</td>
             </tr>
             {{end}}
           </tbody>
@@ -524,8 +524,8 @@ found in the LICENSE file.
             {{range .distributions}}
             <tr>
               <td>{{.Key}}</td>
-              <td class="text-right">{{.Count}}</td>
-              <td class="text-right">{{.Percentage | printf "%.01f"}}%</td>
+              <td class="text-right">{{.CntStr}}</td>
+              <td class="text-right">{{.PctStr}}</td>
             </tr>
             {{end}}
           </tbody>
@@ -563,9 +563,9 @@ found in the LICENSE file.
                   {{range $featureValues}}
                   <tr>
                       <td style="width: 50%">{{.Key}} ({{.Version}})</td>
-                      <td style="width: 10%" class="text-right">{{if ge .Pct 10.0}}{{.Pct | printf "%.0f"}}{{else if ge .Pct 1.0}}{{.Pct | printf "%.01f"}}{{else}}{{.Pct | printf "%.02f"}}{{end}}%</td>
-                      <td style="width: 40%" {{if lt .Pct 5.0}}data-toggle="tooltip" title='{{.Count}}'{{end}}>
-                          <div class="progress-bar" role="progressbar" aria-valuenow="{{.Pct | printf "%.02f"}}" aria-valuemin="0" aria-valuemax="100" style="width: {{.Pct | printf "%.02f"}}%; height:20px" {{if ge .Pct 5.0}}data-toggle="tooltip" title='{{.Count}}'{{end}}></div>
+											<td style="width: 10%" class="text-right">{{.PctStr}}</td>
+                      <td style="width: 40%" {{if lt .Pct 5.0}}data-toggle="tooltip" title='{{.CntStr}}'{{end}}>
+                          <div class="progress-bar" role="progressbar" aria-valuenow="{{.Pct | printf "%.02f"}}" aria-valuemin="0" aria-valuemax="100" style="width: {{.Pct | printf "%.02f"}}%; height:20px" {{if ge .Pct 5.0}}data-toggle="tooltip" title='{{.CntStr}}'{{end}}></div>
                       </td>
                   </tr>
                   {{end}}
@@ -603,7 +603,7 @@ found in the LICENSE file.
                   {{$counts := .Counts}}
                   <tr>
                       <td style="width: 50%">
-                          <div data-toggle="tooltip" title='{{range $key, $value := .Counts}}{{$key}} ({{$value | proportion $counts | printf "%.02f"}}% - {{$value}})</br>{{end}}'>
+                          <div data-toggle="tooltip" title='{{range $key, $value := .Counts}}{{$key}} ({{$value.N | proportion $counts | printf "%.02f"}}% - {{$value.S}})</br>{{end}}'>
                               {{.Key}} ({{.Version}})
                           </div>
                       </td>
@@ -611,8 +611,8 @@ found in the LICENSE file.
                           <div class="progress" role="progressbar" style="width: 100%">
                           {{$j := counter}}
                           {{range $key, $value := .Counts}}
-                              {{with $valuePct := $value | proportion $counts}}
-                              <div class="progress-bar {{ $j.Current | progressBarClassByIndex }}" style='width: {{$valuePct | printf "%.02f"}}%' data-toggle="tooltip" title='{{$key}} ({{$valuePct | printf "%.02f"}}% - {{$value}})'>
+                              {{with $valuePct := $value.N | proportion $counts}}
+                              <div class="progress-bar {{ $j.Current | progressBarClassByIndex }}" style='width: {{$valuePct | printf "%.02f"}}%' data-toggle="tooltip" title='{{$key}} ({{$valuePct | printf "%.02f"}}% - {{$value.S}})'>
                                   {{if ge $valuePct 30.0}}{{$key}}{{end}}
                               </div>
                               {{end}}


### PR DESCRIPTION
### Purpose

Makes small numbers and percentages more private by obfuscating them. Small numbers are obfuscated with `< 10` label instead of their number and the corresponding percentage `< x%`. Currently the threshold for making a number private is 10, though this might need increasing, or changing depending on the total group size. Changes 100th percentile to 99th percentile. Fixes issue #7787 

### Testing
I tested manually that the code compiles and the parts that appear in a browser without a dataset look correct.
I don't know how/what to test. The added `privacy.go` might need testing.

### Screenshots

Before (note the numbers smaller than 10)
![Screenshot from 2021-06-28 14-50-43](https://user-images.githubusercontent.com/86428957/123657655-82cda380-d820-11eb-868b-8834e884eb69.png)

After:
![Screenshot from 2021-06-28 14-51-22](https://user-images.githubusercontent.com/86428957/123657645-806b4980-d820-11eb-9b14-89d3d8aa38cf.png)


### Documentation

No documentation change

