### PR TITLE
gui: Fix ignoreDelete warning formatting (ref #8054)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -430,9 +430,10 @@
                           </div>
                           <div ng-if="folder.ignoreDelete">
                             <i class="small">
-                              <span translate style="white-space: normal;">Altered by ignoring deletes.</span>
-                              <br>
-                              <a href="{{docsURL('advanced/folder-ignoredelete')}}" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
+                              <span translate>Altered by ignoring deletes.</span>
+                              <a href="{{docsURL('advanced/folder-ignoredelete')}}" target="_blank">
+                                <span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span>
+                              </a>
                             </i>
                           </div>
                         </td>


### PR DESCRIPTION
The ignoreDelete warning code originally comprised of two sentences,
which in total were much longer than the current one. Because of that,
some additional fixes were added to make it present itself better, e.g.
white-space was set to normal to allow for text wrap on narrow screens,
and the help link was moved to a new line to make sure both the anchor
and the question mark always stayed together.

However, the code fixes remained despite the final text being much
shorter than the original. Therefore, remove the unnecessary white-space
formatting, and also move the help link right next to the warning. This
makes it clear that the link is related to this particular warning when
both it and the ignore patterns warning are displayed at the same time.

Ref: https://github.com/syncthing/syncthing/pull/8054#issuecomment-978148117

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/5626656/150702623-f47cce40-69f8-4fe9-a913-7939f3989d28.png)

### After

![image](https://user-images.githubusercontent.com/5626656/150702627-437031ef-9fb6-4fbd-b251-be2dad349a66.png)
