### PR TITLE
lib/model: Print device when a block request fails

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1554,7 +1554,7 @@ loop:
 		buf, lastError = f.model.requestGlobal(f.ctx, selected.ID, f.folderID, state.file.Name, blockNo, state.block.Offset, int(state.block.Size), state.block.Hash, state.block.WeakHash, selected.FromTemporary)
 		activity.done(selected)
 		if lastError != nil {
-			l.Debugln("request:", f.folderID, state.file.Name, state.block.Offset, state.block.Size, "returned error:", lastError)
+			l.Debugln("request:", f.folderID, state.file.Name, state.block.Offset, state.block.Size, selected.ID.Short(), "returned error:", lastError)
 			continue
 		}
 


### PR DESCRIPTION
There's a ton of info in these lines, but not which device caused the error. Which is/was annoying for debugging https://forum.syncthing.net/t/kdbx-files-cannot-be-synced/17944/15