### PR TITLE
Fix incorrect cli help text

### DIFF
--- a/cmd/syncthing/cli/main.go
+++ b/cmd/syncthing/cli/main.go
@@ -70,7 +70,7 @@ func runInternal(c preCli, cliArgs []string) error {
 	fakeFlags := []cli.Flag{
 		cli.StringFlag{
 			Name:  "gui-address",
-			Usage: "Override GUI address to `URL` (e.g. \"http://192.0.2.42:8443\")",
+			Usage: "Override GUI address to `URL` (e.g. \"192.0.2.42:8443\")",
 		},
 		cli.StringFlag{
 			Name:  "gui-apikey",


### PR DESCRIPTION
### Purpose

The current help text for the gui-address option in the cli is incorrect.

It currently displays needing a full URL.

```
Override GUI address to `URL` (e.g. \"http://192.0.2.42:8443\")
```

If you pass a full url as the gui-address option, you get a failure.

```
syncthing cli --gui-address http://127.0.0.1:8385 --gui-apikey wjvTg743GgzEuUGJhG6QxVMMTpyX2gKi config folders list
parse "http://http:%2F%2F127.0.0.1:8385/rest/system/config": invalid URL escape "%2F"
```

If you pass without the protocol (http://) it works

```
syncthing cli --gui-address 127.0.0.1:8385 --gui-apikey wjvTg743GgzEuUGJhG6QxVMMTpyX2gKi config folders list
default
```

This fixes the help text to reflect what should actually be passed.

### Testing

Run a cli command with the options as described above.