### PR TITLE
gui: Use large modals for Listeners and Discovery

### DIFF
--- a/gui/default/syncthing/core/connectivityStatusModalView.html
+++ b/gui/default/syncthing/core/connectivityStatusModalView.html
@@ -1,4 +1,4 @@
-<modal id="connectivity-status" status="{{connectivityStatusParams.status}}" icon="fas fa-fw {{connectivityStatusParams.type == 'listeners' ? 'fa-sitemap' : 'fa-map-signs'}}" heading="{{connectivityStatusParams.heading}}" large="no" closeable="yes">
+<modal id="connectivity-status" status="{{connectivityStatusParams.status}}" icon="fas fa-fw {{connectivityStatusParams.type == 'listeners' ? 'fa-sitemap' : 'fa-map-signs'}}" heading="{{connectivityStatusParams.heading}}" large="yes" closeable="yes">
   <div class="modal-body" ng-switch="connectivityStatusParams.type">
     <div ng-switch-when="listeners">
       <p translate ng-if="listenersRunning.length == 0">


### PR DESCRIPTION
Right now, small modals are used for Listeners and Discovery. However,
especially in the case Discovery, quite a lot of information is crammed
into the modal, which basically fills it completely in order to fit the
long sentences and long error messages. Because of this, change the type
of the modal to "large", so that everything has more space to fit more
comfortably.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

Before:

![image](https://user-images.githubusercontent.com/5626656/129362604-bbb0cb16-5c01-460b-ab78-05da8b71f55e.png)

After:

![image](https://user-images.githubusercontent.com/5626656/129362610-619e3ea9-a22c-4430-9a6e-8140c09267de.png)
