### PR TITLE
gui: Always show vertical scroll bar.

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -10,6 +10,7 @@
 body {
     padding-bottom: 70px;
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+    overflow-y: scroll;
 }
 
 h1, h2, h3, h4, h5 {


### PR DESCRIPTION
### Purpose

This stops interface from jumping left and right when page content no longer fits into screen.

### Screenshots

Before:
![Peek 2022-04-22 21-10](https://user-images.githubusercontent.com/1540305/164771002-f47f3e30-19d8-49e0-be5c-88963b4efe9c.gif)

After:
![Peek 2022-04-22 20-59](https://user-images.githubusercontent.com/1540305/164769442-c7b9fec7-4051-4830-80fb-a486c33c5672.gif)
