### PR TITLE
lib/syncthing: Set system timezone on android

### DIFF
--- a/lib/syncthing/time_android.go
+++ b/lib/syncthing/time_android.go
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package syncthing
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// https://github.com/golang/go/issues/20455#issuecomment-342287698
+func init() {
+	out, err := exec.Command("/system/bin/getprop", "persist.sys.timezone").Output()
+	if err != nil {
+		return
+	}
+	z, err := time.LoadLocation(strings.TrimSpace(string(out)))
+	if err != nil {
+		return
+	}
+	time.Local = z
+}


### PR DESCRIPTION
Go doesn't use the system timezone on android.

https://forum.syncthing.net/t/is-it-possible-to-use-local-time-in-logfile-instead-of-utc-on-android/17199
https://github.com/golang/go/issues/20455