### PR TITLE
Refactor CLI code to allow passing CLI arguments via function parameter

### DIFF
--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -38,7 +38,16 @@ func Run() error {
 	// add flags there...
 	c := preCli{}
 	parseFlags(&c)
+	return runInternal(c, os.Args)
+}
 
+func RunWithArgs(cliArgs []string) error {
+	c := preCli{}
+	parseFlagsWithArgs(cliArgs, &c)
+	return runInternal(c, cliArgs)
+}
+
+func runInternal(c preCli, cliArgs []string) error {
 	// Not set as default above because the strings can be really long.
 	err := cmdutil.SetConfigDataLocationsFromFlags(c.HomeDir, c.ConfDir, c.DataDir)
 	if err != nil {
@@ -107,8 +116,8 @@ func Run() error {
 					}
 
 					// Drop the `-` not to recurse into self.
-					args := make([]string, len(os.Args)-1)
-					copy(args, os.Args)
+					args := make([]string, len(cliArgs)-1)
+					copy(args, cliArgs)
 
 					fmt.Println("Reading commands from stdin...", args)
 					scanner := bufio.NewScanner(os.Stdin)
@@ -131,7 +140,7 @@ func Run() error {
 		},
 	}}
 
-	return app.Run(os.Args)
+	return app.Run(cliArgs)
 }
 
 func parseFlags(c *preCli) error {
@@ -140,7 +149,10 @@ func parseFlags(c *preCli) error {
 	if len(os.Args) <= 2 {
 		return nil
 	}
-	args := os.Args[2:]
+	return parseFlagsWithArgs(os.Args[2:], c)
+}
+
+func parseFlagsWithArgs(args []string, c *preCli) error {
 	for i := 0; i < len(args); i++ {
 		if !strings.HasPrefix(args[i], "--") {
 			args = args[:i]


### PR DESCRIPTION
Currently the `Run()` function of the CLI always uses `os.Args` directly.
This change adds an additional `RunWithArgs()` function that allows passing
arguments as `[]string` instead.

### Purpose
This is useful when linking against Syncthing as a library to be able to also
expose the CLI. For instance, this is used by
[Syncthing Tray](https://github.com/Martchus/syncthingtray) which can have
Syncthing as built-in library. Like Syncthing itself it then features the `cli`
sub-command exposing Syncthing's CLI.

### Testing
This change has been tested manually within the context of Syncthing Tray. It
is actually already part of recent Syncthing Tray releases (relevant commit is
in my forked Syncthing repository used by Syncthing Tray as submodule, e.g.
https://github.com/Martchus/syncthing/commit/ced426eac9a1ceb778c0c4e487ef0aa93a9f4aee).
The Syncthing Tray binaries [on GitHub](https://github.com/Martchus/syncthingtray/releases/tag/v1.2.2)
have the feature enabled if one wants to check.

I have also added a rudimentary unit/integration test on my side (see
https://github.com/Martchus/syncthingtray/blob/6f0c5af8fc3fd56c9084a35729b69fe33f624257/libsyncthing/tests/interfacetests.cpp#L260).

Syncthing's own behavior should remain unaffected by the refactoring so
I hope that extending its test suite is not necessary.

### Screenshots
The GUI wrapper behaves like Syncthing itself when attempting to use the CLI. That looks quite neat:
![Screenshot_20220804_184603](https://user-images.githubusercontent.com/10248953/182905862-ef4bcff6-a66c-4c96-9165-86bfed7e2df1.png)