### PR TITLE
cmd/syncthing/generate: Log DeviceId to stdout instead of stderr (fix…

### DIFF
--- a/cmd/syncthing/generate/generate.go
+++ b/cmd/syncthing/generate/generate.go
@@ -24,6 +24,11 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/syncthing"
+	"github.com/syncthing/syncthing/lib/logger"
+)
+
+var (
+	l = logger.DefaultLogger.NewFacility("app", "Main run facility")
 )
 
 type CLI struct {
@@ -88,8 +93,7 @@ func Generate(confDir, guiUser, guiPassword string, noDefaultFolder, skipPortPro
 		}
 	}
 	myID = protocol.NewDeviceID(cert.Certificate[0])
-	log.Println("Device ID:", myID)
-
+	l.Infoln("Device ID:", myID)
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, _, err := config.Load(cfgFile, myID, events.NoopLogger)
 	if fs.IsNotExist(err) {


### PR DESCRIPTION
…es #8682)

### Purpose
I explained the problem in the issue I opened, it seemed like a very simple fix, so I thought I help on that. though not sure I got it right. I am very new to go, but it seems log module prints to stderr by default and other places in the codebase are using an internal logger to log to stdout. I tried to use that in generate package as well. but again I am not 100% sure I got it right.
