### PR TITLE
gui: Sort language names vertically and don't truncate on small screens

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -358,8 +358,9 @@ ul.three-columns li, ul.two-columns li {
         margin-right: 15px;
         margin-top: -12px !important;
         max-width: 450px;
-        height: 265px;
         overflow-y: scroll;
+        /* height of 5.5 elements + negative margin-top */
+        height: 276px;
     }
 
     table.table-condensed td,

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -166,16 +166,13 @@ table.table-auto td {
     display: none;
 }
 
-*[language-select] > .dropdown-menu {
+li[language-select] > .dropdown-menu {
+    column-count: 2;
+    column-gap: 0;
     width: 450px;
 }
 
-*[language-select] > .dropdown-menu > li {
-    float: left;
-    width: 50%;
-}
-
-*[language-select] > .dropdown-menu > li > a {
+li[language-select] > .dropdown-menu > li > a {
     overflow: hidden;
     text-overflow: ellipsis;
 }
@@ -351,11 +348,12 @@ ul.three-columns li, ul.two-columns li {
         border-radius: 2px;
     }
 
-    *[language-select] {
+    li[language-select] {
         position: static !important;
     }
 
-    *[language-select] > .dropdown-menu {
+    li[language-select] > .dropdown-menu {
+        column-count: auto;
         margin-left: 15px;
         margin-right: 15px;
         margin-top: -12px !important;


### PR DESCRIPTION
Currently, language names are always displayed in two columns and sorted
from left to right first, and from top to bottom next. This commit
changes the sort order to go from top to bottom first, and only then
move to the next column.

Also, on small screens, display the languages in a single column only,
which allows for language names not to be truncated as much as they are
right now.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Old sort order

![image](https://user-images.githubusercontent.com/5626656/148616241-d63203e7-78ea-4546-980d-680e738da5b7.png)

#### New sort order

![image](https://user-images.githubusercontent.com/5626656/148616324-c417371d-7e39-44e0-885d-e73a3442ca8d.png)

#### Old small screen display

![image](https://user-images.githubusercontent.com/5626656/148616275-393ed598-b8bf-45af-914c-0b0797a9d20d.png)

#### New small screen display

![image](https://user-images.githubusercontent.com/5626656/148616281-2ff5bde2-6af0-402c-acb7-fa74f5001065.png)
