### PR TITLE
cmd/syncthing: Implement generate as a subcommand with optional API credential setting (fixes #8021)

### DIFF
--- a/cmd/syncthing/cmdutil/options_common.go
+++ b/cmd/syncthing/cmdutil/options_common.go
@@ -1,0 +1,14 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cmdutil
+
+// CommonOptions are reused among several subcommands
+type CommonOptions struct {
+	ConfDir         string `name:"config" placeholder:"PATH" help:"Set configuration directory (config and keys)"`
+	HomeDir         string `name:"home" placeholder:"PATH" help:"Set configuration and data directory"`
+	NoDefaultFolder bool   `env:"STNODEFAULTFOLDER" help:"Don't create the \"default\" folder on first startup"`
+}

--- a/cmd/syncthing/cmdutil/options_common.go
+++ b/cmd/syncthing/cmdutil/options_common.go
@@ -8,6 +8,7 @@ package cmdutil
 
 // CommonOptions are reused among several subcommands
 type CommonOptions struct {
+	buildCommonOptions
 	ConfDir         string `name:"config" placeholder:"PATH" help:"Set configuration directory (config and keys)"`
 	HomeDir         string `name:"home" placeholder:"PATH" help:"Set configuration and data directory"`
 	NoDefaultFolder bool   `env:"STNODEFAULTFOLDER" help:"Don't create the \"default\" folder on first startup"`

--- a/cmd/syncthing/cmdutil/options_others.go
+++ b/cmd/syncthing/cmdutil/options_others.go
@@ -7,8 +7,8 @@
 //go:build !windows
 // +build !windows
 
-package main
+package cmdutil
 
-type buildServeOptions struct {
+type buildCommonOptions struct {
 	HideConsole bool `hidden:""`
 }

--- a/cmd/syncthing/cmdutil/options_windows.go
+++ b/cmd/syncthing/cmdutil/options_windows.go
@@ -4,8 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
-package main
+package cmdutil
 
-type buildServeOptions struct {
+type buildCommonOptions struct {
 	HideConsole bool `name:"no-console" help:"Hide console window"`
 }

--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -1,0 +1,62 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package generate implements the `syncthing generate` subcommand.
+package generate
+
+import (
+	"crypto/tls"
+	"log"
+	"os"
+
+	"github.com/pkg/errors"
+
+	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/syncthing"
+)
+
+func Generate(confDir string, noDefaultFolder bool) error {
+	dir, err := fs.ExpandTilde(confDir)
+	if err != nil {
+		return err
+	}
+
+	if err := syncthing.EnsureDir(dir, 0700); err != nil {
+		return err
+	}
+	locations.SetBaseDir(locations.ConfigBaseDir, dir)
+
+	var myID protocol.DeviceID
+	certFile, keyFile := locations.Get(locations.CertFile), locations.Get(locations.KeyFile)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err == nil {
+		log.Println("WARNING: Key exists; will not overwrite.")
+	} else {
+		cert, err = syncthing.GenerateCertificate(certFile, keyFile)
+		if err != nil {
+			return errors.Wrap(err, "create certificate")
+		}
+	}
+	myID = protocol.NewDeviceID(cert.Certificate[0])
+	log.Println("Device ID:", myID)
+
+	cfgFile := locations.Get(locations.ConfigFile)
+	if _, err := os.Stat(cfgFile); err == nil {
+		log.Println("WARNING: Config exists; will not overwrite.")
+		return nil
+	}
+	cfg, err := syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder)
+	if err != nil {
+		return err
+	}
+	if err := cfg.Save(); err != nil {
+		return errors.Wrap(err, "save config")
+	}
+	return nil
+}

--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -15,8 +15,6 @@ import (
 	"log"
 	"os"
 
-	"github.com/pkg/errors"
-
 	"github.com/syncthing/syncthing/cmd/syncthing/cmdutil"
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
@@ -61,7 +59,7 @@ func (c *CLI) Run() error {
 	}
 
 	if err := Generate(c.ConfDir, c.GUIUser, c.GUIPassword, c.NoDefaultFolder); err != nil {
-		return errors.Wrap(err, "Failed to generate config and keys")
+		return fmt.Errorf("Failed to generate config and keys: %w", err)
 	}
 	return nil
 }
@@ -85,7 +83,7 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 	} else {
 		cert, err = syncthing.GenerateCertificate(certFile, keyFile)
 		if err != nil {
-			return errors.Wrap(err, "create certificate")
+			return fmt.Errorf("create certificate: %w", err)
 		}
 	}
 	myID = protocol.NewDeviceID(cert.Certificate[0])
@@ -100,11 +98,11 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 		}
 
 		if cfg, _, err = config.Load(cfgFile, myID, events.NoopLogger); err != nil {
-			return errors.Wrap(err, "load config")
+			return fmt.Errorf("load config: %w", err)
 		}
 	} else {
 		if cfg, err = syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder); err != nil {
-			return errors.Wrap(err, "create config")
+			return fmt.Errorf("create config: %w", err)
 		}
 	}
 
