### PR TITLE
lib/model: Correctly set xattrs on temp files (fixes #8667)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -2120,7 +2120,7 @@ func (f *sendReceiveFolder) checkToBeDeleted(file, cur protocol.FileInfo, hasCur
 func (f *sendReceiveFolder) setPlatformData(file *protocol.FileInfo, name string) error {
 	if f.SyncXattrs {
 		// Set extended attributes.
-		if err := f.mtimefs.SetXattr(file.Name, file.Platform.Xattrs(), f.XattrFilter); errors.Is(err, fs.ErrXattrsNotSupported) {
+		if err := f.mtimefs.SetXattr(name, file.Platform.Xattrs(), f.XattrFilter); errors.Is(err, fs.ErrXattrsNotSupported) {
 			l.Debugf("Cannot set xattrs on %q: %v", file.Name, err)
 		} else if err != nil {
 			return err


### PR DESCRIPTION
There was an error, where setPlatformData took the name to operate on from the FileInfo instead of the given parameter. This worked in some cases, but not when applied to a file being synced (new, or data was changed). Bonus: a small test.