### PR TITLE
Update settingsModalView.html

### DIFF
--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -129,13 +129,13 @@
             <div class="col-md-6">
               <div class="form-group">
                 <label translate for="User">GUI Authentication User</label>
-                <input id="User" class="form-control" type="text" ng-model="tmpGUI.user" />
+                <input id="User" class="form-control" type="text" ng-model="tmpGUI.user" autocomplete="off" />
               </div>
             </div>
             <div class="col-md-6">
               <div class="form-group">
                 <label translate for="Password">GUI Authentication Password</label>
-                <input id="Password" class="form-control" type="password" ng-model="tmpGUI.password" ng-trim="false" />
+                <input id="Password" class="form-control" type="password" ng-model="tmpGUI.password" ng-trim="false" autocomplete="new-password" />
               </div>
             </div>
           </div>


### PR DESCRIPTION
Disable Chrome autofill username/password in GUI settings modal dialog.

### Purpose

Disable Chrome autofill of username/password in GUI settings modal dialog, fixes #8376.

### Testing

Forgive me, I'm a hobbyist and haven't contributed to a project like this before. At worst, this should have no effect.

### Screenshots

It is a GUI change, but not end-user visible.

## Authorship
Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.