### PR TITLE
lib/relay: Send SNI when the address is a host name (fixes #8014)

### DIFF
--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -145,12 +145,13 @@ func (c *staticClient) connect(ctx context.Context) error {
 	// many cases this will be an IP address, in which case it's a no-op. In
 	// other cases it will be a hostname, which will cause the TLS stack to
 	// send SNI.
-	cfg := *c.config
+	cfg := c.config
 	if host, _, err := net.SplitHostPort(c.uri.Host); err == nil {
+		cfg = cfg.Clone()
 		cfg.ServerName = host
 	}
 
-	conn := tls.Client(tcpConn, &cfg)
+	conn := tls.Client(tcpConn, cfg)
 
 	if err := conn.SetDeadline(time.Now().Add(c.connectTimeout)); err != nil {
 		conn.Close()

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -141,7 +141,16 @@ func (c *staticClient) connect(ctx context.Context) error {
 		return err
 	}
 
-	conn := tls.Client(tcpConn, c.config)
+	// Copy the TLS config and set the server name we're connecting to. In
+	// many cases this will be an IP address, in which case it's a no-op. In
+	// other cases it will be a hostname, which will cause the TLS stack to
+	// send SNI.
+	cfg := *c.config
+	if host, _, err := net.SplitHostPort(c.uri.Host); err == nil {
+		cfg.ServerName = host
+	}
+
+	conn := tls.Client(tcpConn, &cfg)
 
 	if err := conn.SetDeadline(time.Now().Add(c.connectTimeout)); err != nil {
 		conn.Close()


### PR DESCRIPTION
### Purpose

Allow easier running of relay servers behind proxies.

### Testing

I added `relay://www.google.com:443/` and looked in Wireshark, and saw SNI. 