### PR TITLE
lib/fs: Optimize TempName + some cosmetic changes

### DIFF
--- a/lib/fs/tempname_test.go
+++ b/lib/fs/tempname_test.go
@@ -7,20 +7,31 @@
 package fs
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
 func TestLongTempFilename(t *testing.T) {
-	filename := ""
-	for i := 0; i < 300; i++ {
-		filename += "l"
-	}
+	filename := strings.Repeat("l", 300)
 	tFile := TempName(filename)
-	if len(tFile) < 10 || len(tFile) > 200 {
+	if len(tFile) < 10 || len(tFile) > 160 {
 		t.Fatal("Invalid long filename")
 	}
 	if !strings.HasSuffix(TempName("short"), "short.tmp") {
 		t.Fatal("Invalid short filename", TempName("short"))
 	}
 }
+
+func benchmarkTempName(b *testing.B, filename string) {
+	filename = filepath.Join("/Users/marieantoinette", filename)
+
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		TempName(filename)
+	}
+}
+
+func BenchmarkTempNameShort(b *testing.B) { benchmarkTempName(b, "somefile.txt") }
+func BenchmarkTempNameLong(b *testing.B)  { benchmarkTempName(b, strings.Repeat("a", 270)) }


### PR DESCRIPTION
Micro-optimizations for fs.TempName. The test has also been made more strict.

There's at least one change that should be reviewed carefully, which is that the long filename handling now hashes the basename of a file instead of a full path. Since f4372710bfa57abd9ae22d8de6d22c38c25b01eb also changed the hash, I reckoned this should be safe to do.

I was aiming for a lower allocation rate, but got a nice speedup too:

```
name             old time/op    new time/op    delta
TempNameLong-8     4.05µs ± 4%    3.76µs ± 3%   -7.13%  (p=0.000 n=10+10)
TempNameShort-8     635ns ± 2%     440ns ± 3%  -30.76%  (p=0.000 n=9+10)

name             old alloc/op   new alloc/op   delta
TempNameLong-8       672B ± 0%      560B ± 0%  -16.67%  (p=0.000 n=10+10)
TempNameShort-8      128B ± 0%       96B ± 0%  -25.00%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
TempNameLong-8       8.00 ± 0%      6.00 ± 0%  -25.00%  (p=0.000 n=10+10)
TempNameShort-8      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=10+10)
```