### PR TITLE
docker: Add env var to control capabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,12 @@ EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 
 VOLUME ["/var/syncthing"]
 
-RUN apk add --no-cache ca-certificates su-exec tzdata
+RUN apk add --no-cache ca-certificates su-exec tzdata libcap
 
 COPY --from=builder /src/syncthing /bin/syncthing
 COPY --from=builder /src/script/docker-entrypoint.sh /bin/entrypoint.sh
 
-ENV PUID=1000 PGID=1000 HOME=/var/syncthing
+ENV PUID=1000 PGID=1000 HOME=/var/syncthing PCAP=
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z 127.0.0.1 8384 || exit 1

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -7,9 +7,13 @@ Use the `/var/syncthing` volume to have the synchronized files available on the
 host. You can add more folders and map them as you prefer.
 
 Note that Syncthing runs as UID 1000 and GID 1000 by default. These may be
-altered with the ``PUID`` and ``PGID`` environment variables. In addition
+altered with the `PUID` and `PGID` environment variables. In addition
 the name of the Syncthing instance can be optionally defined by using
-``--hostname=syncthing`` parameter.
+`--hostname=syncthing` parameter.
+
+To grant Syncthing additional capabilities without running as root, use the
+`PCAP` environment variable with the same syntax as that for `setcap(8)`.
+For example, `PCAP=cap_chown,cap_fowner+ep`.
 
 ## Example Usage
 

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -2,6 +2,17 @@
 
 set -eu
 
+binary="$1"
+if [ "$PCAP" == "" ] ; then
+  # If Syncthing should have no extra capabilities, make sure to remove them
+  # from the binary. This will fail with an error if there are no
+  # capabilities to remove, hence the || true etc.
+	setcap -r "$binary" 2>/dev/null || true
+else
+  # Set capabilities on the Syncthing binary before launching it.
+	setcap "$PCAP" "$binary"
+fi
+
 if [ "$(id -u)" = '0' ]; then
   chown "${PUID}:${PGID}" "${HOME}" \
     && exec su-exec "${PUID}:${PGID}" \

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -7,10 +7,10 @@ if [ "$PCAP" == "" ] ; then
   # If Syncthing should have no extra capabilities, make sure to remove them
   # from the binary. This will fail with an error if there are no
   # capabilities to remove, hence the || true etc.
-	setcap -r "$binary" 2>/dev/null || true
+  setcap -r "$binary" 2>/dev/null || true
 else
   # Set capabilities on the Syncthing binary before launching it.
-	setcap "$PCAP" "$binary"
+  setcap "$PCAP" "$binary"
 fi
 
 if [ "$(id -u)" = '0' ]; then

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -2,18 +2,18 @@
 
 set -eu
 
-binary="$1"
-if [ "$PCAP" == "" ] ; then
-  # If Syncthing should have no extra capabilities, make sure to remove them
-  # from the binary. This will fail with an error if there are no
-  # capabilities to remove, hence the || true etc.
-  setcap -r "$binary" 2>/dev/null || true
-else
-  # Set capabilities on the Syncthing binary before launching it.
-  setcap "$PCAP" "$binary"
-fi
-
 if [ "$(id -u)" = '0' ]; then
+  binary="$1"
+  if [ "$PCAP" == "" ] ; then
+    # If Syncthing should have no extra capabilities, make sure to remove them
+    # from the binary. This will fail with an error if there are no
+    # capabilities to remove, hence the || true etc.
+    setcap -r "$binary" 2>/dev/null || true
+  else
+    # Set capabilities on the Syncthing binary before launching it.
+    setcap "$PCAP" "$binary"
+  fi
+
   chown "${PUID}:${PGID}" "${HOME}" \
     && exec su-exec "${PUID}:${PGID}" \
        env HOME="$HOME" "$@"


### PR DESCRIPTION
As it's not simple to run a container under Docker/Kubernetes as non-root but with additional capabilities, add an internal hack.

Tested to work under TrueNAS Scale, which is Kubernetes...