### PR TITLE
A couple of tiny fixes...

### DIFF
--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -89,11 +89,9 @@ func newFakeFilesystem(rootURI string, _ ...Option) *fakeFS {
 	fakeFSMut.Lock()
 	defer fakeFSMut.Unlock()
 
-	root := rootURI
 	var params url.Values
 	uri, err := url.Parse(rootURI)
 	if err == nil {
-		root = uri.Path
 		params = uri.Query()
 	}
 
@@ -157,7 +155,7 @@ func newFakeFilesystem(rootURI string, _ ...Option) *fakeFS {
 	// the filesystem initially.
 	fs.latency, _ = time.ParseDuration(params.Get("latency"))
 
-	fakeFSCache[root] = fs
+	fakeFSCache[rootURI] = fs
 	return fs
 }
 

--- a/lib/model/folder_recvonly.go
+++ b/lib/model/folder_recvonly.go
@@ -68,7 +68,7 @@ func (f *receiveOnlyFolder) Revert() {
 }
 
 func (f *receiveOnlyFolder) revert() error {
-	l.Infof("Reverting folder %v", f.Description)
+	l.Infof("Reverting folder %v", f.Description())
 
 	f.setState(FolderScanning)
 	defer f.setState(FolderIdle)


### PR DESCRIPTION
- Use of wrong cache key in fakefs resulted in fakefs getting (expensively) recreated for every request
- Printed address of function pointer instead of folder description...

(rebase merge)