### PR TITLE
gui: Fix error in Restore Versions when path exists as both directory and file (fixes #7068)

### DIFF
--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -184,7 +184,7 @@ function buildTree(children) {
             keySoFar.push(part);
             var found = false;
             for (var i = 0; i < parent.children.length; i++) {
-                if (parent.children[i].folder === true && parent.children[i].title == part) {
+                if (parent.children[i].title == part && parent.children[i].folder === true) {
                     parent = parent.children[i];
                     found = true;
                     break;

--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -184,7 +184,7 @@ function buildTree(children) {
             keySoFar.push(part);
             var found = false;
             for (var i = 0; i < parent.children.length; i++) {
-                if (parent.children[i].title == part) {
+                if (parent.children[i].folder === true && parent.children[i].title == part) {
                     parent = parent.children[i];
                     found = true;
                     break;


### PR DESCRIPTION
The current code checks whether the same-named item exists in the tree,
and when it does, it re-uses it when adding new children to it. However,
the code doesn't check whether the existing item is a folder or a file.
It rather assumes that it is always a folder, which is not necessarily
the case.

This commit adds a new check to the code, so that the existing element
is reused only when it is a folder, and ignored otherwise.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>