### PR TITLE
gui: Remove non-existent customicons.css file reference (fixes #8797)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -24,7 +24,6 @@
   <link href="assets/css/tree.css" rel="stylesheet"/>
   <link href="assets/css/overrides.css" rel="stylesheet"/>
   <link href="assets/css/theme.css" rel="stylesheet"/>
-  <link href="assets/css/customicons.css" rel="stylesheet"/>
 </head>
 
 <body>


### PR DESCRIPTION
The reference comes from fd0a6225aadce9cee19ab058465fa5c8658f0be9,
but the file itself was removed in the process of working on the pull
request, yet the reference to it was still left in the index.html.