### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 updates:
-- package-ecosystem: gomod
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+  
+- package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: weekly


### PR DESCRIPTION
Configure Dependabot to update GitHub Actions in workflows.

### Purpose

Since GitHub Actions are pinned to commit hashes in workflows, it's important to ensure that they are kept up to date. This PR ensures that Dependabot will create new PRs when newer releases of Actions are available.

### Testing

This config has been tested in multiple other repos with no issues.

