### PR TITLE
cmd/syncthing/cli: Add command to show pending devices/folders (fixes #8068)

### DIFF
--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -94,7 +94,6 @@ func Run() error {
 		Subcommands: []cli.Command{
 			configCommand,
 			showCommand,
-			pendingCommand,
 			operationCommand,
 			errorsCommand,
 			debugCommand,

--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -94,6 +94,7 @@ func Run() error {
 		Subcommands: []cli.Command{
 			configCommand,
 			showCommand,
+			pendingCommand,
 			operationCommand,
 			errorsCommand,
 			debugCommand,

--- a/cmd/syncthing/cli/pending.go
+++ b/cmd/syncthing/cli/pending.go
@@ -13,7 +13,7 @@ import (
 var pendingCommand = cli.Command{
 	Name:     "pending",
 	HideHelp: true,
-	Usage:    "Pending command group",
+	Usage:    "Pending subcommand group",
 	Subcommands: []cli.Command{
 		{
 			Name:   "devices",

--- a/cmd/syncthing/cli/pending.go
+++ b/cmd/syncthing/cli/pending.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"github.com/urfave/cli"
+)
+
+var pendingCommand = cli.Command{
+	Name:     "pending",
+	HideHelp: true,
+	Usage:    "Pending command group",
+	Subcommands: []cli.Command{
+		{
+			Name:   "devices",
+			Usage:  "Show pending devices",
+			Action: expects(0, indexDumpOutput("cluster/pending/devices")),
+		},
+		{
+			Name:   "folders",
+			Usage:  "Show pending folders",
+			Action: expects(0, indexDumpOutput("cluster/pending/folders")),
+		},
+	},
+} 

--- a/cmd/syncthing/cli/pending.go
+++ b/cmd/syncthing/cli/pending.go
@@ -26,4 +26,4 @@ var pendingCommand = cli.Command{
 			Action: expects(0, indexDumpOutput("cluster/pending/folders")),
 		},
 	},
-} 
+}

--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -35,6 +35,7 @@ var showCommand = cli.Command{
 			Usage:  "Report about connections to other devices",
 			Action: expects(0, indexDumpOutput("system/connections")),
 		},
+        pendingCommand,
 		{
 			Name:   "usage",
 			Usage:  "Show usage report",

--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -35,7 +35,7 @@ var showCommand = cli.Command{
 			Usage:  "Report about connections to other devices",
 			Action: expects(0, indexDumpOutput("system/connections")),
 		},
-        pendingCommand,
+		pendingCommand,
 		{
 			Name:   "usage",
 			Usage:  "Show usage report",


### PR DESCRIPTION
…the CLI (fixes #8068)

Simple wrapper for an API call.

### Purpose

fixes #8068

### Testing

All tests pass.
