### PR TITLE
advancedSettings: Collapse all, inc. GUI section, on open.

### DIFF
--- a/gui/default/syncthing/settings/advancedSettingsModalView.html
+++ b/gui/default/syncthing/settings/advancedSettingsModalView.html
@@ -9,10 +9,10 @@
     <div class="panel-group" id="advancedAccordion" role="tablist" aria-multiselectable="true">
 
       <div class="panel panel-default">
-        <div class="panel-heading" role="tab" id="guiHeading" data-toggle="collapse" data-parent="#advancedAccordion" href="#guiConfig" aria-expanded="true" aria-controls="guiConfig" style="cursor: pointer;">
+        <div class="panel-heading" role="tab" id="guiHeading" data-toggle="collapse" data-parent="#advancedAccordion" href="#guiConfig" aria-expanded="false" aria-controls="guiConfig" style="cursor: pointer;">
           <h4 class="panel-title" translate tabindex="0">GUI</h4>
         </div>
-        <div id="guiConfig" class="panel-collapse collapse in" role="tabpanel" aria-labelledby="guiHeading">
+        <div id="guiConfig" class="panel-collapse collapse" role="tabpanel" aria-labelledby="guiHeading">
           <div class="panel-body">
             <form class="form-horizontal" role="form">
               <div ng-repeat="(key, value) in advancedConfig.gui" ng-init="type = inputTypeFor(key, value)" ng-if="type != 'skip'" class="form-group">


### PR DESCRIPTION
### Purpose
The GUI section is one of the least commonly accessed sections, which is accessed. Maybe accessed once, on first install. Compared to other sections, such as Folders, Devices, or Options, it shouldn't be more important.

Currently, it fills the screen (especially 100% zoom resolutions less than 2K (with FHD you still need to scroll around, with HD, and HD+, both still common resolutions, it's 1.5-2 pages of scrolling).  
When accessing the menu, it's almost always more practical to first collapse the GUI section, since scrolling takes more time.

Collapsing the GUI tab by default removes the need to collapse it, removing annoyance and saving time, while not removing much discoverability. Perhaps even making it not so welcoming for users, and dumber password managers, to start changing parameters without thought.

### Testing
Opened 'Advanced' modal with:
 - latest stable Linux binary, with `STGUIASSETS` to branch jtagcat:patch-1
 - TC build: [syncthing-linux-amd64-v1.18.1-rc.1.dev.2.g5be24323.tar.gz](https://build.syncthing.net/repository/download/Syncthing_BuildLinux/106773:id/syncthing-linux-amd64-v1.18.1-rc.1.dev.2.g5be24323.tar.gz)

### Screenshots

#### Before:
![Screenshot_20210714_153901](https://user-images.githubusercontent.com/38327267/125623943-0a6627f8-a7b3-482b-80eb-fa44694f8551.png)

#### After:
![Screenshot_20210714_154007](https://user-images.githubusercontent.com/38327267/125623968-cbe976bc-9a05-409f-b187-67f2530cb9bd.png)

### ~~Documentation~~

### Additional

Class `in` is used in `default/index.html`, as such it can't / doesn't have to be removed.