### PR TITLE
Normalize CLI options to always use two dashes.

### DIFF
--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -75,7 +75,7 @@ func Run() error {
 			Usage: "Set configuration and data directory",
 		},
 		cli.StringFlag{
-			Name:  "conf",
+			Name:  "config",
 			Value: "PATH",
 			Usage: "Set configuration directory (config and keys)",
 		},

--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -75,6 +75,10 @@ func Run() error {
 			Name:  "config",
 			Usage: "Set configuration directory (config and keys) to `PATH`",
 		},
+		cli.StringFlag{
+			Name:  "data",
+			Usage: "Set data directory (database and logs) to `PATH`",
+		},
 	}
 
 	// Construct the actual CLI

--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -61,23 +61,19 @@ func Run() error {
 	fakeFlags := []cli.Flag{
 		cli.StringFlag{
 			Name:  "gui-address",
-			Value: "URL",
-			Usage: "Override GUI address (e.g. \"http://192.0.2.42:8443\")",
+			Usage: "Override GUI address to `URL` (e.g. \"http://192.0.2.42:8443\")",
 		},
 		cli.StringFlag{
 			Name:  "gui-apikey",
-			Value: "API-KEY",
-			Usage: "Override GUI API key",
+			Usage: "Override GUI API key to `API-KEY`",
 		},
 		cli.StringFlag{
 			Name:  "home",
-			Value: "PATH",
-			Usage: "Set configuration and data directory",
+			Usage: "Set configuration and data directory to `PATH`",
 		},
 		cli.StringFlag{
 			Name:  "config",
-			Value: "PATH",
-			Usage: "Set configuration directory (config and keys)",
+			Usage: "Set configuration directory (config and keys) to `PATH`",
 		},
 	}
 

--- a/cmd/syncthing/cmdutil/util.go
+++ b/cmd/syncthing/cmdutil/util.go
@@ -18,9 +18,9 @@ func SetConfigDataLocationsFromFlags(homeDir, confDir, dataDir string) error {
 	dataSet := dataDir != ""
 	switch {
 	case dataSet != confSet:
-		return errors.New("either both or none of -conf and -data must be given, use -home to set both at once")
+		return errors.New("either both or none of --config and --data must be given, use --home to set both at once")
 	case homeSet && dataSet:
-		return errors.New("-home must not be used together with -conf and -data")
+		return errors.New("--home must not be used together with --config and --data")
 	case homeSet:
 		confDir = homeDir
 		dataDir = homeDir

--- a/cmd/syncthing/decrypt/decrypt.go
+++ b/cmd/syncthing/decrypt/decrypt.go
@@ -45,7 +45,7 @@ func (c *CLI) Run() error {
 	log.SetFlags(0)
 
 	if c.To == "" && !c.VerifyOnly {
-		return fmt.Errorf("must set --to or --verify")
+		return fmt.Errorf("must set --to or --verify-only")
 	}
 
 	if c.TokenPath == "" {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -76,9 +76,9 @@ above). The value 0 is used to disable all of the above. The default is to
 show time only (2).
 
 Logging always happens to the command line (stdout) and optionally to the
-file at the path specified by -logfile=path. In addition to an path, the special
+file at the path specified by --logfile=path. In addition to an path, the special
 values "default" and "-" may be used. The former logs to DATADIR/syncthing.log
-(see -data-dir), which is the default on Windows, and the latter only to stdout,
+(see --data), which is the default on Windows, and the latter only to stdout,
 no file, which is the default anywhere else.
 
 

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -40,10 +40,10 @@ const (
 type BaseDirEnum string
 
 const (
-	// Overridden by -home flag
+	// Overridden by --home flag
 	ConfigBaseDir BaseDirEnum = "config"
 	DataBaseDir   BaseDirEnum = "data"
-	// User's home directory, *not* -home flag
+	// User's home directory, *not* --home flag
 	UserHomeBaseDir BaseDirEnum = "userHome"
 
 	LevelDBDir = "index-v0.14.0.db"
@@ -98,7 +98,7 @@ var locationTemplates = map[LocationEnum]string{
 	HTTPSCertFile: "${config}/https-cert.pem",
 	HTTPSKeyFile:  "${config}/https-key.pem",
 	Database:      "${data}/" + LevelDBDir,
-	LogFile:       "${data}/syncthing.log", // -logfile on Windows
+	LogFile:       "${data}/syncthing.log", // --logfile on Windows
 	CsrfTokens:    "${data}/csrftokens.txt",
 	PanicLog:      "${data}/panic-${timestamp}.log",
 	AuditLog:      "${data}/audit-${timestamp}.log",

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -90,7 +90,7 @@ func LoadConfigAtStartup(path string, cert tls.Certificate, evLogger events.Logg
 			l.Infof("Now, THAT's what we call a config from the future! Don't worry. As long as you hit that wire with the connecting hook at precisely eighty-eight miles per hour the instant the lightning strikes the tower... everything will be fine.")
 		}
 		if originalVersion > config.CurrentVersion && !allowNewerConfig {
-			return nil, fmt.Errorf("config file version (%d) is newer than supported version (%d). If this is expected, use -allow-newer-config to override.", originalVersion, config.CurrentVersion)
+			return nil, fmt.Errorf("config file version (%d) is newer than supported version (%d). If this is expected, use --allow-newer-config to override.", originalVersion, config.CurrentVersion)
 		}
 		err = archiveAndSaveConfig(cfg, originalVersion)
 		if err != nil {

--- a/test/cli_test.go
+++ b/test/cli_test.go
@@ -31,7 +31,7 @@ func TestCLIReset(t *testing.T) {
 
 	// Run reset to clean up
 
-	cmd := exec.Command("../bin/syncthing", "-no-browser", "-home", "h1", "-reset-database")
+	cmd := exec.Command("../bin/syncthing", "--no-browser", "--home", "h1", "--reset-database")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout
 	err := cmd.Run()
@@ -63,9 +63,9 @@ func TestCLIGenerate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// -generate should create a bunch of stuff
+	// --generate should create a bunch of stuff
 
-	cmd := exec.Command("../bin/syncthing", "-no-browser", "-generate", "home.out")
+	cmd := exec.Command("../bin/syncthing", "--no-browser", "--generate", "home.out")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout
 	err = cmd.Run()
@@ -91,7 +91,7 @@ func TestCLIFirstStartup(t *testing.T) {
 
 	// First startup should create config, BEP certificate, and HTTP certificate.
 
-	cmd := exec.Command("../bin/syncthing", "-no-browser", "-home", "home.out")
+	cmd := exec.Command("../bin/syncthing", "--no-browser", "--home", "home.out")
 	cmd.Env = append(os.Environ(), "STNORESTART=1")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout

--- a/test/override_test.go
+++ b/test/override_test.go
@@ -199,7 +199,7 @@ func TestOverrideIgnores(t *testing.T) {
 	log.Println("Starting sendOnly...")
 	sendOnly := syncthingProcess{ // id1
 		instance: "1",
-		argv:     []string{"-home", "h1"},
+		argv:     []string{"--home", "h1"},
 		port:     8081,
 		apiKey:   apiKey,
 	}
@@ -212,7 +212,7 @@ func TestOverrideIgnores(t *testing.T) {
 	log.Println("Starting sendRecv...")
 	sendRecv := syncthingProcess{ // id2
 		instance: "2",
-		argv:     []string{"-home", "h2"},
+		argv:     []string{"--home", "h2"},
 		port:     8082,
 		apiKey:   apiKey,
 	}

--- a/test/util.go
+++ b/test/util.go
@@ -542,7 +542,7 @@ func startInstance(t *testing.T, i int) *rc.Process {
 
 	p := rc.NewProcess(addr)
 	p.LogTo(log)
-	if err := p.Start("../bin/syncthing", "-home", fmt.Sprintf("h%d", i), "-no-browser"); err != nil {
+	if err := p.Start("../bin/syncthing", "--home", fmt.Sprintf("h%d", i), "--no-browser"); err != nil {
 		t.Fatal(err)
 	}
 	p.AwaitStartup()


### PR DESCRIPTION
Consistently use double dashes for option flags, as the CLI help output does as well.

Fix typos:
 * `-conf` :arrow_right: `--config`
 * `-data-dir` :arrow_right:  `--data`
 * `-verify.` :arrow_right: `--verify-only`

Applies also to tests running the syncthing binary for consistency.  Other binaries (`stevents`, `stsigtool`, `build.go`, `stdisco`, `strelaysrv`) are not affected as they output single-dash options in their own CLI help.

### Testing

No functional changes, only affects help strings and uses options already parsed correctly in test, just now with two dashes.

### Documentation

Related: https://github.com/syncthing/docs/pull/692