### PR TITLE
gui: Make QR code image downloadable on click

### DIFF
--- a/gui/default/syncthing/device/idqrModalView.html
+++ b/gui/default/syncthing/device/idqrModalView.html
@@ -1,7 +1,11 @@
 <modal id="idqr" status="info" icon="fas fa-qrcode" heading="{{'Device Identification' | translate}} - {{deviceName(currentDevice)}}" large="yes" closeable="yes">
-  <div class="modal-body">
-    <div class="well well-sm text-monospace text-center" select-on-click>{{currentDevice.deviceID}}</div>
-    <img ng-if="currentDevice.deviceID" class="center-block img-thumbnail" ng-src="qr/?text={{currentDevice.deviceID}}" alt="qr code" />
+  <div class="modal-body text-center">
+    <div class="well well-sm text-monospace" select-on-click>{{currentDevice.deviceID}}</div>
+    <div>
+      <a href="qr/?text={{currentDevice.deviceID}}" target="_blank" download="{{currentDevice.deviceID}}.png">
+        <img class="img-thumbnail" ng-src="qr/?text={{currentDevice.deviceID}}" height="328" width="328" alt="{{'QR code' | translate}}">
+      </a>
+    </div>
   </div>
   <div class="modal-footer">
     <button type="button" class="btn btn-default btn-sm" data-dismiss="modal">


### PR DESCRIPTION
Currently, the QR code is displayed as a simple image. This means that if the user wants to download it, they need to right click (or long press) it to display the menu first, and only the save it as image.

This commit transforms the image into a clickable link that presents the user with a download dialog window on click. This way, it is easier to download the image by non-tech-savvy users, and also the image filename is automatically set to the actual device ID instead of being called "download".

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>