### PR TITLE
cmd/ursrv: Silence linter with correct regexps

### DIFF
--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -47,19 +47,19 @@ var (
 	knownDistributions = []distributionMatch{
 		// Maps well known builders to the official distribution method that
 		// they represent
-		{regexp.MustCompile("android-.*teamcity@build.syncthing.net"), "Google Play"},
-		{regexp.MustCompile("teamcity@build.syncthing.net"), "GitHub"},
-		{regexp.MustCompile("deb@build.syncthing.net"), "APT"},
-		{regexp.MustCompile("docker@syncthing.net"), "Docker Hub"},
-		{regexp.MustCompile("jenkins@build.syncthing.net"), "GitHub"},
-		{regexp.MustCompile("snap@build.syncthing.net"), "Snapcraft"},
-		{regexp.MustCompile("android-.*vagrant@basebox-stretch64"), "F-Droid"},
-		{regexp.MustCompile("builduser@(archlinux|svetlemodry)"), "Arch (3rd party)"},
-		{regexp.MustCompile("synology@kastelo.net"), "Synology (Kastelo)"},
-		{regexp.MustCompile("@debian"), "Debian (3rd party)"},
-		{regexp.MustCompile("@fedora"), "Fedora (3rd party)"},
+		{regexp.MustCompile(`android-.*teamcity@build\.syncthing\.net`), "Google Play"},
+		{regexp.MustCompile(`teamcity@build\.syncthing\.net`), "GitHub"},
+		{regexp.MustCompile(`deb@build\.syncthing\.net`), "APT"},
+		{regexp.MustCompile(`docker@syncthing\.net`), "Docker Hub"},
+		{regexp.MustCompile(`jenkins@build\.syncthing\.net`), "GitHub"},
+		{regexp.MustCompile(`snap@build\.syncthing\.net`), "Snapcraft"},
+		{regexp.MustCompile(`android-.*vagrant@basebox-stretch64`), "F-Droid"},
+		{regexp.MustCompile(`builduser@(archlinux|svetlemodry)`), "Arch (3rd party)"},
+		{regexp.MustCompile(`synology@kastelo\.net`), "Synology (Kastelo)"},
+		{regexp.MustCompile(`@debian`), "Debian (3rd party)"},
+		{regexp.MustCompile(`@fedora`), "Fedora (3rd party)"},
 		{regexp.MustCompile(`\bbrew@`), "Homebrew (3rd party)"},
-		{regexp.MustCompile("."), "Others"},
+		{regexp.MustCompile(`.`), "Others"},
 	}
 )
 


### PR DESCRIPTION
No practical difference.