### PR TITLE
cmd/syncthing/cli: Add show discovery command (fixes #8007)

### DIFF
--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -35,6 +35,11 @@ var showCommand = cli.Command{
 			Usage:  "Report about connections to other devices",
 			Action: expects(0, indexDumpOutput("system/connections")),
 		},
+		{
+			Name:   "discovery",
+			Usage:  "Report about the local discovery cache",
+			Action: expects(0, indexDumpOutput("system/discovery")),
+		},
 		pendingCommand,
 		{
 			Name:   "usage",

--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -37,7 +37,7 @@ var showCommand = cli.Command{
 		},
 		{
 			Name:   "discovery",
-			Usage:  "Report about the local discovery cache",
+			Usage:  "Show the discovered addresses of remote devices (from cache of the running syncthing instance)",
 			Action: expects(0, indexDumpOutput("system/discovery")),
 		},
 		pendingCommand,


### PR DESCRIPTION
### Purpose

Add show disovery command to cli (fixes #8007)

### Testing

Execute `syncthing cli show discovery` on the command line

### Documentation

Since the other show commands are not described in the documentation as far as I have seen, I don't think a change is necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

