### PR TITLE
lib/discover: Increase global discovery timeout

### DIFF
--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -46,7 +46,7 @@ type httpClient interface {
 const (
 	defaultReannounceInterval             = 30 * time.Minute
 	announceErrorRetryInterval            = 5 * time.Minute
-	requestTimeout                        = 5 * time.Second
+	requestTimeout                        = 30 * time.Second
 	maxAddressChangesBetweenAnnouncements = 10
 )
 


### PR DESCRIPTION
Global discovery just failed for me being on a network with terrible latencies. I don't see a good reason for such a stringent global discovery timeout as we have now (while I agree any sensible network should be able to complete it in 5s - well, thanks UPC for that one :) ).