### PR TITLE
gui: Move filesystem watcher explanation from tooltip to help block

### DIFF
--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -206,7 +206,10 @@
                   <label>
                     <input type="checkbox" ng-model="currentFolder.fsWatcherEnabled" ng-change="setFSWatcherIntervalDefault()">&nbsp;<span translate>Watch for Changes</span>
                   </label>
-                  <p class="help-block"><span translate>Use notifications from the filesystem to detect changed items.</span> <span translate>Watching for changes discovers most changes without periodic scanning.</p>
+                  <p class="help-block">
+                    <span translate>Use notifications from the filesystem to detect changed items.</span>
+                    <span translate>Watching for changes discovers most changes without periodic scanning.</span>
+                  </p>
                 </div>
                 <div class="col-md-6">
                   <label for="rescanIntervalS" translate>Full Rescan Interval (s)</label>

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -204,9 +204,9 @@
               <div class="row">
                 <div class="col-md-6">
                   <label>
-                    <input type="checkbox" ng-model="currentFolder.fsWatcherEnabled" ng-change="setFSWatcherIntervalDefault()" tooltip data-original-title="{{'Use notifications from the filesystem to detect changed items.' | translate }}">&nbsp;<span translate>Watch for Changes</span>
+                    <input type="checkbox" ng-model="currentFolder.fsWatcherEnabled" ng-change="setFSWatcherIntervalDefault()">&nbsp;<span translate>Watch for Changes</span>
                   </label>
-                  <p translate class="help-block">Watching for changes discovers most changes without periodic scanning.</p>
+                  <p class="help-block"><span translate>Use notifications from the filesystem to detect changed items.</span> <span translate>Watching for changes discovers most changes without periodic scanning.</p>
                 </div>
                 <div class="col-md-6">
                   <label for="rescanIntervalS" translate>Full Rescan Interval (s)</label>


### PR DESCRIPTION
Currently, the filesystem watcher explanation in the Advanced tab in the
Edit Folder modal window is split into two parts. The first is location
in a tooltip that is visible only when hovering the mouse over the small
checkbox, which makes it not easily accessible, e.g. for new or touch
screen users.

No other settings in the Edit Folder window have their explanation
presentend like that. When needed, it is always displayed in their
respective help blocks, which are always visible on the screen. Thus,
move the filesystem watcher explanation from the tooltip to the help
block, merging it with the other part of the explanation in the process.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/5626656/178741857-2ed7e6a0-cfec-4908-af8d-4870003b0542.png)

#### After

![image](https://user-images.githubusercontent.com/5626656/178741876-8398e7c9-f945-4a0a-83a0-143abca07a8e.png)
