### PR TITLE
lib/connections: Make request tests sequential

### DIFF
--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -482,7 +482,7 @@ func TestAPIServiceRequests(t *testing.T) {
 // testHTTPRequest tries the given test case, comparing the result code,
 // content type, and result prefix.
 func testHTTPRequest(t *testing.T, baseURL string, tc httpTestCase, apikey string) {
-	t.Parallel()
+	// Should not be parallelized, as that just causes timeouts eventually with more test-cases
 
 	timeout := time.Second
 	if tc.Timeout > 0 {


### PR DESCRIPTION
I recently changed those test-cases to run in parallel, because parallel = more good - well obviously no: There's timeouts on individual requests, requests are not parallelizable and the tiny amount of time spent in between requests to check the results is, well tiny. The test has already flaked out on (slower) CI machines.