### PR TITLE
cmd/syncthing: Use os.executable in monitor, only fallback to PATH

### DIFF
--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -84,7 +84,7 @@ func monitorMain(options serveOptions) {
 
 	args := os.Args
 	binary, err := getBinary(args[0])
-	if build.IsWindows {
+	if err != nil {
 		l.Warnln("Error starting the main Syncthing process:", err)
 		panic("Error starting the main Syncthing process")
 	}

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -214,21 +214,11 @@ func getBinary(args0 string) (string, error) {
 		return e, nil
 	}
 	// Check if args0 cuts it
-	_, err = exec.LookPath(args0)
-	if err == nil {
-		return args0, nil
+	e, lerr := exec.LookPath(args0)
+	if lerr == nil {
+		return e, nil
 	}
-	// Works around a restriction added in go1.19 that executables in the
-	// current directory are not resolved when specifying just an executable
-	// name (like e.g. "syncthing")
-	if !strings.ContainsRune(args0, os.PathSeparator) {
-		e = "." + string(os.PathSeparator) + args0
-		_, err := exec.LookPath(args0)
-		if err == nil {
-			return e, nil
-		}
-	}
-	return "", fmt.Errorf("can't find executable")
+	return "", err
 }
 
 func copyStderr(stderr io.Reader, dst io.Writer) {


### PR DESCRIPTION
Use `os.Executable` regardless of OS and only fall back to PATH lookups if that fails (not sure why it ever would).

Followup for https://github.com/syncthing/syncthing/pull/8500 to be delayed until the next release as it's a behaviour change that warrants a full RC phase of testing (thus draft).