### PR TITLE
logmsg: Clarify 'Cleaning data for folder'

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2765,7 +2765,7 @@ func (m *model) BringToFront(folder, file string) {
 }
 
 func (m *model) ResetFolder(folder string) {
-	l.Infof("Cleaning data for folder %q", folder)
+	l.Infof("Cleaning metadata for reset folder %q", folder)
 	db.DropFolder(m.db, folder)
 }
 

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -206,7 +206,7 @@ func (a *App) startup() error {
 	folders := a.cfg.Folders()
 	for _, folder := range a.ll.ListFolders() {
 		if _, ok := folders[folder]; !ok {
-			l.Infof("Cleaning data for dropped folder %q", folder)
+			l.Infof("Cleaning metadata for dropped folder %q", folder)
 			db.DropFolder(a.ll, folder)
 		}
 	}


### PR DESCRIPTION
Instead of data (could be read as user data), use metadata.

Alternatively, s/metadata/internal data/g

### Purpose
Needed to read it twice to be 'ok we are not going to restore a snapshot today'. A casual user might panic.

### Testing
Not tested, change in string.
