### PR TITLE
gui: Add default ignores to the advanced configuration editor modal (fixes #8264)

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -75,6 +75,7 @@
    "Default Device": "Default Device",
    "Default Folder": "Default Folder",
    "Default Folder Path": "Default Folder Path",
+   "Default Ignore Patterns": "Default Ignore Patterns",
    "Defaults": "Defaults",
    "Delete": "Delete",
    "Delete Unexpected Items": "Delete Unexpected Items",

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2777,6 +2777,12 @@ angular.module('syncthing.core')
             $scope.advancedConfig = angular.copy($scope.config);
             $scope.advancedConfig.devices.sort(deviceCompare);
             $scope.advancedConfig.folders.sort(folderCompare);
+            $scope.advancedConfig.defaults.ignores._lines = function (newValue) {
+                if (arguments.length) {
+                    $scope.advancedConfig.defaults.ignores.lines = newValue.split('\n');
+                }
+                return $scope.advancedConfig.defaults.ignores.lines.join('\n');
+            };
             $('#advanced').modal('show');
         };
 

--- a/gui/default/syncthing/settings/advancedSettingsModalView.html
+++ b/gui/default/syncthing/settings/advancedSettingsModalView.html
@@ -176,8 +176,12 @@
                   <div ng-repeat="(key, value) in advancedConfig.defaults.ignores" ng-if="inputTypeFor(key, value) != 'skip'" class="form-group">
                     <label for="advancedDefaultIgnoresInput{{$index}}" class="col-sm-4 control-label">{{key | uncamel}}&nbsp;<a href="{{docsURL('users/config#config-option-defaults.ignores.')}}{{key | lowercase}}" target="_blank"><span class="fas fa-question-circle"></span></a></label>
                     <div class="col-sm-8">
-                      <textarea ng-if="inputTypeFor(key, value) == 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" ng-model="advancedConfig.defaults.ignores[key]" ng-list="&#10;" ng-trim="false"></textarea>
-                      <input ng-if="inputTypeFor(key, value) != 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="{{inputTypeFor(key, value)}}" ng-model="advancedConfig.defaults.ignores[key]" />
+		      <div ng-switch="key">
+			<!-- Special case to preserve empty lines in multi-line input -->
+			<textarea ng-switch-when="lines" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" ng-model="advancedConfig.defaults.ignores._lines" ng-model-options="{ getterSetter: true }"></textarea>
+			<input ng-switch-default ng-if="inputTypeFor(key, value) == 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="text" ng-model="advancedConfig.defaults.ignores[key]" ng-list />
+			<input ng-switch-default ng-if="inputTypeFor(key, value) != 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="{{inputTypeFor(key, value)}}" ng-model="advancedConfig.defaults.ignores[key]" />
+                      </div>
                     </div>
                   </div>
                 </form>

--- a/gui/default/syncthing/settings/advancedSettingsModalView.html
+++ b/gui/default/syncthing/settings/advancedSettingsModalView.html
@@ -178,7 +178,7 @@
                     <div class="col-sm-8">
                       <div ng-switch="key">
                         <!-- Special case to preserve empty lines in multi-line input -->
-                        <textarea ng-switch-when="lines" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" ng-model="advancedConfig.defaults.ignores._lines" ng-model-options="{ getterSetter: true }"></textarea>
+                        <textarea ng-switch-when="lines" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" rows="5" ng-model="advancedConfig.defaults.ignores._lines" ng-model-options="{ getterSetter: true }"></textarea>
                         <input ng-switch-default ng-if="inputTypeFor(key, value) == 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="text" ng-model="advancedConfig.defaults.ignores[key]" ng-list />
                         <input ng-switch-default ng-if="inputTypeFor(key, value) != 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="{{inputTypeFor(key, value)}}" ng-model="advancedConfig.defaults.ignores[key]" />
                       </div>

--- a/gui/default/syncthing/settings/advancedSettingsModalView.html
+++ b/gui/default/syncthing/settings/advancedSettingsModalView.html
@@ -167,6 +167,22 @@
                 </form>
               </div>
             </div>
