### PR TITLE
gui: Add device sync status (fixes #7981)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -759,6 +759,13 @@
                         <td translate ng-if="!deviceStats[deviceCfg.deviceID].lastSeenDays || deviceStats[deviceCfg.deviceID].lastSeenDays >= 365" class="text-right">Never</td>
                         <td ng-if="deviceStats[deviceCfg.deviceID].lastSeenDays < 365" class="text-right">{{deviceStats[deviceCfg.deviceID].lastSeen | date:"yyyy-MM-dd HH:mm:ss"}}</td>
                       </tr>
+                      <tr ng-if="!connections[deviceCfg.deviceID].connected && deviceFolders(deviceCfg).length > 0">
+                        <th><span class="fas fa-fw fa-cloud"></span>&nbsp;<span translate>Sync Status</span></th>
+                        <td translate ng-if="completion[deviceCfg.deviceID]._total == 100" class="text-right">Up to Date</td>
+                        <td ng-if="completion[deviceCfg.deviceID]._total < 100" class="text-right">
+                            <span class="hidden-xs" translate>Out of Sync</span> ({{completion[deviceCfg.deviceID]._total | percent}}, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
+                        </td>
+                      </tr>
                       <tr ng-if="connections[deviceCfg.deviceID].connected">
                         <th><span class="fas fa-fw fa-cloud-download-alt"></span>&nbsp;<span translate>Download Rate</span></th>
                         <td class="text-right">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -210,10 +210,6 @@ angular.module('syncthing.core')
                 if (data.from === 'scanning' && data.to === 'idle') {
                     refreshFolderStats();
                 }
-
-                $scope.folders[data.folder].devices.forEach(function (deviceCfg) {
-                    refreshCompletion(deviceCfg.deviceID, data.folder);
-                });
             }
         });
 

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -210,6 +210,10 @@ angular.module('syncthing.core')
                 if (data.from === 'scanning' && data.to === 'idle') {
                     refreshFolderStats();
                 }
+
+                $scope.folders[data.folder].devices.forEach(function (deviceCfg) {
+                    refreshCompletion(deviceCfg.deviceID, data.folder);
+                });
             }
         });
 

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -407,10 +407,6 @@ func (c *folderSummaryService) sendSummary(ctx context.Context, folder string) {
 			// We already know about ourselves.
 			continue
 		}
-		if _, ok := c.model.Connection(devCfg.DeviceID); !ok {
-			// We're not interested in disconnected devices.
-			continue
-		}
 
 		// Get completion percentage of this folder for the
 		// remote device.


### PR DESCRIPTION
### Purpose

Adds a sync status row to remote devices (fixes #7981)
Also updates device sync completion on folder rescan 

### Screenshots
If device is unused, the row does not appear:
![Screen Shot 2022-06-23 at 3 16 28 PM](https://user-images.githubusercontent.com/94762716/175386047-029d3b18-809f-416a-92d9-1af7c874c6e8.png)
Device up to date:
![Screen Shot 2022-06-23 at 2 07 39 PM](https://user-images.githubusercontent.com/94762716/175386463-7c3e0164-03d0-4395-af71-81be71c49bb6.png)
Device out of sync:
![Screen Shot 2022-06-23 at 2 04 20 PM](https://user-images.githubusercontent.com/94762716/175386151-33bb979d-e419-4f50-8de7-389c21f5ec57.png)
