### PR TITLE
lib/model: Correct type of event data (fixes #8294)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -1065,7 +1065,7 @@ func (f *folder) setWatchError(err error, nextTryIn time.Duration) {
 	f.watchErr = err
 	f.watchMut.Unlock()
 	if err != prevErr {
-		data := map[string]string{
+		data := map[string]interface{}{
 			"folder": f.ID,
 		}
 		if prevErr != nil {


### PR DESCRIPTION
These things are fragile, every event should use an ${eventType}Data struct or something instead.

(This was changed recently because it *looks* like an innocent change...)