### PR TITLE
lib/db/backend: Inline sync.Once in releaser

### DIFF
--- a/lib/db/backend/backend.go
+++ b/lib/db/backend/backend.go
@@ -154,25 +154,20 @@ func IsNotFound(err error) bool {
 // releaser manages counting on top of a waitgroup
 type releaser struct {
 	wg   *closeWaitGroup
-	once *sync.Once
+	once sync.Once
 }
 
 func newReleaser(wg *closeWaitGroup) (*releaser, error) {
 	if err := wg.Add(1); err != nil {
 		return nil, err
 	}
-	return &releaser{
-		wg:   wg,
-		once: new(sync.Once),
-	}, nil
+	return &releaser{wg: wg}, nil
 }
 
-func (r releaser) Release() {
+func (r *releaser) Release() {
 	// We use the Once because we may get called multiple times from
 	// Commit() and deferred Release().
-	r.once.Do(func() {
-		r.wg.Done()
-	})
+	r.once.Do(r.wg.Done)
 }
 
 // closeWaitGroup behaves just like a sync.WaitGroup, but does not require


### PR DESCRIPTION
Clarifies the code: having a pointer to a Once suggests that it is shared with other objects, but it never is.

Also removed a useless anonymous function.