### PR TITLE
gui: Allow to translate Twitter footer link

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -392,6 +392,7 @@
    "Time the item was last modified": "Time the item was last modified",
    "Today": "Today",
    "Trash Can File Versioning": "Trash Can File Versioning",
+   "Twitter": "Twitter",
    "Type": "Type",
    "UNIX Permissions": "UNIX Permissions",
    "Unavailable": "Unavailable",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -898,7 +898,7 @@
         <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/releases" target="_blank"><span class="far fa-file-alt"></span>&nbsp;<span translate>Changelog</span></a></li>
         <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/issues" target="_blank"><span class="fas fa-bug"></span>&nbsp;<span translate>Bugs</span></a></li>
         <li><a class="navbar-link" href="https://github.com/syncthing/syncthing" target="_blank"><span class="fas fa-wrench"></span>&nbsp;<span translate>Source Code</span></a></li>
-        <li><a class="navbar-link" href="https://twitter.com/syncthing" target="_blank"><span class="fab fa-twitter"></span>&nbsp;Twitter</a></li>
+        <li><a class="navbar-link" href="https://twitter.com/syncthing" target="_blank"><span class="fab fa-twitter"></span>&nbsp;<span translate>Twitter</span></a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
Allow to translate the word "Twitter" in the footer. This is useful for
non-Latin languages which write the name using their own letters or
characters. For instance, Twitter themselves officially write their name
as "트위터" in Korean.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
