### PR TITLE
gui: Fix detailed staggered versioning information in folder info (ref #8348)

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -155,6 +155,7 @@
    "Folder type \"{%receiveEncrypted%}\" cannot be changed after adding the folder. You need to remove the folder, delete or decrypt the data on disk, and add the folder again.": "Folder type \"{{receiveEncrypted}}\" cannot be changed after adding the folder. You need to remove the folder, delete or decrypt the data on disk, and add the folder again.",
    "Folders": "Folders",
    "For the following folders an error occurred while starting to watch for changes. It will be retried every minute, so the errors might go away soon. If they persist, try to fix the underlying issue and ask for help if you can't.": "For the following folders an error occurred while starting to watch for changes. It will be retried every minute, so the errors might go away soon. If they persist, try to fix the underlying issue and ask for help if you can't.",
+   "Forever": "Forever",
    "Full Rescan Interval (s)": "Full Rescan Interval (s)",
    "GUI": "GUI",
    "GUI Authentication Password": "GUI Authentication Password",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -537,8 +537,8 @@
                             <span ng-if="folder.versioning.type == 'simple' && folder.versioning.params.keep != versioningDefaults.simpleKeep" tooltip data-original-title="{{'Keep Versions' | translate}}">
                               &ensp;<span class="fa fa-file-archive-o"></span>&nbsp;{{folder.versioning.params.keep}}
                             </span>
-                            <span ng-if="folder.versioning.type == 'staggered' && folder.versioning.params.maxAge != versioningDefaults.staggeredMaxAge" tooltip data-original-title="{{'Maximum Age' | translate}}">
-                              &ensp;<span class="fa fa-calendar"></span>&nbsp;{{folder.versioning.params.maxAge | duration}}
+                            <span ng-if="folder.versioning.type == 'staggered' && folder.versioning.params.maxAge / 86400 != versioningDefaults.staggeredMaxAge" tooltip data-original-title="{{'Maximum Age' | translate}}">
+                              &ensp;<span class="fa fa-calendar"></span>&nbsp;<span ng-if="folder.versioning.params.maxAge == 0" translate>Forever</span><span ng-if="folder.versioning.params.maxAge > 0">{{folder.versioning.params.maxAge | duration}}</span>
                             </span>
                             <span ng-if="folder.versioning.cleanupIntervalS != versioningDefaults.cleanupIntervalS" tooltip data-original-title="{{'Cleanup Interval' | translate}}">
                               &ensp;<span class="fa fa-recycle"></span>&nbsp;<span ng-if="folder.versioning.cleanupIntervalS == 0" translate>Disabled</span><span ng-if="folder.versioning.cleanupIntervalS > 0">{{folder.versioning.cleanupIntervalS | duration}}</span>


### PR DESCRIPTION
Currently, there are two issues with the detailed staggered versioning
information displayed in the folder info. Firstly, the maxAge value of
365d is displayed despite matching the default. Secondly, there is no
consideration for the special case of maxAge equal to 0, meaning that
versions are kept forever.

This commit fixes both of those issues, so that the default maxAge is
not displayed and its value of 0 is displayed as "forever".

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before

##### maxAge set to 365d

![image](https://user-images.githubusercontent.com/5626656/178748646-a46c2b89-717d-4360-adac-8c46b89d05af.png)

##### maxAge set to 0

![image](https://user-images.githubusercontent.com/5626656/178748660-3dcae1c0-621d-4cf6-ad90-aeb4f1d897be.png)

#### After

##### maxAge set to 365d

![image](https://user-images.githubusercontent.com/5626656/178748686-b7682f80-e4ea-48f7-9874-91dbe6dc7b75.png)

##### maxAge set to 0

![image](https://user-images.githubusercontent.com/5626656/178748678-7f17fd3c-4d24-4199-884e-73868d437ca6.png)
