### PR TITLE
gui: Display "days" next to "maximum age" in Staggered Versioning

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -119,7 +119,10 @@
             <p class="help-block"><span translate>Files are moved to date stamped versions in a .stversions directory when replaced or deleted by Syncthing.</span> <span translate>Versions are automatically deleted if they are older than the maximum age or exceed the number of files allowed in an interval.</span></p>
             <p translate class="help-block">The following intervals are used: for the first hour a version is kept every 30 seconds, for the first day a version is kept every hour, for the first 30 days a version is kept every day, until the maximum age a version is kept every week.</p>
             <label translate for="staggeredMaxAge">Maximum Age</label>
-            <input name="staggeredMaxAge" id="staggeredMaxAge" class="form-control" type="number" ng-model="currentFolder._guiVersioning.staggeredMaxAge" required="" aria-required="true" min="0" />
+            <div class="input-group">
+              <input name="staggeredMaxAge" id="staggeredMaxAge" class="form-control text-right" type="number" ng-model="currentFolder._guiVersioning.staggeredMaxAge" required="" aria-required="true" min="0" />
+              <div class="input-group-addon" translate>days</div>
+            </div>
             <p class="help-block">
               <span translate ng-if="folderEditor.staggeredMaxAge.$valid || folderEditor.staggeredMaxAge.$pristine">The maximum time to keep a version (in days, set to 0 to keep versions forever).</span>
               <span translate ng-if="folderEditor.staggeredMaxAge.$error.required && folderEditor.staggeredMaxAge.$dirty">The maximum age must be a number and cannot be blank.</span>


### PR DESCRIPTION
Currently, the user is supposed to set the maximum age for Staggered
Versioning, with its default value being "365". However, there is no
indication what the value actually corresponds to.

This commit adds the text "days" displayed right to the input value,
which makes it clearer what the number actually means. This makes the
code identical to the clear out after input field in Simple Versioning
that also displays "days" next to its value.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/5626656/171997237-9e430a65-9d28-4b84-a2fb-01017c496aff.png)

#### After

![image](https://user-images.githubusercontent.com/5626656/171997240-2825edc4-26ac-4826-aa01-c715ecfd029e.png)

#### Reference (Simple Versioning)

![image](https://user-images.githubusercontent.com/5626656/171997247-e7179c77-3205-4f1f-a87e-751a7d231088.png)
