### PR TITLE
Disable missing syscall on android-amd64, support AVD 12+ and Chromebook arch x86_64

### DIFF
--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -36,7 +36,7 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 		eventMask |= permEventMask
 	}
 
-	if (runtime.GOOS == "android" && runtime.GOARCH == "amd64") {
+	if runtime.GOOS == "android" && runtime.GOARCH == "amd64" {
 		err = errors.New("failed to setup inotify handler, see https://github.com/Catfriend1/syncthing-android/issues/583")
 		return nil, nil, err
 	}

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -12,6 +12,7 @@ package fs
 import (
 	"context"
 	"errors"
+	"runtime"
 
 	"github.com/syncthing/notify"
 )
@@ -35,6 +36,10 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 		eventMask |= permEventMask
 	}
 
+	if (runtime.GOOS == "android" && runtime.GOARCH == "amd64") {
+		err = errors.New("failed to setup inotify handler, see https://github.com/Catfriend1/syncthing-android/issues/583")
+		return nil, nil, err
+	}
 	if ignore.SkipIgnoredDirs() {
 		absShouldIgnore := func(absPath string) bool {
 			rel, err := f.unrootedChecked(absPath, roots)


### PR DESCRIPTION
### Purpose

Without this PR, "libsyncthing.so" (SyncthingNative) crashes with "bad syscall error".
ref: https://github.com/Catfriend1/syncthing-android/issues/583#issuecomment-1341022101

Affected: Both Syncthing(Android) and Syncthing-Fork (for Android). The missing syscall is called by "unix.EpollWait" from the god module "github.com/syncthing/notify". "unix.EpollWait" is part of "golang.org/x/sys". Upgrading "golang.org/x/sys" to the most recent version 0.3.0 doesn't solve the problem. So I've made this PR. 

Issue: https://github.com/syncthing/syncthing-android/issues/1703

### Testing

Verified on Android AVD 13. The disabled syscall (unix.epollwait) which isn't available on android-amd64 arch allows SyncthingNative to run without the file watcher. Platforms using this arch are for example: Android emulator >= 12, Google Chromebook. The arch is also labeled "x86_64" in app/src/jniLibs.

### Screenshots

![image](https://user-images.githubusercontent.com/16361913/206311703-5634df78-115a-41e8-b25e-243f04f52b81.png)

### Documentation

ref: https://github.com/Catfriend1/syncthing-android/issues/583

Please go light on me, I don't know much about the go stuff and appreciate any help on this. My main goal isn't dealing with the affected go lib or syscall stuff but I really need my Android emulator be able to execute the Syncthing Android app to continue my work on newer API levels and Android releases 12+.

## Authorship

Catfriend1

