### PR TITLE
lib/protocol: Require at least 3.125% savings from compression

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -540,7 +540,7 @@ func (c *rawConnection) readMessageAfterHeader(hdr Header, fourByteBuf []byte) (
 
 	// ... and is then unmarshalled
 
-	msg, err := c.newMessage(hdr.Type)
+	msg, err := newMessage(hdr.Type)
 	if err != nil {
 		BufferPool.Put(buf)
 		return nil, err
@@ -747,7 +747,7 @@ func (c *rawConnection) writeMessage(msg message) error {
 
 	size := msg.ProtoSize()
 	hdr := Header{
-		Type: c.typeOf(msg),
+		Type: typeOf(msg),
 	}
 	hdrSize := hdr.ProtoSize()
 	if hdrSize > 1<<16-1 {
@@ -795,7 +795,7 @@ func (c *rawConnection) writeMessage(msg message) error {
 // If not, the caller should retry without compression.
 func (c *rawConnection) writeCompressedMessage(msg message, marshaled []byte) (ok bool, err error) {
 	hdr := Header{
-		Type:        c.typeOf(msg),
+		Type:        typeOf(msg),
 		Compression: MessageCompressionLZ4,
 	}
 	hdrSize := hdr.ProtoSize()
@@ -834,7 +834,7 @@ func (c *rawConnection) writeCompressedMessage(msg message, marshaled []byte) (o
 	return true, nil
 }
 
-func (c *rawConnection) typeOf(msg message) MessageType {
+func typeOf(msg message) MessageType {
 	switch msg.(type) {
 	case *ClusterConfig:
 		return MessageTypeClusterConfig
@@ -857,7 +857,7 @@ func (c *rawConnection) typeOf(msg message) MessageType {
 	}
 }
 
-func (c *rawConnection) newMessage(t MessageType) (message, error) {
+func newMessage(t MessageType) (message, error) {
 	switch t {
 	case MessageTypeClusterConfig:
 		return new(ClusterConfig), nil

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -1017,15 +1017,15 @@ func (c *rawConnection) Statistics() Statistics {
 }
 
 func lz4Compress(src, buf []byte) (int, error) {
-	// The compressed block is prefixed by the size of the uncompressed data.
-	binary.BigEndian.PutUint32(buf, uint32(len(src)))
-
 	n, err := lz4.CompressBlock(src, buf[4:], nil)
 	if err != nil {
 		return -1, err
-	} else if len(src) > 0 && n == 0 {
+	} else if n == 0 {
 		return -1, errNotCompressible
 	}
+
+	// The compressed block is prefixed by the size of the uncompressed data.
+	binary.BigEndian.PutUint32(buf, uint32(len(src)))
 
 	return n + 4, nil
 }

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -466,7 +466,7 @@ func TestWriteCompressed(t *testing.T) {
 			t.Error("received the wrong message")
 		}
 
-		hdr := Header{Type: c.typeOf(msg)}
+		hdr := Header{Type: typeOf(msg)}
 		size := int64(2 + hdr.ProtoSize() + 4 + msg.ProtoSize())
 		if c.cr.tot > size {
 			t.Errorf("compression enlarged message from %d to %d",


### PR DESCRIPTION
The new lz4 library doesn't need its output buffer to be the maximum size, unlike the old one (which would allocate if it weren't). It can take a buffer that is of a smaller size and will report if compressed data can fit inside the buffer (with a small chance of reporting a false negative). This patch uses that property by requiring compressed data to be at most n-n>>5 = .96875*n bytes long for n input bytes.