### PR TITLE
lib/fs: Watching is unsupported on android/amd64 (fixes #8709)

### DIFF
--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -4,8 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build (!solaris && !darwin) || (solaris && cgo) || (darwin && cgo)
-// +build !solaris,!darwin solaris,cgo darwin,cgo
+//go:build !(solaris && !cgo) && !(darwin && !cgo) && !(android && amd64)
+// +build !solaris cgo
+// +build !darwin cgo
+// +build !android !amd64
 
 package fs
 

--- a/lib/fs/basicfs_watch_unsupported.go
+++ b/lib/fs/basicfs_watch_unsupported.go
@@ -4,8 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build (solaris && !cgo) || (darwin && !cgo)
-// +build solaris,!cgo darwin,!cgo
+//go:build (solaris && !cgo) || (darwin && !cgo) || (android && amd64)
+// +build solaris,!cgo darwin,!cgo android,amd64
 
 package fs
 


### PR DESCRIPTION
Apparently watching on android/amd64 causes a `SIGSYS: bad syscall` crash. This avoids that.