### PR TITLE
lib/model: Improve remoteFolderState reporting (fixes #8266)

### DIFF
--- a/gui/default/syncthing/core/eventService.js
+++ b/gui/default/syncthing/core/eventService.js
@@ -64,7 +64,7 @@ angular.module('syncthing.core')
             PENDING_DEVICES_CHANGED: 'PendingDevicesChanged',   // Emitted when pending devices were added / updated (connection from unknown ID) or removed (device is ignored or added)
             DEVICE_PAUSED: 'DevicePaused',   // Emitted when a device has been paused
             DEVICE_RESUMED: 'DeviceResumed',   // Emitted when a device has been resumed
-            REMOTE_CLUSTER_CONFIG_RECEIVED: 'RemoteClusterConfigReceived',   // Emitted when receiving a remote device's cluster config
+            CLUSTER_CONFIG_RECEIVED: 'ClusterConfigReceived',   // Emitted when receiving a remote device's cluster config
             DOWNLOAD_PROGRESS: 'DownloadProgress',   // Emitted during file downloads for each folder for each file
             FAILURE: 'Failure',   // Specific errors sent to the usage reporting server for diagnosis
             FOLDER_COMPLETION: 'FolderCompletion',   //Emitted when the local or remote contents for a folder changes

--- a/gui/default/syncthing/core/eventService.js
+++ b/gui/default/syncthing/core/eventService.js
@@ -64,6 +64,7 @@ angular.module('syncthing.core')
             PENDING_DEVICES_CHANGED: 'PendingDevicesChanged',   // Emitted when pending devices were added / updated (connection from unknown ID) or removed (device is ignored or added)
             DEVICE_PAUSED: 'DevicePaused',   // Emitted when a device has been paused
             DEVICE_RESUMED: 'DeviceResumed',   // Emitted when a device has been resumed
+            REMOTE_CLUSTER_CONFIG_RECEIVED: 'RemoteClusterConfigReceived',   // Emitted when receiving a remote device's cluster config
             DOWNLOAD_PROGRESS: 'DownloadProgress',   // Emitted during file downloads for each folder for each file
             FAILURE: 'Failure',   // Specific errors sent to the usage reporting server for diagnosis
             FOLDER_COMPLETION: 'FolderCompletion',   //Emitted when the local or remote contents for a folder changes

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2368,7 +2368,7 @@ angular.module('syncthing.core')
         $scope.deviceNameMarkUnaccepted = function (deviceID, folderID) {
             var name = $scope.deviceName($scope.devices[deviceID]);
             // Add footnote if sharing was not accepted on the remote device
-            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && $scope.completion[deviceID][folderID].remoteState == 'notsharing') {
+            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && $scope.completion[deviceID][folderID].remoteState == 'notSharing') {
                 name += '<sup>1</sup>';
             }
             return name;
@@ -2389,7 +2389,7 @@ angular.module('syncthing.core')
             for (var deviceID in $scope.completion) {
                 if (deviceID in $scope.devices
                     && folderCfg.id in $scope.completion[deviceID]
-                    && $scope.completion[deviceID][folderCfg.id].remoteState == 'notsharing') {
+                    && $scope.completion[deviceID][folderCfg.id].remoteState == 'notSharing') {
                     return true;
                 }
             }

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2420,7 +2420,7 @@ angular.module('syncthing.core')
         $scope.folderLabelMarkUnaccepted = function (folderID, deviceID) {
             var label = $scope.folderLabel(folderID);
             // Add footnote if sharing was not accepted on the remote device
-            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && $scope.completion[deviceID][folderID].remoteState == 'notsharing') {
+            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && $scope.completion[deviceID][folderID].remoteState == 'notSharing') {
                 label += '<sup>1</sup>';
             }
             return label;
@@ -2440,7 +2440,7 @@ angular.module('syncthing.core')
             }
             for (var folderID in $scope.completion[deviceCfg.deviceID]) {
                 if (folderID in $scope.folders
-                    && $scope.completion[deviceCfg.deviceID][folderID].remoteState == 'notsharing') {
+                    && $scope.completion[deviceCfg.deviceID][folderID].remoteState == 'notSharing') {
                     return true;
                 }
             }

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2368,7 +2368,7 @@ angular.module('syncthing.core')
         $scope.deviceNameMarkUnaccepted = function (deviceID, folderID) {
             var name = $scope.deviceName($scope.devices[deviceID]);
             // Add footnote if sharing was not accepted on the remote device
-            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && !$scope.completion[deviceID][folderID].accepted) {
+            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && $scope.completion[deviceID][folderID].remoteState == 'notsharing') {
                 name += '<sup>1</sup>';
             }
             return name;
