### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/update-docs-translations.yaml
+++ b/.github/workflows/update-docs-translations.yaml
@@ -4,9 +4,14 @@ on:
   schedule:
     - cron:  '42 3 * * 1'
 
+permissions:
+  contents: read
+
 jobs:
 
   update_transifex_docs:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     name: Update translations and documentation
     steps:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
