### PR TITLE
lib/api, lib/config: Remove config.ReadJSON (fixes #7957)

### DIFF
--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -808,7 +808,20 @@ func TestConfigPostDupFolder(t *testing.T) {
 }
 
 func testConfigPost(data io.Reader) (*http.Response, error) {
-	baseURL, cancel, err := startHTTP(apiCfg)
+	cfg := config.Configuration{
+		GUI: config.GUIConfiguration{APIKey: "foobarbaz"},
+	}
+	tmpFile, err := ioutil.TempFile("", "syncthing-testConfig-")
+	if err != nil {
+		panic(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	w := config.Wrap(tmpFile.Name(), cfg, protocol.LocalDeviceID, events.NoopLogger)
+	ctx, cancel := context.WithCancel(context.Background())
+	go w.Serve(ctx)
+	defer cancel()
+
+	baseURL, cancel, err := startHTTP(w)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -814,8 +814,10 @@ func testConfigPost(data io.Reader) (*http.Response, error) {
 	if err != nil {
 		panic(err)
 	}
-	defer os.Remove(tmpFile.Name())
-	w := config.Wrap(tmpFile.Name(), cfg, protocol.LocalDeviceID, events.NoopLogger)
+	tmpFileName := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpFileName)
+	w := config.Wrap(tmpFileName, cfg, protocol.LocalDeviceID, events.NoopLogger)
 	ctx, cancel := context.WithCancel(context.Background())
 	go w.Serve(ctx)
 	defer cancel()

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -783,7 +783,6 @@ func TestConfigPostOK(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Error("Expected 200 OK, not", resp.Status)
 	}
-	os.RemoveAll("TestConfigPostOK")
 }
 
 func TestConfigPostDupFolder(t *testing.T) {

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -289,7 +289,7 @@ func (c *configMuxBuilder) adjustConfig(w http.ResponseWriter, r *http.Request) 
 	var to config.Configuration
 	util.SetDefaults(&to)
 	if err := json.Unmarshal(bs, &to); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("unmarshalling config: %s", err), http.StatusBadRequest)
 		return
 	}
 

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -8,6 +8,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -281,7 +282,7 @@ func (c *configMuxBuilder) adjustConfig(w http.ResponseWriter, r *http.Request) 
 	bs, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("readying request body: %s", err), http.StatusInternalServerError)
 		return
 	}
 
@@ -329,7 +330,7 @@ func (c *configMuxBuilder) adjustConfig(w http.ResponseWriter, r *http.Request) 
 	if errMsg != "" {
 		http.Error(w, errMsg, status)
 	} else if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, fmt.Sprintf("modifying config: %s", err), http.StatusBadRequest)
 		return
 	}
 	c.finish(w, waiter)
@@ -474,6 +475,6 @@ func (c *configMuxBuilder) finish(w http.ResponseWriter, waiter config.Waiter) {
 	waiter.Wait()
 	if err := c.cfg.Save(); err != nil {
 		l.Warnln("Saving config:", err)
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("saving config: %s", err), http.StatusInternalServerError)
 	}
 }

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -471,14 +471,6 @@ func unmarshalDevicesWithDefaults(data []json.RawMessage, defaultDevice config.D
 	return devices, nil
 }
 
