### PR TITLE
docker: Fix handling of PCAP variable (fixes #8567)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk add --no-cache ca-certificates su-exec tzdata libcap
 COPY --from=builder /src/syncthing /bin/syncthing
 COPY --from=builder /src/script/docker-entrypoint.sh /bin/entrypoint.sh
 
-ENV PUID=1000 PGID=1000 HOME=/var/syncthing PCAP=
+ENV PUID=1000 PGID=1000 HOME=/var/syncthing
 
 HEALTHCHECK --interval=1m --timeout=10s \
   CMD nc -z 127.0.0.1 8384 || exit 1

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -eu
 
 if [ "$(id -u)" = '0' ]; then
   binary="$1"
-  if [ "$PCAP" == "" ] ; then
+  if [ "${PCAP:-}" == "" ] ; then
     # If Syncthing should have no extra capabilities, make sure to remove them
     # from the binary. This will fail with an error if there are no
     # capabilities to remove, hence the || true etc.


### PR DESCRIPTION
This correctly handles the absense of the PCAP environment variable, which was broken in the previous change.

Requires a new RC.