### PR TITLE
lib/connections: Remove future go build constraints on quic

### DIFF
--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -4,8 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-//go:build go1.14 && !noquic && !go1.17
-// +build go1.14,!noquic,!go1.17
+//go:build go1.15 && !noquic
+// +build go1.15,!noquic
 
 package connections
 

--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -4,8 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build go1.14 && !noquic && !go1.17
-// +build go1.14,!noquic,!go1.17
+//go:build go1.15 && !noquic
+// +build go1.15,!noquic
 
 package connections
 

--- a/lib/connections/quic_misc.go
+++ b/lib/connections/quic_misc.go
@@ -4,8 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build go1.14 && !noquic && !go1.17
-// +build go1.14,!noquic,!go1.17
+//go:build go1.15 && !noquic
+// +build go1.15,!noquic
 
 package connections
 

--- a/lib/connections/quic_unsupported.go
+++ b/lib/connections/quic_unsupported.go
@@ -4,8 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build noquic || !go1.14 || go1.17
-// +build noquic !go1.14 go1.17
+//go:build noquic || !go1.15
+// +build noquic !go1.15
 
 package connections
 


### PR DESCRIPTION
I checked and the quic folks already supported go1.17 since beta, so I'd say it's fairly save to stop guarding against future go releases (and forgetting to adjust it on every go release - I would have forgotten if not for the PR from the brew people). While at it I also bumped the lower constraint to go1.15 which is the oldest they support on the quic version we have (not that it matters much as we don't support go1.14 anyway).