### PR TITLE
docker: Update healthcheck cmd for buildx (ref #8640)

### DIFF
--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -5,7 +5,7 @@ EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 
 VOLUME ["/var/syncthing"]
 
-RUN apk add --no-cache ca-certificates su-exec tzdata libcap
+RUN apk add --no-cache ca-certificates curl libcap su-exec tzdata
 
 COPY ./syncthing-linux-$TARGETARCH /bin/syncthing
 COPY ./script/docker-entrypoint.sh /bin/entrypoint.sh

--- a/Dockerfile.buildx
+++ b/Dockerfile.buildx
@@ -13,7 +13,7 @@ COPY ./script/docker-entrypoint.sh /bin/entrypoint.sh
 ENV PUID=1000 PGID=1000 HOME=/var/syncthing
 
 HEALTHCHECK --interval=1m --timeout=10s \
-  CMD nc -z 127.0.0.1 8384 || exit 1
+  CMD curl -fkLsS -m 2 127.0.0.1:8384/rest/noauth/health | grep -o --color=never OK || exit 1
 
 ENV STGUIADDRESS=0.0.0.0:8384
 ENTRYPOINT ["/bin/entrypoint.sh", "/bin/syncthing", "-home", "/var/syncthing/config"]


### PR DESCRIPTION
This is the Dockerfile that's actually used in the multi-platform builds published to Docker hub.