### PR TITLE
gui: Fix broken link to Transifex in lang/README.txt

### DIFF
--- a/gui/default/assets/lang/README.txt
+++ b/gui/default/assets/lang/README.txt
@@ -1,7 +1,7 @@
 All files in this directory are auto generated. Do not change any of
 them. To contribute translations, please head over to
 
- https://www.transifex.com/projects/p/syncthing/
+https://explore.transifex.com/syncthing/
 
 Any updates made on Transifex will be automatically pulled into these
 files.


### PR DESCRIPTION
Updated URL

### Purpose

I decided to update the URL, since the old one did not lead to the project page
