### PR TITLE
lib/fs: Try to remove read only Windows files (fixes #3744)

### DIFF
--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -178,14 +178,6 @@ func (f *BasicFilesystem) Lstat(name string) (FileInfo, error) {
 	return basicFileInfo{fi}, err
 }
 
-func (f *BasicFilesystem) Remove(name string) error {
-	name, err := f.rooted(name)
-	if err != nil {
-		return err
-	}
-	return os.Remove(name)
-}
-
 func (f *BasicFilesystem) RemoveAll(name string) error {
 	name, err := f.rooted(name)
 	if err != nil {

--- a/lib/fs/basicfs_unix.go
+++ b/lib/fs/basicfs_unix.go
@@ -74,6 +74,14 @@ func (f *BasicFilesystem) Lchown(name, uid, gid string) error {
 	return os.Lchown(name, nuid, ngid)
 }
 
+func (f *BasicFilesystem) Remove(name string) error {
+	name, err := f.rooted(name)
+	if err != nil {
+		return err
+	}
+	return os.Remove(name)
+}
+
 // unrootedChecked returns the path relative to the folder root (same as
 // unrooted) or an error if the given path is not a subpath and handles the
 // special case when the given path is the folder root without a trailing

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"syscall"
 	"testing"
-
-	"github.com/syncthing/syncthing/lib/build"
 )
 
 func TestWindowsPaths(t *testing.T) {
@@ -208,7 +206,7 @@ func TestRemoveWindowsDirIcon(t *testing.T) {
 	}
 	ptr, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
-		t.Fatal(e)
+		t.Fatal(err)
 	}
 	if err := syscall.SetFileAttributes(ptr, uint32(syscall.FILE_ATTRIBUTE_DIRECTORY+syscall.FILE_ATTRIBUTE_READONLY)); err != nil {
 		t.Fatal(err)

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -197,29 +197,23 @@ func TestGetFinalPath(t *testing.T) {
 }
 
 func TestRemoveWindowsDirIcon(t *testing.T) {
-
-	if !build.IsWindows {
-		t.Skip("only Windows")
-		return
-	}
+	//Try to delete a folder with a custom icon with os.Remove (simulated by the readonly file attribute)
 
 	fs, dir := setup(t)
 	relativePath := "folder_with_icon"
 	path := filepath.Join(dir, relativePath)
 
-	//Try to delete a folder with a custom icon with os.Remove (simulated by the readonly file attribute)
-	err := os.Mkdir(path, os.ModeDir)
-
-	a, e := syscall.UTF16PtrFromString(path)
-	if e == nil {
-		syscall.SetFileAttributes(a, uint32(syscall.FILE_ATTRIBUTE_DIRECTORY+syscall.FILE_ATTRIBUTE_READONLY))
-	} else {
+	if err := os.Mkdir(path, os.ModeDir); err != nil {
+		t.Fatal(err)
+	}
+	ptr, err := syscall.UTF16PtrFromString(path)
+	if err != nil {
 		t.Fatal(e)
 	}
-
-	err = fs.Remove(relativePath)
-
-	if err != nil {
+	if err := syscall.SetFileAttributes(ptr, uint32(syscall.FILE_ATTRIBUTE_DIRECTORY+syscall.FILE_ATTRIBUTE_READONLY)); err != nil {
+		t.Fatal(err)
+	}
+	if err := fs.Remove(relativePath); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
This adds a hack to remove read-only and retry remove on Windows. This works for me to sync and then remove a directory with a custom icon set on it, on Windows 11.