### PR TITLE
lib/stun: Prevent nil deref when naming service

### DIFF
--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -107,8 +107,14 @@ func New(cfg config.Wrapper, subscriber Subscriber, conn *net.UDPConn) (*Service
 	client.SetSoftwareName("") // Explicitly unset this, seems to freak some servers out.
 
 	// Return the service and the other conn to the client
+	name := "Stun@"
+	if local := conn.LocalAddr(); local != nil {
+		name += local.Network() + "://" + local.String()
+	} else {
+		name += "unknown"
+	}
 	s := &Service{
-		name: "Stun@" + conn.LocalAddr().Network() + "://" + conn.LocalAddr().String(),
+		name: name,
 
 		cfg:        cfg,
 		subscriber: subscriber,


### PR DESCRIPTION
https://sentry.syncthing.net/organizations/syncthing/issues/11568

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x18 pc=0x12cf8e4]

goroutine 320 [running]:
github.com/syncthing/syncthing/lib/stun.New(0x1942ad8, 0xc000434000, 0x1926670, 0xc000115200, 0xc0000d4238, 0x0, 0x0, 0x0)
	github.com/syncthing/syncthing/lib/stun/stun.go:111 +0x2e4
github.com/syncthing/syncthing/lib/connections.(*quicListener).serve(0xc000115200, 0x19308a8, 0xc0000de700, 0x0, 0x0)
	github.com/syncthing/syncthing/lib/connections/quic_listen.go:98 +0x365
github.com/syncthing/syncthing/lib/svcutil.(*service).Serve(0xc0000d07c0, 0x19308a8, 0xc0000de700, 0x192c698, 0xc0001977c0)
	github.com/syncthing/syncthing/lib/svcutil/svcutil.go:125 +0xa3
github.com/thejerf/suture/v4.(*Supervisor).runService.func2(0xc00027a000, 0xc000000000, 0x173713419b8, 0xc000115200, 0x19308a8, 0xc0000de700, 0xc000a60210, 0xc00085c1e0)
	github.com/thejerf/suture/v4@v4.0.1/supervisor.go:551 +0x7e
created by github.com/thejerf/suture/v4.(*Supervisor).runService
	github.com/thejerf/suture/v4@v4.0.1/supervisor.go:539 +0x185
```

This is a silly API from Go in my opinion: `conn.LocalAddress` might return `nil` if there's a problem with the connection. Other methods return an error in this case, this doesn't. So anyway, lets just not panic.