### PR TITLE
cmd/syncthing: Add --skip-port-probing (fixes #8090)

### DIFF
--- a/cmd/syncthing/cmdutil/options_common.go
+++ b/cmd/syncthing/cmdutil/options_common.go
@@ -12,4 +12,5 @@ type CommonOptions struct {
 	ConfDir         string `name:"config" placeholder:"PATH" help:"Set configuration directory (config and keys)"`
 	HomeDir         string `name:"home" placeholder:"PATH" help:"Set configuration and data directory"`
 	NoDefaultFolder bool   `env:"STNODEFAULTFOLDER" help:"Don't create the \"default\" folder on first startup"`
+	SkipPortProbing bool   `help:"Don't try to find free ports for GUI and listen addresses on first startup"`
 }

--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -58,13 +58,13 @@ func (c *CLI) Run() error {
 		c.GUIPassword = string(password)
 	}
 
-	if err := Generate(c.ConfDir, c.GUIUser, c.GUIPassword, c.NoDefaultFolder); err != nil {
+	if err := Generate(c.ConfDir, c.GUIUser, c.GUIPassword, c.NoDefaultFolder, c.SkipPortProbing); err != nil {
 		return fmt.Errorf("Failed to generate config and keys: %w", err)
 	}
 	return nil
 }
 
-func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error {
+func Generate(confDir, guiUser, guiPassword string, noDefaultFolder, skipPortProbing bool) error {
 	dir, err := fs.ExpandTilde(confDir)
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, _, err := config.Load(cfgFile, myID, events.NoopLogger)
 	if fs.IsNotExist(err) {
-		if cfg, err = syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder); err != nil {
+		if cfg, err = syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder, skipPortProbing); err != nil {
 			return fmt.Errorf("create config: %w", err)
 		}
 	} else if err != nil {

--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -90,20 +90,13 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder bool) error 
 	log.Println("Device ID:", myID)
 
 	cfgFile := locations.Get(locations.ConfigFile)
-	var cfg config.Wrapper
-	if _, err := os.Stat(cfgFile); err == nil {
-		if guiUser == "" && guiPassword == "" {
-			log.Println("WARNING: Config exists; will not overwrite.")
-			return nil
-		}
-
-		if cfg, _, err = config.Load(cfgFile, myID, events.NoopLogger); err != nil {
-			return fmt.Errorf("load config: %w", err)
-		}
-	} else {
+	cfg, _, err := config.Load(cfgFile, myID, events.NoopLogger)
+	if fs.IsNotExist(err) {
 		if cfg, err = syncthing.DefaultConfig(cfgFile, myID, events.NoopLogger, noDefaultFolder); err != nil {
 			return fmt.Errorf("create config: %w", err)
 		}
+	} else if err != nil {
+		return fmt.Errorf("load config: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -711,12 +711,15 @@ func setupSignalHandling(app *syncthing.App) {
 	}()
 }
 
+// loadOrDefaultConfig creates a temporary, minimal configuration wrapper if no file
+// exists.  As it disregards some command-line options, that should never be persisted.
 func loadOrDefaultConfig() (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, _, err := config.Load(cfgFile, protocol.EmptyDeviceID, events.NoopLogger)
 
 	if err != nil {
-		cfg, err = syncthing.DefaultConfig(cfgFile, protocol.EmptyDeviceID, events.NoopLogger, true)
+		newCfg := config.New(protocol.EmptyDeviceID)
+		return config.Wrap(cfgFile, newCfg, protocol.EmptyDeviceID, events.NoopLogger), nil
 	}
 
 	return cfg, err

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -329,7 +329,7 @@ func (options serveOptions) Run() error {
 	}
 
 	if options.BrowserOnly {
-		if err := openGUI(protocol.EmptyDeviceID); err != nil {
+		if err := openGUI(); err != nil {
 			l.Warnln("Failed to open web UI:", err)
 			os.Exit(svcutil.ExitError.AsInt())
 		}
@@ -406,8 +406,8 @@ func (options serveOptions) Run() error {
 	return nil
 }
 
-func openGUI(myID protocol.DeviceID) error {
-	cfg, err := loadOrDefaultConfig(myID, events.NoopLogger)
+func openGUI() error {
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		return err
 	}
@@ -452,7 +452,7 @@ func (e *errNoUpgrade) Error() string {
 }
 
 func checkUpgrade() (upgrade.Release, error) {
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		return upgrade.Release{}, err
 	}
@@ -471,7 +471,7 @@ func checkUpgrade() (upgrade.Release, error) {
 }
 
 func upgradeViaRest() error {
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		return err
 	}
@@ -711,12 +711,12 @@ func setupSignalHandling(app *syncthing.App) {
 	}()
 }
 
-func loadOrDefaultConfig(myID protocol.DeviceID, evLogger events.Logger) (config.Wrapper, error) {
+func loadOrDefaultConfig() (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
-	cfg, _, err := config.Load(cfgFile, myID, evLogger)
+	cfg, _, err := config.Load(cfgFile, protocol.EmptyDeviceID, events.NoopLogger)
 
 	if err != nil {
-		cfg, err = syncthing.DefaultConfig(cfgFile, myID, evLogger, true)
+		cfg, err = syncthing.DefaultConfig(cfgFile, protocol.EmptyDeviceID, events.NoopLogger, true)
 	}
 
 	return cfg, err

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -337,7 +337,7 @@ func (options serveOptions) Run() error {
 	}
 
 	if options.GenerateDir != "" {
-		if err := generate.Generate(options.GenerateDir, "", "", options.NoDefaultFolder); err != nil {
+		if err := generate.Generate(options.GenerateDir, "", "", options.NoDefaultFolder, options.SkipPortProbing); err != nil {
 			l.Warnln("Failed to generate config and keys:", err)
 			os.Exit(svcutil.ExitError.AsInt())
 		}
@@ -551,7 +551,7 @@ func syncthingMain(options serveOptions) {
 	evLogger := events.NewLogger()
 	earlyService.Add(evLogger)
 
-	cfgWrapper, err := syncthing.LoadConfigAtStartup(locations.Get(locations.ConfigFile), cert, evLogger, options.AllowNewerConfig, options.NoDefaultFolder)
+	cfgWrapper, err := syncthing.LoadConfigAtStartup(locations.Get(locations.ConfigFile), cert, evLogger, options.AllowNewerConfig, options.NoDefaultFolder, options.SkipPortProbing)
 	if err != nil {
 		l.Warnln("Failed to initialize config:", err)
 		os.Exit(svcutil.ExitError.AsInt())

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -20,11 +20,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/locations"
 	"github.com/syncthing/syncthing/lib/osutil"
-	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/sync"
 )
@@ -564,7 +562,7 @@ func childEnv() []string {
 // panicUploadMaxWait uploading panics...
 func maybeReportPanics() {
 	// Try to get a config to see if/where panics should be reported.
-	cfg, err := loadOrDefaultConfig(protocol.EmptyDeviceID, events.NoopLogger)
+	cfg, err := loadOrDefaultConfig()
 	if err != nil {
 		l.Warnln("Couldn't load config; not reporting crash")
 		return

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -113,18 +113,16 @@ func New(myID protocol.DeviceID) Configuration {
 	return cfg
 }
 
-func NewWithFreePorts(myID protocol.DeviceID) (Configuration, error) {
-	cfg := New(myID)
-
+func (cfg *Configuration) ProbeFreePorts() error {
 	port, err := getFreePort("127.0.0.1", DefaultGUIPort)
 	if err != nil {
-		return Configuration{}, errors.Wrap(err, "get free port (GUI)")
+		return errors.Wrap(err, "get free port (GUI)")
 	}
 	cfg.GUI.RawAddress = fmt.Sprintf("127.0.0.1:%d", port)
 
 	port, err = getFreePort("0.0.0.0", DefaultTCPPort)
 	if err != nil {
-		return Configuration{}, errors.Wrap(err, "get free port (BEP)")
+		return errors.Wrap(err, "get free port (BEP)")
 	}
 	if port == DefaultTCPPort {
 		cfg.Options.RawListenAddresses = []string{"default"}
@@ -136,7 +134,7 @@ func NewWithFreePorts(myID protocol.DeviceID) (Configuration, error) {
 		}
 	}
 
-	return cfg, nil
+	return nil
 }
 
 type xmlConfiguration struct {

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -60,8 +60,9 @@ func GenerateCertificate(certFile, keyFile string) (tls.Certificate, error) {
 }
 
 func DefaultConfig(path string, myID protocol.DeviceID, evLogger events.Logger, noDefaultFolder bool) (config.Wrapper, error) {
-	newCfg, err := config.NewWithFreePorts(myID)
-	if err != nil {
+	newCfg := config.New(myID)
+
+	if err := newCfg.ProbeFreePorts(); err != nil {
 		return nil, err
 	}
 

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -59,10 +59,12 @@ func GenerateCertificate(certFile, keyFile string) (tls.Certificate, error) {
 	return tlsutil.NewCertificate(certFile, keyFile, tlsDefaultCommonName, deviceCertLifetimeDays)
 }
 
-func DefaultConfig(path string, myID protocol.DeviceID, evLogger events.Logger, noDefaultFolder bool) (config.Wrapper, error) {
+func DefaultConfig(path string, myID protocol.DeviceID, evLogger events.Logger, noDefaultFolder, skipPortProbing bool) (config.Wrapper, error) {
 	newCfg := config.New(myID)
 
-	if err := newCfg.ProbeFreePorts(); err != nil {
+	if skipPortProbing {
+		l.Infoln("Using default network port numbers instead of probing for free ports")
+	} else if err := newCfg.ProbeFreePorts(); err != nil {
 		return nil, err
 	}
 
@@ -85,11 +87,11 @@ func DefaultConfig(path string, myID protocol.DeviceID, evLogger events.Logger, 
 // creates a default one, without the default folder if noDefaultFolder is ture.
 // Otherwise it checks the version, and archives and upgrades the config if
 // necessary or returns an error, if the version isn't compatible.
-func LoadConfigAtStartup(path string, cert tls.Certificate, evLogger events.Logger, allowNewerConfig, noDefaultFolder bool) (config.Wrapper, error) {
+func LoadConfigAtStartup(path string, cert tls.Certificate, evLogger events.Logger, allowNewerConfig, noDefaultFolder, skipPortProbing bool) (config.Wrapper, error) {
 	myID := protocol.NewDeviceID(cert.Certificate[0])
 	cfg, originalVersion, err := config.Load(path, myID, evLogger)
 	if fs.IsNotExist(err) {
-		cfg, err = DefaultConfig(path, myID, evLogger, noDefaultFolder)
+		cfg, err = DefaultConfig(path, myID, evLogger, noDefaultFolder, skipPortProbing)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate default config")
 		}


### PR DESCRIPTION
### Purpose

The conditions during `syncthing generate` (or the first run of `syncthing serve`) do not necessarily reflect what network ports will be available later on.  The new command line option allows to skip the probing heuristics to use currently unused port numbers for the GUI and listen addresses in a freshly created `config.xml`.  Instead the default ports are simply applied, avoiding unexpected firewall alert messages on Windows at least.

This is based on (and includes the commits of) #8098.  Same origin issue #8090, but the two independent changes should not be munged into one commit.

### Testing

With a running Syncthing instance on the default ports, `syncthing --home=/tmp/foo --skip-port-probing` now fails because it cannot bind the default addresses, instead of choosing random different ports.

### Documentation

Description of the new CLI option in https://github.com/syncthing/docs/pull/706. (Together with #8098)