### PR TITLE
gui: Adjust connection type icon size scaling and alignment

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -169,7 +169,8 @@ table.table-auto td {
     width: 1em;
     height: 1em;
     display: inline-block;
-    vertical-align: -20%;
+    vertical-align: -10%;
+    background-size: contain;
 }
 
 .remote-devices-panel {


### PR DESCRIPTION
Currently, the connection type icon size is fixed at 1em (or 16px). This makes it behave differently from the other GUI icons coming from Fork Awesome, which automatically scale to their parent element's font size. Thus, set the background-size to contain in order to automatically let the icon resize itself to the font size.

Also, improve the alignment to a more middle position in relation to text, making it similar to Fork Awesome icons.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

#### Before:

![image](https://user-images.githubusercontent.com/5626656/200034558-97a5a668-f6e4-4693-b1e8-d5d9da9a17a4.png)

#### After (larger icon in the title bar and adjusted alignment):

![image](https://user-images.githubusercontent.com/5626656/200034573-19b64084-a46b-4878-83c9-c84f034c6f08.png)
