### PR TITLE
lib/connections: Resolve IPv6 for quic6:// peers

### DIFF
--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -13,6 +13,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/lucas-clemente/quic-go"
@@ -45,7 +46,9 @@ type quicDialer struct {
 func (d *quicDialer) Dial(ctx context.Context, _ protocol.DeviceID, uri *url.URL) (internalConn, error) {
 	uri = fixupPort(uri, config.DefaultQUICPort)
 
-	addr, err := net.ResolveUDPAddr("udp", uri.Host)
+	network := strings.ReplaceAll(uri.Scheme, "quic", "udp")
+
+	addr, err := net.ResolveUDPAddr(network, uri.Host)
 	if err != nil {
 		return internalConn{}, err
 	}


### PR DESCRIPTION
### Purpose

Before this patch, IPv4-compatible addresses (`::ffff:aaa.bbb.ccc.ddd`)
may be used if a `quic6://some.domain:port` is specified and both IPv4 and
IPv6 addresses exist for that domain name.

Fixes #7809

### Testing

Follow "steps to reproduce the problem" as described in #7809, and check if I got connections with normal IPv6 addresses.

### Screenshots N/A

### Documentation N/A

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.