### PR TITLE
all: Unused args, retvals, assignments

### DIFF
--- a/cmd/stfindignored/main.go
+++ b/cmd/stfindignored/main.go
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-// Commmand stfindignored lists ignored files under a given folder root.
+// Command stfindignored lists ignored files under a given folder root.
 package main
 
 import (

--- a/cmd/syncthing/cli/utils.go
+++ b/cmd/syncthing/cli/utils.go
@@ -54,7 +54,7 @@ func indexDumpOutput(url string) cli.ActionFunc {
 		if err != nil {
 			return err
 		}
-		return prettyPrintResponse(c, response)
+		return prettyPrintResponse(response)
 	}
 }
 
@@ -130,7 +130,7 @@ func prettyPrintJSON(data interface{}) error {
 	return enc.Encode(data)
 }
 
-func prettyPrintResponse(c *cli.Context, response *http.Response) error {
+func prettyPrintResponse(response *http.Response) error {
 	bytes, err := responseToBArray(response)
 	if err != nil {
 		return err

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -516,7 +516,11 @@ func checkUpgrade() (upgrade.Release, error) {
 }
 
 func upgradeViaRest() error {
-	cfg, _ := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	if err != nil {
+		return err
+	}
+
 	u, err := url.Parse(cfg.GUI().URL())
 	if err != nil {
 		return err

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -412,7 +412,7 @@ func (options serveOptions) Run() error {
 }
 
 func openGUI(myID protocol.DeviceID) error {
-	cfg, err := loadOrDefaultConfig(myID, events.NoopLogger, true)
+	cfg, err := loadOrDefaultConfig(myID, events.NoopLogger)
 	if err != nil {
 		return err
 	}
@@ -497,7 +497,7 @@ func (e *errNoUpgrade) Error() string {
 }
 
 func checkUpgrade() (upgrade.Release, error) {
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger, true)
+	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
 	if err != nil {
 		return upgrade.Release{}, err
 	}
@@ -516,7 +516,7 @@ func checkUpgrade() (upgrade.Release, error) {
 }
 
 func upgradeViaRest() error {
-	cfg, _ := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger, true)
+	cfg, _ := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
 	u, err := url.Parse(cfg.GUI().URL())
 	if err != nil {
 		return err
@@ -752,12 +752,12 @@ func setupSignalHandling(app *syncthing.App) {
 	}()
 }
 
-func loadOrDefaultConfig(myID protocol.DeviceID, evLogger events.Logger, noDefaultFolder bool) (config.Wrapper, error) {
+func loadOrDefaultConfig(myID protocol.DeviceID, evLogger events.Logger) (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, _, err := config.Load(cfgFile, myID, evLogger)
 
 	if err != nil {
-		cfg, err = syncthing.DefaultConfig(cfgFile, myID, evLogger, noDefaultFolder)
+		cfg, err = syncthing.DefaultConfig(cfgFile, myID, evLogger, true)
 	}
 
 	return cfg, err

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -564,7 +564,7 @@ func childEnv() []string {
 // panicUploadMaxWait uploading panics...
 func maybeReportPanics() {
 	// Try to get a config to see if/where panics should be reported.
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger, true)
+	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
 	if err != nil {
 		l.Warnln("Couldn't load config; not reporting crash")
 		return

--- a/lib/api/api_statics.go
+++ b/lib/api/api_statics.go
@@ -66,7 +66,7 @@ func newStaticsServer(theme, assetDir string) *staticsServer {
 func (s *staticsServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	switch r.URL.Path {
 	case "/themes.json":
-		s.serveThemes(w, r)
+		s.serveThemes(w)
 	default:
 		s.serveAsset(w, r)
 	}
@@ -153,7 +153,7 @@ func (s *staticsServer) serveFromAssets(file, theme string, modificationTime tim
 	return true
 }
 
-func (s *staticsServer) serveThemes(w http.ResponseWriter, r *http.Request) {
+func (s *staticsServer) serveThemes(w http.ResponseWriter) {
 	sendJSON(w, map[string][]string{
 		"themes": s.availableThemes,
 	})

--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -103,7 +103,7 @@ func writeBroadcasts(ctx context.Context, inbox <-chan []byte, port int) error {
 		}
 
 		if success == 0 {
-			l.Debugln("couldn't send any braodcasts")
+			l.Debugln("couldn't send any broadcasts")
 			return err
 		}
 	}

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -180,7 +180,7 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 		if err != nil {
 			return err
 		}
-		keyBuf, _, err = t.updateGlobal(gk, keyBuf, folder, device, f, meta)
+		keyBuf, err = t.updateGlobal(gk, keyBuf, folder, device, f, meta)
 		if err != nil {
 			return err
 		}
@@ -272,7 +272,7 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		if err != nil {
 			return err
 		}
-		keyBuf, _, err = t.updateGlobal(gk, keyBuf, folder, protocol.LocalDeviceID[:], f, meta)
+		keyBuf, err = t.updateGlobal(gk, keyBuf, folder, protocol.LocalDeviceID[:], f, meta)
 		if err != nil {
 			return err
 		}

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -528,7 +528,7 @@ func (db *schemaUpdater) updateSchemaTo9(prev int) error {
 	}
 	defer t.close()
 
-	if err := db.rewriteFiles(t); err != nil {
+	if err := rewriteFiles(t); err != nil {
 		return err
 	}
 
@@ -537,7 +537,7 @@ func (db *schemaUpdater) updateSchemaTo9(prev int) error {
 	return t.Commit()
 }
 
-func (db *schemaUpdater) rewriteFiles(t readWriteTransaction) error {
+func rewriteFiles(t readWriteTransaction) error {
 	it, err := t.NewPrefixIterator([]byte{KeyTypeDevice})
 	if err != nil {
 		return err
@@ -695,12 +695,12 @@ func (db *schemaUpdater) updateSchemaTo13(prev int) error {
 	defer t.close()
 
 	if prev < 12 {
-		if err := db.rewriteFiles(t); err != nil {
+		if err := rewriteFiles(t); err != nil {
 			return err
 		}
 	}
 
-	if err := db.rewriteGlobals(t); err != nil {
+	if err := rewriteGlobals(t); err != nil {
 		return err
 	}
 
@@ -835,7 +835,7 @@ func (db *schemaUpdater) dropIndexIDsMigration(_ int) error {
 	return db.dropIndexIDs()
 }
 
-func (db *schemaUpdater) rewriteGlobals(t readWriteTransaction) error {
+func rewriteGlobals(t readWriteTransaction) error {
 	it, err := t.NewPrefixIterator([]byte{KeyTypeGlobal})
 	if err != nil {
 		return err

--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -244,8 +244,7 @@ func (db *schemaUpdater) updateSchema0to1(_ int) error {
 			if err != nil && !backend.IsNotFound(err) {
 				return err
 			}
-			i := 0
-			i = sort.Search(len(fl.Versions), func(j int) bool {
+			i := sort.Search(len(fl.Versions), func(j int) bool {
 				return fl.Versions[j].Invalid
 			})
 			for ; i < len(fl.Versions); i++ {
@@ -759,7 +758,7 @@ func (db *schemaUpdater) updateSchemaTo14(_ int) error {
 			if err != nil {
 				return err
 			}
-			key, _, err = t.updateGlobal(gk, key, folder, protocol.LocalDeviceID[:], fi, meta)
+			key, err = t.updateGlobal(gk, key, folder, protocol.LocalDeviceID[:], fi, meta)
 			if err != nil {
 				return err
 			}
@@ -909,11 +908,9 @@ outer:
 			switch nfv.Version.Compare(fv.Version) {
 			case protocol.Equal:
 				newVl.RawVersions[newPos].InvalidDevices = append(newVl.RawVersions[newPos].InvalidDevices, fv.Device)
-				lastVersion = fv.Version
 				continue outer
 			case protocol.Lesser:
 				newVl.insertAt(newPos, newFileVersion(fv.Device, fv.Version, true, fv.Deleted))
-				lastVersion = fv.Version
 				continue outer
 			case protocol.ConcurrentLesser, protocol.ConcurrentGreater:
 				// The version is invalid, i.e. it looses anyway,
@@ -923,7 +920,6 @@ outer:
 		}
 		// Couldn't insert into any existing versions
 		newVl.RawVersions = append(newVl.RawVersions, newFileVersion(fv.Device, fv.Version, true, fv.Deleted))
-		lastVersion = fv.Version
 		newPos++
 	}
 

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -713,7 +713,10 @@ func (t readWriteTransaction) updateGlobal(gk, keyBuf, folder, device []byte, fi
 			// The inserted file is the global file
 			global = file
 		} else {
-			keyBuf, global, _ = t.getGlobalFromFileVersion(keyBuf, folder, name, true, globalFV)
+			keyBuf, global, err = t.getGlobalFromFileVersion(keyBuf, folder, name, true, globalFV)
+			if err != nil {
+				return nil, err
+			}
 		}
 		gotGlobal = true
 	}

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -189,7 +189,7 @@ func (m *Matcher) Load(file string) error {
 		return nil
 	}
 
-	fd, info, err := loadIgnoreFile(m.fs, file, m.changeDetector)
+	fd, info, err := loadIgnoreFile(m.fs, file)
 	if err != nil {
 		m.parseLocked(&bytes.Buffer{}, file)
 		return err
@@ -381,7 +381,7 @@ func hashPatterns(patterns []Pattern) string {
 	return fmt.Sprintf("%x", h.Sum(nil))
 }
 
-func loadIgnoreFile(fs fs.Filesystem, file string, cd ChangeDetector) (fs.File, fs.FileInfo, error) {
+func loadIgnoreFile(fs fs.Filesystem, file string) (fs.File, fs.FileInfo, error) {
 	fd, err := fs.Open(file)
 	if err != nil {
 		return fd, nil, err
@@ -411,7 +411,7 @@ func loadParseIncludeFile(filesystem fs.Filesystem, file string, cd ChangeDetect
 		return nil, parseError(fmt.Errorf("multiple include of ignore file %q", file))
 	}
 
-	fd, info, err := loadIgnoreFile(filesystem, file, cd)
+	fd, info, err := loadIgnoreFile(filesystem, file)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Also two typos. These were all found by golangci-lint or DeepSource.