### PR TITLE
gui: Remove superfluous Trash Can info text from Simple Versioning

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -87,7 +87,8 @@
             </select>
           </div>
           <div class="form-group" ng-if="currentFolder._guiVersioning.selector=='trashcan' || currentFolder._guiVersioning.selector=='simple'" ng-class="{'has-error': folderEditor.trashcanClean.$invalid && folderEditor.trashcanClean.$dirty}">
-            <p translate class="help-block">Files are moved to .stversions directory when replaced or deleted by Syncthing.</p>
+            <p translate class="help-block" ng-if="currentFolder._guiVersioning.selector=='trashcan'">Files are moved to .stversions directory when replaced or deleted by Syncthing.</p>
+            <p translate class="help-block" ng-if="currentFolder._guiVersioning.selector=='simple'">Files are moved to date stamped versions in a .stversions directory when replaced or deleted by Syncthing.</p>
             <label translate for="trashcanClean">Clean out after</label>
             <div class="input-group">
               <input name="trashcanClean" id="trashcanClean" class="form-control text-right" type="number" ng-model="currentFolder._guiVersioning.trashcanClean" required="" aria-required="true" min="0" />
@@ -100,7 +101,6 @@
             </p>
           </div>
           <div class="form-group" ng-if="currentFolder._guiVersioning.selector=='simple'" ng-class="{'has-error': folderEditor.simpleKeep.$invalid && folderEditor.simpleKeep.$dirty}">
-            <p translate class="help-block">Files are moved to date stamped versions in a .stversions directory when replaced or deleted by Syncthing.</p>
             <label translate for="simpleKeep">Keep Versions</label>
             <input name="simpleKeep" id="simpleKeep" class="form-control" type="number" ng-model="currentFolder._guiVersioning.simpleKeep" required="" aria-required="true" min="1" />
             <p class="help-block">


### PR DESCRIPTION
Right now, the Trash Can versioning info text is displayed for both the
Trash Can and Simple versioning. However, the Simple versioning has its
own info text that is also displayed, which results in two very similar
sentences being shown on the screen.

This commit limits the Trash Can info text to be displayed only when the
Trash Can versioning is selected, and moves the Simple versioning info
text up to the same location as the other one.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before:

![image](https://user-images.githubusercontent.com/5626656/153020086-c7e299b0-ad6d-4e60-bb73-19092ff75b67.png)

#### After:

![image](https://user-images.githubusercontent.com/5626656/153020098-d208ea3d-b4d1-4525-bb13-c263288bede9.png)
