### PR TITLE
Set build metadata correctly in Windows build

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -96,7 +96,7 @@ jobs:
           path: |
             ~\AppData\Local\go-build
             ~\go\pkg\mod
-          key: ${{ runner.os }}-go-${{ env.GOVERSION }}-package-${{ hashFiles('**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -16,6 +16,10 @@ env:
   # Avoid hilarious amounts of obscuring log output when running tests.
   LOGGER_DISCARD: "1"
 
+  # Our build metadata
+  BUILD_USER: builder
+  BUILD_HOST: github.syncthing.net
+
 # A note on actions and third party code... The actions under actions/ (like
 # `uses: actions/checkout`) are maintained by GitHub, and we need to trust
 # GitHub to maintain their code and infrastructure or we're in deep shit in

--- a/build.go
+++ b/build.go
@@ -1115,7 +1115,12 @@ func buildStamp() int64 {
 		return time.Now().Unix()
 	}
 
-	s, _ := strconv.ParseInt(string(bs), 10, 64)
+	s, err := strconv.ParseInt(string(bs), 10, 64)
+	if err != nil {
+		// Fall back to "now".
+		log.Printf("Failed to parse git output: %q: %v", string(bs), err)
+		return time.Now().Unix()
+	}
 	return s
 }
 

--- a/build.go
+++ b/build.go
@@ -1115,12 +1115,7 @@ func buildStamp() int64 {
 		return time.Now().Unix()
 	}
 
-	s, err := strconv.ParseInt(string(bs), 10, 64)
-	if err != nil {
-		// Fall back to "now".
-		log.Printf("Failed to parse git output: %q: %v", string(bs), err)
-		return time.Now().Unix()
-	}
+	s, _ := strconv.ParseInt(string(bs), 10, 64)
 	return s
 }
 


### PR DESCRIPTION
Without this, we tag the build as made by some random user account on some random host name which is not useful.

(And minor bug in the cache key which has no effect on the build itself.)