### PR TITLE
Add a link to docs source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ binaries are also properly code signed.
 
 ## Documentation
 
-Please see the [Syncthing documentation site][6].
+Please see the Syncthing [documentation site][6] [[source]][17].
 
 All code is licensed under the [MPLv2 License][7].
 
@@ -112,4 +112,4 @@ All code is licensed under the [MPLv2 License][7].
 [14]: assets/logo-text-128.png
 [15]: https://syncthing.net/
 [16]: https://github.com/syncthing/syncthing/blob/main/README-Docker.md
-
+[17]: https://github.com/syncthing/docs


### PR DESCRIPTION
### Purpose

Jump to docs source is now possible, when you already know where you want to go. The usual Ctrl-f source for docs doesn't work (most repos keep their docs in the same repo, so PRs can/must include docs for the changes.