### PR TITLE
chore: fix typo in folder_recvonly.go

### DIFF
--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -26,7 +26,7 @@ func init() {
 /*
 receiveOnlyFolder is a folder that does not propagate local changes outward.
 It does this by the following general mechanism (not all of which is
-implemted in this file):
+implemented in this file):
 
 - Local changes are scanned and versioned as usual, but get the
   FlagLocalReceiveOnly bit set.


### PR DESCRIPTION
### Purpose

Fix typo in comments.
