### PR TITLE
gui, api: Indicate running under container

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2 // indirect
+	github.com/calmh/incontainer v0.0.0-20221224151841-a0bf9955b52f // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/calmh/incontainer v0.0.0-20221224151841-a0bf9955b52f // indirect
+	github.com/calmh/incontainer v0.0.0-20221224152218-b3e71b103d7a // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/golang/mock v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -31,6 +31,8 @@ github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2 h1:1e21mRtyPbUn5
 github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2/go.mod h1:eOhqnw15c9X+4RNBe0W3HlUZFfX16O0EDsCOInTndHY=
 github.com/calmh/incontainer v0.0.0-20221224151841-a0bf9955b52f h1:a0rHjaYZeQgEn/oB956REp1A2mUFQY83iQlICIu7Oo4=
 github.com/calmh/incontainer v0.0.0-20221224151841-a0bf9955b52f/go.mod h1:eOhqnw15c9X+4RNBe0W3HlUZFfX16O0EDsCOInTndHY=
+github.com/calmh/incontainer v0.0.0-20221224152218-b3e71b103d7a h1:CjrQbpvnV4BMzPHf0r8p2FAvzEp/bp761CmBBeNIHXI=
+github.com/calmh/incontainer v0.0.0-20221224152218-b3e71b103d7a/go.mod h1:eOhqnw15c9X+4RNBe0W3HlUZFfX16O0EDsCOInTndHY=
 github.com/calmh/xdr v1.1.0 h1:U/Dd4CXNLoo8EiQ4ulJUXkgO1/EyQLgDKLgpY1SOoJE=
 github.com/calmh/xdr v1.1.0/go.mod h1:E8sz2ByAdXC8MbANf1LCRYzedSnnc+/sXXJs/PVqoeg=
 github.com/ccding/go-stun v0.1.4 h1:lC0co3Q3vjAuu2Jz098WivVPBPbemYFqbwE1syoka4M=

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/calmh/glob v0.0.0-20220615080505-1d823af5017b h1:Fjm4GuJ+TGMgqfGHN42I
 github.com/calmh/glob v0.0.0-20220615080505-1d823af5017b/go.mod h1:91K7jfEsgJSyfSrX+gmrRfZMtntx6JsHolWubGXDopg=
 github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2 h1:1e21mRtyPbUn5W/lFvk+rCBVuzkfiiflv1vn8p4Btho=
 github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2/go.mod h1:eOhqnw15c9X+4RNBe0W3HlUZFfX16O0EDsCOInTndHY=
+github.com/calmh/incontainer v0.0.0-20221224151841-a0bf9955b52f h1:a0rHjaYZeQgEn/oB956REp1A2mUFQY83iQlICIu7Oo4=
+github.com/calmh/incontainer v0.0.0-20221224151841-a0bf9955b52f/go.mod h1:eOhqnw15c9X+4RNBe0W3HlUZFfX16O0EDsCOInTndHY=
 github.com/calmh/xdr v1.1.0 h1:U/Dd4CXNLoo8EiQ4ulJUXkgO1/EyQLgDKLgpY1SOoJE=
 github.com/calmh/xdr v1.1.0/go.mod h1:E8sz2ByAdXC8MbANf1LCRYzedSnnc+/sXXJs/PVqoeg=
 github.com/ccding/go-stun v0.1.4 h1:lC0co3Q3vjAuu2Jz098WivVPBPbemYFqbwE1syoka4M=

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/calmh/glob v0.0.0-20220615080505-1d823af5017b h1:Fjm4GuJ+TGMgqfGHN42IQArJb77CfD/mAwLbDUoJe6g=
 github.com/calmh/glob v0.0.0-20220615080505-1d823af5017b/go.mod h1:91K7jfEsgJSyfSrX+gmrRfZMtntx6JsHolWubGXDopg=
+github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2 h1:1e21mRtyPbUn5W/lFvk+rCBVuzkfiiflv1vn8p4Btho=
+github.com/calmh/incontainer v0.0.0-20221224114231-8fd484b086d2/go.mod h1:eOhqnw15c9X+4RNBe0W3HlUZFfX16O0EDsCOInTndHY=
 github.com/calmh/xdr v1.1.0 h1:U/Dd4CXNLoo8EiQ4ulJUXkgO1/EyQLgDKLgpY1SOoJE=
 github.com/calmh/xdr v1.1.0/go.mod h1:E8sz2ByAdXC8MbANf1LCRYzedSnnc+/sXXJs/PVqoeg=
 github.com/ccding/go-stun v0.1.4 h1:lC0co3Q3vjAuu2Jz098WivVPBPbemYFqbwE1syoka4M=

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -720,9 +720,7 @@
                     </tr>
                     <tr>
                       <th><span class="fas fa-fw fa-tag"></span>&nbsp;<span translate>Version</span></th>
-                      <td class="text-right">
-                        <span tooltip data-original-title="{{versionString()}}">{{versionString()}}</span>
-                      </td>
+                      <td class="text-right no-overflow-ellipse">{{versionString()}}</td>
                     </tr>
                   </tbody>
                 </table>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3079,6 +3079,10 @@ angular.module('syncthing.core')
                 's390x': '64-bit z/Architecture',
             }[$scope.version.arch] || $scope.version.arch;
 
+            if ($scope.version.container) {
+                arch += " Container";
+            }
+
             return $scope.version.version + ', ' + os + ' (' + arch + ')';
         };
 

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -30,6 +30,7 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/calmh/incontainer"
 	"github.com/julienschmidt/httprouter"
 	"github.com/rcrowley/go-metrics"
 	"github.com/thejerf/suture/v4"
@@ -721,6 +722,7 @@ func (*service) getSystemVersion(w http.ResponseWriter, _ *http.Request) {
 		"tags":        build.TagsList(),
 		"stamp":       build.Stamp,
 		"user":        build.User,
+		"container":   incontainer.Detect(),
 	})
 }
 


### PR DESCRIPTION
This adds a word to the version string when running containerized. The purpose is mostly to facilitate troubleshooting via screenshot by "leaking" this rather important aspect of the setup. Additionally, the version row gets "no-overflow-ellipsis" treatment so that the whole thing is actually visible in the GUI and the (now useless) tooltip is removed. In production releases this won't make a difference as the whole thing will typically fit, but in odd setups it provides more info up front.

<img width="601" alt="Screenshot 2022-12-24 at 13 00 49" src="https://user-images.githubusercontent.com/125426/209435204-e7bb2305-8dcd-462b-a1f0-91a8581f7d52.png">

Arguably this thing should be localized, but ... the version strings aren't currently, because they're proper names of sort, the "64-bit" part could be...