### PR TITLE
gui: Fix text wrapping on tablet-sized screens (fixes #8529)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -420,15 +420,6 @@ ul.three-columns li, ul.two-columns li {
         height: 276px;
     }
 
-    table.table-auto td,
-    table.table-auto th,
-    table.table-condensed td,
-    table.table-condensed th {
-        /* for mobile phones to allow linebreaks in long repro folder/shared with
-        * columns. */
-        white-space: normal;
-    }
-
     .two-columns {
         -webkit-column-count: 1;
         -moz-column-count: 1;
@@ -487,6 +478,15 @@ ul.three-columns li, ul.two-columns li {
     }
     .modal-footer {
         padding-bottom: 5px;
+    }
+
+    table.table-auto td,
+    table.table-auto th,
+    table.table-condensed td,
+    table.table-condensed th {
+        /* for mobile phones to allow linebreaks in long repro folder/shared with
+        * columns. */
+        white-space: normal;
     }
 }
 


### PR DESCRIPTION
Currently, the code contains a "mobile phone" fix to allow wrapping of long lines in table heading and cells. However, the fix is applied to all screen sizes equal or below 768 px wide, which causes the layout to break on tablet-sized screens.

The commit moves the "mobile" fix to the actual mobile media query, which is applied to screens up to 419 px wide. It is only really needed there, where it synergises with the existing fix that changes table cell display to "block". There is no need to wrap the text on larger screens, as there is more than enough space to display the lines in full on them.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

Below are two screenshots taken exactly at the 419 px breakpoint. Apart from the fix on resolutions between 419 and 768 px wide, there is no difference in the GUI display between before and after.

#### Before

![image](https://user-images.githubusercontent.com/5626656/189549792-ec2543c6-5e6e-4ee9-b97d-baad987dd344.png)

#### Later

![image](https://user-images.githubusercontent.com/5626656/189549795-ecaff88d-45ae-4088-8187-65eeb5dda0bb.png)