### PR TITLE
Add port for local discovery broadcasts to Docker documentation

### DIFF
--- a/README-Docker.md
+++ b/README-Docker.md
@@ -16,7 +16,7 @@ the name of the Syncthing instance can be optionally defined by using
 **Docker cli**
 ```
 $ docker pull syncthing/syncthing
-$ docker run -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp \
+$ docker run -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp -p 21027:21027/udp \
     -v /wherever/st-sync:/var/syncthing \
     --hostname=my-syncthing \
     syncthing/syncthing:latest
@@ -40,6 +40,7 @@ services:
       - 8384:8384 # Web UI
       - 22000:22000/tcp # TCP file transfers
       - 22000:22000/udp # QUIC file transfers
+      - 21027:21027/udp # Receive local discovery broadcasts
     restart: unless-stopped
 ```
 

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -37,9 +37,9 @@ services:
     volumes:
       - /wherever/st-sync:/var/syncthing
     ports:
-      - 8384:8384
-      - 22000:22000/tcp
-      - 22000:22000/udp
+      - 8384:8384 # Web UI
+      - 22000:22000/tcp # TCP file transfers
+      - 22000:22000/udp # QUIC file transfers
     restart: unless-stopped
 ```
 


### PR DESCRIPTION
Add an additional port to the recommended docker config.

For more details on this port, see https://docs.syncthing.net/specs/localdisco-v4.html