### PR TITLE
lib/api: Expose `blocksHash` in file info

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1828,6 +1828,7 @@ func fileIntfJSONMap(f protocol.FileIntf) map[string]interface{} {
 		"localFlags":    f.FileLocalFlags(),
 		"platform":      f.PlatformData(),
 		"inodeChange":   f.InodeChangeTime(),
+		"blocksHash":    f.FileBlocksHash(),
 	}
 	if f.HasPermissionBits() {
 		out["permissions"] = fmt.Sprintf("%#o", f.FilePermissions())

--- a/lib/db/structs.go
+++ b/lib/db/structs.go
@@ -133,6 +133,10 @@ func (f FileInfoTruncated) InodeChangeTime() time.Time {
 	return time.Unix(0, f.InodeChangeNs)
 }
 
+func (f FileInfoTruncated) FileBlocksHash() []byte {
+	return f.BlocksHash
+}
+
 func (f FileInfoTruncated) ConvertToIgnoredFileInfo() protocol.FileInfo {
 	file := f.copyToFileInfo()
 	file.SetIgnored()

--- a/lib/protocol/bep_extensions.go
+++ b/lib/protocol/bep_extensions.go
@@ -46,6 +46,7 @@ type FileIntf interface {
 	ModTime() time.Time
 	PlatformData() PlatformData
 	InodeChangeTime() time.Time
+	FileBlocksHash() []byte
 }
 
 func (Hello) Magic() uint32 {
@@ -168,6 +169,10 @@ func (f FileInfo) PlatformData() PlatformData {
 
 func (f FileInfo) InodeChangeTime() time.Time {
 	return time.Unix(0, f.InodeChangeNs)
+}
+
+func (f FileInfo) FileBlocksHash() []byte {
+	return f.BlocksHash
 }
 
 // WinsConflict returns true if "f" is the one to choose when it is in


### PR DESCRIPTION
This adds the BlocksHash field from the FileInfo to our API output. It can be useful for debugging, or for external tools. I'm intentionally leaving it as an opaque base64 string because no meaning should be derived from it: it's just a string.
