### PR TITLE
docs: clarify docker network mode limitations

### DIFF
--- a/README-Docker.md
+++ b/README-Docker.md
@@ -23,7 +23,7 @@ $ docker run -p 8384:8384 -p 22000:22000/tcp -p 22000:22000/udp -p 21027:21027/u
 ```
 
 **Docker compose**
-```
+```yml
 ---
 version: "3"
 services:
@@ -46,17 +46,37 @@ services:
 
 ## Discovery
 
-Note that local device discovery will not work with the above command,
-resulting in poor local transfer rates if local device addresses are not
-manually configured.
+Note that Docker's default network mode prevents local IP addresses from
+being discovered, as Syncthing is only able to see the internal IP of the
+container on the `172.17.0.0/16` subnet. This will result in poor transfer rates
+if local device addresses are not manually configured.
 
-To allow local discovery, the docker host network can be used instead:
+It is therefore advisable to use the [host network mode](https://docs.docker.com/network/host/) instead:
 
+**Docker cli**
 ```
 $ docker pull syncthing/syncthing
 $ docker run --network=host \
     -v /wherever/st-sync:/var/syncthing \
     syncthing/syncthing:latest
+```
+
+**Docker compose**
+```yml
+---
+version: "3"
+services:
+  syncthing:
+    image: syncthing/syncthing
+    container_name: syncthing
+    hostname: my-syncthing
+    environment:
+      - PUID=1000
+      - PGID=1000
+    volumes:
+      - /wherever/st-sync:/var/syncthing
+    network_mode: host
+    restart: unless-stopped
 ```
 
 Be aware that syncthing alone is now in control of what interfaces and ports it


### PR DESCRIPTION
This should make the limitations a bit clearer.