### PR TITLE
all: Fix various user-facing and non-user-facing typos

### DIFF
--- a/GOALS.md
+++ b/GOALS.md
@@ -57,7 +57,7 @@ latest technology is not always available to any given individual.
 > Computers include desktops, laptops, servers, virtual machines, small
 > general purpose computers such as Raspberry Pis and, *where possible*,
 > tablets and phones. NAS appliances, toasters, cars, firearms, thermostats
-> and so on may include computing capabitilies but it is not our goal for
+> and so on may include computing capabilities but it is not our goal for
 > Syncthing to run smoothly on these devices.
 
 ### 6. For Individuals

--- a/cmd/stdiscosrv/replication.go
+++ b/cmd/stdiscosrv/replication.go
@@ -120,7 +120,7 @@ func (s *replicationSender) Serve(ctx context.Context) error {
 			if _, err := conn.Write(buf[:4+n]); err != nil {
 				replicationSendsTotal.WithLabelValues("error").Inc()
 				log.Println("Replication write:", err)
-				// Yes, we are loosing the replication event here.
+				// Yes, we are losing the replication event here.
 				return err
 			}
 			replicationSendsTotal.WithLabelValues("success").Inc()

--- a/cmd/syncthing/cli/index_idxck.go
+++ b/cmd/syncthing/cli/index_idxck.go
@@ -57,7 +57,7 @@ func indexCheck(*cli.Context) (err error) {
 	defer func() {
 		if err == nil {
 			if success {
-				fmt.Println("Index check completed succesfully.")
+				fmt.Println("Index check completed successfully.")
 			} else {
 				err = errors.New("Inconsistencies found in the index")
 			}
@@ -349,7 +349,7 @@ func indexCheck(*cli.Context) (err error) {
 
 func needsLocally(vl db.VersionList) bool {
 	gfv, gok := vl.GetGlobal()
-	if !gok { // That's weird, but we hardly need something non-existant
+	if !gok { // That's weird, but we hardly need something non-existent
 		return false
 	}
 	fv, ok := vl.Get(protocol.LocalDeviceID[:])

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -591,7 +591,7 @@ func syncthingMain(options serveOptions) {
 	}
 
 	// Check if auto-upgrades is possible, and if yes, and it's enabled do an initial
-	// upgrade immedately. The auto-upgrade routine can only be started
+	// upgrade immediately. The auto-upgrade routine can only be started
 	// later after App is initialised.
 
 	autoUpgradePossible := autoUpgradePossible(options)

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -273,7 +273,7 @@ func copyStderr(stderr io.Reader, dst io.Writer) {
 * This crash usually occurs due to one of the following reasons:                *
 *  - Syncthing being stopped abruptly (killed/loss of power)                    *
 *  - Bad hardware (memory/disk issues)                                          *
-*  - Software that affects disk writes (SSD caching software and simillar)      *
+*  - Software that affects disk writes (SSD caching software and similar)       *
 *                                                                               *
 * Please see the following URL for instructions on how to recover:              *
 *   https://docs.syncthing.net/users/faq.html#my-syncthing-database-is-corrupt  *

--- a/etc/freebsd-rc/README.md
+++ b/etc/freebsd-rc/README.md
@@ -13,4 +13,4 @@ syncthing_log_file=</path/to/syncthing/log/file>
 syncthing_user=<syncthing_user>
 syncthing_group=<syncthing_group>
 ```
-See the rc.d script for more informations.
+See the rc.d script for more information.

--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -215,7 +215,7 @@ function buildTree(children) {
 
 // unitPrefixed converts the input such that it returns a string representation
 // <1000 (<1024) with the metric unit prefix suffixed. I.e. when calling this with
-// binary == true, you need to suffix an additon 'i'.  The "biggest" prefix used
+// binary == true, you need to suffix an addition 'i'.  The "biggest" prefix used
 // is 'T', numbers > 1000T are just returned as such big numbers. If ever deemed
 // useful 'P' can be added easily.
 function unitPrefixed(input, binary) {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2630,7 +2630,7 @@ angular.module('syncthing.core')
                                     noData: $translate.instant("There are no file versions to restore.")
                                 },
                                 // Set to '1' to silence errors after pressing arrow keys on file nodes.
-                                // Happens on the official option cofiguration from the developer's site
+                                // Happens on the official option configuration from the developer's site
                                 // too, so probably a bug?
                                 debugLevel: 1,
                                 source: buildTree($scope.restoreVersions.versions),

--- a/gui/default/vendor/fancytree/jquery.fancytree-all-deps.js
+++ b/gui/default/vendor/fancytree/jquery.fancytree-all-deps.js
@@ -12900,7 +12900,7 @@ var uniqueId = $.fn.extend( {
 		},
 		// Overide virtual methods for this extension.
 		// `this`       : is this extension object
-		// `this._super`: the virtual function that was overriden (member of prev. extension or Fancytree)
+		// `this._super`: the virtual function that was overridden (member of prev. extension or Fancytree)
 		treeInit: function(ctx) {
 			var i,
 				n,
@@ -13715,7 +13715,7 @@ var uniqueId = $.fn.extend( {
 			}
 			// Add level-n class to apply indentation padding.
 			// (Setting element style would not work, since it cannot easily be
-			// overriden while animations run)
+			// overridden while animations run)
 			$(node.span).addClass("fancytree-level-" + level);
 			return res;
 		},

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -1189,7 +1189,7 @@ func TestBrowse(t *testing.T) {
 		current string
 		returns []string
 	}{
-		// The direcotory without slash is completed to one with slash.
+		// The directory without slash is completed to one with slash.
 		{tmpDir, []string{tmpDir + pathSep}},
 		// With slash it's completed to its contents.
 		// Dirs are given pathSeps.
@@ -1201,7 +1201,7 @@ func TestBrowse(t *testing.T) {
 		{tmpDir + pathSep + "dir", []string{dirPath}},
 		{tmpDir + pathSep + "f", nil},
 		{tmpDir + pathSep + "q", nil},
-		// Globbing is case-insensitve
+		// Globbing is case-insensitive
 		{tmpDir + pathSep + "mixed", []string{mixedCaseDirPath}},
 	}
 
@@ -1387,7 +1387,7 @@ func TestConfigChanges(t *testing.T) {
 		t.Fatal(err)
 	}
 	if opts.MaxSendKbps != 50 {
-		t.Error("Exepcted 50 for MaxSendKbps, got", opts.MaxSendKbps)
+		t.Error("Expected 50 for MaxSendKbps, got", opts.MaxSendKbps)
 	}
 }
 

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -45,7 +45,7 @@ func (f FolderConfiguration) Copy() FolderConfiguration {
 
 // Filesystem creates a filesystem for the path and options of this folder.
 // The fset parameter may be nil, in which case no mtime handling on top of
-// the fileystem is provided.
+// the filesystem is provided.
 func (f FolderConfiguration) Filesystem(fset *db.FileSet) fs.Filesystem {
 	// This is intentionally not a pointer method, because things like
 	// cfg.Folders["default"].Filesystem(nil) should be valid.

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -189,7 +189,7 @@ func (opts OptionsConfiguration) FeatureFlag(name string) bool {
 
 // LowestConnectionLimit is the lower of ConnectionLimitEnough or
 // ConnectionLimitMax, or whichever of them is actually set if only one of
-// them is set. It's the point where we should stop dialling.
+// them is set. It's the point where we should stop dialing.
 func (opts OptionsConfiguration) LowestConnectionLimit() int {
 	limit := opts.ConnectionLimitEnough
 	if limit == 0 || (opts.ConnectionLimitMax != 0 && opts.ConnectionLimitMax < limit) {

--- a/lib/connections/dialqueue_test.go
+++ b/lib/connections/dialqueue_test.go
@@ -20,7 +20,7 @@ func TestDialQueueSort(t *testing.T) {
 	t.Run("ByLastSeen", func(t *testing.T) {
 		t.Parallel()
 
-		// Devices seen within the last week or so should be sorted stricly in order.
+		// Devices seen within the last week or so should be sorted strictly in order.
 		now := time.Now()
 		queue := dialQueue{
 			{id: device1, lastSeen: now.Add(-5 * time.Hour)},  // 1

--- a/lib/db/db_test.go
+++ b/lib/db/db_test.go
@@ -754,7 +754,7 @@ func TestUpdateTo14(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Initally add the correct file the usual way, all good here.
+	// Initially add the correct file the usual way, all good here.
 	if err := db.updateLocalFiles(folder, []protocol.FileInfo{file}, meta); err != nil {
 		t.Fatal(err)
 	}

--- a/lib/db/set_test.go
+++ b/lib/db/set_test.go
@@ -1020,7 +1020,7 @@ func TestWithHaveSequence(t *testing.T) {
 }
 
 func TestStressWithHaveSequence(t *testing.T) {
-	// This races two loops against each other: one that contiously does
+	// This races two loops against each other: one that continuously does
 	// updates, and one that continuously does sequence walks. The test fails
 	// if the sequence walker sees a discontinuity.
 
@@ -1306,7 +1306,7 @@ func TestReceiveOnlyAccounting(t *testing.T) {
 		t.Fatal("expected 1 receive only changed file after local change, not", n)
 	}
 	if n := receiveOnlyChangedSize(t, s).Bytes; n != 100 {
-		t.Fatal("expected 100 receive only changed btyes after local change, not", n)
+		t.Fatal("expected 100 receive only changed bytes after local change, not", n)
 	}
 
 	// Fake a revert. That's a two step process, first converting our

--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -137,7 +137,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 		evLogger:       evLogger,
 	}
 	if !opts.noAnnounce {
-		// If we are supposed to annonce, it's an error until we've done so.
+		// If we are supposed to announce, it's an error until we've done so.
 		cl.setError(errors.New("not announced"))
 	}
 

--- a/lib/fs/basicfs_fileinfo_windows.go
+++ b/lib/fs/basicfs_fileinfo_windows.go
@@ -37,7 +37,7 @@ func (e basicFileInfo) Mode() FileMode {
 		// NTFS deduped files. Remove the symlink bit.
 		m &^= os.ModeSymlink
 	}
-	// Set executable bits on files with executable extenions (.exe, .bat, etc).
+	// Set executable bits on files with executable extensions (.exe, .bat, etc).
 	if isWindowsExecutable(e.Name()) {
 		m |= 0111
 	}

--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -242,7 +242,7 @@ func benchmarkWalkFakeFS(b *testing.B, fsys Filesystem, paths []string, otherOpE
 }
 
 func TestStressCaseFS(t *testing.T) {
-	// Exercise a bunch of paralell operations for stressing out race
+	// Exercise a bunch of parallel operations for stressing out race
 	// conditions in the realnamer cache etc.
 
 	const limit = 10 * time.Second

--- a/lib/fs/mtimefs_test.go
+++ b/lib/fs/mtimefs_test.go
@@ -205,7 +205,7 @@ func TestMtimeFSInsensitive(t *testing.T) {
 			t.Error("Should not have failed:", err)
 		}
 
-		// Check that we get back the mtime we set, if we were supposed to succed.
+		// Check that we get back the mtime we set, if we were supposed to succeed.
 		info, err := fs.Lstat("testdata/FILE")
 		if err != nil {
 			t.Error("Lstat shouldn't fail:", err)

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -556,7 +556,7 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			} else {
 				// Wrap the error, as if the include does not exist, we get a
 				// IsNotExists(err) == true error, which we use to check
-				// existance of the .stignore file, and just end up assuming
+				// existence of the .stignore file, and just end up assuming
 				// there is none, rather than a broken include.
 				err = parseError(fmt.Errorf("failed to load include file %s: %w", includeFile, err))
 			}

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -503,7 +503,7 @@ nextFile:
 		devices := snap.Availability(fileName)
 		for _, dev := range devices {
 			if _, ok := f.model.Connection(dev); ok {
-				// Handle the file normally, by coping and pulling, etc.
+				// Handle the file normally, by copying and pulling, etc.
 				f.handleFile(fi, snap, copyChan)
 				continue nextFile
 			}
@@ -1877,7 +1877,7 @@ func (f *sendReceiveFolder) newPullError(path string, err error) {
 
 	// Establish context to differentiate from errors while scanning.
 	// Use "syncing" as opposed to "pulling" as the latter might be used
-	// for errors occurring specificly in the puller routine.
+	// for errors occurring specifically in the puller routine.
 	errStr := fmt.Sprintln("syncing:", err)
 	f.tempPullErrors[path] = errStr
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1433,7 +1433,7 @@ func (m *model) ccCheckEncryption(fcfg config.FolderConfiguration, folderDevice 
 	}
 
 	if !(hasTokenRemote || hasTokenLocal || isEncryptedRemote || isEncryptedLocal) {
-		// Noone cares about encryption here
+		// No one cares about encryption here
 		return nil
 	}
 
@@ -1515,7 +1515,7 @@ func (m *model) ccCheckEncryption(fcfg config.FolderConfiguration, folderDevice 
 			m.fmut.Lock()
 			m.folderEncryptionPasswordTokens[fcfg.ID] = ccToken
 			m.fmut.Unlock()
-			// We can only announce ourselfs once we have the token,
+			// We can only announce ourselves once we have the token,
 			// thus we need to resend CCs now that we have it.
 			m.sendClusterConfig(fcfg.DeviceIDs())
 			return nil

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -1174,7 +1174,7 @@ func TestRequestIndexSenderPause(t *testing.T) {
 	var seq int64 = 1
 	files := []protocol.FileInfo{{Name: "foo", Size: 10, Version: protocol.Vector{}.Update(myID.Short()), Sequence: seq}}
 
-	// Both devices connected, noone paused
+	// Both devices connected, none paused
 	localIndexUpdate(m, fcfg.ID, files)
 	select {
 	case <-time.After(5 * time.Second):

--- a/lib/model/sentdownloadstate.go
+++ b/lib/model/sentdownloadstate.go
@@ -78,7 +78,7 @@ func (s *sentFolderDownloadState) update(pullers []*sharedPullerState) []protoco
 		}
 
 		if !pullerVersion.Equal(localFile.version) || !pullerCreated.Equal(localFile.created) {
-			// The version has changed or the puller was reconstrcuted due to failure.
+			// The version has changed or the puller was reconstructed due to failure.
 			// Clean up whatever we had for the old file, and advertise the new file.
 			updates = append(updates,
 				protocol.FileDownloadProgressUpdate{

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -702,7 +702,7 @@ func TestIsEquivalent(t *testing.T) {
 		// Empty FileInfos are equivalent
 		{eq: true},
 
-		// Various basic attributes, all of which cause ineqality when
+		// Various basic attributes, all of which cause inequality when
 		// they differ
 		{
 			a:  FileInfo{Name: "foo"},

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -30,7 +30,7 @@ func EnsureDir(dir string, mode fs.FileMode) error {
 	}
 
 	if fi, err := fs.Stat("."); err == nil {
-		// Apprently the stat may fail even though the mkdirall passed. If it
+		// Apparently the stat may fail even though the mkdirall passed. If it
 		// does, we'll just assume things are in order and let other things
 		// fail (like loading or creating the config...).
 		currentMode := fi.Mode() & 0777
@@ -83,7 +83,7 @@ func DefaultConfig(path string, myID protocol.DeviceID, evLogger events.Logger, 
 }
 
 // LoadConfigAtStartup loads an existing config. If it doesn't yet exist, it
-// creates a default one, without the default folder if noDefaultFolder is ture.
+// creates a default one, without the default folder if noDefaultFolder is true.
 // Otherwise it checks the version, and archives and upgrades the config if
 // necessary or returns an error, if the version isn't compatible.
 func LoadConfigAtStartup(path string, cert tls.Certificate, evLogger events.Logger, allowNewerConfig, noDefaultFolder, skipPortProbing bool) (config.Wrapper, error) {

--- a/lib/upgrade/upgrade_test.go
+++ b/lib/upgrade/upgrade_test.go
@@ -144,7 +144,7 @@ func TestSelectedReleaseMacOS(t *testing.T) {
 			},
 		}
 
-		// Check that it is selected and the asset is as epected
+		// Check that it is selected and the asset is as expected
 		sel, err := SelectLatestRelease(rels, "v0.14.46", false)
 		if err != nil {
 			t.Fatal("Unexpected error:", err)

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -399,7 +399,7 @@ func (a *aggregator) popOldEventsTo(to map[string]*aggregatedEvent, dir *eventDi
 
 func (a *aggregator) isOld(ev *aggregatedEvent, currTime time.Time, delayRem bool) bool {
 	// Deletes should in general be scanned last, therefore they are delayed by
-	// letting them time out. This behaviour is overriden by delayRem == false.
+	// letting them time out. This behaviour is overridden by delayRem == false.
 	// Refer to following comments as to why.
 	// An event that has not registered any new modifications recently is scanned.
 	// a.notifyDelay is the user facing value signifying the normal delay between
@@ -413,7 +413,7 @@ func (a *aggregator) isOld(ev *aggregatedEvent, currTime time.Time, delayRem boo
 	// is delayed to reduce resource usage, but after a certain time (notifyTimeout)
 	// passed it is scanned anyway.
 	// If only removals are remaining to be scanned, there is no point to delay
-	// removals further, so this behaviour is overriden by delayRem == false.
+	// removals further, so this behaviour is overridden by delayRem == false.
 	return currTime.Sub(ev.firstModTime) > a.notifyTimeout
 }
 

--- a/man/syncthing-rest-api.7
+++ b/man/syncthing-rest-api.7
@@ -1944,7 +1944,7 @@ These endpoints require the \fBgui.debugging\fP configuration option to
 be enabled and yield an access denied error code otherwise.
 .SS GET /rest/debug/peerCompletion
 .sp
-Summarizes the completion precentage for each remote device.  Returns an object
+Summarizes the completion percentage for each remote device.  Returns an object
 with device IDs as keys and an integer percentage as values.
 .SS GET /rest/debug/httpmetrics
 .sp

--- a/script/codecov-upload.sh
+++ b/script/codecov-upload.sh
@@ -155,8 +155,8 @@ cat << EOF
 
     -c           Move discovered coverage reports to the trash
     -z FILE      Upload specified file directly to Codecov and bypass all report generation.
-                 This is inteded to be used only with a pre-formatted Codecov report and is not
-                 expected to work under any other circumstances.
+                 This is intended to be used only with a pre-formatted Codecov report and is
+                 not expected to work under any other circumstances.
     -Z           Exit with 1 if not successful. Default will Exit with 0
 
     -- xcode --


### PR DESCRIPTION
Found via `codespell -q 3 -S lang,./gui/default/vendor -L benchs,bu,inflight,ro`