### PR TITLE
lib: Don't bump version when inode time only changes (fixes #8654)

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -1426,10 +1426,10 @@ func (db *Lowlevel) checkErrorForRepair(err error) {
 }
 
 // unchanged checks if two files are the same and thus don't need to be updated.
-// Local flags or the invalid bit might change without the version
+// Local flags, the invalid bit and inode time might change without the version
 // being bumped.
 func unchanged(nf, ef protocol.FileIntf) bool {
-	return ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid() && ef.FileLocalFlags() == nf.FileLocalFlags()
+	return ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid() && ef.FileLocalFlags() == nf.FileLocalFlags() && ef.InodeChangeTime() == nf.InodeChangeTime()
 }
 
 func (db *Lowlevel) handleFailure(err error) {

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -207,6 +207,7 @@ type FileInfoComparison struct {
 	IgnoreFlags     uint32
 	IgnoreOwnership bool
 	IgnoreXattrs    bool
+	IgnoreInodeTime bool
 }
 
 func (f FileInfo) IsEquivalent(other FileInfo, modTimeWindow time.Duration) bool {
@@ -246,7 +247,7 @@ func (f FileInfo) isEquivalent(other FileInfo, comp FileInfoComparison) bool {
 
 	// If we are recording inode change times and it changed, they are not
 	// equal.
-	if (f.InodeChangeNs != 0 && other.InodeChangeNs != 0) && f.InodeChangeNs != other.InodeChangeNs {
+	if !comp.IgnoreInodeTime && (f.InodeChangeNs != 0 && other.InodeChangeNs != 0) && f.InodeChangeNs != other.InodeChangeNs {
 		return false
 	}
 


### PR DESCRIPTION
The inode time is only a local thing (e.g. updated on sync) so bumping the version vector on it's change only is meaningless and potentially harmful. It indicates a meaningful change on this device, while in fact nothing changed. Without that behaviour the conflicts in #8654 wouldn't have happened.