### PR TITLE
Buffer allocation optimizations

### DIFF
--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -114,19 +114,18 @@ func (c *localClient) announcementPkt(instanceID int64, msg []byte) ([]byte, boo
 		return msg, false
 	}
 
-	if cap(msg) >= 4 {
-		msg = msg[:4]
-	} else {
-		msg = make([]byte, 4)
-	}
-	binary.BigEndian.PutUint32(msg, Magic)
-
 	pkt := Announce{
 		ID:         c.myID,
 		Addresses:  addrs,
 		InstanceID: instanceID,
 	}
 	bs, _ := pkt.Marshal()
+
+	if pktLen := 4 + len(bs); cap(msg) < pktLen {
+		msg = make([]byte, 0, pktLen)
+	}
+	msg = msg[:4]
+	binary.BigEndian.PutUint32(msg, Magic)
 	msg = append(msg, bs...)
 
 	return msg, true

--- a/lib/protocol/hello.go
+++ b/lib/protocol/hello.go
@@ -90,7 +90,7 @@ func writeHello(c io.Writer, h HelloIntf) error {
 		panic("bug: attempting to serialize too large hello message")
 	}
 
-	header := make([]byte, 6)
+	header := make([]byte, 6, 6+len(msg))
 	binary.BigEndian.PutUint32(header[:4], h.Magic())
 	binary.BigEndian.PutUint16(header[4:], uint16(len(msg)))
 

--- a/lib/relay/protocol/packets.go
+++ b/lib/relay/protocol/packets.go
@@ -60,13 +60,9 @@ func (i SessionInvitation) String() string {
 	if address, err := syncthingprotocol.DeviceIDFromBytes(i.From); err == nil {
 		device = address.String()
 	}
-	return fmt.Sprintf("%s@%s", device, i.AddressString())
+	return fmt.Sprintf("%s@%s:%d", device, net.IP(i.Address), i.Port)
 }
 
 func (i SessionInvitation) GoString() string {
 	return i.String()
-}
-
-func (i SessionInvitation) AddressString() string {
-	return fmt.Sprintf("%s:%d", net.IP(i.Address), i.Port)
 }


### PR DESCRIPTION
Here's some small optimizations to buffer allocations. They remove a public method that was used only once.