### PR TITLE
lib/fs: Use io/fs errors as recommended in std lib

### DIFF
--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,20 +193,25 @@ const OptWriteOnly = os.O_WRONLY
 // as an error by any function.
 var SkipDir = filepath.SkipDir
 
-// IsExist is the equivalent of os.IsExist
-var IsExist = os.IsExist
+func IsExist(err error) bool {
+	return errors.Is(err, ErrExist)
+}
 
-// IsExist is the equivalent of os.ErrExist
-var ErrExist = os.ErrExist
+// ErrExist is the equivalent of os.ErrExist
+var ErrExist = fs.ErrExist
 
 // IsNotExist is the equivalent of os.IsNotExist
-var IsNotExist = os.IsNotExist
+func IsNotExist(err error) bool {
+	return errors.Is(err, ErrNotExist)
+}
 
 // ErrNotExist is the equivalent of os.ErrNotExist
-var ErrNotExist = os.ErrNotExist
+var ErrNotExist = fs.ErrNotExist
 
 // IsPermission is the equivalent of os.IsPermission
-var IsPermission = os.IsPermission
+func IsPermission(err error) bool {
+	return errors.Is(err, fs.ErrPermission)
+}
 
 // IsPathSeparator is the equivalent of os.IsPathSeparator
 var IsPathSeparator = os.IsPathSeparator

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -996,8 +996,8 @@ func TestIssue4901(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error")
 		}
-		if fs.IsNotExist(err) {
-			t.Fatal("unexpected error type")
+		if err == fs.ErrNotExist {
+			t.Fatalf("unexpected error type: %T", err)
 		}
 		if !IsParseError(err) {
 			t.Fatal("failure to load included file should be a parse error")


### PR DESCRIPTION
Stumbled over this randomly, small housekeeping: The os package tells one to use errors.Is with the errors in io/fs instead of these functions predating the newer style error handling.