### PR TITLE
cmd/syncthing: Always update config.xml with generate subcommand (ref #8090)

### DIFF
--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -90,20 +90,13 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 	log.Println("Device ID:", myID)
 
 	cfgFile := locations.Get(locations.ConfigFile)
-	var cfg config.Wrapper
-	if _, err := os.Stat(cfgFile); err == nil {
-		if guiUser == "" && guiPassword == "" {
-			log.Println("WARNING: Config exists; will not overwrite.")
-			return nil
-		}
-
-		if cfg, _, err = config.Load(cfgFile, myID, events.NoopLogger); err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-	} else {
+	cfg, _, err := config.Load(cfgFile, myID, events.NoopLogger)
+	if fs.IsNotExist(err) {
 		if cfg, err = syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder); err != nil {
 			return fmt.Errorf("create config: %w", err)
 		}
+	} else if err != nil {
+		return fmt.Errorf("load config: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -711,12 +711,15 @@ func setupSignalHandling(app *syncthing.App) {
 	}()
 }
 
+// loadOrDefaultConfig creates a temporary, minimal configuration wrapper if no file
+// exists.  As it disregards some command-line options, that should never be persisted.
 func loadOrDefaultConfig() (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, _, err := config.Load(cfgFile, protocol.EmptyDeviceID, events.NoopLogger)
 
 	if err != nil {
-		cfg, err = syncthing.DefaultConfig(cfgFile, protocol.EmptyDeviceID, events.NoopLogger, true)
+		newCfg := config.New(protocol.EmptyDeviceID)
+		return config.Wrap(cfgFile, newCfg, protocol.EmptyDeviceID, events.NoopLogger), nil
 	}
 
 	return cfg, err

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -329,7 +329,7 @@ func (options serveOptions) Run() error {
 	}
 
 	if options.BrowserOnly {
-		if err := openGUI(protocol.EmptyDeviceID); err != nil {
+		if err := openGUI(); err != nil {
 			l.Warnln("Failed to open web UI:", err)
 			os.Exit(svcutil.ExitError.AsInt())
 		}
@@ -406,8 +406,8 @@ func (options serveOptions) Run() error {
 	return nil
 }
 
-func openGUI(myID protocol.DeviceID) error {
-	cfg, err := loadOrDefaultConfig(myID, events.NoopLogger)
+func openGUI() error {
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (e *errNoUpgrade) Error() string {
 }
 
 func checkUpgrade() (upgrade.Release, error) {
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		return upgrade.Release{}, err
 	}
@@ -471,7 +471,7 @@ func checkUpgrade() (upgrade.Release, error) {
 }
 
 func upgradeViaRest() error {
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		return err
 	}
@@ -711,12 +711,12 @@ func setupSignalHandling(app *syncthing.App) {
 	}()
 }
 
-func loadOrDefaultConfig(myID protocol.DeviceID, evLogger events.Logger) (config.Wrapper, error) {
+func loadOrDefaultConfig() (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
-	cfg, _, err := config.Load(cfgFile, myID, evLogger)
+	cfg, _, err := config.Load(cfgFile, protocol.EmptyDeviceID, events.NoopLogger)
 
 	if err != nil {
-		cfg, err = syncthing.DefaultConfig(cfgFile, myID, evLogger, true)
+		cfg, err = syncthing.DefaultConfig(cfgFile, protocol.EmptyDeviceID, events.NoopLogger, true)
 	}
 
 	return cfg, err

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -20,11 +20,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/locations"
 	"github.com/syncthing/syncthing/lib/osutil"
-	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/sync"
 )
@@ -564,7 +562,7 @@ func childEnv() []string {
 // panicUploadMaxWait uploading panics...
 func maybeReportPanics() {
 	// Try to get a config to see if/where panics should be reported.
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		l.Warnln("Couldn't load config; not reporting crash")
 		return


### PR DESCRIPTION
### Purpose

For usage in installers or similar, a pre-populated `config.xml` file should be able to get parsed, validated and expanded with default values when calling `syncthing generate` (or the deprecated `--generate` option).  That currently only happens when an option to override the GUI credentials was passed.  Doing it always makes it easier to override some options using a minimal `config.xml` and validate it before running `syncthing serve` for the first time.

This includes some code cleanup and a fix for misleading info log messages from the monitor process.

### Testing

* `syncthing serve --home=/tmp/foo1 --upgrade-check ; ls /tmp/foo1/` creates no `config.xml` and therefore doesn't claim "We will skip creation of a default folder on first start".
* `syncthing serve --home=/tmp/foo2 ; ls /tmp/foo2/` doesn't claim "We will skip creation of a default folder on first start" from the `[monitor]` process anymore.
* `syncthing serve --home=/tmp/foo3 --no-default-folder ; ls /tmp/foo3/` doesn't claim "We will skip creation of a default folder on first start" twice.
* `syncthing generate --home=/tmp/foo4 --no-default-folder ; ls -l /tmp/foo4` correctly states no default folder will be created.
* `syncthing generate --home=/tmp/foo4 ; ls -l /tmp/foo4` updates the timestamp of the existing `config.xml`.

### Documentation

Description of some CLI options adjusted in https://github.com/syncthing/docs/pull/706.