### PR TITLE
Update update-docs-translations.yaml

### DIFF
--- a/.github/workflows/update-docs-translations.yaml
+++ b/.github/workflows/update-docs-translations.yaml
@@ -16,7 +16,7 @@ jobs:
           token: ${{ secrets.ACTIONS_GITHUB_TOKEN }}
       - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
         with:
-          go-version: ^1.17.6
+          go-version: ^1.18.4
       - run: |
           set -euo pipefail
           git config --global user.name 'Syncthing Release Automation'


### PR DESCRIPTION
Bump Go minimum version to 1.18.4

### Purpose

Go 1.17 is now EOL with the release of 1.19

### Testing

Since the minimum version is set to 1.17.x, looking at the last run, Go 1.18.4 is actually being set and used. So this is already a working config, just moving the minimum version to 1.18.4

See https://github.com/syncthing/syncthing/runs/7718592933?check_suite_focus=true#step:3:1



