### PR TITLE
Container start-time volume check

### DIFF
--- a/README-Docker.md
+++ b/README-Docker.md
@@ -107,3 +107,13 @@ $ docker run -e STGUIADDRESS= \
 
 With the environment variable unset Syncthing will follow what is set in the
 configuration file / GUI settings dialog.
+
+## Remote Mounted Volume
+
+In case the volume is temporarily unreachable during boot time, container may
+start re-creating configuration locally before volume gets mounted and data
+becomes available.
+
+Flagging dedicated `NOCREATE` environment variable combined with
+`--restart=unless-stopped` shall make container self-restart until volume
+mounts and data becomes available.

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+# If NOCREATE is defined, check if configuration exists.
+# Missing configuration is treated as volume not yet mounted (boot time race condition)
+# and container exits for Docker to handle restart.
+if [ ! -z "${NOCREATE}" -a ! -f "/var/syncthing/config/config.xml" ]; then
+  echo "Volume is not mounted; waiting and quitting."
+  sleep 1
+  exit 1
+fi
+
 set -eu
 
 if [ "$(id -u)" = '0' ]; then


### PR DESCRIPTION
### Purpose

Opt-in to check if mapped volume contains configuration file. If mapped volume is mounted from remote host, it may be temporarily unavailable during boot time. Which the optional `NOCREATE` environment variable entrypoint script checks if config.xml is available; if not - container exits for Docker to handle restarting periodically until configuration appears (volume mounts).

### Testing

Tested on local setup: container keeps restarted by Docker until mounted volume with data (config/config.xml) becomes available.

### Documentation

Related paragraph added to README.