### PR TITLE
lib/fs: Handle permission change events on macos (fixes #7924)

### DIFF
--- a/lib/fs/basicfs_watch_eventtypes_darwin.go
+++ b/lib/fs/basicfs_watch_eventtypes_darwin.go
@@ -12,7 +12,8 @@ package fs
 import "github.com/syncthing/notify"
 
 const (
-	subEventMask  = notify.Create | notify.Remove | notify.Write | notify.Rename | notify.FSEventsInodeMetaMod
-	permEventMask = 0
+	subEventMask = notify.Create | notify.Remove | notify.Write | notify.Rename | notify.FSEventsInodeMetaMod
+	// FSEventsChangeOwner fires on permission change
+	permEventMask = notify.FSEventsChangeOwner
 	rmEventMask   = notify.Remove | notify.Rename
 )


### PR DESCRIPTION
### Purpose

Add the `FSEventsChangeOwner` event to the `permEventMask` on Darwin, which was previously 0. This allows Syncthing to handle chmod events, which were previously ignored. 

Fixes #7924

### Testing

Create a shared folder, add a file, chmod, check that permissions are synced within FSWatcherDelay window

[Script](https://gist.github.com/yyogo/62d41e0013fd38e8cfce4cc5cae04b06)

Tested on macOS Monterey 12.1 21C52 (x86_64)