### PR TITLE
lib/syncthing: Remove the warning when insecureAdminAccess is enabled

### DIFF
--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -414,10 +414,6 @@ func (a *App) setupGUI(m model.Model, defaultSub, diskSub events.BufferedSubscri
 		return nil
 	}
 
-	if guiCfg.InsecureAdminAccess {
-		l.Warnln("Insecure admin access is enabled.")
-	}
-
 	summaryService := model.NewFolderSummaryService(a.cfg, m, a.myID, a.evLogger)
 	a.mainService.Add(summaryService)
 

--- a/man/syncthing-config.5
+++ b/man/syncthing-config.5
@@ -750,7 +750,7 @@ If set, this is the API key that enables usage of the REST interface.
 .TP
 .B insecureAdminAccess
 If true, this allows access to the web GUI from outside (i.e. not localhost)
-without authorization. A warning will displayed about this setting on startup.
+without authorization.
 .TP
 .B theme
 The name of the theme to use.


### PR DESCRIPTION
### Purpose

My use case is having Syncthing listen on a private WireGuard address. It's annoying to have this warning in my face even after explicitly enabling the setting that starts with "insecure".

See https://github.com/syncthing/syncthing/pull/2478#discussion_r45117737 for prior discussion.

### Testing

Trivial change, no testing done.

### Documentation

https://github.com/syncthing/docs/pull/656