### PR TITLE
lib/model: Subscribe to correct event for fs watching (ref #8249)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -989,7 +989,7 @@ func (f *folder) monitorWatch(ctx context.Context) {
 	var summarySub events.Subscription
 	var summaryChan <-chan events.Event
 	if fs.WatchKqueue && !f.warnedKqueue {
-		summarySub = f.evLogger.Subscribe(events.FolderCompletion)
+		summarySub = f.evLogger.Subscribe(events.FolderSummary)
 		summaryChan = summarySub.C()
 	}
 	defer func() {


### PR DESCRIPTION
Fixes a bug in a new feature in the current RC (introduced in #8249). Thanks to checking the correctness of the type assertion and sending a failure report it's not an urgent problem (just no warning, but also no panicking): https://sentry.syncthing.net/share/issue/e142516b1b274570a7660c613f16e48a/