### PR TITLE
gui: Use neutral color for zero out of zero listeners

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -669,7 +669,7 @@
                       <th><span class="fas fa-fw fa-sitemap"></span>&nbsp;<span translate>Listeners</span></th>
                       <td class="text-right">
                         <span class="data" tooltip data-original-title="{{'Show detailed listener status' | translate}}.">
-                          <a href="" ng-class="{'text-success': listenersFailed.length == 0, 'text-danger': listenersFailed.length == listenersTotal}" ng-click="showListenerStatus()">
+                          <a href="" ng-class="{'text-success': listenersTotal > 0 && listenersFailed.length == 0, 'text-danger': listenersTotal > 0 && listenersFailed.length == listenersTotal}" ng-click="showListenerStatus()">
                             {{listenersTotal-listenersFailed.length}}/{{listenersTotal}}
                           </a>
                         </span>


### PR DESCRIPTION
### Purpose

I asked for zero listeners and got zero listeners so this is a success case, not a failure.

### Testing

Before:

<img width="572" alt="Screenshot 2022-04-14 at 17 48 59" src="https://user-images.githubusercontent.com/125426/163406020-abeb2080-f5f4-4a15-aa8d-d4941cb29474.png">

After:

<img width="571" alt="Screenshot 2022-04-14 at 17 52 54" src="https://user-images.githubusercontent.com/125426/163406050-de0567aa-8cd0-494d-9adf-da4bf1344b1c.png">


