### PR TITLE
lib/events: Remove unused method noopLogger.Stop

### DIFF
--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -553,8 +553,6 @@ var NoopLogger Logger = &noopLogger{}
 
 func (*noopLogger) Serve(ctx context.Context) error { return nil }
 
-func (*noopLogger) Stop() {}
-
 func (*noopLogger) Log(t EventType, data interface{}) {}
 
 func (*noopLogger) Subscribe(mask EventType) Subscription {


### PR DESCRIPTION
This was needed for the old suture API, abandoned in 9524b51708d57e90d9e7728f480ee3b84c997c25.