### PR TITLE
Fix restarting after system suspend (#8341)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -763,7 +763,7 @@ func resetDB() error {
 
 func standbyMonitor(app *syncthing.App, cfg config.Wrapper) {
 	restartDelay := 60 * time.Second
-	now := time.Now()
+	now := time.Now().Round(0)
 	for {
 		time.Sleep(10 * time.Second)
 		if time.Since(now) > 2*time.Minute && cfg.Options().RestartOnWakeup {
@@ -777,7 +777,7 @@ func standbyMonitor(app *syncthing.App, cfg config.Wrapper) {
 			app.Stop(svcutil.ExitRestart)
 			return
 		}
-		now = time.Now()
+		now = time.Now().Round(0)
 	}
 }
 


### PR DESCRIPTION
Currently suspend detection does not work on Linux, as go's time.Since()
compares monotonic time, instead of wall time, which is halted during suspend.
This fixes the issue.