### PR TITLE
lib/ur: Fix panic build goroutines for failures

### DIFF
--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -49,8 +49,8 @@ type FailureData struct {
 }
 
 func FailureDataWithGoroutines(description string) FailureData {
-	var buf *strings.Builder
-	pprof.Lookup("goroutine").WriteTo(buf, 1)
+	var buf strings.Builder
+	pprof.Lookup("goroutine").WriteTo(&buf, 1)
 	return FailureData{
 		Description: description,
 		Goroutines:  buf.String(),


### PR DESCRIPTION
Variable is not initialized 