### PR TITLE
gui: Sort already shared devices in edit folder modal (fixes #7940).

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -799,6 +799,7 @@ angular.module('syncthing.core')
                 }
                 $scope.currentSharing.selected[n.deviceID] = true;
             });
+            $scope.currentSharing.shared.sort(deviceCompare);
             $scope.currentSharing.unrelated = $scope.deviceList().filter(function (n) {
                 return n.deviceID !== $scope.myID && !$scope.currentSharing.selected[n.deviceID];
             });


### PR DESCRIPTION
### Purpose

The list of unshared devices is built from deviceList(), which sorts
the result.  But the shared devices are listed in undefined order from
the unsorted currentFolder.devices array.  Apply the same sorting
after building the array used in the dialog.

### Testing

Manual GUI verification.