### PR TITLE
lib/ur: Fix panic build goroutines for failures

### DIFF
--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -49,7 +49,7 @@ type FailureData struct {
 }
 
 func FailureDataWithGoroutines(description string) FailureData {
-	var buf *strings.Builder
+	var buf strings.Builder
 	pprof.Lookup("goroutine").WriteTo(buf, 1)
 	return FailureData{
 		Description: description,


### PR DESCRIPTION
Variable is not initialized 