@@ -2389,7 +2389,7 @@ angular.module('syncthing.core')
             for (var deviceID in $scope.completion) {
                 if (deviceID in $scope.devices
                     && folderCfg.id in $scope.completion[deviceID]
-                    && !$scope.completion[deviceID][folderCfg.id].accepted) {
+                    && $scope.completion[deviceID][folderCfg.id].remoteState == 'notsharing') {
                     return true;
                 }
             }
@@ -2420,7 +2420,7 @@ angular.module('syncthing.core')
         $scope.folderLabelMarkUnaccepted = function (folderID, deviceID) {
             var label = $scope.folderLabel(folderID);
             // Add footnote if sharing was not accepted on the remote device
-            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && !$scope.completion[deviceID][folderID].accepted) {
+            if (deviceID in $scope.completion && folderID in $scope.completion[deviceID] && $scope.completion[deviceID][folderID].remoteState == 'notsharing') {
                 label += '<sup>1</sup>';
             }
             return label;
@@ -2440,7 +2440,7 @@ angular.module('syncthing.core')
             }
             for (var folderID in $scope.completion[deviceCfg.deviceID]) {
                 if (folderID in $scope.folders
-                    && !$scope.completion[deviceCfg.deviceID][folderID].accepted) {
+                    && $scope.completion[deviceCfg.deviceID][folderID].remoteState == 'notsharing') {
                     return true;
                 }
             }

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -35,6 +35,7 @@ const (
 	PendingDevicesChanged
 	DevicePaused
 	DeviceResumed
+	RemoteClusterConfigReceived
 	LocalChangeDetected
 	RemoteChangeDetected
 	LocalIndexUpdated
@@ -118,6 +119,8 @@ func (t EventType) String() string {
 		return "DevicePaused"
 	case DeviceResumed:
 		return "DeviceResumed"
+	case RemoteClusterConfigReceived:
+		return "RemoteClusterConfigReceived"
 	case FolderScanProgress:
 		return "FolderScanProgress"
 	case FolderPaused:
@@ -203,6 +206,8 @@ func UnmarshalEventType(s string) EventType {
 		return DevicePaused
 	case "DeviceResumed":
 		return DeviceResumed
+	case "RemoteClusterConfigReceived":
+		return RemoteClusterConfigReceived
 	case "FolderScanProgress":
 		return FolderScanProgress
 	case "FolderPaused":

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -35,7 +35,7 @@ const (
 	PendingDevicesChanged
 	DevicePaused
 	DeviceResumed
-	RemoteClusterConfigReceived
+	ClusterConfigReceived
 	LocalChangeDetected
 	RemoteChangeDetected
 	LocalIndexUpdated
@@ -119,8 +119,8 @@ func (t EventType) String() string {
 		return "DevicePaused"
 	case DeviceResumed:
 		return "DeviceResumed"
-	case RemoteClusterConfigReceived:
-		return "RemoteClusterConfigReceived"
+	case ClusterConfigReceived:
+		return "ClusterConfigReceived"
 	case FolderScanProgress:
 		return "FolderScanProgress"
 	case FolderPaused:
@@ -206,8 +206,8 @@ func UnmarshalEventType(s string) EventType {
 		return DevicePaused
 	case "DeviceResumed":
 		return DeviceResumed
-	case "RemoteClusterConfigReceived":
-		return RemoteClusterConfigReceived
+	case "ClusterConfigReceived":
+		return ClusterConfigReceived
 	case "FolderScanProgress":
 		return FolderScanProgress
 	case "FolderPaused":

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -249,7 +249,11 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 		// folders shared with that device.
 
 		data := ev.Data.(map[string]string)
-		deviceID, _ := protocol.DeviceIDFromString(data["id"])
+		key := "id"
+		if ev.Type == events.ClusterConfigReceived {
+			key = "device"
+		}
+		deviceID, _ := protocol.DeviceIDFromString(data[key])
 
 		c.foldersMut.Lock()
 	nextFolder:

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -221,7 +221,7 @@ func (c *folderSummaryService) OnEventRequest() {
 // listenForUpdates subscribes to the event bus and makes note of folders that
 // need their data recalculated.
 func (c *folderSummaryService) listenForUpdates(ctx context.Context) error {
-	sub := c.evLogger.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged | events.RemoteDownloadProgress | events.DeviceConnected | events.RemoteClusterConfigReceived | events.FolderWatchStateChanged | events.DownloadProgress)
+	sub := c.evLogger.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged | events.RemoteDownloadProgress | events.DeviceConnected | events.ClusterConfigReceived | events.FolderWatchStateChanged | events.DownloadProgress)
 	defer sub.Unsubscribe()
 
 	for {
@@ -244,7 +244,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 	var folder string
 
 	switch ev.Type {
-	case events.DeviceConnected, events.RemoteClusterConfigReceived:
+	case events.DeviceConnected, events.ClusterConfigReceived:
 		// When a device connects we schedule a refresh of all
 		// folders shared with that device.
 

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -221,7 +221,7 @@ func (c *folderSummaryService) OnEventRequest() {
 // listenForUpdates subscribes to the event bus and makes note of folders that
 // need their data recalculated.
 func (c *folderSummaryService) listenForUpdates(ctx context.Context) error {
-	sub := c.evLogger.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged | events.RemoteDownloadProgress | events.DeviceConnected | events.FolderWatchStateChanged | events.DownloadProgress)
+	sub := c.evLogger.Subscribe(events.LocalIndexUpdated | events.RemoteIndexUpdated | events.StateChanged | events.RemoteDownloadProgress | events.DeviceConnected | events.RemoteClusterConfigReceived | events.FolderWatchStateChanged | events.DownloadProgress)
 	defer sub.Unsubscribe()
 
 	for {
@@ -244,7 +244,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 	var folder string
 
 	switch ev.Type {
-	case events.DeviceConnected:
+	case events.DeviceConnected, events.RemoteClusterConfigReceived:
 		// When a device connects we schedule a refresh of all
 		// folders shared with that device.
 

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -248,12 +248,14 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 		// When a device connects we schedule a refresh of all
 		// folders shared with that device.
 
-		data := ev.Data.(map[string]string)
-		key := "id"
-		if ev.Type == events.ClusterConfigReceived {
-			key = "device"
+		var deviceID protocol.DeviceID
+		if ev.Type == events.DeviceConnected {
+			data := ev.Data.(map[string]string)
+			deviceID, _ = protocol.DeviceIDFromString(data["id"])
+		} else {
+			data := ev.Data.(ClusterConfigReceivedEventData)
+			deviceID = data.Device
 		}
-		deviceID, _ := protocol.DeviceIDFromString(data[key])
 
 		c.foldersMut.Lock()
 	nextFolder:

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -55,10 +55,26 @@ func (s folderState) String() string {
 type remoteFolderState int
 
 const (
-	remoteValid remoteFolderState = iota
+	remoteUnknown remoteFolderState = iota
 	remoteNotSharing
 	remotePaused
+	remoteValid
 )
+
+func (s remoteFolderState) String() string {
+	switch s {
+	case remoteUnknown:
+		return "unknown"
+	case remoteNotSharing:
+		return "notsharing"
+	case remotePaused:
+		return "paused"
+	case remoteValid:
+		return "valid"
+	default:
+		return "unknown"
+	}
+}
 
 type stateTracker struct {
 	folderID string

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -76,6 +76,10 @@ func (s remoteFolderState) String() string {
 	}
 }
 
+func (s remoteFolderState) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
 type stateTracker struct {
 	folderID string
 	evLogger events.Logger

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -55,21 +55,21 @@ func (s folderState) String() string {
 type remoteFolderState int
 
 const (
-	remoteUnknown remoteFolderState = iota
-	remoteNotSharing
-	remotePaused
-	remoteValid
+	remoteFolderUnknown remoteFolderState = iota
+	remoteFolderNotSharing
+	remoteFolderPaused
+	remoteFolderValid
 )
 
 func (s remoteFolderState) String() string {
 	switch s {
-	case remoteUnknown:
+	case remoteFolderUnknown:
 		return "unknown"
-	case remoteNotSharing:
-		return "notsharing"
-	case remotePaused:
+	case remoteFolderNotSharing:
+		return "notSharing"
+	case remoteFolderPaused:
 		return "paused"
-	case remoteValid:
+	case remoteFolderValid:
 		return "valid"
 	default:
 		return "unknown"

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1147,6 +1147,10 @@ type clusterConfigDeviceInfo struct {
 	local, remote protocol.Device
 }
 
+type ClusterConfigReceivedEventData struct {
+	Device protocol.DeviceID `json:"device"`
+}
+
 func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterConfig) error {
 	// Check the peer device's announced folders against our own. Emits events
 	// for folders that we don't expect (unknown or not shared).
@@ -1234,8 +1238,8 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	m.remoteFolderStates[deviceID] = states
 	m.pmut.Unlock()
 
-	m.evLogger.Log(events.ClusterConfigReceived, map[string]string{
-		"device": deviceID.String(),
+	m.evLogger.Log(events.ClusterConfigReceived, ClusterConfigReceivedEventData{
+		Device: deviceID,
 	})
 
 	if len(tempIndexFolders) > 0 {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1147,7 +1147,7 @@ type clusterConfigDeviceInfo struct {
 	local, remote protocol.Device
 }
 
-type RemoteClusterConfigReceivedEventData struct {
+type ClusterConfigReceivedEventData struct {
 	ID string `json:"id"`
 }
 
@@ -1238,7 +1238,7 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	m.remoteFolderStates[deviceID] = states
 	m.pmut.Unlock()
 
-	m.evLogger.Log(events.RemoteClusterConfigReceived, RemoteClusterConfigReceivedEventData{
+	m.evLogger.Log(events.ClusterConfigReceived, ClusterConfigReceivedEventData{
 		ID: deviceID.String(),
 	})
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2712,7 +2712,7 @@ func (m *model) availabilityInSnapshotPRlocked(cfg config.FolderConfiguration, s
 		if _, ok := m.remoteFolderStates[device]; !ok {
 			continue
 		}
-		if state, ok := m.remoteFolderStates[device][cfg.ID]; !ok || state == remotePaused {
+		if state := m.remoteFolderStates[device][cfg.ID]; state != remoteValid {
 			continue
 		}
 		_, ok := m.conn[device]

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1282,7 +1282,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 	}
 	of := db.ObservedFolder{Time: time.Now().Truncate(time.Second)}
 	for _, folder := range folders {
-		seenFolders[folder.ID] = remoteValid
+		seenFolders[folder.ID] = remoteFolderValid
 
 		cfg, ok := m.cfg.Folder(folder.ID)
 		if ok {
@@ -1323,7 +1323,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 
 		if folder.Paused {
 			indexHandlers.Remove(folder.ID)
-			seenFolders[cfg.ID] = remotePaused
+			seenFolders[cfg.ID] = remoteFolderPaused
 			continue
 		}
 
@@ -1379,7 +1379,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 	for folderID, cfg := range m.cfg.Folders() {
 		if _, seen := seenFolders[folderID]; !seen && cfg.SharedWith(deviceID) {
 			l.Debugf("Remote device %v has not accepted sharing folder %s", deviceID.Short(), cfg.Description())
-			seenFolders[folderID] = remoteNotSharing
+			seenFolders[folderID] = remoteFolderNotSharing
 		}
 	}
 
@@ -2716,7 +2716,7 @@ func (m *model) availabilityInSnapshotPRlocked(cfg config.FolderConfiguration, s
 		if _, ok := m.remoteFolderStates[device]; !ok {
 			continue
 		}
-		if state := m.remoteFolderStates[device][cfg.ID]; state != remoteValid {
+		if state := m.remoteFolderStates[device][cfg.ID]; state != remoteFolderValid {
 			continue
 		}
 		_, ok := m.conn[device]

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1147,6 +1147,10 @@ type clusterConfigDeviceInfo struct {
 	local, remote protocol.Device
 }
 
+type RemoteClusterConfigReceivedEventData struct {
+	ID string `json:"id"`
+}
+
 func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterConfig) error {
 	// Check the peer device's announced folders against our own. Emits events
 	// for folders that we don't expect (unknown or not shared).
@@ -1234,8 +1238,8 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	m.remoteFolderStates[deviceID] = states
 	m.pmut.Unlock()
 
-	m.evLogger.Log(events.RemoteClusterConfigReceived, map[string]string{
-		"id": deviceID.String(),
+	m.evLogger.Log(events.RemoteClusterConfigReceived, RemoteClusterConfigReceivedEventData{
+		ID: deviceID.String(),
 	})
 
 	if len(tempIndexFolders) > 0 {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1147,10 +1147,6 @@ type clusterConfigDeviceInfo struct {
 	local, remote protocol.Device
 }
 
-type ClusterConfigReceivedEventData struct {
-	ID string `json:"id"`
-}
-
 func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterConfig) error {
 	// Check the peer device's announced folders against our own. Emits events
 	// for folders that we don't expect (unknown or not shared).
@@ -1238,8 +1234,8 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	m.remoteFolderStates[deviceID] = states
 	m.pmut.Unlock()
 
-	m.evLogger.Log(events.ClusterConfigReceived, ClusterConfigReceivedEventData{
-		ID: deviceID.String(),
+	m.evLogger.Log(events.ClusterConfigReceived, map[string]string{
+		"device": deviceID.String(),
 	})
 
 	if len(tempIndexFolders) > 0 {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1234,6 +1234,10 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 	m.remoteFolderStates[deviceID] = states
 	m.pmut.Unlock()
 
+	m.evLogger.Log(events.RemoteClusterConfigReceived, map[string]string{
+		"id": deviceID.String(),
+	})
+
 	if len(tempIndexFolders) > 0 {
 		m.pmut.RLock()
 		conn, ok := m.conn[deviceID]

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -800,7 +800,7 @@ type FolderCompletion struct {
 	NeedItems     int
 	NeedDeletes   int
 	Sequence      int64
-	RemoteState   string
+	RemoteState   remoteFolderState
 }
 
 func newFolderCompletion(global, need db.Counts, sequence int64, state remoteFolderState) FolderCompletion {
@@ -811,7 +811,7 @@ func newFolderCompletion(global, need db.Counts, sequence int64, state remoteFol
 		NeedItems:   need.Files + need.Directories + need.Symlinks,
 		NeedDeletes: need.Deleted,
 		Sequence:    sequence,
-		RemoteState: state.String(),
+		RemoteState: state,
 	}
 	comp.setComplectionPct()
 	return comp

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -843,7 +843,7 @@ func (comp *FolderCompletion) setComplectionPct() {
 	}
 }
 
-// Map returns the members as a map, e.g. used in api to serialize as Json.
+// Map returns the members as a map, e.g. used in api to serialize as JSON.
 func (comp FolderCompletion) Map() map[string]interface{} {
 	return map[string]interface{}{
 		"completion":  comp.CompletionPct,
@@ -1374,7 +1374,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 	// Explicitly mark folders we offer, but the remote has not accepted
 	for folderID, cfg := range m.cfg.Folders() {
 		if _, seen := seenFolders[folderID]; !seen && cfg.SharedWith(deviceID) {
-			l.Debugf("Remote device %v has not accepted folder %s", deviceID.Short(), cfg.Description())
+			l.Debugf("Remote device %v has not accepted sharing folder %s", deviceID.Short(), cfg.Description())
 			seenFolders[folderID] = remoteNotSharing
 		}
 	}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3773,7 +3773,7 @@ func TestAddFolderCompletion(t *testing.T) {
 	// Completion is of the whole
 	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{}, 0, remoteFolderValid)             // 100% complete
 	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50}, 0, remoteFolderValid)) // 82.5% complete
-	if comp.CompletionPct != 90 {                                                              // 100 * (1 - 50/500)
+	if comp.CompletionPct != 90 {                                                                    // 100 * (1 - 50/500)
 		t.Error(comp.CompletionPct)
 	}
 }

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3764,16 +3764,16 @@ func TestClusterConfigOnFolderUnpause(t *testing.T) {
 
 func TestAddFolderCompletion(t *testing.T) {
 	// Empty folders are always 100% complete.
-	comp := newFolderCompletion(db.Counts{}, db.Counts{}, 0, true)
-	comp.add(newFolderCompletion(db.Counts{}, db.Counts{}, 0, false))
+	comp := newFolderCompletion(db.Counts{}, db.Counts{}, 0, remoteValid)
+	comp.add(newFolderCompletion(db.Counts{}, db.Counts{}, 0, remotePaused))
 	if comp.CompletionPct != 100 {
 		t.Error(comp.CompletionPct)
 	}
 
 	// Completion is of the whole
-	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{}, 0, true)             // 100% complete
-	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50}, 0, true)) // 82.5% complete
-	if comp.CompletionPct != 90 {                                                       // 100 * (1 - 50/500)
+	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{}, 0, remoteValid)             // 100% complete
+	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50}, 0, remoteValid)) // 82.5% complete
+	if comp.CompletionPct != 90 {                                                              // 100 * (1 - 50/500)
 		t.Error(comp.CompletionPct)
 	}
 }

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3764,15 +3764,15 @@ func TestClusterConfigOnFolderUnpause(t *testing.T) {
 
 func TestAddFolderCompletion(t *testing.T) {
 	// Empty folders are always 100% complete.
-	comp := newFolderCompletion(db.Counts{}, db.Counts{}, 0, remoteValid)
-	comp.add(newFolderCompletion(db.Counts{}, db.Counts{}, 0, remotePaused))
+	comp := newFolderCompletion(db.Counts{}, db.Counts{}, 0, remoteFolderValid)
+	comp.add(newFolderCompletion(db.Counts{}, db.Counts{}, 0, remoteFolderPaused))
 	if comp.CompletionPct != 100 {
 		t.Error(comp.CompletionPct)
 	}
 
 	// Completion is of the whole
-	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{}, 0, remoteValid)             // 100% complete
-	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50}, 0, remoteValid)) // 82.5% complete
+	comp = newFolderCompletion(db.Counts{Bytes: 100}, db.Counts{}, 0, remoteFolderValid)             // 100% complete
+	comp.add(newFolderCompletion(db.Counts{Bytes: 400}, db.Counts{Bytes: 50}, 0, remoteFolderValid)) // 82.5% complete
 	if comp.CompletionPct != 90 {                                                              // 100 * (1 - 50/500)
 		t.Error(comp.CompletionPct)
 	}

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -146,9 +146,8 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Device %v was resumed", device)
 
 	case events.ClusterConfigReceived:
-		data := ev.Data.(map[string]string)
-		device := data["device"]
-		return fmt.Sprintf("Received ClusterConfig from device %v", device)
+		data := ev.Data.(model.ClusterConfigReceivedEventData)
+		return fmt.Sprintf("Received ClusterConfig from device %v", data.Device)
 
 	case events.FolderPaused:
 		data := ev.Data.(map[string]string)

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -117,7 +117,7 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 
 	case events.FolderCompletion:
 		data := ev.Data.(map[string]interface{})
-		return fmt.Sprintf("Completion for folder %q on device %v is %v%% (accepted: %v)", data["folder"], data["device"], data["completion"], data["accepted"])
+		return fmt.Sprintf("Completion for folder %q on device %v is %v%% (state: %s)", data["folder"], data["device"], data["completion"], data["remoteState"])
 
 	case events.FolderSummary:
 		data := ev.Data.(model.FolderSummaryEventData)
@@ -144,6 +144,11 @@ func (s *verboseService) formatEvent(ev events.Event) string {
 		data := ev.Data.(map[string]string)
 		device := data["device"]
 		return fmt.Sprintf("Device %v was resumed", device)
+
+	case events.ClusterConfigReceived:
+		data := ev.Data.(map[string]string)
+		device := data["device"]
+		return fmt.Sprintf("Received ClusterConfig from device %v", device)
 
 	case events.FolderPaused:
 		data := ev.Data.(map[string]string)


### PR DESCRIPTION
### Purpose

As discussed in #8266, this replaces the `accepted` boolean in `FolderCompletion` with a string derived from the recorded `remoteFolderState` value.  A new event type `RemoteClusterConfigReceived` causes the folder summary to be sent again shortly after learning the remote updates.

The new event doesn't have any meaningful content yet, I'd welcome suggestions on how to handle that.  Skipping in case the remote folder states haven't changed would be easy though, if we want that.

### Testing

Accepting or unsharing a folder on a remote device is reflected in the GUI within a few seconds now.

### Documentation

https://github.com/syncthing/docs/pull/736 needs to be adapted for this.