### PR TITLE
lib/api: Add /rest/status health-check (#8430) 

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1567,7 +1567,7 @@ func (s *service) postDBPrio(w http.ResponseWriter, r *http.Request) {
 	s.getDBNeed(w, r)
 }
 
-func (s *service) getStatus(w http.ResponseWriter, r *http.Request) {
+func (*service) getStatus(w http.ResponseWriter, _ *http.Request) {
 	sendJSON(w, map[string]string{"status": "OK"})
 }
 

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -260,6 +260,7 @@ func (s *service) Serve(ctx context.Context) error {
 	restMux.HandlerFunc(http.MethodGet, "/rest/events/disk", s.getDiskEvents)                 // [since] [limit] [timeout]
 	restMux.HandlerFunc(http.MethodGet, "/rest/stats/device", s.getDeviceStats)               // -
 	restMux.HandlerFunc(http.MethodGet, "/rest/stats/folder", s.getFolderStats)               // -
+	restMux.HandlerFunc(http.MethodGet, "/rest/status", s.getStatus)                          // -
 	restMux.HandlerFunc(http.MethodGet, "/rest/svc/deviceid", s.getDeviceID)                  // id
 	restMux.HandlerFunc(http.MethodGet, "/rest/svc/lang", s.getLang)                          // -
 	restMux.HandlerFunc(http.MethodGet, "/rest/svc/report", s.getReport)                      // -
@@ -1564,6 +1565,10 @@ func (s *service) postDBPrio(w http.ResponseWriter, r *http.Request) {
 	file := qs.Get("file")
 	s.model.BringToFront(folder, file)
 	s.getDBNeed(w, r)
+}
+
+func (s *service) getStatus(w http.ResponseWriter, r *http.Request) {
+	sendJSON(w, map[string]string{"status": "OK"})
 }
 
 func (*service) getQR(w http.ResponseWriter, r *http.Request) {

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -258,9 +258,9 @@ func (s *service) Serve(ctx context.Context) error {
 	restMux.HandlerFunc(http.MethodGet, "/rest/folder/pullerrors", s.getFolderErrors)         // folder (deprecated)
 	restMux.HandlerFunc(http.MethodGet, "/rest/events", s.getIndexEvents)                     // [since] [limit] [timeout] [events]
 	restMux.HandlerFunc(http.MethodGet, "/rest/events/disk", s.getDiskEvents)                 // [since] [limit] [timeout]
+	restMux.HandlerFunc(http.MethodGet, "/rest/noauth/health", s.getHealth)                   // -
 	restMux.HandlerFunc(http.MethodGet, "/rest/stats/device", s.getDeviceStats)               // -
 	restMux.HandlerFunc(http.MethodGet, "/rest/stats/folder", s.getFolderStats)               // -
-	restMux.HandlerFunc(http.MethodGet, "/rest/status", s.getStatus)                          // -
 	restMux.HandlerFunc(http.MethodGet, "/rest/svc/deviceid", s.getDeviceID)                  // id
 	restMux.HandlerFunc(http.MethodGet, "/rest/svc/lang", s.getLang)                          // -
 	restMux.HandlerFunc(http.MethodGet, "/rest/svc/report", s.getReport)                      // -
@@ -1567,7 +1567,7 @@ func (s *service) postDBPrio(w http.ResponseWriter, r *http.Request) {
 	s.getDBNeed(w, r)
 }
 
-func (*service) getStatus(w http.ResponseWriter, _ *http.Request) {
+func (*service) getHealth(w http.ResponseWriter, _ *http.Request) {
 	sendJSON(w, map[string]string{"status": "OK"})
 }
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -44,8 +44,8 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 			return
 		}
 
-		if strings.HasPrefix(r.URL.Path, "/rest/status") {
-			// This page should be available without authentication.
+		// Exception for REST calls that don't require authentication.
+		if strings.HasPrefix(r.URL.Path, "/rest/noauth") {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -44,6 +44,12 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 			return
 		}
 
+		if strings.HasPrefix(r.URL.Path, "/rest/status") {
+			// This page should be available without authentication.
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		cookie, err := r.Cookie(cookieName)
 		if err == nil && cookie != nil {
 			sessionsMut.Lock()

--- a/lib/api/api_csrf.go
+++ b/lib/api/api_csrf.go
@@ -74,9 +74,9 @@ func (m *csrfManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if strings.HasPrefix(r.URL.Path, "/rest/status") {
-		// The Status page should be accessible without a CSRF-token
-		// so other services or devices can monitor it freely
+	if strings.HasPrefix(r.URL.Path, "/rest/noauth") {
+		// REST calls that don't require authentication also do not
+		// need a CSRF token.
 		m.next.ServeHTTP(w, r)
 		return
 	}

--- a/lib/api/api_csrf.go
+++ b/lib/api/api_csrf.go
@@ -74,6 +74,13 @@ func (m *csrfManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if strings.HasPrefix(r.URL.Path, "/rest/status") {
+		// The Status page should be accessible without a CSRF-token
+		// so other services or devices can monitor it freely
+		m.next.ServeHTTP(w, r)
+		return
+	}
+
 	// Allow requests for anything not under the protected path prefix,
 	// and set a CSRF cookie if there isn't already a valid one.
 	if !strings.HasPrefix(r.URL.Path, m.prefix) {


### PR DESCRIPTION
### Purpose

Added a status page to the REST API which can act as a health-check, this allows third-party services and devices to check the status of Syncthing without having to use an API-key or plain-texted credentials.

To accomplish this two things were adjusted:
- Exception for /rest/status to the CSRF-token-requirement
- Exception for /rest/status to the otherwise required authentication

And obviously the /rest/status functionality was added, which is a simple return of a JSON object. Since, if you reach that point - it all goes well anyways. If not, you'll get another kind of error before reaching this point.

### Testing

Two parts:
1.) Functional; visit the url and call the url in several ways, browser/curl/wget/...
2.) Security: Since we made an exception in the security-layer; hack-and-slash the URL a little to see if we don't unexpectedly reach other pages from this status-page while being unauthenticated. 

### Documentation

The API documentation will have to be updated to cover this addition.


