### PR TITLE
docker: Use healthcheck endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 
 VOLUME ["/var/syncthing"]
 
-RUN apk add --no-cache ca-certificates su-exec tzdata libcap
+RUN apk add --no-cache ca-certificates curl libcap su-exec tzdata
 
 COPY --from=builder /src/syncthing /bin/syncthing
 COPY --from=builder /src/script/docker-entrypoint.sh /bin/entrypoint.sh
@@ -23,7 +23,7 @@ COPY --from=builder /src/script/docker-entrypoint.sh /bin/entrypoint.sh
 ENV PUID=1000 PGID=1000 HOME=/var/syncthing
 
 HEALTHCHECK --interval=1m --timeout=10s \
-  CMD nc -z 127.0.0.1 8384 || exit 1
+  CMD curl -fkLsS -m 2 127.0.0.1:8384/rest/noauth/health | grep -o --color=never OK || exit 1
 
 ENV STGUIADDRESS=0.0.0.0:8384
 ENTRYPOINT ["/bin/entrypoint.sh", "/bin/syncthing", "-home", "/var/syncthing/config"]


### PR DESCRIPTION
### Purpose

Fixes #8638


### Testing

Tested the cmd against a local instance with HTTP and HTTPS:

```sh
curl -fkLsS -m 2 127.0.0.1:8384/rest/noauth/health | grep -o --color=never OK || exit 1
```

Successful healthcheck:

```
OK
```

Failed healthcheck:

```
curl: (7) Failed to connect to 127.0.0.1 port 8384 after 0 ms: Connection refused
```


curl parameters:

* [-f](https://curl.se/docs/manpage.html#-f) Fail fast with no output at all on server errors. Otherwise error pages are passed to grep
* [-k](https://curl.se/docs/manpage.html#-k) Ignore certificate errors. Important if the UI is using HTTPS with a selfsigned certificate
* [-L](https://curl.se/docs/manpage.html#-L) Follow redirects. Handles the HTTP -> HTTPS redirect
* [-s](https://curl.se/docs/manpage.html#-s) Don't output download meter/progress
* [-S](https://curl.se/docs/manpage.html#-S) Print error messages to stderr
* [-m](https://curl.se/docs/manpage.html#-m) Abort after x seconds

