### PR TITLE
etc/linux-systemd: Mention AmbientCapabilities for syncOwnership.

### DIFF
--- a/etc/linux-systemd/README.md
+++ b/etc/linux-systemd/README.md
@@ -5,4 +5,4 @@ This directory contains configuration files for running Syncthing under the
 systemd user service. For further documentation take a look at the [systemd
 section][1] on https://docs.syncthing.net.
 
-[1]: https://docs.syncthing.net/users/autostart.html#using-systemd
+[1]: https://docs.syncthing.net/users/autostart#using-systemd

--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -20,5 +20,9 @@ SystemCallArchitectures=native
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 
+# Elevated permissions to sync ownership (disabled by default),
+# see https://docs.syncthing.net/advanced/folder-sync-ownership
+#AmbientCapabilities=CAP_CHOWN CAP_FOWNER
+
 [Install]
 WantedBy=multi-user.target

--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -16,5 +16,9 @@ SystemCallArchitectures=native
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 
+# Elevated permissions to sync ownership (disabled by default),
+# see https://docs.syncthing.net/advanced/folder-sync-ownership
+#AmbientCapabilities=CAP_CHOWN CAP_FOWNER
+
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Add a commented entry to the systemd service file templates to point the user in the right direction when using syncOwnership and starting via systemd.  Which is more upgrade-friendly than setting caps on the executable directly, as mentioned in the docs.

Based on info from https://forum.syncthing.net/t/problem-with-syncownership/18934/5

### Testing

Verified the setting is correctly parsed by systemd.  I haven't tried myself whether it works, relying on the forum post instead.

### Documentation

See https://github.com/syncthing/docs/pull/764
