### PR TITLE
gui: Let folder ID be editable when adding folder (fixes #8145)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2145,6 +2145,8 @@ angular.module('syncthing.core')
                 addFolderInit(folderID).then(function() {
                     // Triggers the watch that sets the path
                     $scope.currentFolder.label = $scope.currentFolder.label;
+                    // Let the folder ID be editable
+                    $scope.currentFolder._editing = "new";
                     editFolderModal();
                 });
             });


### PR DESCRIPTION
Somewhere in the recent refactors this got broken so that the folder ID
is not editable. I think it's because it shouldn't be editable when
adding a folder from the folder-rejected prompt. The template checks for
`edit` and `add` and makes the control read only, so I added a new value
`new` for this case.
