### PR TITLE
cmd/syncthing: Implement a subcommand 'override-credentials' (fixes #…

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/syncthing/syncthing/cmd/syncthing/cmdutil"
 	"github.com/syncthing/syncthing/cmd/syncthing/decrypt"
 	"github.com/syncthing/syncthing/cmd/syncthing/generate"
+	"github.com/syncthing/syncthing/cmd/syncthing/override-credentials"
 	"github.com/syncthing/syncthing/lib/build"
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/db"
@@ -132,10 +133,11 @@ var (
 // commands and options here are top level commands to syncthing.
 // Cli is just a placeholder for the help text (see main).
 var entrypoint struct {
-	Serve    serveOptions `cmd:"" help:"Run Syncthing"`
-	Generate generate.CLI `cmd:"" help:"Generate key and config, then exit"`
-	Decrypt  decrypt.CLI  `cmd:"" help:"Decrypt or verify an encrypted folder"`
-	Cli      struct{}     `cmd:"" help:"Command line interface for Syncthing"`
+	Serve               serveOptions             `cmd:"" help:"Run Syncthing"`
+	Generate            generate.CLI             `cmd:"" help:"Generate key and config, then exit"`
+	OverrideCredentials override_credentials.CLI `cmd:"" help:"Override default key, cert and config files, then exit"`
+	Decrypt             decrypt.CLI              `cmd:"" help:"Decrypt or verify an encrypted folder"`
+	Cli                 struct{}                 `cmd:"" help:"Command line interface for Syncthing"`
 }
 
 // serveOptions are the options for the `syncthing serve` command.

--- a/cmd/syncthing/override-credentials/override_credentials.go
+++ b/cmd/syncthing/override-credentials/override_credentials.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2022 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Package override_credentials implements the `syncthing override-credentials` subcommand.
+package override_credentials
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/syncthing"
+)
+
+type CLI struct {
+	SourceDirectory string `name:"src-dir" placeholder:"PATH" help:"Directory with generated key, cert and config files"`
+}
+
+type SourceDestinationPair struct {
+	source      string
+	destination string
+}
+
+func (c *CLI) Run() error {
+	log.SetFlags(0)
+	if c.SourceDirectory == "" {
+		return fmt.Errorf("--src-dir not specified")
+	}
+
+	if err := OverrideCredentials(c.SourceDirectory); err != nil {
+		return fmt.Errorf("Failed to override config and keys: %w", err)
+	}
+	return nil
+}
+
+func OverrideCredentials(srcDir string) error {
+	dir, err := fs.ExpandTilde(srcDir)
+	if err != nil {
+		return err
+	}
+	err = syncthing.EnsureDir(dir, 0700)
+	if err != nil {
+		return err
+	}
+
+	confPath := locations.Get(locations.ConfigFile)
+	certPath := locations.Get(locations.CertFile)
+	keyPath := locations.Get(locations.KeyFile)
+
+	srcKey := filepath.Join(dir, filepath.Base(keyPath))
+	srcCert := filepath.Join(dir, filepath.Base(certPath))
+	srcConf := filepath.Join(dir, filepath.Base(confPath))
+
+	cert, err := tls.LoadX509KeyPair(srcCert, srcKey)
+	if err != nil {
+		return fmt.Errorf("Couldn't load certificate from the source directory: %w", err)
+	}
+
+	srcDestPairs := [3]SourceDestinationPair{
+		SourceDestinationPair{srcKey, keyPath},
+		SourceDestinationPair{srcCert, certPath},
+		SourceDestinationPair{srcConf, confPath},
+	}
+	for _, p := range srcDestPairs {
+		if p.source == p.destination {
+			return fmt.Errorf("Source and destination directories are the same")
+		}
+	}
+	for _, p := range srcDestPairs {
+		source, err := os.Open(p.source)
+		if err != nil {
+			return err
+		}
+		defer source.Close()
+		destination, err := os.OpenFile(p.destination, os.O_WRONLY|os.O_TRUNC, os.ModePerm)
+		if err != nil {
+			return err
+		}
+		defer destination.Close()
+		_, err = io.Copy(destination, source)
+		if err != nil {
+			return err
+		}
+	}
+
+	certFile, keyFile := locations.Get(locations.CertFile), locations.Get(locations.KeyFile)
+	cert, err = tls.LoadX509KeyPair(certFile, keyFile)
+	myID := protocol.NewDeviceID(cert.Certificate[0])
+	log.Println("New device ID:", myID)
+
+	return nil
+}

--- a/cmd/syncthing/override-credentials/override_credentials.go
+++ b/cmd/syncthing/override-credentials/override_credentials.go
@@ -60,15 +60,15 @@ func OverrideCredentials(srcDir string) error {
 	srcCert := filepath.Join(dir, filepath.Base(certPath))
 	srcConf := filepath.Join(dir, filepath.Base(confPath))
 
-	cert, err := tls.LoadX509KeyPair(srcCert, srcKey)
+	_, err = tls.LoadX509KeyPair(srcCert, srcKey)
 	if err != nil {
 		return fmt.Errorf("Couldn't load certificate from the source directory: %w", err)
 	}
 
 	srcDestPairs := [3]SourceDestinationPair{
-		SourceDestinationPair{srcKey, keyPath},
-		SourceDestinationPair{srcCert, certPath},
-		SourceDestinationPair{srcConf, confPath},
+		{srcKey, keyPath},
+		{srcCert, certPath},
+		{srcConf, confPath},
 	}
 	for _, p := range srcDestPairs {
 		if p.source == p.destination {
@@ -93,7 +93,7 @@ func OverrideCredentials(srcDir string) error {
 	}
 
 	certFile, keyFile := locations.Get(locations.CertFile), locations.Get(locations.KeyFile)
-	cert, err = tls.LoadX509KeyPair(certFile, keyFile)
+	cert, _ := tls.LoadX509KeyPair(certFile, keyFile)
 	myID := protocol.NewDeviceID(cert.Certificate[0])
 	log.Println("New device ID:", myID)
 


### PR DESCRIPTION
…8118)

The subcommand takes one argument --src-dir which specifies the source
directory containing key.pem, cert.pem and config.xml files.
Then it replaces the key, cert and config files in the default folder
(.config/syncthing) with the ones from the source directory, which
gives the device a new identity.

The subcommand validates the input files which makes it safer than
replacing the files manually.

### Purpose
Fixes #8118 

### Usage
`syncthing override-credentials --src-dir <source-directory>`

