### PR TITLE
Add windows/arm{,64} support

### DIFF
--- a/build.go
+++ b/build.go
@@ -733,7 +733,13 @@ func shouldBuildSyso(dir string) (string, error) {
 
 	sysoPath := filepath.Join(dir, "cmd", "syncthing", "resource.syso")
 
-	if _, err := runError("goversioninfo", "-o", sysoPath); err != nil {
+	// See https://github.com/josephspurrier/goversioninfo#command-line-flags
+	armOption := ""
+	if strings.Contains(goarch, "arm") {
+		armOption = "-arm=true"
+	}
+
+	if _, err := runError("goversioninfo", "-o", sysoPath, armOption); err != nil {
 		return "", errors.New("failed to create " + sysoPath + ": " + err.Error())
 	}
 


### PR DESCRIPTION
### Purpose

See #7445 .

https://github.com/go-ole/go-ole/pull/223 has been merged. 
Once https://github.com/shirou/gopsutil/pull/1132 is merged, we should be able to target windows/arm and windows/arm64.
