### PR TITLE
lib/protocol: Preserve sequence decrypting fileinfos (fixes #7994)

### DIFF
--- a/lib/protocol/encryption.go
+++ b/lib/protocol/encryption.go
@@ -365,6 +365,10 @@ func DecryptFileInfo(fi FileInfo, folderKey *[keySize]byte) (FileInfo, error) {
 	if err := proto.Unmarshal(dec, &decFI); err != nil {
 		return FileInfo{}, err
 	}
+
+	// Preserve sequence, which is legitimately controlled by the untrusted device
+	decFI.Sequence = fi.Sequence
+
 	return decFI, nil
 }
 


### PR DESCRIPTION
Adds a check to the en/decryption test to ensure sequences are preserved and preserves the sequence on decryption (was already on encryption).