@@ -119,12 +117,12 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 		}
 	})
 	if err != nil {
-		return errors.Wrap(err, "modify config")
+		return fmt.Errorf("modify config: %w", err)
 	}
 
 	waiter.Wait()
 	if err := cfg.Save(); err != nil {
-		return errors.Wrap(err, "save config")
+		return fmt.Errorf("save config: %w", err)
 	}
 	return nil
 }

--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -27,8 +27,8 @@ import (
 
 type CLI struct {
 	cmdutil.CommonOptions
-	GUIUser     string `placeholder:"STRING" help:"Override GUI authentication user name"`
-	GUIPassword string `placeholder:"STRING" help:"Override GUI authentication password (use - to read from standard input)"`
+	GUIUser     string `placeholder:"STRING" help:"Specify new GUI authentication user name"`
+	GUIPassword string `placeholder:"STRING" help:"Specify new GUI authentication password (use - to read from standard input)"`
 }
 
 func (c *CLI) Run() error {
@@ -112,7 +112,7 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 
 	guiCfg := cfg.GUI()
 	waiter, err := cfg.Modify(func(cfg *config.Configuration) {
-		if changed := overrideGUIAuthentication(&guiCfg, guiUser, guiPassword); changed {
+		if changed := updateGUIAuthentication(&guiCfg, guiUser, guiPassword); changed {
 			cfg.GUI = guiCfg
 		}
 	})
@@ -127,11 +127,11 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 	return nil
 }
 
-func overrideGUIAuthentication(guiCfg *config.GUIConfiguration, guiUser, guiPassword string) bool {
+func updateGUIAuthentication(guiCfg *config.GUIConfiguration, guiUser, guiPassword string) bool {
 	changed := false
 	if guiUser != "" && guiCfg.User != guiUser {
 		guiCfg.User = guiUser
-		log.Println("Overriding GUI authentication user name:", guiUser)
+		log.Println("Updated GUI authentication user name:", guiUser)
 		changed = true
 	}
 
@@ -139,7 +139,7 @@ func overrideGUIAuthentication(guiCfg *config.GUIConfiguration, guiUser, guiPass
 		if err := guiCfg.HashAndSetPassword(guiPassword); err != nil {
 			log.Fatal("Failed to set GUI authentication password.")
 		} else {
-			log.Println("Overriding GUI authentication password.")
+			log.Println("Updated GUI authentication password.")
 			changed = true
 		}
 	}

--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -134,7 +134,7 @@ func updateGUIAuthentication(guiCfg *config.GUIConfiguration, guiUser, guiPasswo
 		log.Println("Updated GUI authentication user name:", guiUser)
 	}
 
-	if guiPassword != "" {
+	if guiPassword != "" && guiCfg.Password != guiPassword {
 		if err := guiCfg.HashAndSetPassword(guiPassword); err != nil {
 			return fmt.Errorf("Failed to set GUI authentication password: %w", err)
 		}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -140,24 +140,22 @@ var entrypoint struct {
 // serveOptions are the options for the `syncthing serve` command.
 type serveOptions struct {
 	buildServeOptions
+	cmdutil.CommonOptions
 	AllowNewerConfig bool   `help:"Allow loading newer than current config version"`
 	Audit            bool   `help:"Write events to audit file"`
 	AuditFile        string `name:"auditfile" placeholder:"PATH" help:"Specify audit file (use \"-\" for stdout, \"--\" for stderr)"`
 	BrowserOnly      bool   `help:"Open GUI in browser"`
-	ConfDir          string `name:"config" placeholder:"PATH" help:"Set configuration directory (config and keys)"`
 	DataDir          string `name:"data" placeholder:"PATH" help:"Set data directory (database and logs)"`
 	DeviceID         bool   `help:"Show the device ID"`
 	GenerateDir      string `name:"generate" placeholder:"PATH" help:"Generate key and config in specified dir, then exit"`
 	GUIAddress       string `name:"gui-address" placeholder:"URL" help:"Override GUI address (e.g. \"http://192.0.2.42:8443\")"`
 	GUIAPIKey        string `name:"gui-apikey" placeholder:"API-KEY" help:"Override GUI API key"`
-	HomeDir          string `name:"home" placeholder:"PATH" help:"Set configuration and data directory"`
 	LogFile          string `name:"logfile" default:"${logFile}" placeholder:"PATH" help:"Log file name (see below)"`
 	LogFlags         int    `name:"logflags" default:"${logFlags}" placeholder:"BITS" help:"Select information in log line prefix (see below)"`
 	LogMaxFiles      int    `placeholder:"N" default:"${logMaxFiles}" name:"log-max-old-files" help:"Number of old files to keep (zero to keep only current)"`
 	LogMaxSize       int    `placeholder:"BYTES" default:"${logMaxSize}" help:"Maximum size of any file (zero to disable log rotation)"`
 	NoBrowser        bool   `help:"Do not start browser"`
 	NoRestart        bool   `env:"STNORESTART" help:"Do not restart Syncthing when exiting due to API/GUI command, upgrade, or crash"`
-	NoDefaultFolder  bool   `env:"STNODEFAULTFOLDER" help:"Don't create the \"default\" folder on first startup"`
 	NoUpgrade        bool   `env:"STNOUPGRADE" help:"Disable automatic upgrades"`
 	Paths            bool   `help:"Show configuration paths"`
 	Paused           bool   `help:"Start with all devices and folders paused"`

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -435,7 +435,7 @@ func generate(generateDir string, noDefaultFolder bool) error {
 	certFile, keyFile := locations.Get(locations.CertFile), locations.Get(locations.KeyFile)
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err == nil {
-		l.Warnln("Key exists; will not overwrite.")
+		log.Println("WARNING: Key exists; will not overwrite.")
 	} else {
 		cert, err = syncthing.GenerateCertificate(certFile, keyFile)
 		if err != nil {
@@ -443,11 +443,11 @@ func generate(generateDir string, noDefaultFolder bool) error {
 		}
 	}
 	myID = protocol.NewDeviceID(cert.Certificate[0])
-	l.Infoln("Device ID:", myID)
+	log.Println("Device ID:", myID)
 
 	cfgFile := locations.Get(locations.ConfigFile)
 	if _, err := os.Stat(cfgFile); err == nil {
-		l.Warnln("Config exists; will not overwrite.")
+		log.Println("WARNING: Config exists; will not overwrite.")
 		return nil
 	}
 	cfg, err := syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder)

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -133,9 +133,10 @@ var (
 // commands and options here are top level commands to syncthing.
 // Cli is just a placeholder for the help text (see main).
 var entrypoint struct {
-	Serve   serveOptions `cmd:"" help:"Run Syncthing"`
-	Decrypt decrypt.CLI  `cmd:"" help:"Decrypt or verify an encrypted folder"`
-	Cli     struct{}     `cmd:"" help:"Command line interface for Syncthing"`
+	Serve    serveOptions `cmd:"" help:"Run Syncthing"`
+	Generate generate.CLI `cmd:"" help:"Generate key and config, then exit"`
+	Decrypt  decrypt.CLI  `cmd:"" help:"Decrypt or verify an encrypted folder"`
+	Cli      struct{}     `cmd:"" help:"Command line interface for Syncthing"`
 }
 
 // serveOptions are the options for the `syncthing serve` command.
@@ -147,7 +148,7 @@ type serveOptions struct {
 	BrowserOnly      bool   `help:"Open GUI in browser"`
 	DataDir          string `name:"data" placeholder:"PATH" help:"Set data directory (database and logs)"`
 	DeviceID         bool   `help:"Show the device ID"`
-	GenerateDir      string `name:"generate" placeholder:"PATH" help:"Generate key and config in specified dir, then exit"`
+	GenerateDir      string `name:"generate" placeholder:"PATH" help:"Generate key and config in specified dir, then exit"` //DEPRECATED: replaced by subcommand!
 	GUIAddress       string `name:"gui-address" placeholder:"URL" help:"Override GUI address (e.g. \"http://192.0.2.42:8443\")"`
 	GUIAPIKey        string `name:"gui-apikey" placeholder:"API-KEY" help:"Override GUI API key"`
 	LogFile          string `name:"logfile" default:"${logFile}" placeholder:"PATH" help:"Log file name (see below)"`

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -347,7 +347,7 @@ func (options serveOptions) Run() error {
 	}
 
 	// Ensure that our home directory exists.
-	if err := ensureDir(locations.GetBaseDir(locations.ConfigBaseDir), 0700); err != nil {
+	if err := syncthing.EnsureDir(locations.GetBaseDir(locations.ConfigBaseDir), 0700); err != nil {
 		l.Warnln("Failure on home directory:", err)
 		os.Exit(svcutil.ExitError.AsInt())
 	}
@@ -429,7 +429,7 @@ func generate(generateDir string, noDefaultFolder bool) error {
 		return err
 	}
 
-	if err := ensureDir(dir, 0700); err != nil {
+	if err := syncthing.EnsureDir(dir, 0700); err != nil {
 		return err
 	}
 
@@ -798,29 +798,6 @@ func auditWriter(auditFile string) io.Writer {
 
 func resetDB() error {
 	return os.RemoveAll(locations.Get(locations.Database))
-}
-
-func ensureDir(dir string, mode fs.FileMode) error {
-	fs := fs.NewFilesystem(fs.FilesystemTypeBasic, dir)
-	err := fs.MkdirAll(".", mode)
-	if err != nil {
-		return err
-	}
-
-	if fi, err := fs.Stat("."); err == nil {
-		// Apprently the stat may fail even though the mkdirall passed. If it
-		// does, we'll just assume things are in order and let other things
-		// fail (like loading or creating the config...).
-		currentMode := fi.Mode() & 0777
-		if currentMode != mode {
-			err := fs.Chmod(".", mode)
-			// This can fail on crappy filesystems, nothing we can do about it.
-			if err != nil {
-				l.Warnln(err)
-			}
-		}
-	}
-	return nil
 }
 
 func standbyMonitor(app *syncthing.App, cfg config.Wrapper) {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -139,7 +139,6 @@ var entrypoint struct {
 
 // serveOptions are the options for the `syncthing serve` command.
 type serveOptions struct {
-	buildServeOptions
 	cmdutil.CommonOptions
 	AllowNewerConfig bool   `help:"Allow loading newer than current config version"`
 	Audit            bool   `help:"Write events to audit file"`

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -338,7 +338,7 @@ func (options serveOptions) Run() error {
 	}
 
 	if options.GenerateDir != "" {
-		if err := generate.Generate(options.GenerateDir, options.NoDefaultFolder); err != nil {
+		if err := generate.Generate(options.GenerateDir, "", "", options.NoDefaultFolder); err != nil {
 			l.Warnln("Failed to generate config and keys:", err)
 			os.Exit(svcutil.ExitError.AsInt())
 		}

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -412,8 +412,8 @@ func openGUI(myID protocol.DeviceID) error {
 	if err != nil {
 		return err
 	}
-	if cfg.GUI().Enabled {
-		if err := openURL(cfg.GUI().URL()); err != nil {
+	if guiCfg := cfg.GUI(); guiCfg.Enabled {
+		if err := openURL(guiCfg.URL()); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -429,9 +429,10 @@ func generate(generateDir string, noDefaultFolder bool) error {
 	if err := syncthing.EnsureDir(dir, 0700); err != nil {
 		return err
 	}
+	locations.SetBaseDir(locations.ConfigBaseDir, dir)
 
 	var myID protocol.DeviceID
-	certFile, keyFile := filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem")
+	certFile, keyFile := locations.Get(locations.CertFile), locations.Get(locations.KeyFile)
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err == nil {
 		l.Warnln("Key exists; will not overwrite.")
@@ -444,7 +445,7 @@ func generate(generateDir string, noDefaultFolder bool) error {
 	myID = protocol.NewDeviceID(cert.Certificate[0])
 	l.Infoln("Device ID:", myID)
 
-	cfgFile := filepath.Join(dir, "config.xml")
+	cfgFile := locations.Get(locations.ConfigFile)
 	if _, err := os.Stat(cfgFile); err == nil {
 		l.Warnln("Config exists; will not overwrite.")
 		return nil
@@ -453,8 +454,7 @@ func generate(generateDir string, noDefaultFolder bool) error {
 	if err != nil {
 		return err
 	}
-	err = cfg.Save()
-	if err != nil {
+	if err := cfg.Save(); err != nil {
 		return errors.Wrap(err, "save config")
 	}
 	return nil


### PR DESCRIPTION
### Purpose

The `--generate` option for the `syncthing serve` subcommand allows creating an initial configuration and keypair given a home / config directory.  This functionality is mirrored to a new subcommand `syncthing serve` with the following extensions:

1. Do not require a directory to be specified, but use the default location.
2. Accept the standard `--home` or `--config` options to override the default location, as used in the `serve` subcommand.
3. Accept `--gui-user=...` argument to preconfigure the generated config for GUI authentication.  This overwrites the setting should the `config.xml` file already exist.
4. Accept `--gui-password=...` argument to preconfigure the generated config for GUI authentication.  This overwrites the setting should the `config.xml` file already exist.  The password can be read from the standard input stream by specifying `-` as value.  Hashing the password is automatically taken care of.

Besides tidying up the command line structure, the main use case for this is setting up GUI credentials from an installation wizard on headless systems (like NAS), which otherwise would start out with the GUI wide open.

### Testing

Manual testing only: Generated new cert and config in empty home dir.  Adjusted GUI user and password.  Password read from pipe, standard input (terminated via EOF or line break), fails when empty password is piped in.  Existing config stays untouched if neither `--gui-...` option is given.  Giving the existing password hash as password again skips the modification.  Old `--generate` option still works unmodified.  Verified correct usage / help messages for both `syncthing serve` and `syncthing generate`.

### Screenshots

```
$ ./bin/syncthing generate --help
Usage: syncthing generate

Generate key and config, then exit

Flags:
  -h, --help                   Show context-sensitive help.

      --config=PATH            Set configuration directory (config and keys)
      --home=PATH              Set configuration and data directory
      --no-default-folder      Don't create the "default" folder on first startup ($STNODEFAULTFOLDER)
      --gui-user=STRING        Override GUI authentication user name
      --gui-password=STRING    Override GUI authentication password (use - to read from standard input)
```

### Documentation

See https://github.com/syncthing/docs/pull/694.