### PR TITLE
lib, gui: Removed unused cleanInterval from Staggered Versioning (ref #541)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -74,7 +74,6 @@ angular.module('syncthing.core')
             cleanupIntervalS: 3600,
             simpleKeep: 5,
             staggeredMaxAge: 365,
-            staggeredCleanInterval: 3600,
             externalCommand: "",
         };
 
@@ -2071,7 +2070,6 @@ angular.module('syncthing.core')
                 break;
             case "staggered":
                 $scope.currentFolder._guiVersioning.staggeredMaxAge = Math.floor(+currentVersioning.params.maxAge / 86400);
-                $scope.currentFolder._guiVersioning.staggeredCleanInterval = +currentVersioning.params.cleanInterval;
                 break;
             case "external":
                 $scope.currentFolder._guiVersioning.externalCommand = currentVersioning.params.command;
@@ -2256,7 +2254,6 @@ angular.module('syncthing.core')
                 break;
             case "staggered":
                 folderCfg.versioning.params.maxAge = '' + (folderCfg._guiVersioning.staggeredMaxAge * 86400);
-                folderCfg.versioning.params.cleanInterval = '' + folderCfg._guiVersioning.staggeredCleanInterval;
                 break;
             case "external":
                 folderCfg.versioning.params.command = '' + folderCfg._guiVersioning.externalCommand;

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	OldestHandledVersion = 10
-	CurrentVersion       = 35
+	CurrentVersion       = 36
 	MaxRescanIntervalS   = 365 * 24 * 60 * 60
 )
 

--- a/lib/config/migrations.go
+++ b/lib/config/migrations.go
@@ -27,6 +27,7 @@ import (
 // put the newest on top for readability.
 var (
 	migrations = migrationSet{
+		{36, migrateToConfigV36},
 		{35, migrateToConfigV35},
 		{34, migrateToConfigV34},
 		{33, migrateToConfigV33},
@@ -92,6 +93,12 @@ func (m migration) apply(cfg *Configuration) {
 		m.convert(cfg)
 	}
 	cfg.Version = m.targetVersion
+}
+
+func migrateToConfigV36(cfg *Configuration) {
+	for i := range cfg.Folders {
+		delete(cfg.Folders[i].Versioning.Params, "cleanInterval")
+	}
 }
 
 func migrateToConfigV35(cfg *Configuration) {


### PR DESCRIPTION
Staggered File Versioning used to have its own cleanInterval that
controlled how often file versions were cleaned. Nowadays, there is a
seperate setting called cleanupIntervalS responsible for the cleanup,
which applies to all File Versioning (except External). Thus, remove the
unneeded code and don't set the param up on new folders anymore.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
