### PR TITLE
lib/config: Improve clarity of free space errors (fixes #8180)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -261,8 +261,8 @@ func (f *FolderConfiguration) CheckAvailableSpace(req uint64) error {
 	if err != nil {
 		return nil
 	}
-	if !checkAvailableSpace(req, f.MinDiskFree, usage) {
-		return fmt.Errorf("insufficient space in %v %v", fs.Type(), fs.URI())
+	if err := checkAvailableSpace(req, f.MinDiskFree, usage); err != nil {
+		return fmt.Errorf("insufficient space in folder %v (%v): %w", f.Description(), fs.URI(), err)
 	}
 	return nil
 }

--- a/lib/config/size.go
+++ b/lib/config/size.go
@@ -83,10 +83,10 @@ func CheckFreeSpace(minFree Size, usage fs.Usage) error {
 	if minFree.Percentage() {
 		freePct := (float64(usage.Free) / float64(usage.Total)) * 100
 		if freePct < val {
-			return fmt.Errorf("%.1f %% < %v", freePct, minFree)
+			return fmt.Errorf("current %.2f %% < required %v", freePct, minFree)
 		}
 	} else if float64(usage.Free) < val {
-		return fmt.Errorf("%sB < %v", formatSI(usage.Free), minFree)
+		return fmt.Errorf("current %sB < required %v", formatSI(usage.Free), minFree)
 	}
 
 	return nil
@@ -94,12 +94,12 @@ func CheckFreeSpace(minFree Size, usage fs.Usage) error {
 
 // checkAvailableSpace checks that the free space does not fall below the minimum
 // required free space, considering additional required space for a future operation.
-func checkAvailableSpace(req uint64, minFree Size, usage fs.Usage) bool {
+func checkAvailableSpace(req uint64, minFree Size, usage fs.Usage) error {
 	if usage.Free < req {
-		return false
+		return fmt.Errorf("current %sB < required %sB", formatSI(usage.Free), formatSI(req))
 	}
 	usage.Free -= req
-	return CheckFreeSpace(minFree, usage) == nil
+	return CheckFreeSpace(minFree, usage)
 }
 
 func formatSI(b uint64) string {

--- a/lib/config/size_test.go
+++ b/lib/config/size_test.go
@@ -159,8 +159,10 @@ func TestCheckAvailableSize(t *testing.T) {
 			continue
 		}
 		usage := fs.Usage{Free: tc.free, Total: tc.total}
-		if ok := checkAvailableSpace(tc.req, minFree, usage); ok != tc.ok {
-			t.Errorf("checkAvailableSpace(%v, %v, %v) == %v, expected %v", tc.req, minFree, usage, ok, tc.ok)
+		err = checkAvailableSpace(tc.req, minFree, usage)
+		t.Log(err)
+		if (err == nil) != tc.ok {
+			t.Errorf("checkAvailableSpace(%v, %v, %v) == %v, expected %v", tc.req, minFree, usage, err, tc.ok)
 		}
 	}
 }

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -329,7 +329,7 @@ func (f *folder) getHealthErrorWithoutIgnores() error {
 	dbPath := locations.Get(locations.Database)
 	if usage, err := fs.NewFilesystem(fs.FilesystemTypeBasic, dbPath).Usage("."); err == nil {
 		if err = config.CheckFreeSpace(f.model.cfg.Options().MinHomeDiskFree, usage); err != nil {
-			return errors.Wrapf(err, "insufficient space on disk for database (%v)", dbPath)
+			return fmt.Errorf("insufficient space on disk for database (%v): %w", dbPath, err)
 		}
 	}
 


### PR DESCRIPTION
This tweaks the folder and database free space errors so that the first part is either `insufficient space in folder $description ($folderPath):` or `insufficient space on disk for database ($databasePath):` followed by something on the form `current $value < required $value`, so for example:

 - `insufficient space in folder "foto" (/data/foto): current 0.97 % < required 1 %` (we hit the configured threshold)
 - `insufficient space in folder "foto" (/data/foto): current 100 KB < required 182 MB` (we're processing a file that won't fit)
 - `insufficient space on disk for database (/home/jb/.config/syncthing/index-v0.14.0.db): current 100 KB < required 1 %` (threshold)

Hopefully this should make the errors a little bit more actionable. There'll be some redundancy because the errors will usually be presented as folder errors ("folder foo stopped: $theError") but 🤷 