### PR TITLE
gui: Use case insensitive sort with folders on top in Restore Versions

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2420,6 +2420,14 @@ angular.module('syncthing.core')
                                 debugLevel: 2,
                                 source: buildTree($scope.restoreVersions.versions),
                                 renderColumns: function (event, data) {
+                                    // Case insensitive sort with folders on top.
+                                    var cmp = function(a, b) {
+                                        var x = (a.isFolder() ? "0" : "1") + a.title.toLowerCase(),
+                                            y = (b.isFolder() ? "0" : "1") + b.title.toLowerCase();
+                                        return x === y ? 0 : x > y ? 1 : -1;
+                                    };
+                                    data.tree.getRootNode().sortChildren(cmp, true);
+
                                     var node = data.node,
                                         $tdList = $(node.tr).find(">td"),
                                         template;


### PR DESCRIPTION
Currently, the default sorting of the file list in the Restore Versions
modal in both case sensitive, and it also does not distinguish between
files and folders. With this change, which uses a slightly modified code
from the fancytree itself (with added folder prioritisation), the sort
becomes case insensitive and also always places folders on top. This is
to make it behave more similar to what file managers do in the commonly
used operating systems (including popular Linux desktop environments).

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before:

![image](https://user-images.githubusercontent.com/5626656/135200088-d1534b2c-cde7-482e-9435-5ef26cccd95a.png)

#### After:

![image](https://user-images.githubusercontent.com/5626656/135200039-f5287174-311b-44b8-b0f0-40203283d1f6.png)
