### PR TITLE
lib/model: Clear folder error after loading ignores (fixes #8232)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -382,7 +382,6 @@ func (f *folder) pull() (success bool, err error) {
 		l.Debugln("Skipping pull of", f.Description(), "due to folder error:", err)
 		return false, err
 	}
-	f.setError(nil)
 
 	// Send only folder doesn't do any io, it only checks for out-of-sync
 	// items that differ in metadata and updates those.
@@ -409,6 +408,7 @@ func (f *folder) pull() (success bool, err error) {
 		l.Debugln("Skipping pull of", f.Description(), "due to folder error:", err)
 		return false, err
 	}
+	f.setError(nil)
 
 	success, err = f.puller.pull()
 
@@ -431,10 +431,6 @@ func (f *folder) scanSubdirs(subDirs []string) error {
 
 	err := f.getHealthErrorAndLoadIgnores()
 	if err != nil {
-		// If there is a health error we set it as the folder error. We do not
-		// clear the folder error if there is no health error, as there might be
-		// an *other* folder error (failed to load ignores, for example). Hence
-		// we do not use the CheckHealth() convenience function here.
 		return err
 	}
 	f.setError(nil)


### PR DESCRIPTION
We check health before acquiring the semaphore, but without loading ignores, then get the semaphore, and then check again with loading ignores (to get up-to-date info in case acquiring took a while). However we also clear the folder error after the check without ignores, which then immediately gets set again -> flip-flopperoo. 