### PR TITLE
gui: Warning in folders with ignoreDelete enabled (fixes #8050)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -193,11 +193,6 @@ table.table-auto td {
     margin-bottom: 0;
 }
 
-.panel-body>ul {
-    margin-bottom: 0px;
-    padding-left: 24px;
-}
-
 .dl-horizontal.dl-narrow dt {
     width: 40px;
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -193,6 +193,11 @@ table.table-auto td {
     margin-bottom: 0;
 }
 
+.panel-body>ul {
+    margin-bottom: 0px;
+    padding-left: 24px;
+}
+
 .dl-horizontal.dl-narrow dt {
     width: 40px;
 }

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -428,6 +428,12 @@
                           <div ng-if="model[folder.id].ignorePatterns">
                             <a href="" ng-click="editFolderExisting(folder, '#folder-ignores')"><i class="small" translate>Reduced by ignore patterns</i></a>
                           </div>
+                          <div ng-if="folder.ignoreDelete">
+                            <i>
+                              <span class="small" translate>Altered by ignoring deletes. Sync status may be inconsistent.</span>
+                              <a class="small" href="https://docs.syncthing.net/advanced/folder-ignoredelete" target="_blank"><span class="fas fa-question-circle"></span><span translate>Help</span></a>
+                            </i>
+                          </div>
                         </td>
                       </tr>
                       <tr ng-if="model[folder.id].needTotalItems > 0">
@@ -545,22 +551,6 @@
                       </tr>
                     </tbody>
                   </table>
-                  <div ng-if="folder.ignoreDelete" class="panel panel-warning">
-                    <div class="panel-heading">
-                      <h4 class="panel-title"><span class="fas fa-fw fa-warning"></span><span translate>Warnings</span></h4>
-                    </div>
-                    <div class="panel-body">
-                      <ul>
-                        <li ng-if="folder.ignoreDelete">
-                          <span translate>Ignore Delete is enabled in the folder's advanced settings. Usage of this is not advised.</span>
-                          <a href="https://docs.syncthing.net/advanced/folder-ignoredelete" target="_blank">
-                            <span class="fas fa-question-circle"></span>
-                            <span translate>Help</span>
-                          </a>
-                        </li>
-                      </ul>
-                    </div>
-                  </div>
                 </div>
                 <div class="panel-footer">
                   <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('override', folder.id)" ng-if="folderStatus(folder) == 'outofsync' && folder.type == 'sendonly'">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -429,9 +429,10 @@
                             <a href="" ng-click="editFolderExisting(folder, '#folder-ignores')"><i class="small" translate>Reduced by ignore patterns</i></a>
                           </div>
                           <div ng-if="folder.ignoreDelete">
-                            <i>
-                              <span class="small" translate>Altered by ignoring deletes. Sync status may be inconsistent.</span>
-                              <a class="small" href="https://docs.syncthing.net/advanced/folder-ignoredelete" target="_blank"><span class="fas fa-question-circle"></span><span translate>Help</span></a>
+                            <i class="small">
+                              <span translate style="white-space: normal;">Altered by ignoring deletes. In sync status may be inconsistent.</span>
+                              <br>
+                              <a href="https://docs.syncthing.net/advanced/folder-ignoredelete" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
                             </i>
                           </div>
                         </td>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -547,11 +547,11 @@
                   </table>
                   <div ng-if="folder.ignoreDelete" class="panel panel-warning">
                     <div class="panel-heading">
-                      <h4 class="panel-title"><span class="fas fa-fw fa-warning"></span>&nbsp;<span translate>Warnings</span></h4>
+                      <h4 class="panel-title"><span class="fas fa-fw fa-warning"></span><span translate>Warnings</span></h4>
                     </div>
                     <div class="panel-body">
                       <ul>
-                        <li ng-if="folder.ignoreDelete"><span translate>Folder option ignoreDelete is enabled.</span> <a href="https://docs.syncthing.net/advanced/folder-ignoredelete"><span translate>Usage of this is not advised.</span></a></li>
+                        <li ng-if="folder.ignoreDelete"><a href="https://docs.syncthing.net/advanced/folder-ignoredelete">ignoreDelete</a> <span translate>is enabled in the folder's advanced settings. Usage if this is not advised.</span></li>
                       </ul>
                     </div>
                   </div>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -551,7 +551,7 @@
                     </div>
                     <div class="panel-body">
                       <ul>
-                        <li ng-if="folder.ignoreDelete"><a href="https://docs.syncthing.net/advanced/folder-ignoredelete">ignoreDelete</a> <span translate>is enabled in the folder's advanced settings. Usage if this is not advised.</span></li>
+                        <li ng-if="folder.ignoreDelete"><a href="https://docs.syncthing.net/advanced/folder-ignoredelete">ignoreDelete</a> <span translate>is enabled in the folder's advanced settings. Usage of this is not advised.</span></li>
                       </ul>
                     </div>
                   </div>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -551,7 +551,13 @@
                     </div>
                     <div class="panel-body">
                       <ul>
-                        <li ng-if="folder.ignoreDelete"><a href="https://docs.syncthing.net/advanced/folder-ignoredelete">ignoreDelete</a> <span translate>is enabled in the folder's advanced settings. Usage of this is not advised.</span></li>
+                        <li ng-if="folder.ignoreDelete">
+                          <span translate>Ignore Delete is enabled in the folder's advanced settings. Usage of this is not advised.</span>
+                          <a href="https://docs.syncthing.net/advanced/folder-ignoredelete" target="_blank">
+                            <span class="fas fa-question-circle"></span>
+                            <span translate>Help</span>
+                          </a>
+                        </li>
                       </ul>
                     </div>
                   </div>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -430,7 +430,7 @@
                           </div>
                           <div ng-if="folder.ignoreDelete">
                             <i class="small">
-                              <span translate style="white-space: normal;">Altered by ignoring deletes. In sync status may be inconsistent.</span>
+                              <span translate style="white-space: normal;">Altered by ignoring deletes.</span>
                               <br>
                               <a href="https://docs.syncthing.net/advanced/folder-ignoredelete" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
                             </i>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -543,6 +543,10 @@
                           </span>
                         </td>
                       </tr>
+                      <tr ng-if="folder.ignoreDelete" class="text-danger">
+                        <th><span class="fas fa-fw fa-warning"></span>&nbsp;<span translate>Notice</span></th>
+                        <td class="text-right"><span translate>Folder option ignoreDelete enabled</span></td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -543,12 +543,18 @@
                           </span>
                         </td>
                       </tr>
-                      <tr ng-if="folder.ignoreDelete" class="text-danger">
-                        <th><span class="fas fa-fw fa-warning"></span>&nbsp;<span translate>Notice</span></th>
-                        <td class="text-right"><span translate>Folder option ignoreDelete enabled</span></td>
-                      </tr>
                     </tbody>
                   </table>
+                  <div ng-if="folder.ignoreDelete" class="panel panel-warning">
+                    <div class="panel-heading">
+                      <h4 class="panel-title"><span class="fas fa-fw fa-warning"></span>&nbsp;<span translate>Warnings</span></h4>
+                    </div>
+                    <div class="panel-body">
+                      <ul>
+                        <li ng-if="folder.ignoreDelete"><span translate>Folder option ignoreDelete is enabled.</span> <a href="https://docs.syncthing.net/advanced/folder-ignoredelete"><span translate>Usage of this is not advised.</span></a></li>
+                      </ul>
+                    </div>
+                  </div>
                 </div>
                 <div class="panel-footer">
                   <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('override', folder.id)" ng-if="folderStatus(folder) == 'outofsync' && folder.type == 'sendonly'">


### PR DESCRIPTION
### Purpose

Some users have experienced unexpected behavior with unknowingly having the `ignoreDelete` option enabled (#8050). This adds a simple warning at the bottom of the expanded folder view, on folders with the setting enabled.

Uses the `text-danger` class to make the text red.

### Screenshots
![Black theme](https://i.imgur.com/9pMNIdw.png)
![Dark theme](https://i.imgur.com/FgBzSAW.png)
![Light theme](https://i.imgur.com/JPBxzJl.png)