### PR TITLE
gui: Fix missing folder names in Edit Device > Sharing tab (fixes #8369)

### DIFF
--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -83,7 +83,7 @@
                   <a href="#" ng-click="selectAllSharedFolders(false)" translate>Deselect All</a></small>
               </p>
               <div class="form-group" ng-repeat="folder in currentSharing.shared">
-                <share-template selected="currentSharing.selected" encryption-passwords="currentSharing.encryptionPasswords" id="{{folder.id}}" label="{{folderLabelMarkUnaccepted(folder.id, currentDevice.deviceID)}}" folder-type="{{folder.type}}" untrusted="currentDevice.untrusted" />
+                <share-template selected="currentSharing.selected" encryption-passwords="currentSharing.encryptionPasswords" id="{{folder.id}}" label="{{folderLabelMarkRemoteState(folder.id, currentDevice.deviceID)}}" folder-type="{{folder.type}}" untrusted="currentDevice.untrusted" />
               </div>
               <p class="help-block" ng-if="deviceHasUnacceptedFolders(currentDevice)">
                 <sup>1</sup> <span translate>The remote device has not accepted sharing this folder.</span>


### PR DESCRIPTION
Another renamed function missed from the previous PR #8286 somehow.  Fixes #8369 again.

I'm clueless as to how this could have got lost originally.  I did test the code, but either there were some merge conflicts where I messed things up or my browser had somehow cached the old functions, thus I didn't notice the missing labels. Note to self (and reviewers): When renaming something, do a recursive grep for the old name over the entire code base as a last step.