### PR TITLE
lib/events: added FolderNew and FolderRemove

### DIFF
--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -55,6 +55,8 @@ const (
 	FolderPaused
 	FolderResumed
 	FolderWatchStateChanged
+    FolderNew
+    FolderRemove
 	ListenAddressesChanged
 	LoginAttempt
 	Failure
@@ -127,6 +129,10 @@ func (t EventType) String() string {
 		return "FolderPaused"
 	case FolderResumed:
 		return "FolderResumed"
+    case FolderNew:
+        return "FolderNew"
+    case FolderRemove:
+        return "FolderRemove"
 	case ListenAddressesChanged:
 		return "ListenAddressesChanged"
 	case LoginAttempt:
@@ -214,6 +220,10 @@ func UnmarshalEventType(s string) EventType {
 		return FolderPaused
 	case "FolderResumed":
 		return FolderResumed
+    case "FolderNew":
+        return FolderNew
+    case "FolderRemove":
+        return FolderRemove
 	case "ListenAddressesChanged":
 		return ListenAddressesChanged
 	case "LoginAttempt":

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2808,6 +2808,10 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 					m.fatal(err)
 					return true
 				}
+
+                // Emit the folder add event
+                eventType := events.FolderNew
+                m.evLogger.Log(eventType, map[string]string{"id": cfg.ID, "label": cfg.Label, "path": cfg.Path})
 			}
 			clusterConfigDevices.add(cfg.DeviceIDs())
 		}
@@ -2821,6 +2825,10 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 			m.removeFolder(fromCfg)
 			clusterConfigDevices.add(fromCfg.DeviceIDs())
 			removedFolders[fromCfg.ID] = struct{}{}
+
+            // Emit the folder remove event
+            eventType := events.FolderRemove
+            m.evLogger.Log(eventType, map[string]string{"id": fromCfg.ID, "label": fromCfg.Label, "path": fromCfg.Path})
 			continue
 		}
 


### PR DESCRIPTION
The new events are the most convenient way to implement folder emblems to integrate syncthing in file managers. My evaluation has shown, that [gio](https://docs.gtk.org/gio/) (as successor of gvfs) can be used to set emblems in a portable way accross different file managers, like gnome-files and Thunar with

```sh
gio set -t stringv workspace metadata::emblems star-gold star-red
```

The trouble is, that these emblems are saved under `.local/share/gvfs-metadata/` in a binary format and are persistent between logins. I have considered to monitor the syncthing configuration file for changes instead, but that would mean to compare the current folder list against an saved state in order to "detect" removed folders. That would of cause be error prone and I was unable to find any other event which can be used to inform listeners about the removal of folders. So this implementation seemed to be the easiest way.

As event names I have chosen `FolderNew` and `FolderRemove` after the corresponding functions rather than the log messages, in which a folder gets `added` or `removed` instead.

### Testing

I have manually tested the new events and do not see a chance of any side effects, but I am open to suggestions of cause.