### PR TITLE
test: Fix integration tests choking on event data

### DIFF
--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -50,10 +50,6 @@ var errTooManyModifications = errors.New("too many concurrent config modificatio
 // false will result in a "restart needed" response to the API/user. Note that
 // the new configuration will still have been applied by those who were
 // capable of doing so.
-//
-// A Committer must take care not to hold any locks while changing the
-// configuration (e.g. calling Wrapper.SetFolder), that are also acquired in any
-// methods of the Committer interface.
 type Committer interface {
 	CommitConfiguration(from, to Configuration) (handled bool)
 	String() string

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -76,8 +76,28 @@ func (s remoteFolderState) String() string {
 	}
 }
 
+func remoteFolderStateFromString(s string) remoteFolderState {
+	switch s {
+	case "unknown":
+		return remoteFolderUnknown
+	case "notSharing":
+		return remoteFolderNotSharing
+	case "paused":
+		return remoteFolderPaused
+	case "valid":
+		return remoteFolderValid
+	default:
+		return remoteFolderUnknown
+	}
+}
+
 func (s remoteFolderState) MarshalText() ([]byte, error) {
 	return []byte(s.String()), nil
+}
+
+func (s *remoteFolderState) UnmarshalText(bs []byte) error {
+	*s = remoteFolderStateFromString(string(bs))
+	return nil
 }
 
 type stateTracker struct {

--- a/test/filetype_test.go
+++ b/test/filetype_test.go
@@ -24,9 +24,11 @@ func TestFileTypeChange(t *testing.T) {
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
-	fld := cfg.Folders()["default"]
-	fld.Versioning = config.VersioningConfiguration{}
-	cfg.SetFolder(fld)
+	modifyConfig(t, cfg, func(c *config.Configuration) {
+		fld, _, _ := c.Folder("default")
+		fld.Versioning = config.VersioningConfiguration{}
+		c.SetFolder(fld)
+	})
 	os.Rename("h2/config.xml", "h2/config.xml.orig")
 	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	cfg.Save()
@@ -38,12 +40,14 @@ func TestFileTypeChangeSimpleVersioning(t *testing.T) {
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
-	fld := cfg.Folders()["default"]
-	fld.Versioning = config.VersioningConfiguration{
-		Type:   "simple",
-		Params: map[string]string{"keep": "5"},
-	}
-	cfg.SetFolder(fld)
+	modifyConfig(t, cfg, func(c *config.Configuration) {
+		fld, _, _ := c.Folder("default")
+		fld.Versioning = config.VersioningConfiguration{
+			Type:   "simple",
+			Params: map[string]string{"keep": "5"},
+		}
+		c.SetFolder(fld)
+	})
 	os.Rename("h2/config.xml", "h2/config.xml.orig")
 	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	cfg.Save()
@@ -55,11 +59,13 @@ func TestFileTypeChangeStaggeredVersioning(t *testing.T) {
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
-	fld := cfg.Folders()["default"]
-	fld.Versioning = config.VersioningConfiguration{
-		Type: "staggered",
-	}
-	cfg.SetFolder(fld)
+	modifyConfig(t, cfg, func(c *config.Configuration) {
+		fld, _, _ := c.Folder("default")
+		fld.Versioning = config.VersioningConfiguration{
+			Type: "staggered",
+		}
+		c.SetFolder(fld)
+	})
 	os.Rename("h2/config.xml", "h2/config.xml.orig")
 	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	cfg.Save()

--- a/test/filetype_test.go
+++ b/test/filetype_test.go
@@ -24,14 +24,13 @@ func TestFileTypeChange(t *testing.T) {
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	os.Rename("h2/config.xml", "h2/config.xml.orig")
+	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	modifyConfig(t, cfg, func(c *config.Configuration) {
 		fld, _, _ := c.Folder("default")
 		fld.Versioning = config.VersioningConfiguration{}
 		c.SetFolder(fld)
 	})
-	os.Rename("h2/config.xml", "h2/config.xml.orig")
-	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
-	cfg.Save()
 
 	testFileTypeChange(t)
 }
@@ -40,6 +39,8 @@ func TestFileTypeChangeSimpleVersioning(t *testing.T) {
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	os.Rename("h2/config.xml", "h2/config.xml.orig")
+	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	modifyConfig(t, cfg, func(c *config.Configuration) {
 		fld, _, _ := c.Folder("default")
 		fld.Versioning = config.VersioningConfiguration{
@@ -48,9 +49,6 @@ func TestFileTypeChangeSimpleVersioning(t *testing.T) {
 		}
 		c.SetFolder(fld)
 	})
-	os.Rename("h2/config.xml", "h2/config.xml.orig")
-	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
-	cfg.Save()
 
 	testFileTypeChange(t)
 }
@@ -59,6 +57,8 @@ func TestFileTypeChangeStaggeredVersioning(t *testing.T) {
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	os.Rename("h2/config.xml", "h2/config.xml.orig")
+	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	modifyConfig(t, cfg, func(c *config.Configuration) {
 		fld, _, _ := c.Folder("default")
 		fld.Versioning = config.VersioningConfiguration{
@@ -66,9 +66,6 @@ func TestFileTypeChangeStaggeredVersioning(t *testing.T) {
 		}
 		c.SetFolder(fld)
 	})
-	os.Rename("h2/config.xml", "h2/config.xml.orig")
-	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
-	cfg.Save()
 
 	testFileTypeChange(t)
 }

--- a/test/override_test.go
+++ b/test/override_test.go
@@ -27,14 +27,13 @@ func TestOverride(t *testing.T) {
 	// Enable "send-only" on s1/default
 	id, _ := protocol.DeviceIDFromString(id1)
 	cfg, _, _ := config.Load("h1/config.xml", id, events.NoopLogger)
+	os.Rename("h1/config.xml", "h1/config.xml.orig")
+	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
 	modifyConfig(t, cfg, func(c *config.Configuration) {
 		fld, _, _ := c.Folder("default")
 		fld.Type = config.FolderTypeSendOnly
 		c.SetFolder(fld)
 	})
-	os.Rename("h1/config.xml", "h1/config.xml.orig")
-	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
-	cfg.Save()
 
 	log.Println("Cleaning...")
 	err := removeAll("s1", "s2", "h1/index*", "h2/index*")

--- a/test/override_test.go
+++ b/test/override_test.go
@@ -27,9 +27,11 @@ func TestOverride(t *testing.T) {
 	// Enable "send-only" on s1/default
 	id, _ := protocol.DeviceIDFromString(id1)
 	cfg, _, _ := config.Load("h1/config.xml", id, events.NoopLogger)
-	fld := cfg.Folders()["default"]
-	fld.Type = config.FolderTypeSendOnly
-	cfg.SetFolder(fld)
+	modifyConfig(t, cfg, func(c *config.Configuration) {
+		fld, _, _ := c.Folder("default")
+		fld.Type = config.FolderTypeSendOnly
+		c.SetFolder(fld)
+	})
 	os.Rename("h1/config.xml", "h1/config.xml.orig")
 	defer os.Rename("h1/config.xml.orig", "h1/config.xml")
 	cfg.Save()

--- a/test/symlink_test.go
+++ b/test/symlink_test.go
@@ -28,9 +28,11 @@ func TestSymlinks(t *testing.T) {
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
-	fld := cfg.Folders()["default"]
-	fld.Versioning = config.VersioningConfiguration{}
-	cfg.SetFolder(fld)
+	modifyConfig(t, cfg, func(c *config.Configuration) {
+		fld, _, _ := c.Folder("default")
+		fld.Versioning = config.VersioningConfiguration{}
+		c.SetFolder(fld)
+	})
 	os.Rename("h2/config.xml", "h2/config.xml.orig")
 	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	cfg.Save()
@@ -46,12 +48,14 @@ func TestSymlinksSimpleVersioning(t *testing.T) {
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
-	fld := cfg.Folders()["default"]
-	fld.Versioning = config.VersioningConfiguration{
-		Type:   "simple",
-		Params: map[string]string{"keep": "5"},
-	}
-	cfg.SetFolder(fld)
+	modifyConfig(t, cfg, func(c *config.Configuration) {
+		fld, _, _ := c.Folder("default")
+		fld.Versioning = config.VersioningConfiguration{
+			Type:   "simple",
+			Params: map[string]string{"keep": "5"},
+		}
+		c.SetFolder(fld)
+	})
 	os.Rename("h2/config.xml", "h2/config.xml.orig")
 	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	cfg.Save()
@@ -67,11 +71,13 @@ func TestSymlinksStaggeredVersioning(t *testing.T) {
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
-	fld := cfg.Folders()["default"]
-	fld.Versioning = config.VersioningConfiguration{
-		Type: "staggered",
-	}
-	cfg.SetFolder(fld)
+	modifyConfig(t, cfg, func(c *config.Configuration) {
+		fld, _, _ := c.Folder("default")
+		fld.Versioning = config.VersioningConfiguration{
+			Type: "staggered",
+		}
+		c.SetFolder(fld)
+	})
 	os.Rename("h2/config.xml", "h2/config.xml.orig")
 	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	cfg.Save()

--- a/test/symlink_test.go
+++ b/test/symlink_test.go
@@ -28,14 +28,13 @@ func TestSymlinks(t *testing.T) {
 	// Use no versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	os.Rename("h2/config.xml", "h2/config.xml.orig")
+	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	modifyConfig(t, cfg, func(c *config.Configuration) {
 		fld, _, _ := c.Folder("default")
 		fld.Versioning = config.VersioningConfiguration{}
 		c.SetFolder(fld)
 	})
-	os.Rename("h2/config.xml", "h2/config.xml.orig")
-	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
-	cfg.Save()
 
 	testSymlinks(t)
 }
@@ -48,6 +47,8 @@ func TestSymlinksSimpleVersioning(t *testing.T) {
 	// Use simple versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	os.Rename("h2/config.xml", "h2/config.xml.orig")
+	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	modifyConfig(t, cfg, func(c *config.Configuration) {
 		fld, _, _ := c.Folder("default")
 		fld.Versioning = config.VersioningConfiguration{
@@ -56,9 +57,6 @@ func TestSymlinksSimpleVersioning(t *testing.T) {
 		}
 		c.SetFolder(fld)
 	})
-	os.Rename("h2/config.xml", "h2/config.xml.orig")
-	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
-	cfg.Save()
 
 	testSymlinks(t)
 }
@@ -71,6 +69,8 @@ func TestSymlinksStaggeredVersioning(t *testing.T) {
 	// Use staggered versioning
 	id, _ := protocol.DeviceIDFromString(id2)
 	cfg, _, _ := config.Load("h2/config.xml", id, events.NoopLogger)
+	os.Rename("h2/config.xml", "h2/config.xml.orig")
+	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
 	modifyConfig(t, cfg, func(c *config.Configuration) {
 		fld, _, _ := c.Folder("default")
 		fld.Versioning = config.VersioningConfiguration{
@@ -78,9 +78,6 @@ func TestSymlinksStaggeredVersioning(t *testing.T) {
 		}
 		c.SetFolder(fld)
 	})
-	os.Rename("h2/config.xml", "h2/config.xml.orig")
-	defer os.Rename("h2/config.xml.orig", "h2/config.xml")
-	cfg.Save()
 
 	testSymlinks(t)
 }

--- a/test/util.go
+++ b/test/util.go
@@ -10,6 +10,7 @@
 package integration
 
 import (
+	"context"
 	cr "crypto/rand"
 	"errors"
 	"fmt"
@@ -576,11 +577,11 @@ func checkRemoteInSync(folder string, p1, p2 *rc.Process) error {
 	return nil
 }
 
+// modifyConfig waits until the modification has been saved to the file it was loaded from.
 func modifyConfig(t *testing.T, cfg config.Wrapper, f config.ModifyFunction) {
-	// FIXME: Where to put this?
-	// ctx, cancel := context.WithCancel(context.Background())
-	// go cfg.Serve(ctx)
-	// defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
+	go cfg.Serve(ctx)
+	defer cancel()
 
 	waiter, err := cfg.Modify(f)
 	if err != nil {

--- a/test/util.go
+++ b/test/util.go
@@ -25,6 +25,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/rc"
 	"github.com/syncthing/syncthing/lib/sha256"
 )
@@ -573,4 +574,17 @@ func checkRemoteInSync(folder string, p1, p2 *rc.Process) error {
 		return fmt.Errorf(`from device %v folder "%v" is not in sync on device %v`, p2.ID(), folder, p1.ID())
 	}
 	return nil
+}
+
+func modifyConfig(t *testing.T, cfg config.Wrapper, f config.ModifyFunction) {
+	// FIXME: Where to put this?
+	// ctx, cancel := context.WithCancel(context.Background())
+	// go cfg.Serve(ctx)
+	// defer cancel()
+
+	waiter, err := cfg.Modify(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	waiter.Wait()
 }


### PR DESCRIPTION
### Purpose

As mentioned in https://github.com/syncthing/syncthing/pull/8283#issuecomment-1105836048, the `lib/rc` package will panic because of an invalid typecast for the `FolderSummary` event data, introduced in #8249.  The end goal here is to fix that panic.

Meanwhile, the integration tests no longer even build since #7188, so this is also a stab at making the necessary adjustments.