### PR TITLE
gui: Fix jumping nav tabs in black and dark themes

### DIFF
--- a/gui/black/assets/css/theme.css
+++ b/gui/black/assets/css/theme.css
@@ -42,7 +42,7 @@ a:hover,a:focus,a.focus{
 .nav-tabs > li > a:hover,
 .nav-tabs > li > a:focus {
   background-color: #222222 !important;
-  border: none !important;
+  border-color: transparent !important;
 }
 
 .navbar-text, .dropdown>a, .dropdown-menu>li>a, .hidden-xs>a, .navbar-link {

--- a/gui/dark/assets/css/theme.css
+++ b/gui/dark/assets/css/theme.css
@@ -45,7 +45,7 @@ a:hover,a:focus,a.focus{
 .nav-tabs > li > a:hover,
 .nav-tabs > li > a:focus {
   background-color: #424242 !important;
-  border: none !important;
+  border-color: transparent !important;
 }
 
 


### PR DESCRIPTION
Because of a disappearing border, the navigation tabs jump when being
hovered or focus. Thus, instead of removing the border, let us change
its colour to transparent, which preserves the layout.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

This is the jumping I'm talking about :smile:. If you look closely, you'll see the tabs keep moving a little bit.

https://user-images.githubusercontent.com/5626656/134932288-cc9fe75b-0762-4450-b82c-d6a9dc8cb71a.mp4
