### PR TITLE
cmd/stdiscosrv: Don't start replication listener without peers (fixes #8143)

### DIFF
--- a/cmd/stdiscosrv/main.go
+++ b/cmd/stdiscosrv/main.go
@@ -116,8 +116,11 @@ func main() {
 	var replicationDestinations []string
 	parts := strings.Split(replicationPeers, ",")
 	for _, part := range parts {
-		fields := strings.Split(part, "@")
+		if part == "" {
+			continue
+		}
 
+		fields := strings.Split(part, "@")
 		switch len(fields) {
 		case 2:
 			// This is an id@address specification. Grab the address for the
@@ -136,6 +139,9 @@ func main() {
 			id, err := protocol.DeviceIDFromString(fields[0])
 			if err != nil {
 				log.Fatalln("Parsing device ID:", err)
+			}
+			if id == protocol.EmptyDeviceID {
+				log.Fatalf("Missing device ID for peer in %q", part)
 			}
 			allowedReplicationPeers = append(allowedReplicationPeers, id)
 


### PR DESCRIPTION
The intention was that if no peers are given, we shouldn't start the
listener. We did that anyway, because:

- splitting an empty string on comma returns a slice with one empty
  string in it
- parsing the empty string as a device ID returns the empty device ID

so we end up with a valid replication peer which is the empty device ID.

(For the avoidance of doubt, this is not a security issue. Empty device ID doesn't mean we'd accept any replication peer, it means the remote device would need to present precisely an all-zeroes device ID. ("Empty" is perhaps not the best name, it's really the "zero" device ID.))
