### PR TITLE
gui: Bandaid for null http errors (fixes #8261)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -178,7 +178,8 @@ angular.module('syncthing.core')
 
             console.log('HTTPError', arg);
             online = false;
-            if (!restarting) {
+            // We sometimes get arg == null from angularjs - no idea why
+            if (!restarting && arg) {
                 if (arg.status === 0) {
                     // A network error, not an HTTP error
                     $scope.$emit(Events.OFFLINE);


### PR DESCRIPTION
Definitely a lazy fix, but the error is coming out of angularjs land (no desire to dive into that) and it's reproducible (needs some fix). Fixes #8261 