### PR TITLE
Revert "gui: Allow to resize command in External Versioning (#7410)"

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -128,7 +128,7 @@
           <div class="form-group" ng-if="currentFolder._guiVersioning.selector=='external'" ng-class="{'has-error': folderEditor.externalCommand.$invalid && folderEditor.externalCommand.$dirty}">
             <p translate class="help-block">An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.</p>
             <label translate for="externalCommand">Command</label>
-            <textarea name="externalCommand" id="externalCommand" class="form-control" rows="1" ng-model="currentFolder._guiVersioning.externalCommand" required="" aria-required="true"></textarea>
+            <input name="externalCommand" id="externalCommand" class="form-control" type="text" ng-model="currentFolder._guiVersioning.externalCommand" required="" aria-required="true" />
             <p class="help-block">
               <span translate ng-if="folderEditor.externalCommand.$valid || folderEditor.externalCommand.$pristine">See external versioning help for supported templated command line parameters.</span>
               <span translate ng-if="folderEditor.externalCommand.$error.required && folderEditor.externalCommand.$dirty">The path cannot be blank.</span>


### PR DESCRIPTION
This reverts commit cca17f53064b1b567a3275eadd5467af1e810f47.

Using textarea instead of input makes it possible to enter new lines,
which then are added to config.xml as `&#xA;`. This breaks the whole
script, because these characters are passed to the command line as `\n`.
Therefore, the script should rather remain a single-lined input field.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>