### PR TITLE
gui: Fix loading default ignores (ref #7530)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2090,7 +2090,12 @@ angular.module('syncthing.core')
 
         function editFolderLoadIgnores() {
             editFolderLoadingIgnores();
-            return editFolderGetIgnores().then(editFolderInitIgnores, $scope.emitHTTPError);
+            return editFolderGetIgnores().then(function(data) {
+                if (!data) {
+                    return;
+                }
+                editFolderInitIgnores(data.ignore, data.error);
+            }, $scope.emitHTTPError);
         }
 
         $scope.editFolderDefaults = function() {
@@ -2109,10 +2114,10 @@ angular.module('syncthing.core')
             });
         }
 
-        function editFolderInitIgnores(data) {
-            $scope.ignores.originalLines = data.ignore || [];
-            setIgnoresText(data.ignore);
-            $scope.ignores.error = data.error;
+        function editFolderInitIgnores(lines, error) {
+            $scope.ignores.originalLines = lines || [];
+            setIgnoresText(lines);
+            $scope.ignores.error = error;
             $scope.ignores.disabled = false;
         }
 
@@ -2288,7 +2293,7 @@ angular.module('syncthing.core')
                     return;
                 }
                 if ((data.ignore && data.ignore.length > 0) || data.error) {
-                    editFolderInitIgnores(data);
+                    editFolderInitIgnores(data.ignore, data.error);
                 } else {
                     getDefaultIgnores().then(function(lines) {
                         setIgnoresText(lines);


### PR DESCRIPTION
Reported here: https://forum.syncthing.net/t/default-ignores-wont-save-7428/17912
Nothing is shown when editing existing defaults. They are shown when adding a new folder.
Fix for #7530 and RC material.