### PR TITLE
gui: Add tooltip to folder error message (fixes #7603)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -402,7 +402,9 @@
                       </tr>
                       <tr ng-if="!folder.paused && (model[folder.id].invalid || model[folder.id].error)">
                         <th><span class="fas fa-fw fa-exclamation-triangle"></span>&nbsp;<span translate>Error</span></th>
-                        <td class="text-right">{{model[folder.id].invalid || model[folder.id].error}}</td>
+                        <td class="text-right">
+                          <span tooltip data-original-title="{{model[folder.id].invalid || model[folder.id].error}}">{{model[folder.id].invalid || model[folder.id].error}}</span>
+                        </td>
                       </tr>
                       <tr ng-if="!folder.paused">
                         <th><span class="fas fa-fw fa-globe"></span>&nbsp;<span translate>Global State</span></th>


### PR DESCRIPTION
Currently, the error message is often quite long and thus it appears truncated with no possibility for the user to view the full string. Thus, add a tooltip that displays the message in full on hover. This follows the convention used in other parts of the GUI in similar cases.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/5626656/189542766-c8b80537-d521-4929-8fbc-7bcea90c5889.png)

#### After

![image](https://user-images.githubusercontent.com/5626656/189542610-eba2678f-e91e-45ae-ae97-eb09a162ec51.png)