### PR TITLE
lib/model: Write trailer when shortcutting on recv-enc (fixes #7991)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -383,10 +383,12 @@ func (f *sendReceiveFolder) processNeeded(snap *db.Snapshot, dbUpdateChan chan<-
 
 		case file.Type == protocol.FileInfoTypeFile:
 			curFile, hasCurFile := snap.Get(protocol.LocalDeviceID, file.Name)
-			if hasCurFile && file.BlocksEqual(curFile) {
+			if hasCurFile && f.Type != config.FolderTypeReceiveEncrypted && file.BlocksEqual(curFile) {
 				// We are supposed to copy the entire file, and then fetch nothing. We
 				// are only updating metadata, so we don't actually *need* to make the
 				// copy.
+				// We can't shortcut files on receive-encrypted folders, as we
+				// need to update the encrypted fileinfo appended to the file.
 				f.shortcutFile(file, dbUpdateChan)
 			} else {
 				// Queue files for processing after directories and symlinks.


### PR DESCRIPTION
I initially intended to never shortcut files on receive-encrypted folders, making them go through the entire copier-puller-finisher routines (first commit). However since this is a single write, and a failure will just result in a locally modified file, i.e. cannot propagate to other devices, I believe writing directly to the file for speed-up over the entire copier-puller-finisher routine is warranted.