### PR TITLE
lib/connections: Use adaptive write size for rate limited connections (fixes #8630)

### DIFF
--- a/lib/connections/limiter_test.go
+++ b/lib/connections/limiter_test.go
@@ -218,7 +218,7 @@ func TestLimitedWriterWrite(t *testing.T) {
 
 	// A buffer with random data that is larger than the write size and not
 	// a precise multiple either.
-	src := make([]byte, int(12.5*maxSingleWriteSize))
+	src := make([]byte, int(12.5*8192))
 	if _, err := crand.Reader.Read(src); err != nil {
 		t.Fatal(err)
 	}
@@ -242,9 +242,14 @@ func TestLimitedWriterWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify there were lots of writes and that the end result is identical.
-	if cw.writeCount != 13 {
-		t.Error("expected lots of smaller writes, but not too many")
+	// Verify there were lots of writes (we expect one kilobyte write size
+	// for the very low rate in this test) and that the end result is
+	// identical.
+	if cw.writeCount < 10*8 {
+		t.Error("expected lots of smaller writes")
+	}
+	if cw.writeCount > 15*8 {
+		t.Error("expected fewer larger writes")
 	}
 	if !bytes.Equal(src, dst.Bytes()) {
 		t.Error("results should be equal")
@@ -319,8 +324,11 @@ func TestLimitedWriterWrite(t *testing.T) {
 	}
 
 	// Verify there were lots of writes and that the end result is identical.
-	if cw.writeCount != 13 {
-		t.Error("expected just the one write")
+	if cw.writeCount < 10*8 {
+		t.Error("expected lots of smaller writes")
+	}
+	if cw.writeCount > 15*8 {
+		t.Error("expected fewer larger writes")
 	}
 	if !bytes.Equal(src, dst.Bytes()) {
 		t.Error("results should be equal")


### PR DESCRIPTION
This is a best guess of what might be wrong in the issue in question, and an attempt to fix it. I've verified it doesn't harm performance in my local tests, and done some prints on the write sizes to verify they are reasonable, but I can't verify that it solves the problem because I haven't reproduced the problem.

That said, previously we'd do 8 KiB writes, which for 100 MB/s which is 12800 writes per second -- a lot of syscalls, and less opportunity for the TCP stack to send large segments maybe. Now we up the size to much larger for high rates, letting the lower layers do their thing in peace. This should improve things.