### PR TITLE
gui: Allow text wrapping in remove folder/device modals

### DIFF
--- a/gui/default/syncthing/device/removeDeviceDialogView.html
+++ b/gui/default/syncthing/device/removeDeviceDialogView.html
@@ -1,9 +1,11 @@
 <modal id="remove-device-confirmation" status="warning" icon="fas fa-question-circle" heading="{{'Remove Device' | translate}}" large="no" closeable="yes">
   <div class="modal-body">
-    <p ng-model="currentDevice.name" style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-      <span translate translate-value-name="{{currentDevice.name}}">Are you sure you want to remove device {%name%}?</span>
+    <p ng-model="currentDevice.name" translate translate-value-name="{{currentDevice.name}}">
+      Are you sure you want to remove device {%name%}?
     </p>
-    <p ng-if="willBeReintroducedBy" translate translate-value-reintroducer="{{willBeReintroducedBy}}">{%reintroducer%} might reintroduce this device.</p>
+    <p ng-if="willBeReintroducedBy" translate translate-value-reintroducer="{{willBeReintroducedBy}}">
+      {%reintroducer%} might reintroduce this device.
+    </p>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-warning pull-left btn-sm" data-dismiss="modal" ng-click="deleteDevice()">

--- a/gui/default/syncthing/folder/removeFolderDialogView.html
+++ b/gui/default/syncthing/folder/removeFolderDialogView.html
@@ -1,7 +1,7 @@
 <modal id="remove-folder-confirmation" status="warning" icon="fas fa-question-circle" heading="{{'Remove Folder' | translate}}" large="no" closeable="yes">
   <div class="modal-body">
-    <p style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
-      <span translate translate-value-label="{{currentFolder.label}}">Are you sure you want to remove folder {%label%}?</span>
+    <p translate translate-value-label="{{currentFolder.label}}">
+      Are you sure you want to remove folder {%label%}?
     </p>
     <p translate>
       No files will be deleted as a result of this operation.


### PR DESCRIPTION
Remove the embedded CSS that prevents the lines from wrapping, resulting
in device and folder names being hidden on small screens.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

The old code prevents wrapping, which cuts the lines on mobile. I'd say this is very bad, because the folder path and/or device names end up being hidden.

#### Before:

<img width=300 src="https://user-images.githubusercontent.com/5626656/136489252-c947179b-1b6e-482b-b36d-0c9d75862e4d.png"> <img width=300 src="https://user-images.githubusercontent.com/5626656/136489255-34326c56-3f64-4337-b083-95177d4fc07d.png">

#### After:

<img width=300 src="https://user-images.githubusercontent.com/5626656/136489169-65c013be-447f-4cde-aa99-e41be571be05.png"> <img width=300 src="https://user-images.githubusercontent.com/5626656/136489181-86794c18-6bf3-4a91-94f9-3d49d9628d45.png">

