### PR TITLE
lib/model, lib/config: Apply sensible defaults for auto-accepted encrypted folder (fixes #8296)

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -222,6 +222,7 @@ func (f *FolderConfiguration) prepare(myID protocol.DeviceID, existingDevices ma
 	if f.Type == FolderTypeReceiveEncrypted {
 		f.DisableTempIndexes = true
 		f.IgnorePerms = true
+		f.Versioning.Reset()
 	}
 }
 

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -222,7 +222,6 @@ func (f *FolderConfiguration) prepare(myID protocol.DeviceID, existingDevices ma
 	if f.Type == FolderTypeReceiveEncrypted {
 		f.DisableTempIndexes = true
 		f.IgnorePerms = true
-		f.Versioning.Reset()
 	}
 }
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1678,6 +1678,7 @@ func (m *model) handleAutoAccepts(deviceID protocol.DeviceID, folder protocol.Fo
 				// Override the user-configured defaults, as normally done by the GUI
 				fcfg.FSWatcherEnabled = false
 				fcfg.RescanIntervalS = 3600 * 24
+				fcfg.Versioning.Reset()
 				// Other necessary settings are ensured by FolderConfiguration itself
 			} else {
 				ignores := m.cfg.DefaultIgnores()

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1675,6 +1675,10 @@ func (m *model) handleAutoAccepts(deviceID protocol.DeviceID, folder protocol.Fo
 
 			if len(ccDeviceInfos.remote.EncryptionPasswordToken) > 0 || len(ccDeviceInfos.local.EncryptionPasswordToken) > 0 {
 				fcfg.Type = config.FolderTypeReceiveEncrypted
+				// Override the user-configured defaults, as normally done by the GUI
+				fcfg.FSWatcherEnabled = false
+				fcfg.RescanIntervalS = 3600 * 24
+				// Other necessary settings are ensured by FolderConfiguration itself
 			} else {
 				ignores := m.cfg.DefaultIgnores()
 				if err := m.setIgnores(fcfg, ignores.Lines); err != nil {


### PR DESCRIPTION
### Purpose

Encrypted folders should not have the fs watcher enabled and rarely benefit from a scheduled rescan.  Versioning does not work well for them either.  The GUI adjusts the suggested settings accordingly (watcher disabled, one day rescan interval, no versioning) when accepting a receive-encrypted folder.  Mirror that behavior to the auto-accept case where the GUI is not involved.

For watcher and rescan, the defaults are overridden especially in `handleAutoAccepts()`, while the versioning is filtered out completely in the backend's `FolderConfiguration.prepare()`.

Fixes #8296.

### Testing

Manual testing with auto-accept enabled or disabled from a certain remote device.

### Documentation

Is it worth mentioning this automatic override in the docs?  The only place I've found is at https://docs.syncthing.net/users/config.html#config-option-device.autoacceptfolders, which is pretty terse in general.