### PR TITLE
cmd/stcrashreceiver: Sanitize failure report fingerprints

### DIFF
--- a/cmd/stcrashreceiver/main.go
+++ b/cmd/stcrashreceiver/main.go
@@ -89,7 +89,8 @@ func handleFailureFn(dsn string) func(w http.ResponseWriter, req *http.Request) 
 			pkt.Extra = raven.Extra{
 				"count": r.Count,
 			}
-			pkt.Fingerprint = []string{r.Description}
+			message := sanitizeMessageLDB(r.Description)
+			pkt.Fingerprint = []string{message}
 
 			if err := sendReport(dsn, pkt, userIDFor(req)); err != nil {
 				log.Println("Failed to send failure report:", err)


### PR DESCRIPTION
Sentry (and my mailbox) is getting flooded with database corruption events because they can since a while occur as failures instead of panics, and the fingerprint isn't sanitized on failures. Now it is.