### PR TITLE
lib/connections: Create the forgotten channel (ref #8263)

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -184,6 +184,7 @@ func NewService(cfg config.Wrapper, myID protocol.DeviceID, mdl Model, tlsCfg *t
 		tlsCfg:               tlsCfg,
 		discoverer:           discoverer,
 		conns:                make(chan internalConn),
+		hellos:               make(chan *connWithHello),
 		bepProtocolName:      bepProtocolName,
 		tlsDefaultCommonName: tlsDefaultCommonName,
 		limiter:              newLimiter(myID, cfg),


### PR DESCRIPTION
Devices running nightlies are not connecting today, thanks to my PR #8263 missing the initiliasition of the new channel.