### PR TITLE
lib/model: Fixed adding empty items to device list (fixes #8646)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1276,7 +1276,7 @@ func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterCon
 			for _, fcfg := range folders {
 				cfg.Folders = append(cfg.Folders, fcfg)
 			}
-			cfg.Devices = make([]config.DeviceConfiguration, len(devices))
+			cfg.Devices = make([]config.DeviceConfiguration, 0, len(devices))
 			for _, dcfg := range devices {
 				cfg.Devices = append(cfg.Devices, dcfg)
 			}


### PR DESCRIPTION
### Purpose

Fixed an obvious typo that resulted in empty entries in the device list.

### Testing

Didn't do any testing.

For testing, you need to create 3 devices, connect 1 and 2, make 1 introducer for 2, connect 1 and 3, make sure that device 3 automatically appears on 2.

### Documentation

No need to change documentation.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

