### PR TITLE
lib/model: Remove bogus fields from connections API endpoint (fixes #8103)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -769,12 +769,10 @@ func (m *model) ConnectionStats() map[string]interface{} {
 	res["connections"] = conns
 
 	in, out := protocol.TotalInOut()
-	res["total"] = ConnectionInfo{
-		Statistics: protocol.Statistics{
-			At:            time.Now().Truncate(time.Second),
-			InBytesTotal:  in,
-			OutBytesTotal: out,
-		},
+	res["total"] = protocol.Statistics{
+		At:            time.Now().Truncate(time.Second),
+		InBytesTotal:  in,
+		OutBytesTotal: out,
 	}
 
 	return res

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -706,26 +706,12 @@ func (m *model) UsageReportingStats(report *contract.Report, version int, previe
 
 type ConnectionInfo struct {
 	protocol.Statistics
-	Connected     bool
-	Paused        bool
-	Address       string
-	ClientVersion string
-	Type          string
-	Crypto        string
-}
-
-func (info ConnectionInfo) MarshalJSON() ([]byte, error) {
-	return json.Marshal(map[string]interface{}{
-		"at":            info.At,
-		"inBytesTotal":  info.InBytesTotal,
-		"outBytesTotal": info.OutBytesTotal,
-		"connected":     info.Connected,
-		"paused":        info.Paused,
-		"address":       info.Address,
-		"clientVersion": info.ClientVersion,
-		"type":          info.Type,
-		"crypto":        info.Crypto,
-	})
+	Connected     bool   `json:"connected"`
+	Paused        bool   `json:"paused"`
+	Address       string `json:"address"`
+	ClientVersion string `json:"clientVersion"`
+	Type          string `json:"type"`
+	Crypto        string `json:"crypto"`
 }
 
 // NumConnections returns the current number of active connected devices.

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -755,10 +755,10 @@ func (m *model) ConnectionStats() map[string]interface{} {
 	res["connections"] = conns
 
 	in, out := protocol.TotalInOut()
-	res["total"] = protocol.Statistics{
-		At:            time.Now().Truncate(time.Second),
-		InBytesTotal:  in,
-		OutBytesTotal: out,
+	res["total"] = map[string]interface{}{
+		"at":            time.Now().Truncate(time.Second),
+		"inBytesTotal":  in,
+		"outBytesTotal": out,
 	}
 
 	return res

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -994,10 +994,10 @@ func (c *rawConnection) pingReceiver() {
 }
 
 type Statistics struct {
-	At            time.Time
-	InBytesTotal  int64
-	OutBytesTotal int64
-	StartedAt     time.Time
+	At            time.Time `json:"at"`
+	InBytesTotal  int64     `json:"inBytesTotal"`
+	OutBytesTotal int64     `json:"outBytesTotal"`
+	StartedAt     time.Time `json:"startedAt"`
 }
 
 func (c *rawConnection) Statistics() Statistics {


### PR DESCRIPTION
Switch the returned data type for the /rest/system/connections element
"total" to use only the Statistics struct.  The other fields of the
ConnectionInfo struct are not populated and misleading.

Make sure the JSON attributes are lowercased as documented.

### Testing

Manual API and GUI verification.

### Documentation

https://github.com/syncthing/docs/pull/708