### PR TITLE
lib/config, lib/ignore: Write Windows line endings (fixes #7115)

### DIFF
--- a/build.go
+++ b/build.go
@@ -1294,7 +1294,7 @@ func zipFile(out string, files []archiveFile) {
 			if err != nil {
 				log.Fatal(err)
 			}
-			bs = bytes.Replace(bs, []byte{'\n'}, []byte{'\n', '\r'}, -1)
+			bs = bytes.Replace(bs, []byte{'\n'}, []byte{'\r', '\n'}, -1)
 			fh.UncompressedSize = uint32(len(bs))
 			fh.UncompressedSize64 = uint64(len(bs))
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -595,6 +595,36 @@ func TestNewSaveLoad(t *testing.T) {
 	}
 }
 
+func TestWindowsLineEndings(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows specific")
+	}
+
+	path := "testdata/temp.xml"
+	os.Remove(path)
+	defer os.Remove(path)
+
+	intCfg := New(device1)
+	cfg := wrap(path, intCfg, device1)
+	defer cfg.stop()
+
+	err := cfg.Save()
+	if err != nil {
+		t.Error(err)
+	}
+
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		t.Error(err)
+	}
+
+	unixLineEndings := bytes.Count(bs, []byte("\n"))
+	windowsLineEndings := bytes.Count(bs, []byte("\r\n"))
+	if unixLineEndings == 0 || windowsLineEndings != unixLineEndings {
+		t.Error("expected there to be a non-zero number of Windows line endings")
+	}
+}
+
 func TestPrepare(t *testing.T) {
 	var cfg Configuration
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -600,7 +600,13 @@ func TestWindowsLineEndings(t *testing.T) {
 		t.Skip("Windows specific")
 	}
 
-	path := "testdata/temp.xml"
+	dir, err := os.MkdirTemp("", "syncthing-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	path := filepath.Join(dir, "config.xml")
 	os.Remove(path)
 	defer os.Remove(path)
 
@@ -608,8 +614,7 @@ func TestWindowsLineEndings(t *testing.T) {
 	cfg := wrap(path, intCfg, device1)
 	defer cfg.stop()
 
-	err := cfg.Save()
-	if err != nil {
+	if err := cfg.Save(); err != nil {
 		t.Error(err)
 	}
 

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -493,7 +493,7 @@ func (w *wrapper) Save() error {
 		return err
 	}
 
-	if err := w.cfg.WriteXML(fd); err != nil {
+	if err := w.cfg.WriteXML(osutil.LineEndingsWriter(fd)); err != nil {
 		l.Debugln("WriteXML:", err)
 		fd.Close()
 		return err

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -595,8 +595,9 @@ func WriteIgnores(filesystem fs.Filesystem, path string, content []string) error
 		return err
 	}
 
+	wr := osutil.LineEndingsWriter(fd)
 	for _, line := range content {
-		fmt.Fprintln(fd, line)
+		fmt.Fprintln(wr, line)
 	}
 
 	if err := fd.Close(); err != nil {

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1201,7 +1201,13 @@ func TestWindowsLineEndings(t *testing.T) {
 
 	lines := "foo\nbar\nbaz\n"
 
-	ffs := fs.NewFilesystem(fs.FilesystemTypeBasic, ".")
+	dir, err := os.MkdirTemp("", "syncthing-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	ffs := fs.NewFilesystem(fs.FilesystemTypeBasic, dir)
 	m := New(ffs)
 	if err := m.Parse(strings.NewReader(lines), ".stignore"); err != nil {
 		t.Fatal(err)

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1193,3 +1193,36 @@ func TestEmptyPatterns(t *testing.T) {
 		}
 	}
 }
+
+func TestWindowsLineEndings(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Windows specific")
+	}
+
+	lines := "foo\nbar\nbaz\n"
+
+	ffs := fs.NewFilesystem(fs.FilesystemTypeFake, "")
+	m := New(ffs)
+	if err := m.Parse(strings.NewReader(lines), ".stignore"); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteIgnores(ffs, ".stignore", m.Lines()); err != nil {
+		t.Fatal(err)
+	}
+
+	fd, err := ffs.Open(".stignore")
+	if err != nil {
+		t.Fatal(err)
+	}
+	bs, err := io.ReadAll(fd)
+	fd.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	unixLineEndings := bytes.Count(bs, []byte("\n"))
+	windowsLineEndings := bytes.Count(bs, []byte("\r\n"))
+	if unixLineEndings == 0 || windowsLineEndings != unixLineEndings {
+		t.Error("expected there to be a non-zero number of Windows line endings")
+	}
+}

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1201,7 +1201,7 @@ func TestWindowsLineEndings(t *testing.T) {
 
 	lines := "foo\nbar\nbaz\n"
 
-	ffs := fs.NewFilesystem(fs.FilesystemTypeFake, "")
+	ffs := fs.NewFilesystem(fs.FilesystemTypeBasic, ".")
 	m := New(ffs)
 	if err := m.Parse(strings.NewReader(lines), ".stignore"); err != nil {
 		t.Fatal(err)

--- a/lib/osutil/replacingwriter.go
+++ b/lib/osutil/replacingwriter.go
@@ -9,6 +9,7 @@ package osutil
 import (
 	"bytes"
 	"io"
+	"runtime"
 )
 
 type ReplacingWriter struct {
@@ -45,4 +46,17 @@ func (w ReplacingWriter) Write(bs []byte) (int, error) {
 	written += n
 
 	return written, err
+}
+
+// LineEndingsWriter returns a writer that writes platform-appropriate line
+// endings. (This is a no-op on non-Windows platforms.)
+func LineEndingsWriter(w io.Writer) io.Writer {
+	if runtime.GOOS != "windows" {
+		return w
+	}
+	return &ReplacingWriter{
+		Writer: w,
+		From:   '\n',
+		To:     []byte{'\r', '\n'},
+	}
 }


### PR DESCRIPTION
Write config.xml and .stignore with appropriate line endings.