### PR TITLE
all: Replace errors.Cause with errors.Is

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -882,7 +882,7 @@ func (s *connectionStatusHandler) ConnectionStatus() map[string]ConnectionStatus
 }
 
 func (s *connectionStatusHandler) setConnectionStatus(address string, err error) {
-	if errors.Cause(err) == context.Canceled {
+	if errors.Is(err, context.Canceled) {
 		return
 	}
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1849,7 +1849,7 @@ func (f *sendReceiveFolder) moveForConflict(name, lastModBy string, scanChan cha
 }
 
 func (f *sendReceiveFolder) newPullError(path string, err error) {
-	if errors.Cause(err) == f.ctx.Err() {
+	if errors.Is(err, f.ctx.Err()) {
 		// Error because the folder stopped - no point logging/tracking
 		return
 	}

--- a/lib/pmp/pmp.go
+++ b/lib/pmp/pmp.go
@@ -8,14 +8,14 @@ package pmp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
 	"time"
 
 	"github.com/jackpal/gateway"
-	"github.com/jackpal/go-nat-pmp"
-	"github.com/pkg/errors"
+	natpmp "github.com/jackpal/go-nat-pmp"
 
 	"github.com/syncthing/syncthing/lib/nat"
 	"github.com/syncthing/syncthing/lib/util"
@@ -50,7 +50,7 @@ func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device 
 		return ierr
 	})
 	if err != nil {
-		if errors.Cause(err) == context.Canceled {
+		if errors.Is(err, context.Canceled) {
 			return nil
 		}
 		if strings.Contains(err.Error(), "Timed out") {

--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -212,7 +212,7 @@ loop:
 			case *UnsupportedDeviceTypeError:
 				l.Debugln(err.Error())
 			default:
-				if errors.Cause(err) != context.Canceled {
+				if !errors.Is(err, context.Canceled) {
 					l.Infoln("UPnP parse:", err)
 				}
 			}


### PR DESCRIPTION
Errors constructed with pkg/errors implement Unwrap, so both stdlib errors.Is and pkg/errors.Is work with them.

This should make it possible to migrate away from pkg/errors in the long run.