### PR TITLE
lib/rand: Optimizations

### DIFF
--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	mathRand "math/rand"
 	"reflect"
+	"strings"
 )
 
 // Reader is the standard crypto/rand.Reader with added buffering.
@@ -37,11 +38,13 @@ var (
 // (taken from randomCharset) of the specified length. The returned string
 // contains ~5.8 bits of entropy per character, due to the character set used.
 func String(l int) string {
-	bs := make([]byte, l)
-	for i := range bs {
-		bs[i] = randomCharset[defaultSecureRand.Intn(len(randomCharset))]
+	var sb strings.Builder
+	sb.Grow(l)
+
+	for i := 0; i < l; i++ {
+		sb.WriteByte(randomCharset[defaultSecureRand.Intn(len(randomCharset))])
 	}
-	return string(bs)
+	return sb.String()
 }
 
 // Int63 returns a cryptographically secure random int63.

--- a/lib/rand/random_test.go
+++ b/lib/rand/random_test.go
@@ -44,3 +44,10 @@ func TestRandomUint64(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkString(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		String(32)
+	}
+}


### PR DESCRIPTION
rand.secureSource.Uint64 no longer allocates. rand.String uses a strings.Builder. Benchmark results on linux/amd64:

```
name            old time/op    new time/op    delta
SecureSource-8    69.1ns ± 3%    51.7ns ± 3%   -25.21%  (p=0.000 n=20+10)
String-8          2.66µs ± 2%    1.95µs ± 1%   -26.61%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
SecureSource-8     8.00B ± 0%     0.00B       -100.00%  (p=0.000 n=20+10)
String-8            288B ± 0%       32B ± 0%   -88.89%  (p=0.000 n=10+10)

name            old allocs/op  new allocs/op  delta
SecureSource-8      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+10)
String-8            33.0 ± 0%       1.0 ± 0%   -96.97%  (p=0.000 n=10+10)
```