### PR TITLE
lib/model: Switch the remoteFolderState default value to valid (ref #8202)

### DIFF
--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -55,9 +55,9 @@ func (s folderState) String() string {
 type remoteFolderState int
 
 const (
-	remoteNotSharing remoteFolderState = iota
+	remoteValid remoteFolderState = iota
+	remoteNotSharing
 	remotePaused
-	remoteValid
 )
 
 type stateTracker struct {


### PR DESCRIPTION
### Purpose

The feature in #8202 treats disconnected or paused devices as having all folders unaccepted.  Change the enum's default value to assume `remoteValid` folders in those cases.  Should be a big step towards fixing #8266.