### PR TITLE
lib/api: extend `db/browse` to filter filename

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -760,12 +760,13 @@ func (s *service) getDBBrowse(w http.ResponseWriter, r *http.Request) {
 	folder := qs.Get("folder")
 	prefix := qs.Get("prefix")
 	dirsOnly := qs.Get("dirsonly") != ""
+	filenameContains := qs.Get("filenamecontains")
 
 	levels, err := strconv.Atoi(qs.Get("levels"))
 	if err != nil {
 		levels = -1
 	}
-	result, err := s.model.GlobalDirectoryTree(folder, prefix, levels, dirsOnly)
+	result, err := s.model.GlobalDirectoryTree(folder, prefix, levels, dirsOnly, filenameContains)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/lib/model/mocks/model.go
+++ b/lib/model/mocks/model.go
@@ -287,13 +287,14 @@ type Model struct {
 		result1 fs.MtimeMapping
 		result2 error
 	}
-	GlobalDirectoryTreeStub        func(string, string, int, bool) ([]*model.TreeEntry, error)
+	GlobalDirectoryTreeStub        func(string, string, int, bool, string) ([]*model.TreeEntry, error)
 	globalDirectoryTreeMutex       sync.RWMutex
 	globalDirectoryTreeArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 int
 		arg4 bool
+		arg5 string
 	}
 	globalDirectoryTreeReturns struct {
 		result1 []*model.TreeEntry
@@ -1923,7 +1924,7 @@ func (fake *Model) GetMtimeMappingReturnsOnCall(i int, result1 fs.MtimeMapping, 
 	}{result1, result2}
 }
 
