### PR TITLE
lib/db: Constant/unused args and return values, double it.Release

### DIFF
--- a/lib/db/schemaupdater.go
+++ b/lib/db/schemaupdater.go
@@ -841,6 +841,7 @@ func rewriteGlobals(t readWriteTransaction) error {
 		return err
 	}
 	defer it.Release()
+
 	for it.Next() {
 		var vl VersionListDeprecated
 		if err := vl.Unmarshal(it.Value()); err != nil {
@@ -858,10 +859,7 @@ func rewriteGlobals(t readWriteTransaction) error {
 			}
 		}
 
-		newVl, err := convertVersionList(vl)
-		if err != nil {
-			return err
-		}
+		newVl := convertVersionList(vl)
 		if err := t.Put(it.Key(), mustMarshal(&newVl)); err != nil {
 			return err
 		}
@@ -869,11 +867,10 @@ func rewriteGlobals(t readWriteTransaction) error {
 			return err
 		}
 	}
-	it.Release()
 	return it.Error()
 }
 
-func convertVersionList(vl VersionListDeprecated) (VersionList, error) {
+func convertVersionList(vl VersionListDeprecated) VersionList {
 	var newVl VersionList
 	var newPos, oldPos int
 	var lastVersion protocol.Vector
@@ -893,7 +890,7 @@ func convertVersionList(vl VersionListDeprecated) (VersionList, error) {
 	}
 
 	if oldPos == len(vl.Versions) {
-		return newVl, nil
+		return newVl
 	}
 
 	if len(newVl.RawVersions) == 0 {
@@ -923,7 +920,7 @@ outer:
 		newPos++
 	}
 
-	return newVl, nil
+	return newVl
 }
 
 func getGlobalVersionsByKeyBefore11(key []byte, t readOnlyTransaction) (VersionListDeprecated, error) {

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -262,11 +262,9 @@ func (vl *VersionList) update(folder, device []byte, file protocol.FileIntf, t r
 	oldFV = oldFV.copy()
 
 	// Remove ourselves first
-	removedFV, haveRemoved, _, err := vl.pop(device, []byte(file.FileName()))
-	if err == nil {
-		// Find position and insert the file
-		err = vl.insert(folder, device, file, t)
-	}
+	removedFV, haveRemoved, _ := vl.pop(device)
+	// Find position and insert the file
+	err := vl.insert(folder, device, file, t)
 	if err != nil {
 		return FileVersion{}, FileVersion{}, FileVersion{}, false, false, false, err
 	}
@@ -315,28 +313,28 @@ func (vl *VersionList) insertAt(i int, v FileVersion) {
 // pop removes the given device from the VersionList and returns the FileVersion
 // before removing the device, whether it was found/removed at all and whether
 // the global changed in the process.
-func (vl *VersionList) pop(device, name []byte) (FileVersion, bool, bool, error) {
+func (vl *VersionList) pop(device []byte) (FileVersion, bool, bool) {
 	invDevice, i, j, ok := vl.findDevice(device)
 	if !ok {
-		return FileVersion{}, false, false, nil
+		return FileVersion{}, false, false
 	}
 	globalPos := vl.findGlobal()
 
 	if vl.RawVersions[i].deviceCount() == 1 {
 		fv := vl.RawVersions[i]
 		vl.popVersionAt(i)
-		return fv, true, globalPos == i, nil
+		return fv, true, globalPos == i
 	}
 
 	oldFV := vl.RawVersions[i].copy()
 	if invDevice {
 		vl.RawVersions[i].InvalidDevices = popDeviceAt(vl.RawVersions[i].InvalidDevices, j)
-		return oldFV, true, false, nil
+		return oldFV, true, false
 	}
 	vl.RawVersions[i].Devices = popDeviceAt(vl.RawVersions[i].Devices, j)
 	// If the last valid device of the previous global was removed above,
 	// the global changed.
-	return oldFV, true, len(vl.RawVersions[i].Devices) == 0 && globalPos == i, nil
+	return oldFV, true, len(vl.RawVersions[i].Devices) == 0 && globalPos == i
 }
 
 // Get returns a FileVersion that contains the given device and whether it has

--- a/lib/db/transactions.go
+++ b/lib/db/transactions.go
@@ -825,10 +825,7 @@ func (t readWriteTransaction) removeFromGlobal(gk, keyBuf, folder, device, file 
 		return keyBuf, t.Delete(gk)
 	}
 
-	removedFV, haveRemoved, globalChanged, err := fl.pop(device, file)
-	if err != nil {
-		return nil, err
-	}
+	removedFV, haveRemoved, globalChanged := fl.pop(device)
 	if !haveRemoved {
 		// There is no version for the given device
 		return keyBuf, nil


### PR DESCRIPTION
Some minor cleanup to lib/db:

* rewriteGlobals released an iterator twice.
* convertVersionList always returned a nil error.
* VersionList.pop ignored its second argument and always returned a nil error.
* keyer.GeneratePending(Device|Folder)Key were always called with a nil first argument.