### PR TITLE
lib/model, lib/protocol: Don't generate encrypted filenames that are reserved on Windows (fixes #7808)

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -587,9 +587,7 @@ func deslashify(s string) (string, error) {
 		return "", fmt.Errorf("invalid encrypted path: %q", s)
 	}
 	s = s[:1] + s[1+len(encryptedDirExtension):]
-	s = strings.Replace(s, "/x", "", 1) // remove "x" escaping in last component; we could simply remove any an all "x"s, but this seems safer
-	s = strings.ReplaceAll(s, "/", "")  // remove all other slashes
-	return s, nil
+	return strings.ReplaceAll(s, "/", ""), nil
 }
 
 type rawResponse struct {

--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -554,7 +554,7 @@ func escapeWindowsReserved(s string) string {
 			// This is a reserved file name; escape it. Adding an "x" is an
 			// adequate escape because that character is not part of our
 			// filename encoding, and no reserved names start with an x.
-			return s[:lastSlash+1] + "x" + s[lastSlash+1:]
+			return s[:lastSlash+1] + "x" + lastComp
 		}
 	}
 	return s

--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -550,10 +550,10 @@ func escapeWindowsReserved(s string) string {
 		return s
 	}
 	for _, n := range windowsDisallowedNames {
-		// This is a reserved file name; escape it. Adding an "x" is an
-		// adequate escape because that character is not part of our
-		// filename encoding, and no reserved names start with an x.
 		if lastComp == n {
+			// This is a reserved file name; escape it. Adding an "x" is an
+			// adequate escape because that character is not part of our
+			// filename encoding, and no reserved names start with an x.
 			return s[:lastSlash+1] + "x" + s[lastSlash+1:]
 		}
 	}

--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -540,6 +540,8 @@ func slashify(s string) string {
 	return strings.Join(comps, "/")
 }
 
+// Escape a filename that contains Windows badness, e.g. ASDF/GHJK/CON =>
+// ASDF/GHJK/xCON
 func escapeWindowsReserved(s string) string {
 	lastSlash := strings.LastIndex(s, "/")
 	lastComp := s[lastSlash+1:]

--- a/lib/protocol/encryption_test.go
+++ b/lib/protocol/encryption_test.go
@@ -223,7 +223,7 @@ func TestEscapeWindowsReserved(t *testing.T) {
 			t.Error("Expected", tc.escaped, "got", esc)
 		}
 
-		unesc := unescapeWindowsReserved(esc)
+		unesc := UnescapeWindowsReserved(esc)
 		if unesc != tc.path {
 			t.Error("Expected", tc.path, "got", unesc)
 		}

--- a/lib/protocol/encryption_test.go
+++ b/lib/protocol/encryption_test.go
@@ -205,6 +205,31 @@ func TestIsEncryptedParent(t *testing.T) {
 	}
 }
 
+func TestEscapeWindowsReserved(t *testing.T) {
+	cases := []struct {
+		path    string
+		escaped string
+	}{
+		{"foo/bar", "foo/bar"},
+		{"foo/BAR", "foo/BAR"},
+		{"foo/CON", "foo/xCON"},
+		{"foo/LPT1", "foo/xLPT1"},
+		{"foo/LPT12", "foo/LPT12"},
+	}
+
+	for _, tc := range cases {
+		esc := escapeWindowsReserved(tc.path)
+		if esc != tc.escaped {
+			t.Error("Expected", tc.escaped, "got", esc)
+		}
+
+		unesc := unescapeWindowsReserved(esc)
+		if unesc != tc.path {
+			t.Error("Expected", tc.path, "got", unesc)
+		}
+	}
+}
+
 var benchmarkFileKey struct {
 	key [keySize]byte
 	sync.Once


### PR DESCRIPTION
### Purpose

Avoid creating reserved filenames by trivial escaping.

### Testing

I don't know? Hence this is draft. How do we test this?

### Badness

This handles the practicalities, but not really all the metadata. If we already have announced a file under a given bad name, the next update will use a better name, but the old metadata will be around forever, causing a conflict if a new trusted device is set up and receives all metadata from the untrusted device. There will be two entries representing the same trusted-side file.