### PR TITLE
lib/events: Sanity check for buffer size

### DIFF
--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -479,7 +479,12 @@ type BufferedSubscription interface {
 	Mask() EventType
 }
 
+// NewBufferedSubscription returns a BufferedSubscription with buffer of size,
+// or nil if size < 1
 func NewBufferedSubscription(s Subscription, size int) BufferedSubscription {
+	if size < 1 {
+		return nil
+	}
 	bs := &bufferedSubscription{
 		sub: s,
 		buf: make([]Event, size),

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -480,10 +480,10 @@ type BufferedSubscription interface {
 }
 
 // NewBufferedSubscription returns a BufferedSubscription with buffer of size,
-// or nil if size < 1
+// will panic on size < 1
 func NewBufferedSubscription(s Subscription, size int) BufferedSubscription {
 	if size < 1 {
-		return nil
+		panic("bug: buffer size <= 0")
 	}
 	bs := &bufferedSubscription{
 		sub: s,

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -259,7 +259,7 @@ func TestBufferedSub(t *testing.T) {
 	}
 }
 
-func TestBufferedSubZero(t *testing.T) {
+func TestBufferedSubZero(*testing.T) {
 	l, cancel := setupLogger()
 	defer cancel()
 

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -259,6 +259,15 @@ func TestBufferedSub(t *testing.T) {
 	}
 }
 
+func TestBufferedSubZero(t *testing.T) {
+	l, cancel := setupLogger()
+	defer cancel()
+
+	s := l.Subscribe(AllEvents)
+	defer s.Unsubscribe()
+	_ = NewBufferedSubscription(s, -15)
+}
+
 func BenchmarkBufferedSub(b *testing.B) {
 	l, cancel := setupLogger()
 	defer cancel()

--- a/lib/events/events_test.go
+++ b/lib/events/events_test.go
@@ -259,12 +259,17 @@ func TestBufferedSub(t *testing.T) {
 	}
 }
 
-func TestBufferedSubZero(*testing.T) {
+func TestBufferedSubZero(t *testing.T) {
 	l, cancel := setupLogger()
 	defer cancel()
 
 	s := l.Subscribe(AllEvents)
 	defer s.Unsubscribe()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("No panic for negative buffer size")
+		}
+	}()
 	_ = NewBufferedSubscription(s, -15)
 }
 


### PR DESCRIPTION
### Purpose

Avoid panic by making calling `NewBufferedSubscription` with non-positive buffer sizes a caller's problem (fixes #8424).

### Testing

`TestBufferedSubZero` added.

### Documentation

Added a comment documenting function's behavior.