### PR TITLE
chore: Quiet numerous DeepSource reported issues

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,6 +1,6 @@
 version = 1
 
-exclude_patterns = ["*.pb.go"]
+exclude_patterns = ["**/*.pb.go"]
 test_patterns = ["*_test.go"]
 
 [[analyzers]]

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -222,20 +222,19 @@ func (f *FolderConfiguration) prepare(myID protocol.DeviceID, existingDevices ma
 // RequiresRestartOnly returns a copy with only the attributes that require
 // restart on change.
 func (f FolderConfiguration) RequiresRestartOnly() FolderConfiguration {
-	// skipcq: CRT-A0001 : shadowing of predeclared identifier: copy
-	copy := f
+	cpy := f
 
 	// Manual handling for things that are not taken care of by the tag
 	// copier, yet should not cause a restart.
 
 	blank := FolderConfiguration{}
-	util.CopyMatchingTag(&blank, &copy, "restart", func(v string) bool {
+	util.CopyMatchingTag(&blank, &cpy, "restart", func(v string) bool {
 		if len(v) > 0 && v != "false" {
 			panic(fmt.Sprintf(`unexpected tag value: %s. expected untagged or "false"`, v))
 		}
 		return v == "false"
 	})
-	return copy
+	return cpy
 }
 
 func (f *FolderConfiguration) Device(device protocol.DeviceID) (FolderDeviceConfiguration, bool) {

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -222,6 +222,7 @@ func (f *FolderConfiguration) prepare(myID protocol.DeviceID, existingDevices ma
 // RequiresRestartOnly returns a copy with only the attributes that require
 // restart on change.
 func (f FolderConfiguration) RequiresRestartOnly() FolderConfiguration {
+	// skipcq: CRT-A0001 : shadowing of predeclared identifier: copy
 	copy := f
 
 	// Manual handling for things that are not taken care of by the tag

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -223,6 +223,7 @@ func (f *BasicFilesystem) DirNames(name string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
 	fd, err := os.OpenFile(name, OptReadOnly, 0777)
 	if err != nil {
 		return nil, err
@@ -273,6 +274,7 @@ func (f *BasicFilesystem) Create(name string) (File, error) {
 	return basicFile{fd, name}, err
 }
 
+// skipcq: RVV-B0012 : parameter 'root' seems to be unused, consider removing or renaming it as _
 func (f *BasicFilesystem) Walk(root string, walkFn WalkFunc) error {
 	// implemented in WalkFilesystem
 	return errors.New("not implemented")
@@ -318,7 +320,7 @@ func (f *BasicFilesystem) Options() []Option {
 	return f.options
 }
 
-func (f *BasicFilesystem) SameFile(fi1, fi2 FileInfo) bool {
+func (*BasicFilesystem) SameFile(fi1, fi2 FileInfo) bool {
 	// Like os.SameFile, we always return false unless fi1 and fi2 were created
 	// by this package's Stat/Lstat method.
 	f1, ok1 := fi1.(basicFileInfo)
@@ -330,11 +332,11 @@ func (f *BasicFilesystem) SameFile(fi1, fi2 FileInfo) bool {
 	return os.SameFile(f1.osFileInfo(), f2.osFileInfo())
 }
 
-func (f *BasicFilesystem) underlying() (Filesystem, bool) {
+func (*BasicFilesystem) underlying() (Filesystem, bool) {
 	return nil, false
 }
 
-func (f *BasicFilesystem) wrapperType() filesystemWrapperType {
+func (*BasicFilesystem) wrapperType() filesystemWrapperType {
 	return filesystemWrapperTypeNone
 }
 

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -28,7 +28,7 @@ var (
 
 type OptionJunctionsAsDirs struct{}
 
-func (o *OptionJunctionsAsDirs) apply(fs Filesystem) {
+func (*OptionJunctionsAsDirs) apply(fs Filesystem) {
 	if basic, ok := fs.(*BasicFilesystem); !ok {
 		l.Warnln("WithJunctionsAsDirs must only be used with FilesystemTypeBasic")
 	} else {
@@ -36,7 +36,7 @@ func (o *OptionJunctionsAsDirs) apply(fs Filesystem) {
 	}
 }
 
-func (o *OptionJunctionsAsDirs) String() string {
+func (*OptionJunctionsAsDirs) String() string {
 	return "junctionsAsDirs"
 }
 
@@ -275,7 +275,7 @@ func (f *BasicFilesystem) Create(name string) (File, error) {
 }
 
 // skipcq: RVV-B0012 : parameter 'root' seems to be unused, consider removing or renaming it as _
-func (f *BasicFilesystem) Walk(root string, walkFn WalkFunc) error {
+func (*BasicFilesystem) Walk(root string, walkFn WalkFunc) error {
 	// implemented in WalkFilesystem
 	return errors.New("not implemented")
 }
@@ -308,7 +308,7 @@ func (f *BasicFilesystem) Usage(name string) (Usage, error) {
 	}, nil
 }
 
-func (f *BasicFilesystem) Type() FilesystemType {
+func (*BasicFilesystem) Type() FilesystemType {
 	return FilesystemTypeBasic
 }
 

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -223,8 +223,7 @@ func (f *BasicFilesystem) DirNames(name string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
-	fd, err := os.OpenFile(name, OptReadOnly, 0777)
+	fd, err := os.OpenFile(name, OptReadOnly, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -274,8 +273,7 @@ func (f *BasicFilesystem) Create(name string) (File, error) {
 	return basicFile{fd, name}, err
 }
 
-// skipcq: RVV-B0012 : parameter 'root' seems to be unused, consider removing or renaming it as _
-func (*BasicFilesystem) Walk(root string, walkFn WalkFunc) error {
+func (*BasicFilesystem) Walk(_ string, _ WalkFunc) error {
 	// implemented in WalkFilesystem
 	return errors.New("not implemented")
 }

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -33,8 +33,7 @@ func TestChmodFile(t *testing.T) {
 	path := filepath.Join(dir, "file")
 	defer os.RemoveAll(dir)
 
-	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
-	defer os.Chmod(path, 0666)
+	defer os.Chmod(path, 0666) #skipcq
 
 	fd, err := os.Create(path)
 	if err != nil {
@@ -42,8 +41,7 @@ func TestChmodFile(t *testing.T) {
 	}
 	fd.Close()
 
-	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
-	if err := os.Chmod(path, 0666); err != nil {
+	if err := os.Chmod(path, 0666); err != nil { #skipcq
 		t.Error(err)
 	}
 
@@ -229,8 +227,7 @@ func TestDirNames(t *testing.T) {
 	sort.Strings(testCases)
 
 	for _, sub := range testCases {
-		// skipcq: GSC-G301 : Expect directory permissions to be 0750 or less
-		if err := os.Mkdir(filepath.Join(dir, sub), 0777); err != nil {
+		if err := os.Mkdir(filepath.Join(dir, sub), 0750); err != nil {
 			t.Error(err)
 		}
 	}

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -33,6 +33,7 @@ func TestChmodFile(t *testing.T) {
 	path := filepath.Join(dir, "file")
 	defer os.RemoveAll(dir)
 
+	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
 	defer os.Chmod(path, 0666)
 
 	fd, err := os.Create(path)
@@ -41,6 +42,7 @@ func TestChmodFile(t *testing.T) {
 	}
 	fd.Close()
 
+	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
 	if err := os.Chmod(path, 0666); err != nil {
 		t.Error(err)
 	}
@@ -74,6 +76,7 @@ func TestChownFile(t *testing.T) {
 	path := filepath.Join(dir, "file")
 	defer os.RemoveAll(dir)
 
+	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
 	defer os.Chmod(path, 0666)
 
 	fd, err := os.Create(path)
@@ -226,6 +229,7 @@ func TestDirNames(t *testing.T) {
 	sort.Strings(testCases)
 
 	for _, sub := range testCases {
+		// skipcq: GSC-G301 : Expect directory permissions to be 0750 or less
 		if err := os.Mkdir(filepath.Join(dir, sub), 0777); err != nil {
 			t.Error(err)
 		}

--- a/lib/fs/basicfs_test.go
+++ b/lib/fs/basicfs_test.go
@@ -33,7 +33,7 @@ func TestChmodFile(t *testing.T) {
 	path := filepath.Join(dir, "file")
 	defer os.RemoveAll(dir)
 
-	defer os.Chmod(path, 0666) #skipcq
+	defer os.Chmod(path, 0666) //skipcq
 
 	fd, err := os.Create(path)
 	if err != nil {
@@ -41,7 +41,7 @@ func TestChmodFile(t *testing.T) {
 	}
 	fd.Close()
 
-	if err := os.Chmod(path, 0666); err != nil { #skipcq
+	if err := os.Chmod(path, 0666); err != nil { //skipcq
 		t.Error(err)
 	}
 
@@ -74,8 +74,7 @@ func TestChownFile(t *testing.T) {
 	path := filepath.Join(dir, "file")
 	defer os.RemoveAll(dir)
 
-	// skipcq: GSC-G302 : Expect file permissions to be 0600 or less
-	defer os.Chmod(path, 0666)
+	defer os.Chmod(path, 0600)
 
 	fd, err := os.Create(path)
 	if err != nil {

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -21,6 +21,7 @@ import (
 // Not meant to be changed, but must be changeable for tests
 var backendBuffer = 500
 
+// skipcq: RVV-A0005 : parameter 'ignorePerms' seems to be a control flag, avoid control coupling
 func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
 	watchPath, roots, err := f.watchPaths(name)
 	if err != nil {

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -21,7 +21,6 @@ import (
 // Not meant to be changed, but must be changeable for tests
 var backendBuffer = 500
 
-// skipcq: RVV-A0005 : parameter 'ignorePerms' seems to be a control flag, avoid control coupling
 func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
 	watchPath, roots, err := f.watchPaths(name)
 	if err != nil {

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -114,7 +114,7 @@ func (f *BasicFilesystem) watchLoop(ctx context.Context, name string, roots []st
 	}
 }
 
-func (f *BasicFilesystem) eventType(notifyType notify.Event) EventType {
+func (*BasicFilesystem) eventType(notifyType notify.Event) EventType {
 	if notifyType&rmEventMask != 0 {
 		return Remove
 	}

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -126,18 +126,17 @@ func TestWatchRename(t *testing.T) {
 	name := "rename"
 
 	old := createTestFile(name, "oldfile")
-	// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
-	new := "newfile"
+	new_ := "newfile"
 
 	testCase := func() {
-		renameTestFile(name, old, new)
+		renameTestFile(name, old, new_)
 	}
 
-	destEvent := Event{new, Remove}
+	destEvent := Event{new_, Remove}
 	// Only on these platforms the removed file can be differentiated from
 	// the created file during renaming
 	if runtime.GOOS == "windows" || runtime.GOOS == "linux" || runtime.GOOS == "solaris" || runtime.GOOS == "freebsd" {
-		destEvent = Event{new, NonRemove}
+		destEvent = Event{new_, NonRemove}
 	}
 	expectedEvents := []Event{
 		{old, Remove},
@@ -520,12 +519,11 @@ func createTestFile(name string, file string) string {
 	return file
 }
 
-// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
-func renameTestFile(name string, old string, new string) {
+func renameTestFile(name string, old string, new_ string) {
 	old = filepath.Join(name, old)
-	new = filepath.Join(name, new)
-	if err := testFs.Rename(old, new); err != nil {
-		panic(fmt.Sprintf("Failed to rename %s to %s: %s", old, new, err))
+	new_ = filepath.Join(name, new_)
+	if err := testFs.Rename(old, new_); err != nil {
+		panic(fmt.Sprintf("Failed to rename %s to %s: %s", old, new_, err))_
 	}
 }
 

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -523,7 +523,7 @@ func renameTestFile(name string, old string, new_ string) {
 	old = filepath.Join(name, old)
 	new_ = filepath.Join(name, new_)
 	if err := testFs.Rename(old, new_); err != nil {
-		panic(fmt.Sprintf("Failed to rename %s to %s: %s", old, new_, err))_
+		panic(fmt.Sprintf("Failed to rename %s to %s: %s", old, new_, err))
 	}
 }
 

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -126,6 +126,7 @@ func TestWatchRename(t *testing.T) {
 	name := "rename"
 
 	old := createTestFile(name, "oldfile")
+	// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
 	new := "newfile"
 
 	testCase := func() {
@@ -519,6 +520,7 @@ func createTestFile(name string, file string) string {
 	return file
 }
 
+// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
 func renameTestFile(name string, old string, new string) {
 	old = filepath.Join(name, old)
 	new = filepath.Join(name, new)
@@ -628,10 +630,10 @@ func (e fakeEventInfo) Path() string {
 	return string(e)
 }
 
-func (e fakeEventInfo) Event() notify.Event {
+func (fakeEventInfo) Event() notify.Event {
 	return notify.Write
 }
 
-func (e fakeEventInfo) Sys() interface{} {
+func (fakeEventInfo) Sys() interface{} {
 	return nil
 }

--- a/lib/fs/errorfs.go
+++ b/lib/fs/errorfs.go
@@ -17,86 +17,39 @@ type errorFilesystem struct {
 	uri    string
 }
 
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Chmod(name string, mode FileMode) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Lchown(name string, uid, gid int) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Chtimes(name string, atime time.Time, mtime time.Time) error {
+func (fs *errorFilesystem) Chmod(_ string, _ FileMode) error { return fs.err }
+func (fs *errorFilesystem) Lchown(_ string, _, _ int) error { return fs.err }
+func (fs *errorFilesystem) Chtimes(_ string, _ time.Time, _ time.Time) error {
 	return fs.err
 }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Create(name string) (File, error) { return nil, fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) CreateSymlink(target, name string) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) DirNames(name string) ([]string, error) { return nil, fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Lstat(name string) (FileInfo, error) { return nil, fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Mkdir(name string, perm FileMode) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) MkdirAll(name string, perm FileMode) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Open(name string) (File, error) { return nil, fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Create(_ string) (File, error) { return nil, fs.err }
+func (fs *errorFilesystem) CreateSymlink(_, _ string) error { return fs.err }
+func (fs *errorFilesystem) DirNames(_ string) ([]string, error) { return nil, fs.err }
+func (fs *errorFilesystem) Lstat(_ string) (FileInfo, error) { return nil, fs.err }
+func (fs *errorFilesystem) Mkdir(_ string, _ FileMode) error { return fs.err }
+func (fs *errorFilesystem) MkdirAll(_ string, _ FileMode) error { return fs.err }
+func (fs *errorFilesystem) Open(_ string) (File, error) { return nil, fs.err }
 func (fs *errorFilesystem) OpenFile(string, int, FileMode) (File, error) { return nil, fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) ReadSymlink(name string) (string, error) { return "", fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Remove(name string) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) RemoveAll(name string) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Rename(oldname, newname string) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Stat(name string) (FileInfo, error) { return nil, fs.err }
+func (fs *errorFilesystem) ReadSymlink(_ string) (string, error) { return "", fs.err }
+func (fs *errorFilesystem) Remove(_ string) error { return fs.err }
+func (fs *errorFilesystem) RemoveAll(_ string) error { return fs.err }
+func (fs *errorFilesystem) Rename(_, _ string) error { return fs.err }
+func (fs *errorFilesystem) Stat(_ string) (FileInfo, error) { return nil, fs.err }
 func (*errorFilesystem) SymlinksSupported() bool               { return false }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Walk(root string, walkFn WalkFunc) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Unhide(name string) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Hide(name string) error { return fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Glob(pattern string) ([]string, error) { return nil, fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) SyncDir(name string) error { return fs.err }
+func (fs *errorFilesystem) Walk(_ string, _ WalkFunc) error { return fs.err }
+func (fs *errorFilesystem) Unhide(_ string) error { return fs.err }
+func (fs *errorFilesystem) Hide(_ string) error { return fs.err }
+func (fs *errorFilesystem) Glob(_ string) ([]string, error) { return nil, fs.err }
+func (fs *errorFilesystem) SyncDir(_ string) error { return fs.err }
 func (fs *errorFilesystem) Roots() ([]string, error)  { return nil, fs.err }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (fs *errorFilesystem) Usage(name string) (Usage, error) { return Usage{}, fs.err }
+func (fs *errorFilesystem) Usage(_ string) (Usage, error) { return Usage{}, fs.err }
 func (fs *errorFilesystem) Type() FilesystemType             { return fs.fsType }
 func (fs *errorFilesystem) URI() string                      { return fs.uri }
 func (*errorFilesystem) Options() []Option {
 	return nil
 }
-
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (*errorFilesystem) SameFile(fi1, fi2 FileInfo) bool { return false }
-
-// skipcq: RVV-B0012,  RVV-A0002 : parameter 'path' seems to be unused, consider removing or renaming it as _ / context.Context should be the first parameter of a function
-func (fs *errorFilesystem) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
+func (*errorFilesystem) SameFile(_, _ FileInfo) bool { return false }
+func (fs *errorFilesystem) Watch(_ string, _ Matcher, _ context.Context, _ bool) (<-chan Event, <-chan error, error) {
 	return nil, nil, fs.err
 }
 

--- a/lib/fs/errorfs.go
+++ b/lib/fs/errorfs.go
@@ -88,7 +88,7 @@ func (fs *errorFilesystem) Roots() ([]string, error)  { return nil, fs.err }
 func (fs *errorFilesystem) Usage(name string) (Usage, error) { return Usage{}, fs.err }
 func (fs *errorFilesystem) Type() FilesystemType             { return fs.fsType }
 func (fs *errorFilesystem) URI() string                      { return fs.uri }
-func (fs *errorFilesystem) Options() []Option {
+func (*errorFilesystem) Options() []Option {
 	return nil
 }
 

--- a/lib/fs/errorfs.go
+++ b/lib/fs/errorfs.go
@@ -17,46 +17,93 @@ type errorFilesystem struct {
 	uri    string
 }
 
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
 func (fs *errorFilesystem) Chmod(name string, mode FileMode) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
 func (fs *errorFilesystem) Lchown(name string, uid, gid int) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
 func (fs *errorFilesystem) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	return fs.err
 }
-func (fs *errorFilesystem) Create(name string) (File, error)             { return nil, fs.err }
-func (fs *errorFilesystem) CreateSymlink(target, name string) error      { return fs.err }
-func (fs *errorFilesystem) DirNames(name string) ([]string, error)       { return nil, fs.err }
-func (fs *errorFilesystem) Lstat(name string) (FileInfo, error)          { return nil, fs.err }
-func (fs *errorFilesystem) Mkdir(name string, perm FileMode) error       { return fs.err }
-func (fs *errorFilesystem) MkdirAll(name string, perm FileMode) error    { return fs.err }
-func (fs *errorFilesystem) Open(name string) (File, error)               { return nil, fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Create(name string) (File, error) { return nil, fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) CreateSymlink(target, name string) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) DirNames(name string) ([]string, error) { return nil, fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Lstat(name string) (FileInfo, error) { return nil, fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Mkdir(name string, perm FileMode) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) MkdirAll(name string, perm FileMode) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Open(name string) (File, error) { return nil, fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
 func (fs *errorFilesystem) OpenFile(string, int, FileMode) (File, error) { return nil, fs.err }
-func (fs *errorFilesystem) ReadSymlink(name string) (string, error)      { return "", fs.err }
-func (fs *errorFilesystem) Remove(name string) error                     { return fs.err }
-func (fs *errorFilesystem) RemoveAll(name string) error                  { return fs.err }
-func (fs *errorFilesystem) Rename(oldname, newname string) error         { return fs.err }
-func (fs *errorFilesystem) Stat(name string) (FileInfo, error)           { return nil, fs.err }
-func (fs *errorFilesystem) SymlinksSupported() bool                      { return false }
-func (fs *errorFilesystem) Walk(root string, walkFn WalkFunc) error      { return fs.err }
-func (fs *errorFilesystem) Unhide(name string) error                     { return fs.err }
-func (fs *errorFilesystem) Hide(name string) error                       { return fs.err }
-func (fs *errorFilesystem) Glob(pattern string) ([]string, error)        { return nil, fs.err }
-func (fs *errorFilesystem) SyncDir(name string) error                    { return fs.err }
-func (fs *errorFilesystem) Roots() ([]string, error)                     { return nil, fs.err }
-func (fs *errorFilesystem) Usage(name string) (Usage, error)             { return Usage{}, fs.err }
-func (fs *errorFilesystem) Type() FilesystemType                         { return fs.fsType }
-func (fs *errorFilesystem) URI() string                                  { return fs.uri }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) ReadSymlink(name string) (string, error) { return "", fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Remove(name string) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) RemoveAll(name string) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Rename(oldname, newname string) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Stat(name string) (FileInfo, error) { return nil, fs.err }
+func (*errorFilesystem) SymlinksSupported() bool               { return false }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Walk(root string, walkFn WalkFunc) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Unhide(name string) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Hide(name string) error { return fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Glob(pattern string) ([]string, error) { return nil, fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) SyncDir(name string) error { return fs.err }
+func (fs *errorFilesystem) Roots() ([]string, error)  { return nil, fs.err }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (fs *errorFilesystem) Usage(name string) (Usage, error) { return Usage{}, fs.err }
+func (fs *errorFilesystem) Type() FilesystemType             { return fs.fsType }
+func (fs *errorFilesystem) URI() string                      { return fs.uri }
 func (fs *errorFilesystem) Options() []Option {
 	return nil
 }
-func (fs *errorFilesystem) SameFile(fi1, fi2 FileInfo) bool { return false }
+
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (*errorFilesystem) SameFile(fi1, fi2 FileInfo) bool { return false }
+
+// skipcq: RVV-B0012,  RVV-A0002 : parameter 'path' seems to be unused, consider removing or renaming it as _ / context.Context should be the first parameter of a function
 func (fs *errorFilesystem) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
 	return nil, nil, fs.err
 }
 
-func (fs *errorFilesystem) underlying() (Filesystem, bool) {
+func (*errorFilesystem) underlying() (Filesystem, bool) {
 	return nil, false
 }
 
-func (fs *errorFilesystem) wrapperType() filesystemWrapperType {
+func (*errorFilesystem) wrapperType() filesystemWrapperType {
 	return filesystemWrapperTypeError
 }

--- a/lib/fs/errorfs.go
+++ b/lib/fs/errorfs.go
@@ -18,33 +18,33 @@ type errorFilesystem struct {
 }
 
 func (fs *errorFilesystem) Chmod(_ string, _ FileMode) error { return fs.err }
-func (fs *errorFilesystem) Lchown(_ string, _, _ int) error { return fs.err }
+func (fs *errorFilesystem) Lchown(_ string, _, _ int) error  { return fs.err }
 func (fs *errorFilesystem) Chtimes(_ string, _ time.Time, _ time.Time) error {
 	return fs.err
 }
-func (fs *errorFilesystem) Create(_ string) (File, error) { return nil, fs.err }
-func (fs *errorFilesystem) CreateSymlink(_, _ string) error { return fs.err }
-func (fs *errorFilesystem) DirNames(_ string) ([]string, error) { return nil, fs.err }
-func (fs *errorFilesystem) Lstat(_ string) (FileInfo, error) { return nil, fs.err }
-func (fs *errorFilesystem) Mkdir(_ string, _ FileMode) error { return fs.err }
-func (fs *errorFilesystem) MkdirAll(_ string, _ FileMode) error { return fs.err }
-func (fs *errorFilesystem) Open(_ string) (File, error) { return nil, fs.err }
+func (fs *errorFilesystem) Create(_ string) (File, error)                { return nil, fs.err }
+func (fs *errorFilesystem) CreateSymlink(_, _ string) error              { return fs.err }
+func (fs *errorFilesystem) DirNames(_ string) ([]string, error)          { return nil, fs.err }
+func (fs *errorFilesystem) Lstat(_ string) (FileInfo, error)             { return nil, fs.err }
+func (fs *errorFilesystem) Mkdir(_ string, _ FileMode) error             { return fs.err }
+func (fs *errorFilesystem) MkdirAll(_ string, _ FileMode) error          { return fs.err }
+func (fs *errorFilesystem) Open(_ string) (File, error)                  { return nil, fs.err }
 func (fs *errorFilesystem) OpenFile(string, int, FileMode) (File, error) { return nil, fs.err }
-func (fs *errorFilesystem) ReadSymlink(_ string) (string, error) { return "", fs.err }
-func (fs *errorFilesystem) Remove(_ string) error { return fs.err }
-func (fs *errorFilesystem) RemoveAll(_ string) error { return fs.err }
-func (fs *errorFilesystem) Rename(_, _ string) error { return fs.err }
-func (fs *errorFilesystem) Stat(_ string) (FileInfo, error) { return nil, fs.err }
-func (*errorFilesystem) SymlinksSupported() bool               { return false }
-func (fs *errorFilesystem) Walk(_ string, _ WalkFunc) error { return fs.err }
-func (fs *errorFilesystem) Unhide(_ string) error { return fs.err }
-func (fs *errorFilesystem) Hide(_ string) error { return fs.err }
-func (fs *errorFilesystem) Glob(_ string) ([]string, error) { return nil, fs.err }
-func (fs *errorFilesystem) SyncDir(_ string) error { return fs.err }
-func (fs *errorFilesystem) Roots() ([]string, error)  { return nil, fs.err }
-func (fs *errorFilesystem) Usage(_ string) (Usage, error) { return Usage{}, fs.err }
-func (fs *errorFilesystem) Type() FilesystemType             { return fs.fsType }
-func (fs *errorFilesystem) URI() string                      { return fs.uri }
+func (fs *errorFilesystem) ReadSymlink(_ string) (string, error)         { return "", fs.err }
+func (fs *errorFilesystem) Remove(_ string) error                        { return fs.err }
+func (fs *errorFilesystem) RemoveAll(_ string) error                     { return fs.err }
+func (fs *errorFilesystem) Rename(_, _ string) error                     { return fs.err }
+func (fs *errorFilesystem) Stat(_ string) (FileInfo, error)              { return nil, fs.err }
+func (*errorFilesystem) SymlinksSupported() bool                         { return false }
+func (fs *errorFilesystem) Walk(_ string, _ WalkFunc) error              { return fs.err }
+func (fs *errorFilesystem) Unhide(_ string) error                        { return fs.err }
+func (fs *errorFilesystem) Hide(_ string) error                          { return fs.err }
+func (fs *errorFilesystem) Glob(_ string) ([]string, error)              { return nil, fs.err }
+func (fs *errorFilesystem) SyncDir(_ string) error                       { return fs.err }
+func (fs *errorFilesystem) Roots() ([]string, error)                     { return nil, fs.err }
+func (fs *errorFilesystem) Usage(_ string) (Usage, error)                { return Usage{}, fs.err }
+func (fs *errorFilesystem) Type() FilesystemType                         { return fs.fsType }
+func (fs *errorFilesystem) URI() string                                  { return fs.uri }
 func (*errorFilesystem) Options() []Option {
 	return nil
 }

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -130,8 +130,7 @@ func newFakeFilesystem(rootURI string, _ ...Option) *fakeFS {
 		// *look* like file I/O, but they are not. Do not worry that they
 		// might fail.
 
-		// skipcq: GSC-G404 : Use of weak random number generator (math/rand instead of crypto/rand)
-		rng := rand.New(rand.NewSource(int64(seed)))
+		rng := rand.New(rand.NewSource(int64(seed))) //skipcq
 		var createdFiles int
 		var writtenData int64
 		for (files == 0 || createdFiles < files) && (maxsize == 0 || writtenData>>20 < int64(maxsize)) {
@@ -238,8 +237,7 @@ func (fs *fakeFS) Lchown(name string, uid, gid int) error {
 	return nil
 }
 
-// skipcq: RVV-B0012 : parameter 'atime' seems to be unused, consider removing or renaming it as _
-func (fs *fakeFS) Chtimes(name string, atime time.Time, mtime time.Time) error {
+func (fs *fakeFS) Chtimes(name string, _ time.Time, mtime time.Time) error {
 	fs.mut.Lock()
 	defer fs.mut.Unlock()
 	fs.counters.Chtimes++
@@ -280,8 +278,7 @@ func (fs *fakeFS) create(name string) (*fakeEntry, error) {
 	if entry == nil {
 		return nil, os.ErrNotExist
 	}
-	// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
-	new := &fakeEntry{
+	new_ := &fakeEntry{
 		name:  base,
 		mode:  0666,
 		mtime: time.Now(),
@@ -292,15 +289,14 @@ func (fs *fakeFS) create(name string) (*fakeEntry, error) {
 	}
 
 	if fs.withContent {
-		new.content = make([]byte, 0)
+		new_.content = make([]byte, 0)
 	}
 
-	entry.children[base] = new
-	return new, nil
+	entry.children[base] = new_
+	return new_, nil
 }
 
-// skipcq: RVV-B0001 : Method 'Create' differs only by capitalization to method 'create' in the same source file
-func (fs *fakeFS) Create(name string) (File, error) {
+func (fs *fakeFS) Create(name string) (File, error) { //skipcq
 	entry, err := fs.create(name)
 	if err != nil {
 		return nil, err
@@ -412,16 +408,15 @@ func (fs *fakeFS) MkdirAll(name string, perm FileMode) error {
 		next, ok := entry.children[key]
 
 		if !ok {
-			// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
-			new := &fakeEntry{
+			new_ := &fakeEntry{
 				name:      comp,
 				entryType: fakeEntryTypeDir,
 				mode:      perm,
 				mtime:     time.Now(),
 				children:  make(map[string]*fakeEntry),
 			}
-			entry.children[key] = new
-			next = new
+			entry.children[key] = new_
+			next = new_
 		} else if next.entryType != fakeEntryTypeDir {
 			return errors.New("not a directory")
 		}
@@ -608,28 +603,23 @@ func (*fakeFS) SymlinksSupported() bool {
 	return false
 }
 
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (*fakeFS) Walk(name string, walkFn WalkFunc) error {
+func (*fakeFS) Walk(_ string, _ WalkFunc) error {
 	return errors.New("not implemented")
 }
 
-// skipcq: RVV-B0012,  RVV-A0002 : parameter 'path' seems to be unused, consider removing or renaming it as _ / context.Context should be the first parameter of a function
-func (*fakeFS) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
+func (*fakeFS) Watch(_ string, _ Matcher, _ context.Context, _ bool) (<-chan Event, <-chan error, error) {
 	return nil, nil, ErrWatchNotSupported
 }
 
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (*fakeFS) Hide(name string) error {
+func (*fakeFS) Hide(_ string) error {
 	return nil
 }
 
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (*fakeFS) Unhide(name string) error {
+func (*fakeFS) Unhide(_ string) error {
 	return nil
 }
 
-// skipcq: RVV-B0012 : parameter 'pattern' seems to be unused, consider removing or renaming it as _
-func (*fakeFS) Glob(pattern string) ([]string, error) {
+func (*fakeFS) Glob(_ string) ([]string, error) {
 	// gnnh we don't seem to actually require this in practice
 	return nil, errors.New("not implemented")
 }
@@ -638,8 +628,7 @@ func (*fakeFS) Roots() ([]string, error) {
 	return []string{"/"}, nil
 }
 
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func (*fakeFS) Usage(name string) (Usage, error) {
+func (*fakeFS) Usage(_ string) (Usage, error) {
 	return Usage{}, errors.New("not implemented")
 }
 
@@ -655,7 +644,6 @@ func (*fakeFS) Options() []Option {
 	return nil
 }
 
-// skipcq: RVV-B0012 : parameter 'fi1' seems to be unused, consider removing or renaming it as _
 func (fs *fakeFS) SameFile(fi1, fi2 FileInfo) bool {
 	// BUG: real systems base file sameness on path, inodes, etc
 	// we try our best, but FileInfo just doesn't have enough data
@@ -794,8 +782,7 @@ func (f *fakeFile) readShortAt(p []byte, offs int64) (int, error) {
 	nextBlockOffs := (seedNo + 1) << randomBlockShift
 	if f.rng == nil || f.offset != offs || seedNo != f.seedOffs {
 		// This is not a straight read continuing from a previous one
-		// skipcq: GSC-G404 : Use of weak random number generator (math/rand instead of crypto/rand)
-		f.rng = rand.New(rand.NewSource(f.seed + seedNo))
+		f.rng = rand.New(rand.NewSource(f.seed + seedNo)) //skipcq
 
 		// If the read is not at the start of the block, discard data
 		// accordingly.

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -130,6 +130,7 @@ func newFakeFilesystem(rootURI string, _ ...Option) *fakeFS {
 		// *look* like file I/O, but they are not. Do not worry that they
 		// might fail.
 
+		// skipcq: GSC-G404 : Use of weak random number generator (math/rand instead of crypto/rand)
 		rng := rand.New(rand.NewSource(int64(seed)))
 		var createdFiles int
 		var writtenData int64
@@ -237,6 +238,7 @@ func (fs *fakeFS) Lchown(name string, uid, gid int) error {
 	return nil
 }
 
+// skipcq: RVV-B0012 : parameter 'atime' seems to be unused, consider removing or renaming it as _
 func (fs *fakeFS) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	fs.mut.Lock()
 	defer fs.mut.Unlock()
@@ -278,6 +280,7 @@ func (fs *fakeFS) create(name string) (*fakeEntry, error) {
 	if entry == nil {
 		return nil, os.ErrNotExist
 	}
+	// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
 	new := &fakeEntry{
 		name:  base,
 		mode:  0666,
@@ -296,6 +299,7 @@ func (fs *fakeFS) create(name string) (*fakeEntry, error) {
 	return new, nil
 }
 
+// skipcq: RVV-B0001 : Method 'Create' differs only by capitalization to method 'create' in the same source file
 func (fs *fakeFS) Create(name string) (File, error) {
 	entry, err := fs.create(name)
 	if err != nil {
@@ -408,6 +412,7 @@ func (fs *fakeFS) MkdirAll(name string, perm FileMode) error {
 		next, ok := entry.children[key]
 
 		if !ok {
+			// skipcq: CRT-A0001 : shadowing of predeclared identifier: new
 			new := &fakeEntry{
 				name:      comp,
 				entryType: fakeEntryTypeDir,
@@ -599,40 +604,46 @@ func (fs *fakeFS) Stat(name string) (FileInfo, error) {
 	return fs.Lstat(name)
 }
 
-func (fs *fakeFS) SymlinksSupported() bool {
+func (*fakeFS) SymlinksSupported() bool {
 	return false
 }
 
-func (fs *fakeFS) Walk(name string, walkFn WalkFunc) error {
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (*fakeFS) Walk(name string, walkFn WalkFunc) error {
 	return errors.New("not implemented")
 }
 
-func (fs *fakeFS) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
+// skipcq: RVV-B0012,  RVV-A0002 : parameter 'path' seems to be unused, consider removing or renaming it as _ / context.Context should be the first parameter of a function
+func (*fakeFS) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
 	return nil, nil, ErrWatchNotSupported
 }
 
-func (fs *fakeFS) Hide(name string) error {
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (*fakeFS) Hide(name string) error {
 	return nil
 }
 
-func (fs *fakeFS) Unhide(name string) error {
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (*fakeFS) Unhide(name string) error {
 	return nil
 }
 
-func (fs *fakeFS) Glob(pattern string) ([]string, error) {
+// skipcq: RVV-B0012 : parameter 'pattern' seems to be unused, consider removing or renaming it as _
+func (*fakeFS) Glob(pattern string) ([]string, error) {
 	// gnnh we don't seem to actually require this in practice
 	return nil, errors.New("not implemented")
 }
 
-func (fs *fakeFS) Roots() ([]string, error) {
+func (*fakeFS) Roots() ([]string, error) {
 	return []string{"/"}, nil
 }
 
-func (fs *fakeFS) Usage(name string) (Usage, error) {
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
+func (*fakeFS) Usage(name string) (Usage, error) {
 	return Usage{}, errors.New("not implemented")
 }
 
-func (fs *fakeFS) Type() FilesystemType {
+func (*fakeFS) Type() FilesystemType {
 	return FilesystemTypeFake
 }
 
@@ -640,10 +651,11 @@ func (fs *fakeFS) URI() string {
 	return fs.uri
 }
 
-func (fs *fakeFS) Options() []Option {
+func (*fakeFS) Options() []Option {
 	return nil
 }
 
+// skipcq: RVV-B0012 : parameter 'fi1' seems to be unused, consider removing or renaming it as _
 func (fs *fakeFS) SameFile(fi1, fi2 FileInfo) bool {
 	// BUG: real systems base file sameness on path, inodes, etc
 	// we try our best, but FileInfo just doesn't have enough data
@@ -659,11 +671,11 @@ func (fs *fakeFS) SameFile(fi1, fi2 FileInfo) bool {
 	return ok && fi1.ModTime().Equal(fi2.ModTime()) && fi1.Mode() == fi2.Mode() && fi1.IsDir() == fi2.IsDir() && fi1.IsRegular() == fi2.IsRegular() && fi1.IsSymlink() == fi2.IsSymlink() && fi1.Owner() == fi2.Owner() && fi1.Group() == fi2.Group()
 }
 
-func (fs *fakeFS) underlying() (Filesystem, bool) {
+func (*fakeFS) underlying() (Filesystem, bool) {
 	return nil, false
 }
 
-func (fs *fakeFS) wrapperType() filesystemWrapperType {
+func (*fakeFS) wrapperType() filesystemWrapperType {
 	return filesystemWrapperTypeNone
 }
 
@@ -696,7 +708,7 @@ type fakeFile struct {
 	presentedName string // present (i.e. != "") on insensitive fs only
 }
 
-func (f *fakeFile) Close() error {
+func (*fakeFile) Close() error {
 	return nil
 }
 
@@ -782,6 +794,7 @@ func (f *fakeFile) readShortAt(p []byte, offs int64) (int, error) {
 	nextBlockOffs := (seedNo + 1) << randomBlockShift
 	if f.rng == nil || f.offset != offs || seedNo != f.seedOffs {
 		// This is not a straight read continuing from a previous one
+		// skipcq: GSC-G404 : Use of weak random number generator (math/rand instead of crypto/rand)
 		f.rng = rand.New(rand.NewSource(f.seed + seedNo))
 
 		// If the read is not at the start of the block, discard data
@@ -910,7 +923,7 @@ func (f *fakeFile) Stat() (FileInfo, error) {
 	return info, nil
 }
 
-func (f *fakeFile) Sync() error {
+func (*fakeFile) Sync() error {
 	return nil
 }
 

--- a/lib/fs/fakefs_test.go
+++ b/lib/fs/fakefs_test.go
@@ -162,6 +162,7 @@ func testFakeFSRead(t *testing.T, fs Filesystem) {
 		t.Error("wrong number of bytes:", len(buf1))
 	}
 
+	// skipcq: CRT-D0001 : append result not assigned to the same slice
 	bs1 := append(buf0, buf1...)
 	if !bytes.Equal(bs0, bs1) {
 		t.Error("data mismatch")
@@ -296,6 +297,7 @@ func runTests(t *testing.T, tests []test, filesystems []testFS) {
 	}
 }
 
+// skipcq: RVV-B0001 : Method 'testFakeFSCaseInsensitive' differs only by capitalization to function 'TestFakeFSCaseInsensitive' in the same source file
 func testFakeFSCaseInsensitive(t *testing.T, fs Filesystem) {
 	bs1 := []byte("test")
 
@@ -849,6 +851,7 @@ func testFakeFSSameFileInsens(t *testing.T, fs Filesystem) {
 	}
 }
 
+// skipcq: RVV-A0005 : parameter 'want' seems to be a control flag, avoid control coupling
 func assertSameFile(t *testing.T, fs Filesystem, f1, f2 string, want bool) {
 	t.Helper()
 

--- a/lib/fs/fakefs_test.go
+++ b/lib/fs/fakefs_test.go
@@ -162,8 +162,7 @@ func testFakeFSRead(t *testing.T, fs Filesystem) {
 		t.Error("wrong number of bytes:", len(buf1))
 	}
 
-	// skipcq: CRT-D0001 : append result not assigned to the same slice
-	bs1 := append(buf0, buf1...)
+	bs1 := append(buf0, buf1...) //skipcq
 	if !bytes.Equal(bs0, bs1) {
 		t.Error("data mismatch")
 	}
@@ -297,8 +296,7 @@ func runTests(t *testing.T, tests []test, filesystems []testFS) {
 	}
 }
 
-// skipcq: RVV-B0001 : Method 'testFakeFSCaseInsensitive' differs only by capitalization to function 'TestFakeFSCaseInsensitive' in the same source file
-func testFakeFSCaseInsensitive(t *testing.T, fs Filesystem) {
+func testFakeFSCaseInsensitive(t *testing.T, fs Filesystem) { //skipcq
 	bs1 := []byte("test")
 
 	err := fs.Mkdir("/fUbar", 0755)
@@ -851,7 +849,6 @@ func testFakeFSSameFileInsens(t *testing.T, fs Filesystem) {
 	}
 }
 
-// skipcq: RVV-A0005 : parameter 'want' seems to be a control flag, avoid control coupling
 func assertSameFile(t *testing.T, fs Filesystem, f1, f2 string, want bool) {
 	t.Helper()
 

--- a/lib/fs/mtimefs_test.go
+++ b/lib/fs/mtimefs_test.go
@@ -19,6 +19,7 @@ import (
 func TestMtimeFS(t *testing.T) {
 	os.RemoveAll("testdata")
 	defer os.RemoveAll("testdata")
+	// skipcq: GSC-G301 : Expect directory permissions to be 0750 or less
 	os.Mkdir("testdata", 0755)
 	ioutil.WriteFile("testdata/exists0", []byte("hello"), 0644)
 	ioutil.WriteFile("testdata/exists1", []byte("hello"), 0644)
@@ -199,6 +200,7 @@ func TestMtimeFSInsensitive(t *testing.T) {
 	theTest := func(t *testing.T, fs *mtimeFS, shouldSucceed bool) {
 		os.RemoveAll("testdata")
 		defer os.RemoveAll("testdata")
+		// skipcq: GSC-G301 : Expect directory permissions to be 0750 or less
 		os.Mkdir("testdata", 0755)
 		ioutil.WriteFile("testdata/FiLe", []byte("hello"), 0644)
 
@@ -252,6 +254,7 @@ func (s mapStore) Delete(key string) error {
 }
 
 // failChtimes does nothing, and fails
+// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
 func failChtimes(name string, mtime, atime time.Time) error {
 	return errors.New("no")
 }

--- a/lib/fs/mtimefs_test.go
+++ b/lib/fs/mtimefs_test.go
@@ -19,8 +19,7 @@ import (
 func TestMtimeFS(t *testing.T) {
 	os.RemoveAll("testdata")
 	defer os.RemoveAll("testdata")
-	// skipcq: GSC-G301 : Expect directory permissions to be 0750 or less
-	os.Mkdir("testdata", 0755)
+	os.Mkdir("testdata", 0750)
 	ioutil.WriteFile("testdata/exists0", []byte("hello"), 0644)
 	ioutil.WriteFile("testdata/exists1", []byte("hello"), 0644)
 	ioutil.WriteFile("testdata/exists2", []byte("hello"), 0644)
@@ -200,8 +199,7 @@ func TestMtimeFSInsensitive(t *testing.T) {
 	theTest := func(t *testing.T, fs *mtimeFS, shouldSucceed bool) {
 		os.RemoveAll("testdata")
 		defer os.RemoveAll("testdata")
-		// skipcq: GSC-G301 : Expect directory permissions to be 0750 or less
-		os.Mkdir("testdata", 0755)
+		os.Mkdir("testdata", 0750)
 		ioutil.WriteFile("testdata/FiLe", []byte("hello"), 0644)
 
 		// a random time with nanosecond precision
@@ -254,8 +252,7 @@ func (s mapStore) Delete(key string) error {
 }
 
 // failChtimes does nothing, and fails
-// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
-func failChtimes(name string, mtime, atime time.Time) error {
+func failChtimes(_ string, _, _ time.Time) error {
 	return errors.New("no")
 }
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -232,11 +232,11 @@ func (f *folder) Serve(ctx context.Context) error {
 	}
 }
 
-func (f *folder) BringToFront(string) {}
+func (*folder) BringToFront(string) {}
 
-func (f *folder) Override() {}
+func (*folder) Override() {}
 
-func (f *folder) Revert() {}
+func (*folder) Revert() {}
 
 func (f *folder) DelayScan(next time.Duration) {
 	select {
@@ -270,7 +270,7 @@ func (f *folder) SchedulePull() {
 	}
 }
 
-func (f *folder) Jobs(_, _ int) ([]string, []string, int) {
+func (*folder) Jobs(_, _ int) ([]string, []string, int) {
 	return nil, nil, 0
 }
 
@@ -300,6 +300,7 @@ func (f *folder) Reschedule() {
 		return
 	}
 	// Sleep a random time between 3/4 and 5/4 of the configured interval.
+	// skipcq: GSC-G404 : Use of weak random number generator (math/rand instead of crypto/rand)
 	sleepNanos := (f.scanInterval.Nanoseconds()*3 + rand.Int63n(2*f.scanInterval.Nanoseconds())) / 4
 	interval := time.Duration(sleepNanos) * time.Nanosecond
 	l.Debugln(f, "next rescan in", interval)
@@ -999,8 +1000,10 @@ func (f *folder) monitorWatch(ctx context.Context) {
 			}
 			aggrCancel()
 			errChan = nil
+			// skipcq: VET-V0011 : the aggrCancel function is not used on all paths (possible context leak)
 			aggrCtx, aggrCancel = context.WithCancel(ctx)
 		case <-ctx.Done():
+			// skipcq: VET-V0011 : this return statement may be reached without using the aggrCancel var defined on line 1003
 			return
 		}
 	}

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -300,8 +300,7 @@ func (f *folder) Reschedule() {
 		return
 	}
 	// Sleep a random time between 3/4 and 5/4 of the configured interval.
-	// skipcq: GSC-G404 : Use of weak random number generator (math/rand instead of crypto/rand)
-	sleepNanos := (f.scanInterval.Nanoseconds()*3 + rand.Int63n(2*f.scanInterval.Nanoseconds())) / 4
+	sleepNanos := (f.scanInterval.Nanoseconds()*3 + rand.Int63n(2*f.scanInterval.Nanoseconds())) / 4 //skipcq
 	interval := time.Duration(sleepNanos) * time.Nanosecond
 	l.Debugln(f, "next rescan in", interval)
 	f.scanTimer.Reset(interval)
@@ -1000,10 +999,8 @@ func (f *folder) monitorWatch(ctx context.Context) {
 			}
 			aggrCancel()
 			errChan = nil
-			// skipcq: VET-V0011 : the aggrCancel function is not used on all paths (possible context leak)
 			aggrCtx, aggrCancel = context.WithCancel(ctx)
 		case <-ctx.Done():
-			// skipcq: VET-V0011 : this return statement may be reached without using the aggrCancel var defined on line 1003
 			return
 		}
 	}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -279,6 +279,7 @@ func (m *model) serve(ctx context.Context) error {
 	}
 }
 
+// skipcq: CRT-P0003 : cfg is heavy (1528 bytes); consider passing it by pointer
 func (m *model) initFolders(cfg config.Configuration) error {
 	clusterConfigDevices := make(deviceIDSet, len(cfg.Devices))
 	for _, folderCfg := range cfg.Folders {
@@ -2773,6 +2774,7 @@ func (m *model) String() string {
 	return fmt.Sprintf("model@%p", m)
 }
 
+// skipcq: CRT-P0003 : from is heavy (1528 bytes); consider passing it by pointer / to is heavy (1528 bytes); consider passing it by pointer
 func (m *model) VerifyConfiguration(from, to config.Configuration) error {
 	toFolders := to.FolderMap()
 	for _, from := range from.Folders {
@@ -2784,6 +2786,7 @@ func (m *model) VerifyConfiguration(from, to config.Configuration) error {
 	return nil
 }
 
+// skipcq: CRT-P0003 : from is heavy (1528 bytes); consider passing it by pointer / to is heavy (1528 bytes); consider passing it by pointer
 func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 	// TODO: This should not use reflect, and should take more care to try to handle stuff without restart.
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -279,7 +279,6 @@ func (m *model) serve(ctx context.Context) error {
 	}
 }
 
-// skipcq: CRT-P0003 : cfg is heavy (1528 bytes); consider passing it by pointer
 func (m *model) initFolders(cfg config.Configuration) error {
 	clusterConfigDevices := make(deviceIDSet, len(cfg.Devices))
 	for _, folderCfg := range cfg.Folders {
@@ -2774,7 +2773,6 @@ func (m *model) String() string {
 	return fmt.Sprintf("model@%p", m)
 }
 
-// skipcq: CRT-P0003 : from is heavy (1528 bytes); consider passing it by pointer / to is heavy (1528 bytes); consider passing it by pointer
 func (m *model) VerifyConfiguration(from, to config.Configuration) error {
 	toFolders := to.FolderMap()
 	for _, from := range from.Folders {
@@ -2786,7 +2784,6 @@ func (m *model) VerifyConfiguration(from, to config.Configuration) error {
 	return nil
 }
 
-// skipcq: CRT-P0003 : from is heavy (1528 bytes); consider passing it by pointer / to is heavy (1528 bytes); consider passing it by pointer
 func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 	// TODO: This should not use reflect, and should take more care to try to handle stuff without restart.
 


### PR DESCRIPTION
### Purpose

Quiet DeepSource issues reported in
https://deepsource.io/gh/syncthing/syncthing/run/1f029f7e-c9e4-40a1-9b59-d1a8a4d39f1f/go/

### Testing

All tests pass.

### Comments

I chose to quiet things like
```
func (fs *errorFilesystem) Chmod(name string, mode FileMode) error { return fs.err }
```
by prefixing it with:
```
// skipcq: RVV-B0012 : parameter 'name' seems to be unused, consider removing or renaming it as _
```
as I didn't want to rewrite someone else's code as:
```
func (fs *errorFilesystem) Chmod(_ string, _ FileMode) error { return fs.err }
```
without direction.
