### PR TITLE
lib/config, lib/model: Warn about two-way introducer (fixes #8393)

### DIFF
--- a/lib/config/deviceconfiguration.go
+++ b/lib/config/deviceconfiguration.go
@@ -7,6 +7,7 @@
 package config
 
 import (
+	"fmt"
 	"sort"
 )
 
@@ -64,4 +65,11 @@ func deduplicateObservedFoldersToMap(input []ObservedFolder) map[string]Observed
 	}
 
 	return output
+}
+
+func (cfg *DeviceConfiguration) Description() string {
+	if cfg.Name == "" {
+		return fmt.Sprintf("%s", cfg.DeviceID.Short())
+	}
+	return fmt.Sprintf("%s (%s)", cfg.Name, cfg.DeviceID.Short())
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1198,6 +1198,13 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 		ccDeviceInfos[folder.ID] = info
 	}
 
+	for _, info := range ccDeviceInfos {
+		if deviceCfg.Introducer && info.local.Introducer {
+			l.Warnf("Remote %v is an introducer to us, and we are to them - only one should be introducer to the other, see https://docs.syncthing.net/users/introducer.html", deviceCfg.Description())
+		}
+		break
+	}
+
 	// Needs to happen outside of the fmut, as can cause CommitConfiguration
 	if deviceCfg.AutoAcceptFolders {
 		w, _ := m.cfg.Modify(func(cfg *config.Configuration) {


### PR DESCRIPTION
Also added the equivalent of `FolderConfiguration.Description` to `DeviceConfiguration` - for user facing strings that's much nicer than the long and non-descriptive ID string we usually use.