### PR TITLE
gui: Use indexOf instead of startsWith for IE11 compatibility (ref #6940)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2808,7 +2808,7 @@ angular.module('syncthing.core')
 
         $scope.themeName = function (theme) {
             var translation = $translate.instant("theme-name-" + theme);
-            if (translation.startsWith("theme-name-")) {
+            if (translation.indexOf("theme-name-") == 0) {
                 // Fall back to simple Title Casing on missing translation
                 translation = theme.toLowerCase().replace(/(?:^|\s)\S/g, function (a) {
                     return a.toUpperCase();


### PR DESCRIPTION
Use indexOf instead of startsWith to make the now translatable theme
names appear correctly in IE11. This also prevents console log error
spam in the browser. The same problem was previously reported in #6940.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
