### PR TITLE
cmd/syncthing: Use main logger in generate subcommand (fixes #8682)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -251,6 +251,7 @@ func main() {
 
 	ctx, err := parser.Parse(args)
 	parser.FatalIfErrorf(err)
+	ctx.BindTo(l, (*logger.Logger)(nil)) // main logger available to subcommands
 	err = ctx.Run()
 	parser.FatalIfErrorf(err)
 }
@@ -345,7 +346,7 @@ func (options serveOptions) Run() error {
 	}
 
 	if options.GenerateDir != "" {
-		if err := generate.Generate(options.GenerateDir, "", "", options.NoDefaultFolder, options.SkipPortProbing); err != nil {
+		if err := generate.Generate(l, options.GenerateDir, "", "", options.NoDefaultFolder, options.SkipPortProbing); err != nil {
 			l.Warnln("Failed to generate config and keys:", err)
 			os.Exit(svcutil.ExitError.AsInt())
 		}


### PR DESCRIPTION
We had some unholy mix of our own logger and the stdlib logger, probably because for historical reasons we wanted the device ID to stdout and the rest to stderr? But that's not the case any more, and the mix of formats is weird. Ideally I think the generate command should be silent and just print the device ID and nothing else, but that's tricky to accomplish since we have other methods do logging on their own. Hence this just harmonizes it so that we at least use the same logger with the same format and target...
