### PR TITLE
gui: Filter scope ID out of IPv6 addresses in Remote GUI (fixes #8084)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1202,7 +1202,8 @@ angular.module('syncthing.core')
         $scope.remoteGUIAddress = function (deviceCfg) {
             // Assume hasRemoteGUIAddress is true or we would not be here
             var conn = $scope.connections[deviceCfg.deviceID];
-            return 'http://' + replaceAddressPort(conn.address, deviceCfg.remoteGUIPort);
+            // Use regex to filter out scope ID from IPv6 addresses.
+            return 'http://' + replaceAddressPort(conn.address, deviceCfg.remoteGUIPort).replace('%.*?\]:', ']:');
         };
 
         function replaceAddressPort(address, newPort) {


### PR DESCRIPTION
Currently, the link to remote GUI uses device addresses as they are advertised from the router. Because of this, they may end up having a scope ID attached to them. The problem is that browsers do not support such addresses, leaving the user with a non-working URL.

Because of the above, use regex to simply filter out the scope ID from the address before using it for Remote GUI.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>