### PR TITLE
build: Add concise build instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ bug, feel free to report it in the [GitHub issue tracker][10].
 
 ## Building
 
-Building Syncthing from source is easy, and there's [a guide][5]
-that describes it for both Unix and Windows systems.
+Building Syncthing from source is easy. After extracting the source bundle from
+a release or checking out git, you just need to run `go run build.go` and the
+binaries are created in `./bin`. There's [a guide][5] with more details on the
+build process.
 
 ## Signed Releases
 


### PR DESCRIPTION
Have minimal instructions to build within the released source, i.e. without having to access the internet. We even add vendoring so it can be built offline.