### PR TITLE
lib/osutil: Only announce address of interfaces which are up (fixes #7458)

### DIFF
--- a/lib/osutil/lan.go
+++ b/lib/osutil/lan.go
@@ -11,9 +11,20 @@ import (
 )
 
 func GetLans() ([]*net.IPNet, error) {
-	addrs, err := net.InterfaceAddrs()
+	ifs, err := net.Interfaces()
 	if err != nil {
 		return nil, err
+	}
+	addrs := []net.Addr{}
+	for _, currentIf := range ifs {
+		if currentIf.Flags&net.FlagUp != net.FlagUp {
+			continue
+		}
+		currentAddrs, err := currentIf.Addrs()
+		if err != nil {
+			return nil, err
+		}
+		addrs = append(addrs, currentAddrs...)
 	}
 
 	nets := make([]*net.IPNet, 0, len(addrs))


### PR DESCRIPTION
### Purpose

Syncthing will only announce address of interfaces which are up (fixes #7458)

### Testing

Syncthing compiles
Check that Syncthing is announcing only addresses of interfaces which are up

### Documentation

Not sure if the change should be mentioned in the documentation

