### PR TITLE
cmd/strelaysrv: Add optional auth token (fixes #3987)

### DIFF
--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -119,7 +119,7 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 
 			switch msg := message.(type) {
 			case protocol.JoinRelayRequest:
-				if msg.Token != token {
+				if len(token) > 0 && msg.Token != token {
 					if debug {
 						log.Printf("invalid token %s\n", msg.Token)
 					}

--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -23,7 +23,7 @@ var (
 	numConnections int64
 )
 
-func listener(_, addr string, config *tls.Config) {
+func listener(_, addr string, config *tls.Config, token string) {
 	tcpListener, err := net.Listen("tcp", addr)
 	if err != nil {
 		log.Fatalln(err)
@@ -49,7 +49,7 @@ func listener(_, addr string, config *tls.Config) {
 		}
 
 		if isTLS {
-			go protocolConnectionHandler(conn, config)
+			go protocolConnectionHandler(conn, config, token)
 		} else {
 			go sessionConnectionHandler(conn)
 		}
@@ -57,7 +57,7 @@ func listener(_, addr string, config *tls.Config) {
 	}
 }
 
-func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
+func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config, token string) {
 	conn := tls.Server(tcpConn, config)
 	if err := conn.SetDeadline(time.Now().Add(messageTimeout)); err != nil {
 		if debug {
@@ -119,7 +119,7 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 
 			switch msg := message.(type) {
 			case protocol.JoinRelayRequest:
-				if len(token) > 0 && msg.Token != token {
+				if token != "" && msg.Token != token {
 					if debug {
 						log.Printf("invalid token %s\n", msg.Token)
 					}

--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -119,6 +119,15 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config) {
 
 			switch msg := message.(type) {
 			case protocol.JoinRelayRequest:
+				if msg.Token != token {
+					if debug {
+						log.Printf("invalid token %s\n", msg.Token)
+					}
+					protocol.WriteMessage(conn, protocol.ResponseWrongToken)
+					conn.Close()
+					continue
+				}
+
 				if atomic.LoadInt32(&overLimit) > 0 {
 					protocol.WriteMessage(conn, protocol.RelayFull{})
 					if debug {

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -90,7 +90,7 @@ func main() {
 	flag.IntVar(&globalLimitBps, "global-rate", globalLimitBps, "Global rate limit, in bytes/s")
 	flag.BoolVar(&debug, "debug", debug, "Enable debug output")
 	flag.StringVar(&statusAddr, "status-srv", ":22070", "Listen address for status service (blank to disable)")
-	flag.StringVar(&token, "token", "", "optional token for private relay")
+	flag.StringVar(&token, "token", "", "Token to restrict access to the relay (optional). Disables joining any pools.")
 	flag.StringVar(&poolAddrs, "pools", defaultPoolAddrs, "Comma separated list of relay pool addresses to join")
 	flag.StringVar(&providedBy, "provided-by", "", "An optional description about who provides the relay")
 	flag.StringVar(&extAddress, "ext-address", "", "An optional address to advertise as being available on.\n\tAllows listening on an unprivileged port with port forwarding from e.g. 443, and be connected to on port 443.")
@@ -258,6 +258,10 @@ func main() {
 
 	log.Println("URI:", uri.String())
 
+	if token != "" {
+		poolAddrs = ""
+	}
+
 	if poolAddrs == defaultPoolAddrs {
 		log.Println("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
 		log.Println("!!  Joining default relay pools, this relay will be available for public use. !!")
@@ -273,7 +277,7 @@ func main() {
 		}
 	}
 
-	go listener(proto, listen, tlsCfg)
+	go listener(proto, listen, tlsCfg, token)
 
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -56,6 +56,7 @@ var (
 	networkBufferSize int
 
 	statusAddr       string
+	token		 string
 	poolAddrs        string
 	pools            []string
 	providedBy       string
@@ -89,6 +90,7 @@ func main() {
 	flag.IntVar(&globalLimitBps, "global-rate", globalLimitBps, "Global rate limit, in bytes/s")
 	flag.BoolVar(&debug, "debug", debug, "Enable debug output")
 	flag.StringVar(&statusAddr, "status-srv", ":22070", "Listen address for status service (blank to disable)")
+	flag.StringVar(&token, "token", "", "optional token for private relay")
 	flag.StringVar(&poolAddrs, "pools", defaultPoolAddrs, "Comma separated list of relay pool addresses to join")
 	flag.StringVar(&providedBy, "provided-by", "", "An optional description about who provides the relay")
 	flag.StringVar(&extAddress, "ext-address", "", "An optional address to advertise as being available on.\n\tAllows listening on an unprivileged port with port forwarding from e.g. 443, and be connected to on port 443.")

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -56,7 +56,7 @@ var (
 	networkBufferSize int
 
 	statusAddr       string
-	token		 string
+	token            string
 	poolAddrs        string
 	pools            []string
 	providedBy       string

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -173,7 +173,7 @@ func (c *staticClient) disconnect() {
 }
 
 func (c *staticClient) join() error {
-	if err := protocol.WriteMessage(c.conn, protocol.JoinRelayRequest{c.uri.Query().Get("token")}); err != nil {
+	if err := protocol.WriteMessage(c.conn, protocol.JoinRelayRequest{Token: c.uri.Query().Get("token")}); err != nil {
 		return err
 	}
 

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -173,7 +173,7 @@ func (c *staticClient) disconnect() {
 }
 
 func (c *staticClient) join() error {
-	if err := protocol.WriteMessage(c.conn, protocol.JoinRelayRequest{}); err != nil {
+	if err := protocol.WriteMessage(c.conn, protocol.JoinRelayRequest{c.uri.Query().Get("token")}); err != nil {
 		return err
 	}
 

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -27,7 +27,8 @@ type staticClient struct {
 	messageTimeout time.Duration
 	connectTimeout time.Duration
 
-	conn *tls.Conn
+	conn  *tls.Conn
+	token string
 }
 
 func newStaticClient(uri *url.URL, certs []tls.Certificate, invitations chan protocol.SessionInvitation, timeout time.Duration) *staticClient {
@@ -38,6 +39,8 @@ func newStaticClient(uri *url.URL, certs []tls.Certificate, invitations chan pro
 
 		messageTimeout: time.Minute * 2,
 		connectTimeout: timeout,
+
+		token: uri.Query().Get("token"),
 	}
 	c.commonClient = newCommonClient(invitations, c.serve, c.String())
 	return c
@@ -173,7 +176,7 @@ func (c *staticClient) disconnect() {
 }
 
 func (c *staticClient) join() error {
-	if err := protocol.WriteMessage(c.conn, protocol.JoinRelayRequest{Token: c.uri.Query().Get("token")}); err != nil {
+	if err := protocol.WriteMessage(c.conn, protocol.JoinRelayRequest{Token: c.token}); err != nil {
 		return err
 	}
 

--- a/lib/relay/protocol/packets.go
+++ b/lib/relay/protocol/packets.go
@@ -31,8 +31,11 @@ type header struct {
 
 type Ping struct{}
 type Pong struct{}
-type JoinRelayRequest struct{}
 type RelayFull struct{}
+
+type JoinRelayRequest struct {
+	Token string
+}
 
 type JoinSessionRequest struct {
 	Key []byte // max:32

--- a/lib/relay/protocol/packets_xdr.go
+++ b/lib/relay/protocol/packets_xdr.go
@@ -31,7 +31,7 @@ struct header {
 
 */
 
-func (o header) XDRSize() int {
+func (header) XDRSize() int {
 	return 4 + 4 + 4
 }
 
@@ -78,26 +78,26 @@ struct Ping {
 
 */
 
-func (o Ping) XDRSize() int {
+func (Ping) XDRSize() int {
 	return 0
 }
-func (o Ping) MarshalXDR() ([]byte, error) {
+func (Ping) MarshalXDR() ([]byte, error) {
 	return nil, nil
 }
 
-func (o Ping) MustMarshalXDR() []byte {
+func (Ping) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (o Ping) MarshalXDRInto(m *xdr.Marshaller) error {
+func (Ping) MarshalXDRInto(m *xdr.Marshaller) error {
 	return nil
 }
 
-func (o *Ping) UnmarshalXDR(bs []byte) error {
+func (*Ping) UnmarshalXDR(bs []byte) error {
 	return nil
 }
 
-func (o *Ping) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
+func (*Ping) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	return nil
 }
 
@@ -112,26 +112,26 @@ struct Pong {
 
 */
 
-func (o Pong) XDRSize() int {
+func (Pong) XDRSize() int {
 	return 0
 }
-func (o Pong) MarshalXDR() ([]byte, error) {
+func (Pong) MarshalXDR() ([]byte, error) {
 	return nil, nil
 }
 
-func (o Pong) MustMarshalXDR() []byte {
+func (Pong) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (o Pong) MarshalXDRInto(m *xdr.Marshaller) error {
+func (Pong) MarshalXDRInto(m *xdr.Marshaller) error {
 	return nil
 }
 
-func (o *Pong) UnmarshalXDR(bs []byte) error {
+func (*Pong) UnmarshalXDR(bs []byte) error {
 	return nil
 }
 
-func (o *Pong) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
+func (*Pong) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	return nil
 }
 
@@ -146,26 +146,26 @@ struct RelayFull {
 
 */
 
-func (o RelayFull) XDRSize() int {
+func (RelayFull) XDRSize() int {
 	return 0
 }
-func (o RelayFull) MarshalXDR() ([]byte, error) {
+func (RelayFull) MarshalXDR() ([]byte, error) {
 	return nil, nil
 }
 
-func (o RelayFull) MustMarshalXDR() []byte {
+func (RelayFull) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (o RelayFull) MarshalXDRInto(m *xdr.Marshaller) error {
+func (RelayFull) MarshalXDRInto(m *xdr.Marshaller) error {
 	return nil
 }
 
-func (o *RelayFull) UnmarshalXDR(bs []byte) error {
+func (*RelayFull) UnmarshalXDR(bs []byte) error {
 	return nil
 }
 
-func (o *RelayFull) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
+func (*RelayFull) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	return nil
 }
 

--- a/lib/relay/protocol/packets_xdr.go
+++ b/lib/relay/protocol/packets_xdr.go
@@ -89,15 +89,15 @@ func (Ping) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (Ping) MarshalXDRInto(m *xdr.Marshaller) error {
+func (Ping) MarshalXDRInto(_ *xdr.Marshaller) error {
 	return nil
 }
 
-func (*Ping) UnmarshalXDR(bs []byte) error {
+func (*Ping) UnmarshalXDR(_ []byte) error {
 	return nil
 }
 
-func (*Ping) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
+func (*Ping) UnmarshalXDRFrom(_ *xdr.Unmarshaller) error {
 	return nil
 }
 
@@ -123,15 +123,15 @@ func (Pong) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (Pong) MarshalXDRInto(m *xdr.Marshaller) error {
+func (Pong) MarshalXDRInto(_ *xdr.Marshaller) error {
 	return nil
 }
 
-func (*Pong) UnmarshalXDR(bs []byte) error {
+func (*Pong) UnmarshalXDR(_ []byte) error {
 	return nil
 }
 
-func (*Pong) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
+func (*Pong) UnmarshalXDRFrom(_ *xdr.Unmarshaller) error {
 	return nil
 }
 
@@ -157,15 +157,15 @@ func (RelayFull) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (RelayFull) MarshalXDRInto(m *xdr.Marshaller) error {
+func (RelayFull) MarshalXDRInto(_ *xdr.Marshaller) error {
 	return nil
 }
 
-func (*RelayFull) UnmarshalXDR(bs []byte) error {
+func (*RelayFull) UnmarshalXDR(_ []byte) error {
 	return nil
 }
 
-func (*RelayFull) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
+func (*RelayFull) UnmarshalXDRFrom(_ *xdr.Unmarshaller) error {
 	return nil
 }
 

--- a/lib/relay/protocol/packets_xdr.go
+++ b/lib/relay/protocol/packets_xdr.go
@@ -31,7 +31,7 @@ struct header {
 
 */
 
-func (header) XDRSize() int {
+func (o header) XDRSize() int {
 	return 4 + 4 + 4
 }
 
@@ -78,26 +78,26 @@ struct Ping {
 
 */
 
-func (Ping) XDRSize() int {
+func (o Ping) XDRSize() int {
 	return 0
 }
-func (Ping) MarshalXDR() ([]byte, error) {
+func (o Ping) MarshalXDR() ([]byte, error) {
 	return nil, nil
 }
 
-func (Ping) MustMarshalXDR() []byte {
+func (o Ping) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (Ping) MarshalXDRInto(_ *xdr.Marshaller) error {
+func (o Ping) MarshalXDRInto(m *xdr.Marshaller) error {
 	return nil
 }
 
-func (*Ping) UnmarshalXDR(_ []byte) error {
+func (o *Ping) UnmarshalXDR(bs []byte) error {
 	return nil
 }
 
-func (*Ping) UnmarshalXDRFrom(_ *xdr.Unmarshaller) error {
+func (o *Ping) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	return nil
 }
 
@@ -112,60 +112,26 @@ struct Pong {
 
 */
 
-func (Pong) XDRSize() int {
+func (o Pong) XDRSize() int {
 	return 0
 }
-func (Pong) MarshalXDR() ([]byte, error) {
+func (o Pong) MarshalXDR() ([]byte, error) {
 	return nil, nil
 }
 
-func (Pong) MustMarshalXDR() []byte {
+func (o Pong) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (Pong) MarshalXDRInto(_ *xdr.Marshaller) error {
+func (o Pong) MarshalXDRInto(m *xdr.Marshaller) error {
 	return nil
 }
 
-func (*Pong) UnmarshalXDR(_ []byte) error {
+func (o *Pong) UnmarshalXDR(bs []byte) error {
 	return nil
 }
 
-func (*Pong) UnmarshalXDRFrom(_ *xdr.Unmarshaller) error {
-	return nil
-}
-
-/*
-
-JoinRelayRequest Structure:
-(contains no fields)
-
-
-struct JoinRelayRequest {
-}
-
-*/
-
-func (JoinRelayRequest) XDRSize() int {
-	return 0
-}
-func (JoinRelayRequest) MarshalXDR() ([]byte, error) {
-	return nil, nil
-}
-
-func (JoinRelayRequest) MustMarshalXDR() []byte {
-	return nil
-}
-
-func (JoinRelayRequest) MarshalXDRInto(_ *xdr.Marshaller) error {
-	return nil
-}
-
-func (*JoinRelayRequest) UnmarshalXDR(_ []byte) error {
-	return nil
-}
-
-func (*JoinRelayRequest) UnmarshalXDRFrom(_ *xdr.Unmarshaller) error {
+func (o *Pong) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	return nil
 }
 
@@ -180,27 +146,78 @@ struct RelayFull {
 
 */
 
-func (RelayFull) XDRSize() int {
+func (o RelayFull) XDRSize() int {
 	return 0
 }
-func (RelayFull) MarshalXDR() ([]byte, error) {
+func (o RelayFull) MarshalXDR() ([]byte, error) {
 	return nil, nil
 }
 
-func (RelayFull) MustMarshalXDR() []byte {
+func (o RelayFull) MustMarshalXDR() []byte {
 	return nil
 }
 
-func (RelayFull) MarshalXDRInto(_ *xdr.Marshaller) error {
+func (o RelayFull) MarshalXDRInto(m *xdr.Marshaller) error {
 	return nil
 }
 
-func (*RelayFull) UnmarshalXDR(_ []byte) error {
+func (o *RelayFull) UnmarshalXDR(bs []byte) error {
 	return nil
 }
 
-func (*RelayFull) UnmarshalXDRFrom(_ *xdr.Unmarshaller) error {
+func (o *RelayFull) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
 	return nil
+}
+
+/*
+
+JoinRelayRequest Structure:
+
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+/                                                               /
+\                 Token (length + padded data)                  \
+/                                                               /
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+struct JoinRelayRequest {
+	string Token<>;
+}
+
+*/
+
+func (o JoinRelayRequest) XDRSize() int {
+	return 4 + len(o.Token) + xdr.Padding(len(o.Token))
+}
+
+func (o JoinRelayRequest) MarshalXDR() ([]byte, error) {
+	buf := make([]byte, o.XDRSize())
+	m := &xdr.Marshaller{Data: buf}
+	return buf, o.MarshalXDRInto(m)
+}
+
+func (o JoinRelayRequest) MustMarshalXDR() []byte {
+	bs, err := o.MarshalXDR()
+	if err != nil {
+		panic(err)
+	}
+	return bs
+}
+
+func (o JoinRelayRequest) MarshalXDRInto(m *xdr.Marshaller) error {
+	m.MarshalString(o.Token)
+	return m.Error
+}
+
+func (o *JoinRelayRequest) UnmarshalXDR(bs []byte) error {
+	u := &xdr.Unmarshaller{Data: bs}
+	return o.UnmarshalXDRFrom(u)
+}
+func (o *JoinRelayRequest) UnmarshalXDRFrom(u *xdr.Unmarshaller) error {
+	o.Token = u.UnmarshalString()
+	return u.Error
 }
 
 /*

--- a/lib/relay/protocol/protocol.go
+++ b/lib/relay/protocol/protocol.go
@@ -17,6 +17,7 @@ var (
 	ResponseSuccess           = Response{0, "success"}
 	ResponseNotFound          = Response{1, "not found"}
 	ResponseAlreadyConnected  = Response{2, "already connected"}
+	ResponseWrongToken	  = Response{3, "wrong token"}
 	ResponseUnexpectedMessage = Response{100, "unexpected message"}
 )
 

--- a/lib/relay/protocol/protocol.go
+++ b/lib/relay/protocol/protocol.go
@@ -108,6 +108,14 @@ func ReadMessage(r io.Reader) (interface{}, error) {
 		return msg, err
 	case messageTypeJoinRelayRequest:
 		var msg JoinRelayRequest
+
+		// In prior versions of the protocol JoinRelayRequest did not have a
+		// token field. Trying to unmarshal such a request will result in
+		// an error, return msg with an empty token instead.
+		if header.messageLength == 0 {
+			return msg, nil
+		}
+
 		err := msg.UnmarshalXDR(buf)
 		return msg, err
 	case messageTypeJoinSessionRequest:

--- a/lib/relay/protocol/protocol.go
+++ b/lib/relay/protocol/protocol.go
@@ -17,7 +17,7 @@ var (
 	ResponseSuccess           = Response{0, "success"}
 	ResponseNotFound          = Response{1, "not found"}
 	ResponseAlreadyConnected  = Response{2, "already connected"}
-	ResponseWrongToken	  = Response{3, "wrong token"}
+	ResponseWrongToken        = Response{3, "wrong token"}
 	ResponseUnexpectedMessage = Response{100, "unexpected message"}
 )
 


### PR DESCRIPTION
Attempt to implement a sort of authentication for relaysrv by checking for a simple token before allowing clients to join.

tested with
```
./bin/strelaysrv -debug -pools "" -token 'thetoken'
./cmd/strelaysrv/testutil/testutil -relay=relay://localhost:22067?token='thetoken' -keys=/home/user/.config/syncthing/ -test
```

I'm not quite sure if this is a good way to implement this, or if there are security-implications so i am happy for comments.

Relevant issue: https://github.com/syncthing/syncthing/issues/3987



