### PR TITLE
lib/model: Chmod to mode|0700, not 755

### DIFF
--- a/lib/model/util.go
+++ b/lib/model/util.go
@@ -114,26 +114,29 @@ func inWritableDir(fn func(string) error, targetFs fs.Filesystem, path string, i
 	if !info.IsDir() {
 		return errors.New("Not a directory: " + path)
 	}
-	if info.Mode()&0200 == 0 {
+
+	const permBits = fs.ModePerm | fs.ModeSetuid | fs.ModeSetgid | fs.ModeSticky
+	if mode := info.Mode() & permBits; mode&0200 == 0 {
 		// A non-writeable directory (for this user; we assume that's the
 		// relevant part). Temporarily change the mode so we can delete the
 		// file or directory inside it.
-		if err := targetFs.Chmod(dir, 0755); err == nil {
-			// Chmod succeeded, we should change the permissions back on the way
-			// out. If we fail we log the error as we have irrevocably messed up
-			// at this point. :( (The operation we were called to wrap has
-			// succeeded or failed on its own so returning an error to the
-			// caller is inappropriate.)
-			defer func() {
-				if err := targetFs.Chmod(dir, info.Mode()&fs.ModePerm); err != nil && !fs.IsNotExist(err) {
-					logFn := l.Warnln
-					if ignorePerms {
-						logFn = l.Debugln
-					}
-					logFn("Failed to restore directory permissions after gaining write access:", err)
-				}
-			}()
+		if err := targetFs.Chmod(dir, mode|0700); err != nil {
+			return err
 		}
+		// Chmod succeeded, we should change the permissions back on the way
+		// out. If we fail we log the error as we have irrevocably messed up
+		// at this point. :( (The operation we were called to wrap has
+		// succeeded or failed on its own so returning an error to the
+		// caller is inappropriate.)
+		defer func() {
+			if err := targetFs.Chmod(dir, mode); err != nil && !fs.IsNotExist(err) {
+				logFn := l.Warnln
+				if ignorePerms {
+					logFn = l.Debugln
+				}
+				logFn("Failed to restore directory permissions after gaining write access:", err)
+			}
+		}()
 	}
 
 	return fn(path)


### PR DESCRIPTION
inWritableDir doesn't need to make its directory world-readable. Also, it now preserves setuid/setgid/sticky bits and returns Chmod errors early instead of waiting for fn(path) to fail.

From what I understand of how Go simulates Unix file modes on Windows, including some light testing, I think this should be portable. syscall.Chmod on Windows just checks if S_IWRITE = 0200 is being set or unset and sets the read-only bit accordingly, preserving all the other file attributes:

https://github.com/golang/go/blob/489102de18cff38d1b12d09eeb7e60af42492d63/src/syscall/syscall_windows.go#L647-L662