### PR TITLE
build: Fix deepsource test & exclude patterns

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,7 +1,7 @@
 version = 1
 
-exclude_patterns = ["*.pb.go"]
-test_patterns = ["*_test.go"]
+exclude_patterns = ["**/*.pb.go"]
+test_patterns = ["**/*_test.go"]
 
 [[analyzers]]
 name = "go"


### PR DESCRIPTION
### Purpose

Those patterns didn't actually match everywhere as they look like they do.