### PR TITLE
gui: Don't use italic text for CJK languages

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -506,3 +506,10 @@ ul.three-columns li, ul.two-columns li {
   padding-top: 6px;
   padding-bottom: 6px;
 }
+
+/* CJK languages don't use italic at all, hence don't force it on them. */
+html[lang|="zh"] i,
+html[lang="ja"] i,
+html[lang|="ko"] i {
+    font-style: normal;
+}

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -99,6 +99,7 @@ angular.module('syncthing.core')
             function useLocale(language, save2Storage) {
                 if (language) {
                     $translate.use(language).then(function () {
+                        document.documentElement.setAttribute("lang", language);
                         if (save2Storage && _localStorage)
                             _localStorage[_SYNLANG] = language;
                     });


### PR DESCRIPTION
Even though technically possible, CJK languages normally don't use
italic text at all, as not only does it make the characters/letters look
unnatural, but also, in the case of complex characters, unreadable too.
For these reasons, it is usually recommended not to use the italic font
style at all [1][2].

This commit changes the default font-style of the i element for Chinese,
Japanese, and Korean language to "normal" instead of "italic". In order
to do so, the HTML lang attribute is also changed following each change
of the GUI language.

[1] https://bobtung.medium.com/best-practice-in-chinese-layout-f933aff1728f
[2] https://devblogs.microsoft.com/oldnewthing/20060914-02/?p=29743

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Testing

Tested in modern browsers and IE11.

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/5626656/152856912-6ed4d504-cda4-42c2-9e36-59b963a17ced.png)

#### After

![image](https://user-images.githubusercontent.com/5626656/152856938-b5cfb5ba-5f4f-4fea-9747-f351f338625d.png)
