### PR TITLE
CLI await-insync - block until the current dir finishes syncing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ deb
 /proto/scripts/protoc-gen-gosyncthing
 /gui/next-gen-gui
 .idea
+/.history

--- a/cmd/syncthing/cli/await_insync.go
+++ b/cmd/syncthing/cli/await_insync.go
@@ -1,0 +1,98 @@
+// Copyright (C) 2021 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/urfave/cli"
+)
+
+var awaitInsyncCommand = cli.Command{
+	Name:     "await-insync",
+	HideHelp: true,
+	Usage:    "Block until the current dir finishes syncing",
+	Action:   expects(0, isyncAction),
+}
+
+func isyncAction(c *cli.Context) error {
+	// v2:
+	// - read devices from the config
+	// - trigger Rescan on each device
+	// - allow passing the dir as a param
+	dir, err := os.Getwd()
+	if err != nil {
+		return errors.New("couldn't not get the current dir")
+	}
+	client, err := getClientFactory(c).getClient()
+	if err != nil {
+		return err
+	}
+	cfg, err := getConfig(client)
+	if err != nil {
+		return err
+	}
+
+	// get the folder's ID
+	folderID := ""
+	for _, folder := range cfg.Folders {
+		if folder.Path == dir {
+			folderID = folder.ID
+			break
+		}
+	}
+	if folderID == "" {
+		return errors.New("current folder not in the config")
+	}
+
+	waitingDisplayed := false
+	// block until finished
+	for {
+		// request folder's status
+		resp, err := client.Get("db/status?folder=" + folderID)
+		if errors.Is(err, errNotFound) {
+			return errors.New("not found (folder/file not in database)")
+		}
+		if err != nil {
+			return err
+		}
+
+		bs, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+		resp.Body.Close()
+
+		// verify the sync state
+		var status map[string]interface{}
+		if err := json.Unmarshal(bs, &status); err != nil {
+			return err
+		}
+		needTotalItems := int(status["needTotalItems"].(float64))
+		if needTotalItems == 0 {
+			if waitingDisplayed {
+				fmt.Println("Done!")
+			} else {
+				fmt.Println("Already synced")
+			}
+			// synced
+			break
+		}
+		if !waitingDisplayed {
+			fmt.Println("Waiting for syncing to finish...")
+			waitingDisplayed = true
+		}
+		// not synced
+		time.Sleep(250 * time.Millisecond)
+	}
+	return nil
+}

--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -94,6 +94,7 @@ func Run() error {
 		Subcommands: []cli.Command{
 			configCommand,
 			showCommand,
+			awaitInsyncCommand,
 			operationCommand,
 			errorsCommand,
 			debugCommand,


### PR DESCRIPTION
### Purpose

Requested in #7849, this PR adds `syncthing cli await-insync` via pulling `db/status?folder`. The command will block until the current dir finishes syncing.

Demo usage:
```
$ syncthing cli await-insync
Waiting for syncing to finish...
Done!
```

It does not trigger a rescan on remotes, at least not at this point. That means a user has to take 3 actions to use it:
1. Make changes
2. Trigger a rescan on the source device
3. Run `syncthing cli await-insync` on the target device

Ideally step 2 would be automated in the future.

### Testing

Manual testing only:
1. Connect 2 devices
2. Device 1: create a large file (in the sync dir)
3. Device 1: trigger a rescan
4. Device 2: run `syncthing cli await-insync` (in the sync dir)
5. Verify the checksum / size

There was an attempt for integration tests (units wont do in this case), but got blocked by #8071.

### Documentation

Updated the CLI help screen:
```
NAME:
   syncthing cli - Syncthing command line interface

USAGE:
   syncthing cli command [command options] [arguments...]

COMMANDS:
   config        Configuration modification command group
   show          Show command group
   await-insync  Block until the current dir is in sync
   operations    Operation command group
   errors        Error command group
   debug         Debug command group
   -             Read commands from stdin

...
```

