### PR TITLE
lib/connections: switch statement to get the QUIC network

### DIFF
--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -13,7 +13,6 @@ import (
 	"crypto/tls"
 	"net"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/lucas-clemente/quic-go"
@@ -46,7 +45,7 @@ type quicDialer struct {
 func (d *quicDialer) Dial(ctx context.Context, _ protocol.DeviceID, uri *url.URL) (internalConn, error) {
 	uri = fixupPort(uri, config.DefaultQUICPort)
 
-	network := strings.ReplaceAll(uri.Scheme, "quic", "udp")
+	network := quicNetwork(uri)
 
 	addr, err := net.ResolveUDPAddr(network, uri.Host)
 	if err != nil {

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -13,7 +13,6 @@ import (
 	"crypto/tls"
 	"net"
 	"net/url"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -81,7 +80,7 @@ func (t *quicListener) OnExternalAddressChanged(address *stun.Host, via string) 
 }
 
 func (t *quicListener) serve(ctx context.Context) error {
-	network := strings.ReplaceAll(t.uri.Scheme, "quic", "udp")
+	network := quicNetwork(t.uri)
 
 	udpAddr, err := net.ResolveUDPAddr(network, t.uri.Host)
 	if err != nil {
@@ -204,7 +203,7 @@ func (t *quicListener) LANAddresses() []*url.URL {
 	uri := maybeReplacePort(t.uri, t.laddr)
 	t.mut.Unlock()
 	addrs := []*url.URL{uri}
-	network := strings.ReplaceAll(uri.Scheme, "quic", "udp")
+	network := quicNetwork(uri)
 	addrs = append(addrs, getURLsForAllAdaptersIfUnspecified(network, uri)...)
 	return addrs
 }

--- a/lib/connections/quic_misc.go
+++ b/lib/connections/quic_misc.go
@@ -11,6 +11,7 @@ package connections
 import (
 	"crypto/tls"
 	"net"
+	"net/url"
 
 	"github.com/lucas-clemente/quic-go"
 	"github.com/syncthing/syncthing/lib/util"
@@ -22,6 +23,17 @@ var (
 		KeepAlive:          true,
 	}
 )
+
+func quicNetwork(uri *url.URL) string {
+	switch uri.Scheme {
+	case "quic4":
+		return "udp4"
+	case "quic6":
+		return "udp6"
+	default:
+		return "udp"
+	}
+}
 
 type quicTlsConn struct {
 	quic.Session


### PR DESCRIPTION
This patch determines the network (udp, udp4, udp6) for QUIC URLs in a more explicit way than strings.ReplaceAll.