### PR TITLE
gui: Handle folder missing in model on error event

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -399,6 +399,10 @@ angular.module('syncthing.core')
         });
 
         $scope.$on(Events.FOLDER_ERRORS, function (event, arg) {
+            if (!$scope.model[arg.data.folder]) {
+                console.log("Dropping folder errors event for unknown folder", arg.data.folder)
+                return;
+            }
             $scope.model[arg.data.folder].errors = arg.data.errors.length;
         });
 


### PR DESCRIPTION
https://forum.syncthing.net/t/broken-web-gui-with-typeerror-cannot-set-properties-of-undefined-setting-errors/17840