### PR TITLE
build: Fix error in debian install scripts preventing restarts for stdiscosrv + strelaysrv (fixes #8000)

### DIFF
--- a/build.go
+++ b/build.go
@@ -143,7 +143,7 @@ var targets = map[string]target{
 			{src: "LICENSE", dst: "LICENSE.txt", perm: 0644},
 			{src: "AUTHORS", dst: "AUTHORS.txt", perm: 0644},
 		},
-		systemdService: "cmd/stdiscosrv/etc/linux-systemd/stdiscosrv.service",
+		systemdService: "stdiscosrv.service",
 		installationFiles: []archiveFile{
 			{src: "{{binary}}", dst: "deb/usr/bin/{{binary}}", perm: 0755},
 			{src: "cmd/stdiscosrv/README.md", dst: "deb/usr/share/doc/syncthing-discosrv/README.txt", perm: 0644},
@@ -171,7 +171,7 @@ var targets = map[string]target{
 			{src: "LICENSE", dst: "LICENSE.txt", perm: 0644},
 			{src: "AUTHORS", dst: "AUTHORS.txt", perm: 0644},
 		},
-		systemdService: "cmd/strelaysrv/etc/linux-systemd/strelaysrv.service",
+		systemdService: "strelaysrv.service",
 		installationFiles: []archiveFile{
 			{src: "{{binary}}", dst: "deb/usr/bin/{{binary}}", perm: 0755},
 			{src: "cmd/strelaysrv/README.md", dst: "deb/usr/share/doc/syncthing-relaysrv/README.txt", perm: 0644},


### PR DESCRIPTION
### Purpose

More straightforward than expected, renaming the strings in build.go seems to not break anything (at least nothing obvious...). And it does indeed fix the issue, as described in the forum: https://forum.syncthing.net/t/stdiscosrv-strelaysrv-systemd-services-not-restarting-on-upgrade/17451

This fixes issue https://github.com/syncthing/syncthing/issues/8000.

### Testing

Only manual testing performed. Checks done:

- Building the .deb files with fpm still works, no error or warning that wasn't present previously (using Ubuntu 20.04 amd64 as builder, Go 1.17.1, fpm 1.13.1)
- Compared the postinst script before and after the change. New postinst script now contains the valid service name.
- Installing the .deb files via dpkg still works (tested on Ubuntu 20.04)
- Upgrading the .deb now results in a correct systemd service restart, if the service file was running previously.

### Documentation

Thinking about this, the systemd service files for these applications are pretty much undocumented right now? Maybe I'm going to write something someday.


