### PR TITLE
lib/model: Set mod. time after writing trailer in shortcut (ref #7992)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1227,8 +1227,6 @@ func (f *sendReceiveFolder) shortcutFile(file protocol.FileInfo, dbUpdateChan ch
 		}
 	}
 
-	f.mtimefs.Chtimes(file.Name, file.ModTime(), file.ModTime()) // never fails
-
 	// Still need to re-write the trailer with the new encrypted fileinfo.
 	if f.Type == config.FolderTypeReceiveEncrypted {
 		err = inWritableDir(func(path string) error {
@@ -1248,6 +1246,8 @@ func (f *sendReceiveFolder) shortcutFile(file protocol.FileInfo, dbUpdateChan ch
 			return
 		}
 	}
+
+	f.mtimefs.Chtimes(file.Name, file.ModTime(), file.ModTime()) // never fails
 
 	dbUpdateChan <- dbUpdateJob{file, dbUpdateShortcutFile}
 }


### PR DESCRIPTION
The trailer writing introduced in #7992 happened after setting mod. time, which obviously leaves the file with the wrong mod. time. That was an v1.18.4-rc.1 change, so not fully released yet luckily, and should thus make it in to the last rc.