+            <div class="panel panel-default">
+              <div class="panel-heading" role="tab" id="advancedDefaultIgnoresHeading" data-toggle="collapse" data-parent="#advancedDefaults" href="#advancedDefaultIgnores" aria-expanded="false" aria-controls="advancedDefaultIgnores" style="cursor: pointer;">
+                <h4 class="panel-title" tabindex="0" translate>Default Ignore Patterns</h4>
+              </div>
+              <div id="advancedDefaultIgnores" class="panel-collapse collapse" role="tabpanel" aria-labelledby="advancedDefaultIgnoresHeading">
+                <form class="form-horizontal" role="form">
+                  <div ng-repeat="(key, value) in advancedConfig.defaults.ignores" ng-if="inputTypeFor(key, value) != 'skip'" class="form-group">
+                    <label for="advancedDefaultIgnoresInput{{$index}}" class="col-sm-4 control-label">{{key | uncamel}}&nbsp;<a href="{{docsURL('users/config#config-option-defaults.ignores.')}}{{key | lowercase}}" target="_blank"><span class="fas fa-question-circle"></span></a></label>
+                    <div class="col-sm-8">
+                      <textarea ng-if="inputTypeFor(key, value) == 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" ng-model="advancedConfig.defaults.ignores[key]" ng-list="&#10;" ng-trim="false"></textarea>
+                      <input ng-if="inputTypeFor(key, value) != 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="{{inputTypeFor(key, value)}}" ng-model="advancedConfig.defaults.ignores[key]" />
+                    </div>
+                  </div>
+                </form>
+              </div>
+            </div>
 
           </div>
         </div>

--- a/gui/default/syncthing/settings/advancedSettingsModalView.html
+++ b/gui/default/syncthing/settings/advancedSettingsModalView.html
@@ -176,11 +176,11 @@
                   <div ng-repeat="(key, value) in advancedConfig.defaults.ignores" ng-if="inputTypeFor(key, value) != 'skip'" class="form-group">
                     <label for="advancedDefaultIgnoresInput{{$index}}" class="col-sm-4 control-label">{{key | uncamel}}&nbsp;<a href="{{docsURL('users/config#config-option-defaults.ignores.')}}{{key | lowercase}}" target="_blank"><span class="fas fa-question-circle"></span></a></label>
                     <div class="col-sm-8">
-		      <div ng-switch="key">
-			<!-- Special case to preserve empty lines in multi-line input -->
-			<textarea ng-switch-when="lines" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" ng-model="advancedConfig.defaults.ignores._lines" ng-model-options="{ getterSetter: true }"></textarea>
-			<input ng-switch-default ng-if="inputTypeFor(key, value) == 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="text" ng-model="advancedConfig.defaults.ignores[key]" ng-list />
-			<input ng-switch-default ng-if="inputTypeFor(key, value) != 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="{{inputTypeFor(key, value)}}" ng-model="advancedConfig.defaults.ignores[key]" />
+                      <div ng-switch="key">
+                        <!-- Special case to preserve empty lines in multi-line input -->
+                        <textarea ng-switch-when="lines" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" ng-model="advancedConfig.defaults.ignores._lines" ng-model-options="{ getterSetter: true }"></textarea>
+                        <input ng-switch-default ng-if="inputTypeFor(key, value) == 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="text" ng-model="advancedConfig.defaults.ignores[key]" ng-list />
+                        <input ng-switch-default ng-if="inputTypeFor(key, value) != 'list'" id="advancedDefaultIgnoresInput{{$index}}" class="form-control" type="{{inputTypeFor(key, value)}}" ng-model="advancedConfig.defaults.ignores[key]" />
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
### Purpose

Fixes #8264.

Follow the XML / JSON structure and keep it under a separate headline instead of the "default folder" section (as in the regular settings modal).

This section slightly differs in the handling of list-type config options.  Usually they are represented as comma-separated single-line text inputs, which is unsuitable for ignore patterns which may rightfully contain commas.  Thus a textarea is used, using newline as the list delimiter.

### Testing

Verified that patterns entered under Edit Folder Defaults are correctly adapted in Advanced Configuration and vice versa.  Leading and trailing spaces are preserved in both directions.

### Screenshots

![image](https://user-images.githubusercontent.com/6996887/162641775-d16f1ac9-5ad8-4f5e-a860-374957a532db.png)
