### PR TITLE
lib/model: Only log at info level if setting change time fails

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1778,7 +1778,11 @@ loop:
 				// use this change time to check for changes to xattrs etc
 				// on next scan.
 				if err := f.updateFileInfoChangeTime(&job.file); err != nil {
-					l.Warnf("Error updating metadata for %v at database commit: %v", job.file.Name, err)
+					// This means on next scan the likely incorrect change time
+					// (resp. whatever caused the error) will cause this file to
+					// change. Log at info level to leave a trace if a user
+					// notices, but no need to warn
+					l.Infof("Error updating metadata for %v at database commit: %v", job.file.Name, err)
 				}
 			}
 			job.file.Sequence = 0


### PR DESCRIPTION
By @tomasz1986 in https://github.com/syncthing/syncthing/issues/8583#issuecomment-1352971185

> [...] If this isn't a problem per se, is it really necessary to even notify the user about it?

Indeed the error is either inconsequential (if the file is gone, that's going to be picked up by the subsequent scan, change time doesn't matter) or at worst if it's indeed a temporary issue, the next scan will notice the changed time and bump the version. Info level logging seems appropriate, such that there's infos in the logs in case a user encounters weird issues due to that, but no need to warn/send a banner to the UI over this.