### PR TITLE
gui: show encryption status for folder shares

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2468,7 +2468,11 @@ angular.module('syncthing.core')
             var names = [];
             folderCfg.devices.forEach(function (device) {
                 if (device.deviceID !== $scope.myID) {
-                    names.push($scope.deviceNameMarkRemoteState(device.deviceID, folderCfg.id));
+                    var name = $scope.deviceNameMarkRemoteState(device.deviceID, folderCfg.id);
+                    if (device.encryptionPassword !== '') {
+                        name = '<span class="fa fa-lock"></span>&nbsp;' + name;
+                    }
+                    names.push(name);
                 }
             });
             names.sort();


### PR DESCRIPTION
### Purpose

In the folder list: Show a lock icon for encrypted shares. This helps to quickly see which shares are encrypted.

I implemented it by adding the html code for the icon in JS. Since there is already some complexity in how the list is generated, it may be worth refactoring this to a loop in index.html and then having a separate JS function `folderShareEncrypted(folderID, deviceID)`.

Here's the already existing string generation ([link](https://github.com/syncthing/syncthing/blob/8bbf2ba9ac7048cdc7527c3b6e71b3086448fa3a/gui/default/index.html#L557)):
```lang=html
data-original-title="{{sharesFolder(folder)}} {{folderHasUnacceptedDevices(folder) ? '<br/>(<sup>1</sup>' + ('The remote device has not accepted sharing this folder.' | translate) + ')' : ''}} {{folderHasPausedDevices(folder) ? '<br/>(<sup>2</sup>' + ('The remote device has paused this folder.' | translate) + ')' : ''}}"
```

### Testing

Ran it.

### Screenshot

![Screenshot](https://github.com/Craeckie/syncthing/raw/screenshot/assets/Screenshot%20share%20lock.png)

## Authorship

Craeckie

