### PR TITLE
lib/config: Always set mtime window to 2 on Android unless ext detected (ref #7963)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -62,7 +62,7 @@ func (f FolderConfiguration) ModTimeWindow() time.Duration {
 		if usage, err := disk.Usage(f.Filesystem().URI()); err != nil {
 			dur = 2 * time.Second
 			l.Debugf(`Detecting FS at "%v" on android: Setting mtime window to 2s: err == "%v"`, f.Path, err)
-		} else if strings.Contains(strings.ToLower(usage.Fstype), "ext2") || strings.Contains(strings.ToLower(usage.Fstype), "ext3") || strings.Contains(strings.ToLower(usage.Fstype), "ext4") {
+		} else if strings.HasPrefix(strings.ToLower(usage.Fstype), "ext2") || strings.HasPrefix(strings.ToLower(usage.Fstype), "ext3") || strings.HasPrefix(strings.ToLower(usage.Fstype), "ext4") {
 			l.Debugf(`Detecting FS at %v on android: Leaving mtime window at 0: usage.Fstype == "%v"`, f.Path, usage.Fstype)
 		} else {
 			dur = 2 * time.Second

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -62,11 +62,11 @@ func (f FolderConfiguration) ModTimeWindow() time.Duration {
 		if usage, err := disk.Usage(f.Filesystem().URI()); err != nil {
 			dur = 2 * time.Second
 			l.Debugf(`Detecting FS at "%v" on android: Setting mtime window to 2s: err == "%v"`, f.Path, err)
-		} else if usage.Fstype == "" || strings.Contains(strings.ToLower(usage.Fstype), "fat") || strings.Contains(strings.ToLower(usage.Fstype), "msdos") {
+		} else if strings.Contains(strings.ToLower(usage.Fstype), "ext2") || strings.Contains(strings.ToLower(usage.Fstype), "ext3") || strings.Contains(strings.ToLower(usage.Fstype), "ext4") {
+			l.Debugf(`Detecting FS at %v on android: Leaving mtime window at 0: usage.Fstype == "%v"`, f.Path, usage.Fstype)
+		} else {
 			dur = 2 * time.Second
 			l.Debugf(`Detecting FS at "%v" on android: Setting mtime window to 2s: usage.Fstype == "%v"`, f.Path, usage.Fstype)
-		} else {
-			l.Debugf(`Detecting FS at %v on android: Leaving mtime window at 0: usage.Fstype == "%v"`, f.Path, usage.Fstype)
 		}
 	}
 	return dur


### PR DESCRIPTION
The current detection is flawed, because it looks for a few specific
file systems like "msdos" or "fat" to set the mtime window, while in
reality Android seems to report names like "fuseblk", which can stand
for fat, ext4, or even f2fs.

At the moment, we set the mtime window only for a few known names used
for the fat filesystem. With this change, we take a safer approach of
always setting the time window unless we explicitly detect file systems
like ext2/ext3/ex4, which are known not to experience issues with moving
timestamps on Android.
