### PR TITLE
gui: Add direct link to Ignore Patterns from folder panel (fixes #4293)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -56,6 +56,10 @@ ul+h5 {
     word-wrap:break-word;
 }
 
+.text-italic {
+    font-style: italic;
+}
+
 .text-monospace {
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
 }

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -422,8 +422,8 @@
                           <span tooltip data-original-title="{{model[folder.id].localFiles | alwaysNumber | localeNumber}} {{'files' | translate}}, {{model[folder.id].localDirectories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{model[folder.id].localBytes | binary}}B">
                             <span class="far fa-copy"></span>&nbsp;{{model[folder.id].localFiles | alwaysNumber | localeNumber}}&ensp;
                             <span class="far fa-folder"></span>&nbsp;{{model[folder.id].localDirectories | alwaysNumber | localeNumber}}&ensp;
-                            <span class="far fa-hdd"></span>&nbsp;~{{model[folder.id].localBytes | binary}}B<!-- get rid of the annoying trailing whitespace
-                            --><span ng-if="model[folder.id].ignorePatterns"><br/><i><small translate class="text-muted">Reduced by ignore patterns</small></i></span>
+                            <span class="far fa-hdd"></span>&nbsp;~{{model[folder.id].localBytes | binary}}B<br/>
+                            <a href="" class="small text-italic" ng-if="model[folder.id].ignorePatterns" ng-click="editFolderExisting(folder, '#folder-ignores')" translate>Reduced by ignore patterns</a>
                           </span>
                         </td>
                       </tr>


### PR DESCRIPTION
In contrary to many other parts of the folder configuration, Ignore
Patterns are something that the user may need to tweak quite often.
Thus, add an easily accessible link right in the folder panel so that
the user can quickly open and modify their patterns at will, without
having to go through the other folder configuration content.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

![image](https://user-images.githubusercontent.com/5626656/136064827-e41ec76b-784c-474c-8267-7f45bc7495b9.png)
