### PR TITLE
gui: Always show Out of Sync Items for remote devices

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -774,7 +774,7 @@
                         <th><span class="fas fa-fw fa-cloud"></span>&nbsp;<span translate>Sync Status</span></th>
                         <td translate ng-if="completion[deviceCfg.deviceID]._total == 100" class="text-right">Up to Date</td>
                         <td ng-if="completion[deviceCfg.deviceID]._total < 100" class="text-right">
-                            <span class="hidden-xs" translate>Out of Sync</span> ({{completion[deviceCfg.deviceID]._total | percent}}, {{completion[deviceCfg.deviceID]._needBytes | binary}}B)
+                            <span class="hidden-xs" translate>Out of Sync</span> ({{completion[deviceCfg.deviceID]._total | percent}})
                         </td>
                       </tr>
                       <tr ng-if="connections[deviceCfg.deviceID].connected">
@@ -809,7 +809,7 @@
                           </a>
                         </td>
                       </tr>
-                      <tr ng-if="deviceStatus(deviceCfg) == 'syncing'">
+                      <tr ng-if="completion[deviceCfg.deviceID]._needItems">
                         <th><span class="fas fa-fw fa-exchange-alt"></span>&nbsp;<span translate>Out of Sync Items</span></th>
                         <td class="text-right">
                           <a href="" ng-click="showRemoteNeed(deviceCfg)">{{completion[deviceCfg.deviceID]._needItems | alwaysNumber | localeNumber}} <span translate>items</span>, ~{{completion[deviceCfg.deviceID]._needBytes | binary}}B</a>


### PR DESCRIPTION
Right now, the Out of Sync Items list for a specific remote device is
available only when the device is online and currently synchronising.
However, the list itself is being created by Syncthing all the time, so
there is no need to hide it from the user even when the remote device is
offline or paused. This way they can always easily check which files
exactly have not been synchronised yet.

In addition, the Out of Sync Items entry already includes file size next
to it, so there is no need to display it again next to the Sync Status
entry. Thus, remove out-of-sync file size from Sync Status, leaving only
percentage next to it.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before (Out of Sync Items present only when online and syncing)

![image](https://user-images.githubusercontent.com/5626656/199039881-3e3f0879-77bb-4cb3-bd43-9a432109d13e.png)

#### After (Out of sync Items present always, as long as there is any)

![image](https://user-images.githubusercontent.com/5626656/199039909-4b309345-236a-4ade-9ab9-c9fc0fa983c7.png)