### PR TITLE
GitHub: Build with Go 1.19.5 (fixes #8325)

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -6,7 +6,7 @@ on:
 
 env:
   # The go version to use for builds.
-  GO_VERSION: "1.19.4"
+  GO_VERSION: "1.19.5"
 
   # Optimize compatibility on the slow archictures.
   GO386: softfloat


### PR DESCRIPTION
The new Go patch version includes a fix for #8325.  The Synology package, where this error occurred frequently, is going to be built with it by default.  We should upgrade as well to avoid breaking existing installations again when they auto-upgrade to our upcoming release.  See also https://github.com/SynoCommunity/spksrc/issues/5289.

**Is there any other place (TeamCity?) where we need to specify this, or is only this GH action involved in building release artifacts?**