-func (fake *Model) GlobalDirectoryTree(arg1 string, arg2 string, arg3 int, arg4 bool) ([]*model.TreeEntry, error) {
+func (fake *Model) GlobalDirectoryTree(arg1 string, arg2 string, arg3 int, arg4 bool, arg5 string) ([]*model.TreeEntry, error) {
 	fake.globalDirectoryTreeMutex.Lock()
 	ret, specificReturn := fake.globalDirectoryTreeReturnsOnCall[len(fake.globalDirectoryTreeArgsForCall)]
 	fake.globalDirectoryTreeArgsForCall = append(fake.globalDirectoryTreeArgsForCall, struct {
@@ -1931,13 +1932,14 @@ func (fake *Model) GlobalDirectoryTree(arg1 string, arg2 string, arg3 int, arg4 
 		arg2 string
 		arg3 int
 		arg4 bool
-	}{arg1, arg2, arg3, arg4})
+		arg5 string
+	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.GlobalDirectoryTreeStub
 	fakeReturns := fake.globalDirectoryTreeReturns
-	fake.recordInvocation("GlobalDirectoryTree", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("GlobalDirectoryTree", []interface{}{arg1, arg2, arg3, arg4, arg5})
 	fake.globalDirectoryTreeMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1951,17 +1953,17 @@ func (fake *Model) GlobalDirectoryTreeCallCount() int {
 	return len(fake.globalDirectoryTreeArgsForCall)
 }
 
-func (fake *Model) GlobalDirectoryTreeCalls(stub func(string, string, int, bool) ([]*model.TreeEntry, error)) {
+func (fake *Model) GlobalDirectoryTreeCalls(stub func(string, string, int, bool, string) ([]*model.TreeEntry, error)) {
 	fake.globalDirectoryTreeMutex.Lock()
 	defer fake.globalDirectoryTreeMutex.Unlock()
 	fake.GlobalDirectoryTreeStub = stub
 }
 
-func (fake *Model) GlobalDirectoryTreeArgsForCall(i int) (string, string, int, bool) {
+func (fake *Model) GlobalDirectoryTreeArgsForCall(i int) (string, string, int, bool, string) {
 	fake.globalDirectoryTreeMutex.RLock()
 	defer fake.globalDirectoryTreeMutex.RUnlock()
 	argsForCall := fake.globalDirectoryTreeArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *Model) GlobalDirectoryTreeReturns(result1 []*model.TreeEntry, result2 error) {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2594,7 +2594,6 @@ func findByName(slice []*TreeEntry, name string) *TreeEntry {
 // use depth first search to delete empty folders
 func truncateEmptyDirs(slice []*TreeEntry) []*TreeEntry {
 	if slice == nil {
-		fmt.Printf("end search: returning nil\n")
 		return nil
 	}
 	for index, entry := range slice {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -115,7 +115,7 @@ type Model interface {
 	DismissPendingFolder(device protocol.DeviceID, folder string) error
 
 	StartDeadlockDetector(timeout time.Duration)
-	GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly bool) ([]*TreeEntry, error)
+	GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly bool, filenameContains string) ([]*TreeEntry, error)
 }
 
 type model struct {
@@ -2591,7 +2591,7 @@ func findByName(slice []*TreeEntry, name string) *TreeEntry {
 	return nil
 }
 
-func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly bool) ([]*TreeEntry, error) {
+func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly bool, filenameContains string) ([]*TreeEntry, error) {
 	m.fmut.RLock()
 	files, ok := m.folderFiles[folder]
 	m.fmut.RUnlock()
@@ -2628,6 +2628,10 @@ func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly 
 		base := filepath.Base(f.Name)
 
 		if levels > -1 && strings.Count(f.Name, sep) > levels {
+			return true
+		}
+
+		if filenameContains != "" && !strings.Contains(base, filenameContains) {
 			return true
 		}
 

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1811,19 +1811,19 @@ func TestGlobalDirectoryTree(t *testing.T) {
 
 	must(t, m.Index(device1, "default", testdata))
 
-	result, _ := m.GlobalDirectoryTree("default", "", -1, false)
+	result, _ := m.GlobalDirectoryTree("default", "", -1, false, "")
 
 	if mm(result) != mm(expectedResult) {
 		t.Errorf("Does not match:\n%s\n============\n%s", mm(result), mm(expectedResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "another", -1, false)
+	result, _ = m.GlobalDirectoryTree("default", "another", -1, false, "")
 
 	if mm(result) != mm(findByName(expectedResult, "another").Children) {
 		t.Errorf("Does not match:\n%s\n============\n%s", mm(result), mm(findByName(expectedResult, "another").Children))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "", 0, false)
+	result, _ = m.GlobalDirectoryTree("default", "", 0, false, "")
 	currentResult := []*TreeEntry{
 		d("another"),
 		d("other"),
@@ -1835,7 +1835,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n============\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "", 1, false)
+	result, _ = m.GlobalDirectoryTree("default", "", 1, false, "")
 	currentResult = []*TreeEntry{
 		d("another",
 			d("directory"),
@@ -1856,7 +1856,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "", -1, true)
+	result, _ = m.GlobalDirectoryTree("default", "", -1, true, "")
 	currentResult = []*TreeEntry{
 		d("another",
 			d("directory",
@@ -1886,7 +1886,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "", 1, true)
+	result, _ = m.GlobalDirectoryTree("default", "", 1, true, "")
 	currentResult = []*TreeEntry{
 		d("another",
 			d("directory"),
@@ -1905,7 +1905,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "another", 0, false)
+	result, _ = m.GlobalDirectoryTree("default", "another", 0, false, "")
 	currentResult = []*TreeEntry{
 		d("directory"),
 		f("file"),
@@ -1915,7 +1915,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "some/directory", 0, false)
+	result, _ = m.GlobalDirectoryTree("default", "some/directory", 0, false, "")
 	currentResult = []*TreeEntry{
 		d("with"),
 	}
@@ -1924,7 +1924,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "some/directory", 1, false)
+	result, _ = m.GlobalDirectoryTree("default", "some/directory", 1, false, "")
 	currentResult = []*TreeEntry{
 		d("with",
 			d("a"),
@@ -1935,7 +1935,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "some/directory", 2, false)
+	result, _ = m.GlobalDirectoryTree("default", "some/directory", 2, false, "")
 	currentResult = []*TreeEntry{
 		d("with",
 			d("a",
@@ -1948,7 +1948,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
 	}
 
-	result, _ = m.GlobalDirectoryTree("default", "another", -1, true)
+	result, _ = m.GlobalDirectoryTree("default", "another", -1, true, "")
 	currentResult = []*TreeEntry{
 		d("directory",
 			d("with",
@@ -1962,7 +1962,25 @@ func TestGlobalDirectoryTree(t *testing.T) {
 	}
 
 	// No prefix matching!
-	result, _ = m.GlobalDirectoryTree("default", "som", -1, false)
+	result, _ = m.GlobalDirectoryTree("default", "som", -1, false, "")
+	currentResult = []*TreeEntry{}
+
+	if mm(result) != mm(currentResult) {
+		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
+	}
+
+	result, _ = m.GlobalDirectoryTree("default", "another", -1, false, "afil")
+	currentResult = []*TreeEntry{
+		d("directory",
+			f("afile"),
+		),
+	}
+
+	if mm(result) != mm(currentResult) {
+		t.Errorf("Does not match:\n%s\n%s", mm(result), mm(currentResult))
+	}
+
+	result, _ = m.GlobalDirectoryTree("default", "another", -1, false, "dumb")
 	currentResult = []*TreeEntry{}
 
 	if mm(result) != mm(currentResult) {
@@ -2020,7 +2038,7 @@ func benchmarkTree(b *testing.B, n1, n2 int) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		m.GlobalDirectoryTree(fcfg.ID, "", -1, false)
+		m.GlobalDirectoryTree(fcfg.ID, "", -1, false, "")
 	}
 	b.ReportAllocs()
 }


### PR DESCRIPTION
### Purpose
relates to #8114

This is a naive idea to make the API to provide the conflicted file list. I added a simple dfs to truncate all empty dirs in the result. This truncation is applied only when we want to filter files.

IMHO, WebUI cannot use this method to show conflict files as this API can be expensive. But this is enough for GUI wrappers like [syncthingtray](https://github.com/Martchus/syncthingtray) to combine this API and `LocalChangeDetected`, `RemoteChangeDetected` events to provide such info.


### Documentation

I'll update doc if needed.

