### PR TITLE
lib: Get rid of buggy filesystem wrapping

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -457,7 +457,7 @@ func TestIssue1262(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	actual := cfg.Folders()["test"].Filesystem().URI()
+	actual := cfg.Folders()["test"].Filesystem(nil).URI()
 	expected := `e:\`
 
 	if actual != expected {
@@ -494,7 +494,7 @@ func TestFolderPath(t *testing.T) {
 		Path: "~/tmp",
 	}
 
-	realPath := folder.Filesystem().URI()
+	realPath := folder.Filesystem(nil).URI()
 	if !filepath.IsAbs(realPath) {
 		t.Error(realPath, "should be absolute")
 	}

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -43,13 +43,12 @@ func (f FolderConfiguration) Copy() FolderConfiguration {
 	return c
 }
 
-func (f FolderConfiguration) Filesystem() fs.Filesystem {
-	return f.MtimeFilesystem(nil)
-}
-
-func (f FolderConfiguration) MtimeFilesystem(fset *db.FileSet) fs.Filesystem {
+// Filesystem creates a filesystem for the path and options of this folder.
+// The fset parameter may be nil, in which case no mtime handling on top of
+// the fileystem is provided.
+func (f FolderConfiguration) Filesystem(fset *db.FileSet) fs.Filesystem {
 	// This is intentionally not a pointer method, because things like
-	// cfg.Folders["default"].Filesystem() should be valid.
+	// cfg.Folders["default"].Filesystem(nil) should be valid.
 	opts := make([]fs.Option, 0, 3)
 	if f.FilesystemType == fs.FilesystemTypeBasic && f.JunctionsAsDirs {
 		opts = append(opts, new(fs.OptionJunctionsAsDirs))
@@ -66,7 +65,7 @@ func (f FolderConfiguration) MtimeFilesystem(fset *db.FileSet) fs.Filesystem {
 func (f FolderConfiguration) ModTimeWindow() time.Duration {
 	dur := time.Duration(f.RawModTimeWindowS) * time.Second
 	if f.RawModTimeWindowS < 1 && runtime.GOOS == "android" {
-		if usage, err := disk.Usage(f.Filesystem().URI()); err != nil {
+		if usage, err := disk.Usage(f.Filesystem(nil).URI()); err != nil {
 			dur = 2 * time.Second
 			l.Debugf(`Detecting FS at "%v" on android: Setting mtime window to 2s: err == "%v"`, f.Path, err)
 		} else if strings.HasPrefix(strings.ToLower(usage.Fstype), "ext2") || strings.HasPrefix(strings.ToLower(usage.Fstype), "ext3") || strings.HasPrefix(strings.ToLower(usage.Fstype), "ext4") {
@@ -96,7 +95,7 @@ func (f *FolderConfiguration) CreateMarker() error {
 		// begin with.
 		permBits = 0700
 	}
-	fs := f.Filesystem()
+	fs := f.Filesystem(nil)
 	err := fs.Mkdir(DefaultMarkerName, permBits)
 	if err != nil {
 		return err
@@ -113,7 +112,7 @@ func (f *FolderConfiguration) CreateMarker() error {
 
 // CheckPath returns nil if the folder root exists and contains the marker file
 func (f *FolderConfiguration) CheckPath() error {
-	fi, err := f.Filesystem().Stat(".")
+	fi, err := f.Filesystem(nil).Stat(".")
 	if err != nil {
 		if !fs.IsNotExist(err) {
 			return err
@@ -131,7 +130,7 @@ func (f *FolderConfiguration) CheckPath() error {
 		return ErrPathNotDirectory
 	}
 
-	_, err = f.Filesystem().Stat(f.MarkerName)
+	_, err = f.Filesystem(nil).Stat(f.MarkerName)
 	if err != nil {
 		if !fs.IsNotExist(err) {
 			return err
@@ -152,7 +151,7 @@ func (f *FolderConfiguration) CreateRoot() (err error) {
 		permBits = 0700
 	}
 
-	filesystem := f.Filesystem()
+	filesystem := f.Filesystem(nil)
 
 	if _, err = filesystem.Stat("."); fs.IsNotExist(err) {
 		err = filesystem.MkdirAll(".", permBits)
@@ -263,7 +262,7 @@ func (f *FolderConfiguration) CheckAvailableSpace(req uint64) error {
 	if val <= 0 {
 		return nil
 	}
-	fs := f.Filesystem()
+	fs := f.Filesystem(nil)
 	usage, err := fs.Usage(".")
 	if err != nil {
 		return nil

--- a/lib/config/migrations.go
+++ b/lib/config/migrations.go
@@ -199,7 +199,7 @@ func migrateToConfigV23(cfg *Configuration) {
 	// marker name in later versions.
 
 	for i := range cfg.Folders {
-		fs := cfg.Folders[i].Filesystem()
+		fs := cfg.Folders[i].Filesystem(nil)
 		// Invalid config posted, or tests.
 		if fs == nil {
 			continue
@@ -235,18 +235,18 @@ func migrateToConfigV21(cfg *Configuration) {
 		switch folder.Versioning.Type {
 		case "simple", "trashcan":
 			// Clean out symlinks in the known place
-			cleanSymlinks(folder.Filesystem(), ".stversions")
+			cleanSymlinks(folder.Filesystem(nil), ".stversions")
 		case "staggered":
 			versionDir := folder.Versioning.Params["versionsPath"]
 			if versionDir == "" {
 				// default place
-				cleanSymlinks(folder.Filesystem(), ".stversions")
+				cleanSymlinks(folder.Filesystem(nil), ".stversions")
 			} else if filepath.IsAbs(versionDir) {
 				// absolute
 				cleanSymlinks(fs.NewFilesystem(fs.FilesystemTypeBasic, versionDir), ".")
 			} else {
 				// relative to folder
-				cleanSymlinks(folder.Filesystem(), versionDir)
+				cleanSymlinks(folder.Filesystem(nil), versionDir)
 			}
 		}
 	}

--- a/lib/db/set.go
+++ b/lib/db/set.go
@@ -403,8 +403,8 @@ func (s *FileSet) SetIndexID(device protocol.DeviceID, id protocol.IndexID) {
 	}
 }
 
-func (s *FileSet) MtimeFS(filesystem fs.Filesystem) fs.Filesystem {
-	opStr := fmt.Sprintf("%s MtimeFS()", s.folder)
+func (s *FileSet) MtimeOption() fs.Option {
+	opStr := fmt.Sprintf("%s MtimeOption()", s.folder)
 	l.Debugf(opStr)
 	prefix, err := s.db.keyer.GenerateMtimesKey(nil, []byte(s.folder))
 	if backend.IsClosed(err) {
@@ -413,7 +413,7 @@ func (s *FileSet) MtimeFS(filesystem fs.Filesystem) fs.Filesystem {
 		fatalError(err, opStr, s.db)
 	}
 	kv := NewNamespacedKV(s.db, string(prefix))
-	return fs.NewMtimeFS(filesystem, kv)
+	return fs.NewMtimeOption(kv)
 }
 
 func (s *FileSet) ListDevices() []protocol.DeviceID {

--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -27,12 +27,13 @@ var (
 
 type OptionJunctionsAsDirs struct{}
 
-func (o *OptionJunctionsAsDirs) apply(fs Filesystem) {
+func (o *OptionJunctionsAsDirs) apply(fs Filesystem) Filesystem {
 	if basic, ok := fs.(*BasicFilesystem); !ok {
 		l.Warnln("WithJunctionsAsDirs must only be used with FilesystemTypeBasic")
 	} else {
 		basic.junctionsAsDirs = true
 	}
+	return fs
 }
 
 func (o *OptionJunctionsAsDirs) String() string {

--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -123,21 +123,27 @@ func (r *caseFilesystemRegistry) cleaner() {
 
 var globalCaseFilesystemRegistry = caseFilesystemRegistry{fss: make(map[fskey]*caseFilesystem)}
 
-// caseFilesystem is a BasicFilesystem with additional checks to make a
-// potentially case insensitive underlying FS behave like it's case-sensitive.
-type caseFilesystem struct {
-	Filesystem
-	realCaser
-}
-
-// NewCaseFilesystem ensures that the given, potentially case-insensitive filesystem
+// OptionDetectCaseConflicts ensures that the potentially case-insensitive filesystem
 // behaves like a case-sensitive filesystem. Meaning that it takes into account
 // the real casing of a path and returns ErrCaseConflict if the given path differs
 // from the real path. It is safe to use with any filesystem, i.e. also a
 // case-sensitive one. However it will add some overhead and thus shouldn't be
 // used if the filesystem is known to already behave case-sensitively.
-func NewCaseFilesystem(fs Filesystem) Filesystem {
-	return wrapFilesystem(fs, globalCaseFilesystemRegistry.get)
+type OptionDetectCaseConflicts struct{}
+
+func (o *OptionDetectCaseConflicts) apply(fs Filesystem) Filesystem {
+	return globalCaseFilesystemRegistry.get(fs)
+}
+
+func (o *OptionDetectCaseConflicts) String() string {
+	return "detectCaseConflicts"
+}
+
+// caseFilesystem is a BasicFilesystem with additional checks to make a
+// potentially case insensitive underlying FS behave like it's case-sensitive.
+type caseFilesystem struct {
+	Filesystem
+	realCaser
 }
 
 func (f *caseFilesystem) Chmod(name string, mode FileMode) error {

--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -34,8 +34,12 @@ func TestRealCase(t *testing.T) {
 	})
 }
 
+func newCaseFilesystem(fsys Filesystem) *caseFilesystem {
+	return globalCaseFilesystemRegistry.get(fsys).(*caseFilesystem)
+}
+
 func testRealCase(t *testing.T, fsys Filesystem) {
-	testFs := NewCaseFilesystem(fsys).(*caseFilesystem)
+	testFs := newCaseFilesystem(fsys)
 	comps := []string{"Foo", "bar", "BAZ", "bAs"}
 	path := filepath.Join(comps...)
 	testFs.MkdirAll(filepath.Join(comps[:len(comps)-1]...), 0777)
@@ -86,7 +90,7 @@ func TestRealCaseSensitive(t *testing.T) {
 }
 
 func testRealCaseSensitive(t *testing.T, fsys Filesystem) {
-	testFs := NewCaseFilesystem(fsys).(*caseFilesystem)
+	testFs := newCaseFilesystem(fsys)
 
 	names := make([]string, 2)
 	names[0] = "foo"
@@ -139,7 +143,7 @@ func testCaseFSStat(t *testing.T, fsys Filesystem) {
 		sensitive = false
 	}
 
-	testFs := NewCaseFilesystem(fsys)
+	testFs := newCaseFilesystem(fsys)
 	_, err = testFs.Stat("FOO")
 	if sensitive {
 		if IsNotExist(err) {

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -223,6 +223,7 @@ func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem
 			i++
 		}
 	}
+	opts = opts[:i]
 
 	var fs Filesystem
 	switch fsType {

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -246,7 +246,7 @@ func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem
 	}
 
 	// mtime handling should happen inside walking, as filesystem calls while
-	// walking should be mtime-resoved too
+	// walking should be mtime-resolved too
 	if mtimeOpt != nil {
 		fs = mtimeOpt.apply(fs)
 	}

--- a/lib/fs/mtimefs.go
+++ b/lib/fs/mtimefs.go
@@ -33,20 +33,34 @@ func WithCaseInsensitivity(v bool) MtimeFSOption {
 	}
 }
 
-// NewMtimeFS returns a filesystem with nanosecond mtime precision, regardless
+// OptionMtime returns a filesystem with nanosecond mtime precision, regardless
 // of what shenanigans the underlying filesystem gets up to.
-func NewMtimeFS(fs Filesystem, db database, options ...MtimeFSOption) Filesystem {
-	return wrapFilesystem(fs, func(underlying Filesystem) Filesystem {
-		f := &mtimeFS{
-			Filesystem: underlying,
-			chtimes:    underlying.Chtimes, // for mocking it out in the tests
-			db:         db,
-		}
-		for _, opt := range options {
-			opt(f)
-		}
-		return f
-	})
+type optionMtime struct {
+	db      database
+	options []MtimeFSOption
+}
+
+func NewMtimeOption(db database, options ...MtimeFSOption) Option {
+	return &optionMtime{
+		db:      db,
+		options: options,
+	}
+}
+
+func (o *optionMtime) apply(fs Filesystem) Filesystem {
+	f := &mtimeFS{
+		Filesystem: fs,
+		chtimes:    fs.Chtimes, // for mocking it out in the tests
+		db:         o.db,
+	}
+	for _, opt := range o.options {
+		opt(f)
+	}
+	return f
+}
+
+func (_ *optionMtime) String() string {
+	return "mtime"
 }
 
 func (f *mtimeFS) Chtimes(name string, atime, mtime time.Time) error {
@@ -102,25 +116,6 @@ func (f *mtimeFS) Lstat(name string) (FileInfo, error) {
 	}
 
 	return info, nil
-}
-
-func (f *mtimeFS) Walk(root string, walkFn WalkFunc) error {
-	return f.Filesystem.Walk(root, func(path string, info FileInfo, err error) error {
-		if info != nil {
-			mtimeMapping, loadErr := f.load(path)
-			if loadErr != nil && err == nil {
-				// The iterator gets to deal with the error
-				err = loadErr
-			}
-			if mtimeMapping.Real == info.ModTime() {
-				info = mtimeFileInfo{
-					FileInfo: info,
-					mtime:    mtimeMapping.Virtual,
-				}
-			}
-		}
-		return walkFn(path, info, err)
-	})
 }
 
 func (f *mtimeFS) Create(name string) (File, error) {

--- a/lib/fs/mtimefs.go
+++ b/lib/fs/mtimefs.go
@@ -33,13 +33,13 @@ func WithCaseInsensitivity(v bool) MtimeFSOption {
 	}
 }
 
-// OptionMtime returns a filesystem with nanosecond mtime precision, regardless
-// of what shenanigans the underlying filesystem gets up to.
 type optionMtime struct {
 	db      database
 	options []MtimeFSOption
 }
 
+// NewMtimeOption makes any filesystem provide nanosecond mtime precision,
+// regardless of what shenanigans the underlying filesystem gets up to.
 func NewMtimeOption(db database, options ...MtimeFSOption) Option {
 	return &optionMtime{
 		db:      db,

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -108,7 +108,7 @@ func newFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, cfg conf
 		shortID:       model.shortID,
 		fset:          fset,
 		ignores:       ignores,
-		mtimefs:       fset.MtimeFS(cfg.Filesystem()),
+		mtimefs:       cfg.MtimeFilesystem(fset),
 		modTimeWindow: cfg.ModTimeWindow(),
 		done:          make(chan struct{}),
 

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -108,7 +108,7 @@ func newFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, cfg conf
 		shortID:       model.shortID,
 		fset:          fset,
 		ignores:       ignores,
-		mtimefs:       cfg.MtimeFilesystem(fset),
+		mtimefs:       cfg.Filesystem(fset),
 		modTimeWindow: cfg.ModTimeWindow(),
 		done:          make(chan struct{}),
 
@@ -1001,7 +1001,7 @@ func (f *folder) monitorWatch(ctx context.Context) {
 	for {
 		select {
 		case <-failTimer.C:
-			eventChan, errChan, err = f.Filesystem().Watch(".", f.ignores, ctx, f.IgnorePerms)
+			eventChan, errChan, err = f.mtimefs.Watch(".", f.ignores, ctx, f.IgnorePerms)
 			// We do this once per minute initially increased to
 			// max one hour in case of repeat failures.
 			f.scanOnWatchErr()

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -28,7 +28,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 
 	m, f, wcfgCancel := setupROFolder(t)
 	defer wcfgCancel()
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
 	addFakeConn(m, device1, f.ID)
 
@@ -110,7 +110,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 
 	m, f, wcfgCancel := setupROFolder(t)
 	defer wcfgCancel()
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
 	addFakeConn(m, device1, f.ID)
 
@@ -200,7 +200,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 
 	m, f, wcfgCancel := setupROFolder(t)
 	defer wcfgCancel()
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
 	addFakeConn(m, device1, f.ID)
 
@@ -270,7 +270,7 @@ func TestRecvOnlyDeletedRemoteDrop(t *testing.T) {
 
 	m, f, wcfgCancel := setupROFolder(t)
 	defer wcfgCancel()
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
 	addFakeConn(m, device1, f.ID)
 
@@ -335,7 +335,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 
 	m, f, wcfgCancel := setupROFolder(t)
 	defer wcfgCancel()
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
 	addFakeConn(m, device1, f.ID)
 
@@ -425,7 +425,7 @@ func TestRecvOnlyRevertOwnID(t *testing.T) {
 
 	m, f, wcfgCancel := setupROFolder(t)
 	defer wcfgCancel()
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
 	addFakeConn(m, device1, f.ID)
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1264,7 +1264,7 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 	// Hope that it's usually in the same folder, so start with that one.
 	folders := []string{f.folderID}
 	for folder, cfg := range f.model.cfg.Folders() {
-		folderFilesystems[folder] = cfg.Filesystem()
+		folderFilesystems[folder] = cfg.Filesystem(nil)
 		if folder != f.folderID {
 			folders = append(folders, folder)
 		}

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -109,7 +109,7 @@ func setupSendReceiveFolder(t testing.TB, files ...protocol.FileInfo) (*testMode
 func cleanupSRFolder(f *sendReceiveFolder, m *testModel, wrapperCancel context.CancelFunc) {
 	wrapperCancel()
 	os.Remove(m.cfg.ConfigPath())
-	os.RemoveAll(f.Filesystem().URI())
+	os.RemoveAll(f.Filesystem(nil).URI())
 }
 
 // Layout of the files: (indexes from the above array)
@@ -172,7 +172,7 @@ func TestHandleFileWithTemp(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t, existingFile)
 	defer cleanupSRFolder(f, m, wcfgCancel)
 
-	if _, err := prepareTmpFile(f.Filesystem()); err != nil {
+	if _, err := prepareTmpFile(f.Filesystem(nil)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -230,7 +230,7 @@ func TestCopierFinder(t *testing.T) {
 
 			defer cleanupSRFolder(f, m, wcfgCancel)
 
-			if _, err := prepareTmpFile(f.Filesystem()); err != nil {
+			if _, err := prepareTmpFile(f.Filesystem(nil)); err != nil {
 				t.Fatal(err)
 			}
 
@@ -290,7 +290,7 @@ func TestCopierFinder(t *testing.T) {
 			}
 
 			// Verify that the fetched blocks have actually been written to the temp file
-			blks, err := scanner.HashFile(context.TODO(), f.Filesystem(), tempFile, protocol.MinBlockSize, nil, false)
+			blks, err := scanner.HashFile(context.TODO(), f.Filesystem(nil), tempFile, protocol.MinBlockSize, nil, false)
 			if err != nil {
 				t.Log(err)
 			}
@@ -308,7 +308,7 @@ func TestWeakHash(t *testing.T) {
 	// Setup the model/pull environment
 	model, fo, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(fo, model, wcfgCancel)
-	ffs := fo.Filesystem()
+	ffs := fo.Filesystem(nil)
 
 	tempFile := fs.TempName("weakhash")
 	var shift int64 = 10
@@ -673,7 +673,7 @@ func TestDeregisterOnFailInPull(t *testing.T) {
 func TestIssue3164(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	tmpDir := ffs.URI()
 
 	ignDir := filepath.Join("issue3164", "oktodelete")
@@ -764,7 +764,7 @@ func TestDiffEmpty(t *testing.T) {
 func TestDeleteIgnorePerms(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 	f.IgnorePerms = true
 
 	name := "deleteIgnorePerms"
@@ -806,7 +806,7 @@ func TestCopyOwner(t *testing.T) {
 	f.folder.FolderConfiguration.CopyOwnershipFromParent = true
 
 	f.fset = newFileSet(t, f.ID, m.db)
-	f.mtimefs = f.MtimeFilesystem(f.fset)
+	f.mtimefs = f.Filesystem(f.fset)
 
 	// Create a parent dir with a certain owner/group.
 
@@ -905,7 +905,7 @@ func TestCopyOwner(t *testing.T) {
 func TestSRConflictReplaceFileByDir(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 
 	name := "foo"
 
@@ -937,7 +937,7 @@ func TestSRConflictReplaceFileByDir(t *testing.T) {
 func TestSRConflictReplaceFileByLink(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 
 	name := "foo"
 
@@ -970,7 +970,7 @@ func TestSRConflictReplaceFileByLink(t *testing.T) {
 func TestDeleteBehindSymlink(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 
 	destDir := createTmpDir()
 	defer os.RemoveAll(destDir)
@@ -1063,7 +1063,7 @@ func TestPullCtxCancel(t *testing.T) {
 func TestPullDeleteUnscannedDir(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 
 	dir := "foobar"
 	must(t, ffs.MkdirAll(dir, 0777))
@@ -1092,7 +1092,7 @@ func TestPullDeleteUnscannedDir(t *testing.T) {
 func TestPullCaseOnlyPerformFinish(t *testing.T) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 
 	name := "foo"
 	contents := []byte("contents")
@@ -1153,7 +1153,7 @@ func TestPullCaseOnlySymlink(t *testing.T) {
 func testPullCaseOnlyDirOrSymlink(t *testing.T, dir bool) {
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer cleanupSRFolder(f, m, wcfgCancel)
-	ffs := f.Filesystem()
+	ffs := f.Filesystem(nil)
 
 	name := "foo"
 	if dir {

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -806,7 +806,7 @@ func TestCopyOwner(t *testing.T) {
 	f.folder.FolderConfiguration.CopyOwnershipFromParent = true
 
 	f.fset = newFileSet(t, f.ID, m.db)
-	f.mtimefs = f.fset.MtimeFS(f.Filesystem())
+	f.mtimefs = f.MtimeFilesystem(f.fset)
 
 	// Create a parent dir with a certain owner/group.
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2007,7 +2007,7 @@ func (m *model) GetMtimeMapping(folder string, file string) (fs.MtimeMapping, er
 	if !ok {
 		return fs.MtimeMapping{}, ErrFolderMissing
 	}
-	return fs.GetMtimeMapping(ffs.MtimeFS(fcfg.Filesystem()), file)
+	return fs.GetMtimeMapping(fcfg.MtimeFilesystem(ffs), file)
 }
 
 // Connection returns the current connection for device, and a boolean whether a connection was found.

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -334,7 +334,7 @@ func (m *model) StartDeadlockDetector(timeout time.Duration) {
 
 // Need to hold lock on m.fmut when calling this.
 func (m *model) addAndStartFolderLocked(cfg config.FolderConfiguration, fset *db.FileSet, cacheIgnoredFiles bool) {
-	ignores := ignore.New(cfg.Filesystem(), ignore.WithCache(cacheIgnoredFiles))
+	ignores := ignore.New(cfg.Filesystem(nil), ignore.WithCache(cacheIgnoredFiles))
 	if cfg.Type != config.FolderTypeReceiveEncrypted {
 		if err := ignores.Load(".stignore"); err != nil && !fs.IsNotExist(err) {
 			l.Warnln("Loading ignores:", err)
@@ -398,7 +398,7 @@ func (m *model) addAndStartFolderLockedWithIgnores(cfg config.FolderConfiguratio
 	}
 
 	// These are our metadata files, and they should always be hidden.
-	ffs := cfg.Filesystem()
+	ffs := cfg.Filesystem(nil)
 	_ = ffs.Hide(config.DefaultMarkerName)
 	_ = ffs.Hide(".stversions")
 	_ = ffs.Hide(".stignore")
@@ -430,7 +430,7 @@ func (m *model) warnAboutOverwritingProtectedFiles(cfg config.FolderConfiguratio
 	}
 
 	// This is a bit of a hack.
-	ffs := cfg.Filesystem()
+	ffs := cfg.Filesystem(nil)
 	if ffs.Type() != fs.FilesystemTypeBasic {
 		return
 	}
@@ -480,7 +480,7 @@ func (m *model) removeFolder(cfg config.FolderConfiguration) {
 	if isPathUnique {
 		// Remove (if empty and removable) or move away (if non-empty or
 		// otherwise not removable) Syncthing-specific marker files.
-		fs := cfg.Filesystem()
+		fs := cfg.Filesystem(nil)
 		if err := fs.Remove(config.DefaultMarkerName); err != nil {
 			moved := config.DefaultMarkerName + time.Now().Format(".removed-20060102-150405")
 			_ = fs.Rename(config.DefaultMarkerName, moved)
@@ -1841,7 +1841,7 @@ func (m *model) Request(deviceID protocol.DeviceID, folder, name string, blockNo
 	// Grab the FS after limiting, as it causes I/O and we want to minimize
 	// the race time between the symlink check and the read.
 
-	folderFs := folderCfg.Filesystem()
+	folderFs := folderCfg.Filesystem(nil)
 
 	if err := osutil.TraversesSymlink(folderFs, filepath.Dir(name)); err != nil {
 		l.Debugf("%v REQ(in) traversal check: %s - %s: %q / %q o=%d s=%d", m, err, deviceID, folder, name, offset, size)
@@ -2007,7 +2007,7 @@ func (m *model) GetMtimeMapping(folder string, file string) (fs.MtimeMapping, er
 	if !ok {
 		return fs.MtimeMapping{}, ErrFolderMissing
 	}
-	return fs.GetMtimeMapping(fcfg.MtimeFilesystem(ffs), file)
+	return fs.GetMtimeMapping(fcfg.Filesystem(ffs), file)
 }
 
 // Connection returns the current connection for device, and a boolean whether a connection was found.
@@ -2041,7 +2041,7 @@ func (m *model) LoadIgnores(folder string) ([]string, []string, error) {
 	}
 
 	if !ignoresOk {
-		ignores = ignore.New(cfg.Filesystem())
+		ignores = ignore.New(cfg.Filesystem(nil))
 	}
 
 	err := ignores.Load(".stignore")
@@ -2096,7 +2096,7 @@ func (m *model) setIgnores(cfg config.FolderConfiguration, content []string) err
 		return err
 	}
 
-	if err := ignore.WriteIgnores(cfg.Filesystem(), ".stignore", content); err != nil {
+	if err := ignore.WriteIgnores(cfg.Filesystem(nil), ".stignore", content); err != nil {
 		l.Warnln("Saving .stignore:", err)
 		return err
 	}
@@ -3229,7 +3229,7 @@ type storedEncryptionToken struct {
 }
 
 func readEncryptionToken(cfg config.FolderConfiguration) ([]byte, error) {
-	fd, err := cfg.Filesystem().Open(encryptionTokenPath(cfg))
+	fd, err := cfg.Filesystem(nil).Open(encryptionTokenPath(cfg))
 	if err != nil {
 		return nil, err
 	}
@@ -3243,7 +3243,7 @@ func readEncryptionToken(cfg config.FolderConfiguration) ([]byte, error) {
 
 func writeEncryptionToken(token []byte, cfg config.FolderConfiguration) error {
 	tokenName := encryptionTokenPath(cfg)
-	fd, err := cfg.Filesystem().OpenFile(tokenName, fs.OptReadWrite|fs.OptCreate, 0666)
+	fd, err := cfg.Filesystem(nil).OpenFile(tokenName, fs.OptReadWrite|fs.OptCreate, 0666)
 	if err != nil {
 		return err
 	}

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -32,7 +32,7 @@ func TestRequestSimple(t *testing.T) {
 
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	// We listen for incoming index updates and trigger when we see one for
@@ -79,7 +79,7 @@ func TestSymlinkTraversalRead(t *testing.T) {
 
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem().URI())
+	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem(nil).URI())
 
 	// We listen for incoming index updates and trigger when we see one for
 	// the expected test file.
@@ -122,7 +122,7 @@ func TestSymlinkTraversalWrite(t *testing.T) {
 
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem().URI())
+	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem(nil).URI())
 
 	// We listen for incoming index updates and trigger when we see one for
 	// the expected names.
@@ -181,7 +181,7 @@ func TestRequestCreateTmpSymlink(t *testing.T) {
 
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem().URI())
+	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem(nil).URI())
 
 	// We listen for incoming index updates and trigger when we see one for
 	// the expected test file.
@@ -224,7 +224,7 @@ func TestRequestVersioningSymlinkAttack(t *testing.T) {
 	w, fcfg, wCancel := tmpDefaultWrapper()
 	defer wCancel()
 	defer func() {
-		os.RemoveAll(fcfg.Filesystem().URI())
+		os.RemoveAll(fcfg.Filesystem(nil).URI())
 		os.Remove(w.ConfigPath())
 	}()
 
@@ -301,7 +301,7 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 	w, wCancel := createTmpWrapper(defaultCfgWrapper.RawCopy())
 	defer wCancel()
 	fcfg := testFolderConfigTmp()
-	fss := fcfg.Filesystem()
+	fss := fcfg.Filesystem(nil)
 	fcfg.Type = ft
 	setFolder(t, w, fcfg)
 	m := setupModel(t, w)
@@ -430,7 +430,7 @@ func pullInvalidIgnored(t *testing.T, ft config.FolderType) {
 func TestIssue4841(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem().URI())
+	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem(nil).URI())
 
 	received := make(chan []protocol.FileInfo)
 	fc.setIndexFn(func(_ context.Context, _ string, fs []protocol.FileInfo) error {
@@ -478,7 +478,7 @@ func TestIssue4841(t *testing.T) {
 func TestRescanIfHaveInvalidContent(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	payload := []byte("hello")
@@ -544,7 +544,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 func TestParentDeletion(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	testFs := fcfg.Filesystem()
+	testFs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, testFs.URI())
 
 	parent := "foo"
@@ -623,7 +623,7 @@ func TestRequestSymlinkWindows(t *testing.T) {
 
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem().URI())
+	defer cleanupModelAndRemoveDir(m, fcfg.Filesystem(nil).URI())
 
 	received := make(chan []protocol.FileInfo)
 	fc.setIndexFn(func(_ context.Context, folder string, fs []protocol.FileInfo) error {
@@ -691,7 +691,7 @@ func equalContents(path string, contents []byte) error {
 func TestRequestRemoteRenameChanged(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	tmpDir := tfs.URI()
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
@@ -825,7 +825,7 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 func TestRequestRemoteRenameConflict(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	tmpDir := tfs.URI()
 	defer cleanupModelAndRemoveDir(m, tmpDir)
 
@@ -916,7 +916,7 @@ func TestRequestRemoteRenameConflict(t *testing.T) {
 func TestRequestDeleteChanged(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	done := make(chan struct{})
@@ -984,7 +984,7 @@ func TestRequestDeleteChanged(t *testing.T) {
 func TestNeedFolderFiles(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	tmpDir := tfs.URI()
 	defer cleanupModelAndRemoveDir(m, tmpDir)
 
@@ -1032,7 +1032,7 @@ func TestIgnoreDeleteUnignore(t *testing.T) {
 	w, fcfg, wCancel := tmpDefaultWrapper()
 	defer wCancel()
 	m := setupModel(t, w)
-	fss := fcfg.Filesystem()
+	fss := fcfg.Filesystem(nil)
 	tmpDir := fss.URI()
 	defer cleanupModelAndRemoveDir(m, tmpDir)
 
@@ -1127,7 +1127,7 @@ func TestIgnoreDeleteUnignore(t *testing.T) {
 func TestRequestLastFileProgress(t *testing.T) {
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	done := make(chan struct{})
@@ -1162,7 +1162,7 @@ func TestRequestIndexSenderPause(t *testing.T) {
 
 	m, fc, fcfg, wcfgCancel := setupModelWithConnection(t)
 	defer wcfgCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	indexChan := make(chan []protocol.FileInfo)
@@ -1275,7 +1275,7 @@ func TestRequestIndexSenderPause(t *testing.T) {
 func TestRequestIndexSenderClusterConfigBeforeStart(t *testing.T) {
 	w, fcfg, wCancel := tmpDefaultWrapper()
 	defer wCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	dir1 := "foo"
 	dir2 := "bar"
 
@@ -1342,7 +1342,7 @@ func TestRequestReceiveEncrypted(t *testing.T) {
 
 	w, fcfg, wCancel := tmpDefaultWrapper()
 	defer wCancel()
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	fcfg.Type = config.FolderTypeReceiveEncrypted
 	setFolder(t, w, fcfg)
 
@@ -1450,7 +1450,7 @@ func TestRequestGlobalInvalidToValid(t *testing.T) {
 	must(t, err)
 	waiter.Wait()
 	addFakeConn(m, device2, fcfg.ID)
-	tfs := fcfg.Filesystem()
+	tfs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
 	indexChan := make(chan []protocol.FileInfo, 1)

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -40,7 +40,7 @@ func init() {
 	defaultCfgWrapper, defaultCfgWrapperCancel = createTmpWrapper(config.New(myID))
 
 	defaultFolderConfig = testFolderConfig("testdata")
-	defaultFs = defaultFolderConfig.Filesystem()
+	defaultFs = defaultFolderConfig.Filesystem(nil)
 
 	waiter, _ := defaultCfgWrapper.Modify(func(cfg *config.Configuration) {
 		cfg.SetDevice(newDeviceConfiguration(cfg.Defaults.Device, device1, "device1"))
@@ -308,7 +308,7 @@ func folderIgnoresAlwaysReload(t testing.TB, m *testModel, fcfg config.FolderCon
 	t.Helper()
 	m.removeFolder(fcfg)
 	fset := newFileSet(t, fcfg.ID, m.db)
-	ignores := ignore.New(fcfg.Filesystem(), ignore.WithCache(true), ignore.WithChangeDetector(newAlwaysChanged()))
+	ignores := ignore.New(fcfg.Filesystem(nil), ignore.WithCache(true), ignore.WithChangeDetector(newAlwaysChanged()))
 	m.fmut.Lock()
 	m.addAndStartFolderLockedWithIgnores(fcfg, fset, ignores)
 	m.fmut.Unlock()

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -38,10 +38,14 @@ type testfile struct {
 
 type testfileList []testfile
 
+const (
+	testFsType     = fs.FilesystemTypeBasic
+	testFsLocation = "testdata"
+)
+
 var (
-	testFs     fs.Filesystem
-	testFsType = fs.FilesystemTypeBasic
-	testdata   = testfileList{
+	testFs   fs.Filesystem
+	testdata = testfileList{
 		{"afile", 4, "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"},
 		{"dir1", 128, ""},
 		{filepath.Join("dir1", "dfile"), 5, "49ae93732fcf8d63fe1cce759664982dbd5b23161f007dba8561862adc96d063"},
@@ -58,7 +62,7 @@ func init() {
 	// potentially taking down the box...
 	rdebug.SetMaxStack(10 * 1 << 20)
 
-	testFs = fs.NewFilesystem(fs.FilesystemTypeBasic, "testdata")
+	testFs = fs.NewFilesystem(testFsType, testFsLocation)
 }
 
 func TestWalkSub(t *testing.T) {
@@ -258,7 +262,7 @@ func TestNormalizationDarwinCaseFS(t *testing.T) {
 		return
 	}
 
-	testFs := fs.NewCaseFilesystem(testFs)
+	testFs := fs.NewFilesystem(testFsType, testFsLocation, new(fs.OptionDetectCaseConflicts))
 
 	testFs.RemoveAll("normalization")
 	defer testFs.RemoveAll("normalization")

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -41,7 +41,7 @@ func newExternal(cfg config.FolderConfiguration) Versioner {
 
 	s := external{
 		command:    command,
-		filesystem: cfg.Filesystem(),
+		filesystem: cfg.Filesystem(nil),
 	}
 
 	l.Debugf("instantiated %#v", s)

--- a/lib/versioner/simple.go
+++ b/lib/versioner/simple.go
@@ -40,7 +40,7 @@ func newSimple(cfg config.FolderConfiguration) Versioner {
 	s := simple{
 		keep:            keep,
 		cleanoutDays:    cleanoutDays,
-		folderFs:        cfg.Filesystem(),
+		folderFs:        cfg.Filesystem(nil),
 		versionsFs:      versionerFsFromFolderCfg(cfg),
 		copyRangeMethod: cfg.CopyRangeMethod,
 	}

--- a/lib/versioner/simple_test.go
+++ b/lib/versioner/simple_test.go
@@ -70,7 +70,7 @@ func TestSimpleVersioningVersionCount(t *testing.T) {
 			},
 		},
 	}
-	fs := cfg.Filesystem()
+	fs := cfg.Filesystem(nil)
 
 	v := newSimple(cfg)
 

--- a/lib/versioner/staggered.go
+++ b/lib/versioner/staggered.go
@@ -44,7 +44,7 @@ func newStaggered(cfg config.FolderConfiguration) Versioner {
 	versionsFs := versionerFsFromFolderCfg(cfg)
 
 	s := &staggered{
-		folderFs:   cfg.Filesystem(),
+		folderFs:   cfg.Filesystem(nil),
 		versionsFs: versionsFs,
 		interval: [4]interval{
 			{30, 60 * 60},                     // first hour -> 30 sec between versions

--- a/lib/versioner/trashcan.go
+++ b/lib/versioner/trashcan.go
@@ -33,7 +33,7 @@ func newTrashcan(cfg config.FolderConfiguration) Versioner {
 	// On error we default to 0, "do not clean out the trash can"
 
 	s := &trashcan{
-		folderFs:        cfg.Filesystem(),
+		folderFs:        cfg.Filesystem(nil),
 		versionsFs:      versionerFsFromFolderCfg(cfg),
 		cleanoutDays:    cleanoutDays,
 		copyRangeMethod: cfg.CopyRangeMethod,

--- a/lib/versioner/trashcan_test.go
+++ b/lib/versioner/trashcan_test.go
@@ -38,7 +38,7 @@ func TestTrashcanArchiveRestoreSwitcharoo(t *testing.T) {
 			FSPath: tmpDir2,
 		},
 	}
-	folderFs := cfg.Filesystem()
+	folderFs := cfg.Filesystem(nil)
 
 	versionsFs := fs.NewFilesystem(fs.FilesystemTypeBasic, tmpDir2)
 

--- a/lib/versioner/util.go
+++ b/lib/versioner/util.go
@@ -256,7 +256,7 @@ func restoreFile(method fs.CopyRangeMethod, src, dst fs.Filesystem, filePath str
 }
 
 func versionerFsFromFolderCfg(cfg config.FolderConfiguration) (versionsFs fs.Filesystem) {
-	folderFs := cfg.Filesystem()
+	folderFs := cfg.Filesystem(nil)
 	if cfg.Versioning.FSPath == "" {
 		versionsFs = fs.NewFilesystem(folderFs.Type(), filepath.Join(folderFs.URI(), ".stversions"))
 	} else if cfg.Versioning.FSType == fs.FilesystemTypeBasic && !filepath.IsAbs(cfg.Versioning.FSPath) {


### PR DESCRIPTION
Investigating https://github.com/syncthing/syncthing/issues/7974 I found that the log-filesystem is incorrectly wrapped if `walkfs` debug facility is used. And fixing that I further noticed case-fs is also badly wrapped: It's outside of `walkFilesystem`, meaning walking doesn't use the case filesystem. Also there's code in `mtimeFS.Walk` to make walk aware of the mtime-ness - I removed that and instead now `walkFilesystem` wraps `mtimeFS`.  All this wrapping after a filesystem is created is ugly and error prone. Thus I removed the separate constructors for case and mtime fs, and instead made those options to `NewFilesystem`. Like that the "correct layering" happens right there in a single constructor, no re-wrapping later on.

So basically the largest part of the diff is just the refactor for mtime/case-fs creation. The functional changes are:

 - Move `caseFilesystem` from outside to inside `walkFilesystem`.
 - Move `mtimeFS` from outside to inside `walkFilesystem`, removing the need for `mtimeFS.Walk`.
 - As a side-effect of the first item: Fs logging now shows the correct caller, instead of the `caseFilesystem` wrapper method.

I have yet to test if this fixes #7974 (I doubt it).