### PR TITLE
lib/fs: Do not follow symlinks in watcher on solaris (fixes #8020)

### DIFF
--- a/lib/fs/basicfs_watch_eventtypes_fen.go
+++ b/lib/fs/basicfs_watch_eventtypes_fen.go
@@ -12,7 +12,7 @@ package fs
 import "github.com/syncthing/notify"
 
 const (
-	subEventMask  = notify.Create | notify.FileModified | notify.FileRenameFrom | notify.FileDelete | notify.FileRenameTo
+	subEventMask  = notify.Create | notify.FileModified | notify.FileRenameFrom | notify.FileDelete | notify.FileRenameTo | notify.FileNoFollow
 	permEventMask = notify.FileAttrib
 	rmEventMask   = notify.FileDelete | notify.FileRenameFrom
 )


### PR DESCRIPTION
### Purpose

Dangling symlink prevents filesystem watcher on Solaris (fixes #8020)


### Testing

In production on Solaris 11.4


