### PR TITLE
lib/syncthing: Clean up / refactor LoadOrGenerateCertificate() utility function.

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -49,15 +49,12 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/syncthing"
-	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
 
 	"github.com/pkg/errors"
 )
 
 const (
-	tlsDefaultCommonName   = "syncthing"
-	deviceCertLifetimeDays = 20 * 365
 	sigTerm                = syscall.Signal(15)
 )
 
@@ -442,7 +439,7 @@ func generate(generateDir string, noDefaultFolder bool) error {
 	if err == nil {
 		l.Warnln("Key exists; will not overwrite.")
 	} else {
-		cert, err = tlsutil.NewCertificate(certFile, keyFile, tlsDefaultCommonName, deviceCertLifetimeDays)
+		cert, err = syncthing.GenerateCertificate(certFile, keyFile)
 		if err != nil {
 			return errors.Wrap(err, "create certificate")
 		}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -55,7 +55,7 @@ import (
 )
 
 const (
-	sigTerm                = syscall.Signal(15)
+	sigTerm = syscall.Signal(15)
 )
 
 const (

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -1209,15 +1209,9 @@ func TestPrefixMatch(t *testing.T) {
 }
 
 func TestShouldRegenerateCertificate(t *testing.T) {
-	dir, err := ioutil.TempDir("", "syncthing-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	// Self signed certificates expiring in less than a month are errored so we
 	// can regenerate in time.
-	crt, err := tlsutil.NewCertificate(filepath.Join(dir, "crt"), filepath.Join(dir, "key"), "foo.example.com", 29)
+	crt, err := tlsutil.NewCertificate("", "", "foo.example.com", 29)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1226,7 +1220,7 @@ func TestShouldRegenerateCertificate(t *testing.T) {
 	}
 
 	// Certificates with at least 31 days of life left are fine.
-	crt, err = tlsutil.NewCertificate(filepath.Join(dir, "crt"), filepath.Join(dir, "key"), "foo.example.com", 31)
+	crt, err = tlsutil.NewCertificate("", "", "foo.example.com", 31)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1236,7 +1230,7 @@ func TestShouldRegenerateCertificate(t *testing.T) {
 
 	if runtime.GOOS == "darwin" {
 		// Certificates with too long an expiry time are not allowed on macOS
-		crt, err = tlsutil.NewCertificate(filepath.Join(dir, "crt"), filepath.Join(dir, "key"), "foo.example.com", 1000)
+		crt, err = tlsutil.NewCertificate("", "", "foo.example.com", 1000)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -1211,7 +1211,7 @@ func TestPrefixMatch(t *testing.T) {
 func TestShouldRegenerateCertificate(t *testing.T) {
 	// Self signed certificates expiring in less than a month are errored so we
 	// can regenerate in time.
-	crt, err := tlsutil.NewCertificate("", "", "foo.example.com", 29)
+	crt, err := tlsutil.NewCertificateInMemory("foo.example.com", 29)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1220,7 +1220,7 @@ func TestShouldRegenerateCertificate(t *testing.T) {
 	}
 
 	// Certificates with at least 31 days of life left are fine.
-	crt, err = tlsutil.NewCertificate("", "", "foo.example.com", 31)
+	crt, err = tlsutil.NewCertificateInMemory("foo.example.com", 31)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1230,7 +1230,7 @@ func TestShouldRegenerateCertificate(t *testing.T) {
 
 	if runtime.GOOS == "darwin" {
 		// Certificates with too long an expiry time are not allowed on macOS
-		crt, err = tlsutil.NewCertificate("", "", "foo.example.com", 1000)
+		crt, err = tlsutil.NewCertificateInMemory("foo.example.com", 1000)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/lib/connections/connections_test.go
+++ b/lib/connections/connections_test.go
@@ -11,11 +11,9 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/url"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -470,21 +468,9 @@ func withConnectionPair(b *testing.B, connUri string, h func(client, server inte
 }
 
 func mustGetCert(b *testing.B) tls.Certificate {
-	f1, err := ioutil.TempFile("", "")
+	cert, err := tlsutil.NewCertificate("", "", "bench", 10)
 	if err != nil {
 		b.Fatal(err)
 	}
-	f1.Close()
-	f2, err := ioutil.TempFile("", "")
-	if err != nil {
-		b.Fatal(err)
-	}
-	f2.Close()
-	cert, err := tlsutil.NewCertificate(f1.Name(), f2.Name(), "bench", 10)
-	if err != nil {
-		b.Fatal(err)
-	}
-	_ = os.Remove(f1.Name())
-	_ = os.Remove(f2.Name())
 	return cert
 }

--- a/lib/connections/connections_test.go
+++ b/lib/connections/connections_test.go
@@ -468,7 +468,7 @@ func withConnectionPair(b *testing.B, connUri string, h func(client, server inte
 }
 
 func mustGetCert(b *testing.B) tls.Certificate {
-	cert, err := tlsutil.NewCertificate("", "", "bench", 10)
+	cert, err := tlsutil.NewCertificateInMemory("bench", 10)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/lib/discover/global_test.go
+++ b/lib/discover/global_test.go
@@ -107,13 +107,8 @@ func TestGlobalOverHTTP(t *testing.T) {
 }
 
 func TestGlobalOverHTTPS(t *testing.T) {
-	dir, err := ioutil.TempDir("", "syncthing")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Generate a server certificate.
-	cert, err := tlsutil.NewCertificate(dir+"/cert.pem", dir+"/key.pem", "syncthing", 30)
+	cert, err := tlsutil.NewCertificate("", "", "syncthing", 30)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,13 +167,8 @@ func TestGlobalOverHTTPS(t *testing.T) {
 }
 
 func TestGlobalAnnounce(t *testing.T) {
-	dir, err := ioutil.TempDir("", "syncthing")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// Generate a server certificate.
-	cert, err := tlsutil.NewCertificate(dir+"/cert.pem", dir+"/key.pem", "syncthing", 30)
+	cert, err := tlsutil.NewCertificate("", "", "syncthing", 30)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/discover/global_test.go
+++ b/lib/discover/global_test.go
@@ -108,7 +108,7 @@ func TestGlobalOverHTTP(t *testing.T) {
 
 func TestGlobalOverHTTPS(t *testing.T) {
 	// Generate a server certificate.
-	cert, err := tlsutil.NewCertificate("", "", "syncthing", 30)
+	cert, err := tlsutil.NewCertificateInMemory("syncthing", 30)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -168,7 +168,7 @@ func TestGlobalOverHTTPS(t *testing.T) {
 
 func TestGlobalAnnounce(t *testing.T) {
 	// Generate a server certificate.
-	cert, err := tlsutil.NewCertificate("", "", "syncthing", 30)
+	cert, err := tlsutil.NewCertificateInMemory("syncthing", 30)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -9,7 +9,6 @@ package syncthing
 import (
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -57,13 +56,7 @@ func TestShortIDCheck(t *testing.T) {
 }
 
 func TestStartupFail(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "syncthing-TestStartupFail-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	cert, err := tlsutil.NewCertificate(filepath.Join(tmpDir, "cert"), filepath.Join(tmpDir, "key"), "syncthing", 365)
+	cert, err := tlsutil.NewCertificate("", "", "syncthing", 365)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/syncthing/syncthing_test.go
+++ b/lib/syncthing/syncthing_test.go
@@ -56,7 +56,7 @@ func TestShortIDCheck(t *testing.T) {
 }
 
 func TestStartupFail(t *testing.T) {
-	cert, err := tlsutil.NewCertificate("", "", "syncthing", 365)
+	cert, err := tlsutil.NewCertificateInMemory("syncthing", 365)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -27,14 +27,18 @@ import (
 func LoadOrGenerateCertificate(certFile, keyFile string) (tls.Certificate, error) {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		l.Infof("Generating ECDSA key and certificate for %s...", tlsDefaultCommonName)
-		return tlsutil.NewCertificate(
-			certFile, keyFile,
-			tlsDefaultCommonName,
-			deviceCertLifetimeDays,
-		)
+		return GenerateCertificate(certFile, keyFile)
 	}
 	return cert, nil
+}
+
+func GenerateCertificate(certFile, keyFile string) (tls.Certificate, error) {
+	l.Infof("Generating ECDSA key and certificate for %s...", tlsDefaultCommonName)
+	return tlsutil.NewCertificate(
+		certFile, keyFile,
+		tlsDefaultCommonName,
+		deviceCertLifetimeDays,
+	)
 }
 
 func DefaultConfig(path string, myID protocol.DeviceID, evLogger events.Logger, noDefaultFolder bool) (config.Wrapper, error) {

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -34,11 +34,7 @@ func LoadOrGenerateCertificate(certFile, keyFile string) (tls.Certificate, error
 
 func GenerateCertificate(certFile, keyFile string) (tls.Certificate, error) {
 	l.Infof("Generating ECDSA key and certificate for %s...", tlsDefaultCommonName)
-	return tlsutil.NewCertificate(
-		certFile, keyFile,
-		tlsDefaultCommonName,
-		deviceCertLifetimeDays,
-	)
+	return tlsutil.NewCertificate(certFile, keyFile, tlsDefaultCommonName, deviceCertLifetimeDays)
 }
 
 func DefaultConfig(path string, myID protocol.DeviceID, evLogger events.Logger, noDefaultFolder bool) (config.Wrapper, error) {

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -25,15 +25,11 @@ import (
 )
 
 func LoadOrGenerateCertificate(certFile, keyFile string) (tls.Certificate, error) {
-	cert, err := tls.LoadX509KeyPair(
-		locations.Get(locations.CertFile),
-		locations.Get(locations.KeyFile),
-	)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
 		l.Infof("Generating ECDSA key and certificate for %s...", tlsDefaultCommonName)
 		return tlsutil.NewCertificate(
-			locations.Get(locations.CertFile),
-			locations.Get(locations.KeyFile),
+			certFile, keyFile,
 			tlsDefaultCommonName,
 			deviceCertLifetimeDays,
 		)

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -129,37 +129,43 @@ func generateCertificate(commonName string, lifetimeDays int) (*pem.Block, *pem.
 	return certBlock, keyBlock, nil
 }
 
-// NewCertificate generates and returns a new TLS certificate, saved to the given PEM files.  If any file name is empty, the contents are kept only in memory.
+// NewCertificate generates and returns a new TLS certificate, saved to the given PEM files.
 func NewCertificate(certFile, keyFile string, commonName string, lifetimeDays int) (tls.Certificate, error) {
 	certBlock, keyBlock, err := generateCertificate(commonName, lifetimeDays)
 	if err != nil {
 		return tls.Certificate{}, err
 	}
 
-	if certFile != "" {
-		certOut, err := os.Create(certFile)
-		if err != nil {
-			return tls.Certificate{}, errors.Wrap(err, "save cert")
-		}
-		if err = pem.Encode(certOut, certBlock); err != nil {
-			return tls.Certificate{}, errors.Wrap(err, "save cert")
-		}
-		if err = certOut.Close(); err != nil {
-			return tls.Certificate{}, errors.Wrap(err, "save cert")
-		}
+	certOut, err := os.Create(certFile)
+	if err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "save cert")
+	}
+	if err = pem.Encode(certOut, certBlock); err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "save cert")
+	}
+	if err = certOut.Close(); err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "save cert")
 	}
 
-	if keyFile != "" {
-		keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-		if err != nil {
-			return tls.Certificate{}, errors.Wrap(err, "save key")
-		}
-		if err = pem.Encode(keyOut, keyBlock); err != nil {
-			return tls.Certificate{}, errors.Wrap(err, "save key")
-		}
-		if err = keyOut.Close(); err != nil {
-			return tls.Certificate{}, errors.Wrap(err, "save key")
-		}
+	keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "save key")
+	}
+	if err = pem.Encode(keyOut, keyBlock); err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "save key")
+	}
+	if err = keyOut.Close(); err != nil {
+		return tls.Certificate{}, errors.Wrap(err, "save key")
+	}
+
+	return tls.X509KeyPair(pem.EncodeToMemory(certBlock), pem.EncodeToMemory(keyBlock))
+}
+
+// NewCertificateInMemory generates and returns a new TLS certificate, kept only in memory.
+func NewCertificateInMemory(commonName string, lifetimeDays int) (tls.Certificate, error) {
+	certBlock, keyBlock, err := generateCertificate(commonName, lifetimeDays)
+	if err != nil {
+		return tls.Certificate{}, err
 	}
 
 	return tls.X509KeyPair(pem.EncodeToMemory(certBlock), pem.EncodeToMemory(keyBlock))

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -86,11 +86,11 @@ func SecureDefaultWithTLS12() *tls.Config {
 	}
 }
 
-// NewCertificate generates and returns a new TLS certificate.
-func NewCertificate(certFile, keyFile, commonName string, lifetimeDays int) (tls.Certificate, error) {
+// generateCertificate generates a PEM formatted key pair and self-signed certificate in memory.
+func generateCertificate(commonName string, lifetimeDays int) (*pem.Block, *pem.Block, error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "generate key")
+		return nil, nil, errors.Wrap(err, "generate key")
 	}
 
 	notBefore := time.Now().Truncate(24 * time.Hour)
@@ -117,42 +117,52 @@ func NewCertificate(certFile, keyFile, commonName string, lifetimeDays int) (tls
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
 	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "create cert")
+		return nil, nil, errors.Wrap(err, "create cert")
 	}
 
-	certOut, err := os.Create(certFile)
+	certBlock := &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}
+	keyBlock, err := pemBlockForKey(priv)
 	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "save cert")
-	}
-	err = pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "save cert")
-	}
-	err = certOut.Close()
-	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "save cert")
+		return nil, nil, errors.Wrap(err, "save key")
 	}
 
-	keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	return certBlock, keyBlock, nil
+}
+
+// NewCertificate generates and returns a new TLS certificate, saved to the given PEM files.  If any file name is empty, the contents are kept only in memory.
+func NewCertificate(certFile, keyFile string, commonName string, lifetimeDays int) (tls.Certificate, error) {
+	certBlock, keyBlock, err := generateCertificate(commonName, lifetimeDays)
 	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "save key")
+		return tls.Certificate{}, err
 	}
 
-	block, err := pemBlockForKey(priv)
-	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "save key")
+	if certFile != "" {
+		certOut, err := os.Create(certFile)
+		if err != nil {
+			return tls.Certificate{}, errors.Wrap(err, "save cert")
+		}
+		if err = pem.Encode(certOut, certBlock); err != nil {
+			return tls.Certificate{}, errors.Wrap(err, "save cert")
+		}
+		if err = certOut.Close(); err != nil {
+			return tls.Certificate{}, errors.Wrap(err, "save cert")
+		}
 	}
 
-	err = pem.Encode(keyOut, block)
-	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "save key")
-	}
-	err = keyOut.Close()
-	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "save key")
+	if keyFile != "" {
+		keyOut, err := os.OpenFile(keyFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+		if err != nil {
+			return tls.Certificate{}, errors.Wrap(err, "save key")
+		}
+		if err = pem.Encode(keyOut, keyBlock); err != nil {
+			return tls.Certificate{}, errors.Wrap(err, "save key")
+		}
+		if err = keyOut.Close(); err != nil {
+			return tls.Certificate{}, errors.Wrap(err, "save key")
+		}
 	}
 
-	return tls.LoadX509KeyPair(certFile, keyFile)
+	return tls.X509KeyPair(pem.EncodeToMemory(certBlock), pem.EncodeToMemory(keyBlock))
 }
 
 type DowngradingListener struct {


### PR DESCRIPTION
Just some cleanup around the `LoadOrGenerateCertificate()` function.  It should adhere to the given arguments instead of delegating to the `locations` package.  This is technically a no-op change, because the only place calling this function passes exactly the same values.

I've chosen to keep the arguments although in principle the `locations` package already provides the desired paths.  Many other functions here take a path as argument and mix it with some `locations.Get()` values.  If you think the latter should be used consistently, I will switch over to that method as far as possible.

Also a no-op is to factor out the second half of that function and reuse it in `cmd/syncthing`.  That previously had its own independent (but matching) values for certificate name and lifetime, which is prone to get out of sync.