### PR TITLE
gui: Fix connection type icon width (fixes #8592)

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -170,6 +170,9 @@ table.table-auto td {
     height: 1em;
     display: inline-block;
     vertical-align: -20%;
+    /* Simulate same width as Fork Awesome icons. */
+    margin-left: .14285715em;
+    margin-right: .14285715em;
 }
 
 .remote-devices-panel {


### PR DESCRIPTION
The connection type icon comes from Bootstrap. As such, it does not follow the same dimensions as the other GUI icons, which come from Fork Awesome. Thus, add left and right margin to make its width roughly the same as the other GUI icons, which fixes its alignment in relation to text.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
