### PR TITLE
gui: Display identicons for discovered device IDs.

### DIFF
--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -25,7 +25,11 @@
               <p class="help-block" ng-if="discovery && discovery.length !== 0">
                 <span translate>You can also select one of these nearby devices:</span>
                 <ul>
-                  <li ng-repeat="id in discovery"><a href="#" ng-click="currentDevice.deviceID = id">{{id}}</a></li>
+                  <li ng-repeat="id in discovery" style="list-style-type: none;">
+                    <a href="#" ng-click="currentDevice.deviceID = id">
+                      <identicon data-value="id"></identicon>&nbsp;&nbsp;{{id}}
+                    </a>
+                  </li>
                 </ul>
               </p>
               <p class="help-block">


### PR DESCRIPTION
### Purpose

In the Add Device modal dialog, there is a list of up to five locally discovered device IDs.  Choosing from them is a great time-saver, but identifying which is the wanted one requires comparing (partial) device ID strings.  Especially when integrating a new device into an existing cluster, one can more easily remember the identicon shown on one of the existing cluster devices.  Make it easy to recognize that device in the discovered ID list by replacing the bullet points with the corresponding identicon.

### Testing

Open the Add Remote Device modal and admire the beautifully listed identicons.  Requires not yet added remote devices on the local network.

### Screenshots

![Screenshot 2021-10-29 at 16-28-17 devtest Syncthing_add identicons](https://user-images.githubusercontent.com/6996887/139454220-1af16d3d-9227-4e75-8b51-6528e8e6118b.png)
