### PR TITLE
gui: Allow to translate calendar buttons in Restore Versions modal

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -28,6 +28,7 @@
    "An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.": "An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.",
    "Anonymous Usage Reporting": "Anonymous Usage Reporting",
    "Anonymous usage report format has changed. Would you like to move to the new format?": "Anonymous usage report format has changed. Would you like to move to the new format?",
+   "Apply": "Apply",
    "Are you sure you want to continue?": "Are you sure you want to continue?",
    "Are you sure you want to override all remote changes?": "Are you sure you want to override all remote changes?",
    "Are you sure you want to permanently delete all these files?": "Are you sure you want to permanently delete all these files?",

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2624,6 +2624,8 @@ angular.module('syncthing.core')
                                 maxDate: maxDate,
                                 ranges: ranges,
                                 locale: {
+                                    applyLabel: $translate.instant("Apply"),
+                                    cancelLabel: $translate.instant("Cancel"),
                                     customRangeLabel: $translate.instant("Custom Range"),
                                     format: 'YYYY/MM/DD HH:mm:ss',
                                 }


### PR DESCRIPTION
Allow to translate the "Apply" and "Cancel" buttons used in the date
picker calendar in the Restore Versions modal.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
