### PR TITLE
gui: Allow automatic device ID selection on WebKit browsers (ref #8544)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -550,5 +550,6 @@ html[lang|="ko"] i {
 }
 
 .select-on-click {
+    -webkit-user-select: all;
     user-select: all;
 }


### PR DESCRIPTION
Some WebKit browsers select more than needed when using double click to select device IDs, e.g. new lines and white space. This commit adds a prefixed version of user-select in CSS in order to add support for those browsers and allow them to select just device IDs automatically.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

![image](https://user-images.githubusercontent.com/6996887/194652752-db185631-6d9a-4c5f-b7aa-b16c5c053fd4.png)