### PR TITLE
cmd/stdiscosrv: Support deploying behind Caddyserver

### DIFF
--- a/cmd/stdiscosrv/apisrv.go
+++ b/cmd/stdiscosrv/apisrv.go
@@ -234,7 +234,7 @@ func (s *apiSrv) handlePOST(ctx context.Context, remoteAddr *net.TCPAddr, w http
 	rawCert, err := certificateBytes(req)
 	if err != nil {
 		if debug {
-			log.Println(reqID, err.Error())
+			log.Println(reqID, fmt.Sprintf("no certificates: %s", err.Error()))
 		}
 		announceRequestsTotal.WithLabelValues("no_certificate").Inc()
 		w.Header().Set("Retry-After", errorRetryAfterString())

--- a/cmd/stdiscosrv/apisrv.go
+++ b/cmd/stdiscosrv/apisrv.go
@@ -234,7 +234,7 @@ func (s *apiSrv) handlePOST(ctx context.Context, remoteAddr *net.TCPAddr, w http
 	rawCert, err := certificateBytes(req)
 	if err != nil {
 		if debug {
-			log.Println(reqID, fmt.Sprintf("no certificates: %s", err.Error()))
+			log.Println(reqID, "no certificates:", err)
 		}
 		announceRequestsTotal.WithLabelValues("no_certificate").Inc()
 		w.Header().Set("Retry-After", errorRetryAfterString())
@@ -370,13 +370,13 @@ func certificateBytes(req *http.Request) ([]byte, error) {
 	}
 
 	if bs == nil {
-		return nil, errors.New("empty certificate bytes")
+		return nil, errors.New("empty certificate header")
 	}
 
 	block, _ := pem.Decode(bs)
 	if block == nil {
 		// Decoding failed
-		return nil, errors.New("certificate decode results is empty")
+		return nil, errors.New("certificate decode result is empty")
 	}
 
 	return block.Bytes, nil

--- a/cmd/stdiscosrv/apisrv.go
+++ b/cmd/stdiscosrv/apisrv.go
@@ -242,16 +242,6 @@ func (s *apiSrv) handlePOST(ctx context.Context, remoteAddr *net.TCPAddr, w http
 		return
 	}
 
-	if rawCert == nil {
-		if debug {
-			log.Println(reqID, "no certificates")
-		}
-		announceRequestsTotal.WithLabelValues("no_certificate").Inc()
-		w.Header().Set("Retry-After", errorRetryAfterString())
-		http.Error(w, "Forbidden", http.StatusForbidden)
-		return
-	}
-
 	var ann announcement
 	if err := json.NewDecoder(req.Body).Decode(&ann); err != nil {
 		if debug {
@@ -351,6 +341,7 @@ func certificateBytes(req *http.Request) ([]byte, error) {
 			}
 		}
 	} else if hdr := req.Header.Get("X-Tls-Client-Cert-Der-Base64"); hdr != "" {
+		// Caddy {tls_client_certificate_der_base64}
 		hdr, err := base64.StdEncoding.DecodeString(hdr)
 		if err != nil {
 			// Decoding failed


### PR DESCRIPTION
- Log certificate error
- Add `X-Tls-Client-Cert-Der-Base64` header for Caddyserver, so that
  Caddyserver could set `{tls_client_certificate_der_base64}` in the header

### Purpose
 
 Support deploy discovery server behind Caddyserver

### Testing

- Add `header_up X-Tls-Client-Cert-Der-Base64 {tls_client_certificate_der_base64}`  directive in Caddyfile
- Check discovery server debug log, and check Syncthing client discovery status
