### PR TITLE
lib/protocol: Ensure correct blocksize on enc. fileinfo (ref #7861)

### DIFF
--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -122,10 +122,10 @@ func (f FileInfo) FileSize() int64 {
 }
 
 func (f FileInfo) BlockSize() int {
-	if f.RawBlockSize == 0 {
+	if f.RawBlockSize < MinBlockSize {
 		return MinBlockSize
 	}
-	return int(f.RawBlockSize)
+	return f.RawBlockSize
 }
 
 func (f FileInfo) FileName() string {

--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -317,18 +317,20 @@ func encryptFileInfo(fi FileInfo, folderKey *[keySize]byte) FileInfo {
 		typ = FileInfoTypeDirectory
 	}
 	enc := FileInfo{
-		Name:         encryptName(fi.Name, folderKey),
-		Type:         typ,
-		Size:         offset, // new total file size
-		Permissions:  0644,
-		ModifiedS:    1234567890, // Sat Feb 14 00:31:30 CET 2009
-		Deleted:      fi.Deleted,
-		RawInvalid:   fi.IsInvalid(),
-		Version:      version,
-		Sequence:     fi.Sequence,
-		RawBlockSize: fi.RawBlockSize + blockOverhead,
-		Blocks:       blocks,
-		Encrypted:    encryptedFI,
+		Name:        encryptName(fi.Name, folderKey),
+		Type:        typ,
+		Permissions: 0644,
+		ModifiedS:   1234567890, // Sat Feb 14 00:31:30 CET 2009
+		Deleted:     fi.Deleted,
+		RawInvalid:  fi.IsInvalid(),
+		Version:     version,
+		Sequence:    fi.Sequence,
+		Encrypted:   encryptedFI,
+	}
+	if typ == FileInfoTypeFile {
+		enc.Size = offset // new total file size
+		enc.Blocks = blocks
+		enc.RawBlockSize = fi.BlockSize() + blockOverhead
 	}
 
 	return enc

--- a/lib/protocol/encryption_test.go
+++ b/lib/protocol/encryption_test.go
@@ -142,6 +142,9 @@ func TestEnDecryptFileInfo(t *testing.T) {
 	if bytes.Equal(enc.Blocks[0].Hash, enc.Blocks[1].Hash) {
 		t.Error("block hashes should not repeat when on different offsets")
 	}
+	if enc.RawBlockSize < MinBlockSize {
+		t.Error("Too small raw block size:", enc.RawBlockSize)
+	}
 	again := encryptFileInfo(fi, &key)
 	if !bytes.Equal(enc.Blocks[0].Hash, again.Blocks[0].Hash) {
 		t.Error("block hashes should remain stable (0)")


### PR DESCRIPTION
Possible root cause of https://github.com/syncthing/syncthing/issues/7861 / https://forum.syncthing.net/t/untrusted-device-never-finishes-syncing-very-high-memory-usage/17187.

Files predating the variable block sizes might have `RawBlockSize` set to 0. Which we handle in `.BlockSize`, however when encrypting we add `blockOverhead` to `RawBlockSize`, ending up with a block size below `MinBlockSize` but not `0`. Which then uses tons of memory when hashing a large file with such a small block size.

I both corrected `encryptFileInfo` to set a valid `RawBlockSize` and made `BlockSize` return `MinBlockSize` if it encounters a raw value smaller than `MinBlockSize`, to cover any file infos already affected by this issue.