-func checkGUIPassword(oldPassword, newPassword string) (string, error) {
-	if newPassword == oldPassword {
-		return newPassword, nil
-	}
-	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), 0)
-	return string(hash), err
-}
-
 func (c *configMuxBuilder) finish(w http.ResponseWriter, waiter config.Waiter) {
 	waiter.Wait()
 	if err := c.cfg.Save(); err != nil {

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -280,7 +280,7 @@ func (c *configMuxBuilder) registerGUI(path string) {
 }
 
 func (c *configMuxBuilder) adjustConfig(w http.ResponseWriter, r *http.Request) {
-	bs, err := ioutil.ReadAll(r.Body)
+	bs, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -8,11 +8,9 @@
 package config
 
 import (
-	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
@@ -160,51 +158,6 @@ func ReadXML(r io.Reader, myID protocol.DeviceID) (Configuration, int, error) {
 		return Configuration{}, originalVersion, err
 	}
 	return cfg.Configuration, originalVersion, nil
-}
-
-func ReadJSON(r io.Reader, myID protocol.DeviceID) (Configuration, error) {
-	bs, err := ioutil.ReadAll(r)
-	if err != nil {
-		return Configuration{}, err
-	}
-
-	var cfg Configuration
-
-	util.SetDefaults(&cfg)
-
-	if err := json.Unmarshal(bs, &cfg); err != nil {
-		return Configuration{}, err
-	}
-
-	// Unmarshal list of devices and folders separately to set defaults
-	var rawFoldersDevices struct {
-		Folders []json.RawMessage
-		Devices []json.RawMessage
-	}
-	if err := json.Unmarshal(bs, &rawFoldersDevices); err != nil {
-		return Configuration{}, err
-	}
-
-	cfg.Folders = make([]FolderConfiguration, len(rawFoldersDevices.Folders))
-	for i, bs := range rawFoldersDevices.Folders {
-		cfg.Folders[i] = cfg.Defaults.Folder.Copy()
-		if err := json.Unmarshal(bs, &cfg.Folders[i]); err != nil {
-			return Configuration{}, err
-		}
-	}
-
-	cfg.Devices = make([]DeviceConfiguration, len(rawFoldersDevices.Devices))
-	for i, bs := range rawFoldersDevices.Devices {
-		cfg.Devices[i] = cfg.Defaults.Device.Copy()
-		if err := json.Unmarshal(bs, &cfg.Devices[i]); err != nil {
-			return Configuration{}, err
-		}
-	}
-
-	if err := cfg.prepare(myID); err != nil {
-		return Configuration{}, err
-	}
-	return cfg, nil
 }
 
 func (cfg Configuration) Copy() Configuration {

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -993,7 +993,7 @@ func TestIssue4219(t *testing.T) {
 	}`))
 
 	myID := protocol.LocalDeviceID
-	cfg, err := ReadJSON(r, myID)
+	cfg, err := unmarshalAndPrepare(r, myID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1062,7 +1062,7 @@ func TestInvalidDeviceIDRejected(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = ReadJSON(bytes.NewReader(invalidJSON), device1)
+		_, err = unmarshalAndPrepare(bytes.NewReader(invalidJSON), device1)
 		if tc.ok && err != nil {
 			t.Errorf("unexpected error for device ID %q: %v", tc.id, err)
 		} else if !tc.ok && err == nil {
@@ -1101,7 +1101,7 @@ func TestInvalidFolderIDRejected(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		_, err = ReadJSON(bytes.NewReader(invalidJSON), device1)
+		_, err = unmarshalAndPrepare(bytes.NewReader(invalidJSON), device1)
 		if tc.ok && err != nil {
 			t.Errorf("unexpected error for folder ID %q: %v", tc.id, err)
 		} else if !tc.ok && err == nil {
@@ -1369,4 +1369,19 @@ func TestReceiveEncryptedFolderFixed(t *testing.T) {
 	if !f.IgnorePerms {
 		t.Error("IgnorePerms should be true")
 	}
+}
+
+func unmarshalAndPrepare(data io.Reader, myID protocol.DeviceID) (Configuration, error) {
+	bs, err := ioutil.ReadAll(data)
+	if err != nil {
+		return Configuration{}, err
+	}
+	var cfg Configuration
+	if err := json.Unmarshal(bs, &cfg); err != nil {
+		return Configuration{}, err
+	}
+	if err := cfg.prepare(myID); err != nil {
+		return Configuration{}, err
+	}
+	return cfg, nil
 }


### PR DESCRIPTION
When posting a config through the api, `.prepare` is called twice, both in `ReadJSON` and when modifying the posted config in `config.Wrapper`. And `ReadJSON` does some default handling that `ReadXML` doesn't, and which duplicates logic in `lib/api/confighandler.go`. It's also used only there (and in tests) and all the other config objects don't have such a method -> removed it.