### PR TITLE
add gh actions to build and publish multiarch images to dockerhub

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -96,60 +96,60 @@ jobs:
   # Windows
   #
 
-  package-windows:
-    name: Package for Windows
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    environment: signing
-    needs:
-      - build-test
-    runs-on: windows-latest
-    steps:
-      - name: Set git to use LF
-        # Without this, the checkout will happen with CRLF line endings,
-        # which is fine for the source code but messes up tests that depend
-        # on data on disk being as expected. Ideally, those tests should be
-        # fixed, but not today.
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
+  # package-windows:
+  #   name: Package for Windows
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+  #   environment: signing
+  #   needs:
+  #     - build-test
+  #   runs-on: windows-latest
+  #   steps:
+  #     - name: Set git to use LF
+  #       # Without this, the checkout will happen with CRLF line endings,
+  #       # which is fine for the source code but messes up tests that depend
+  #       # on data on disk being as expected. Ideally, those tests should be
+  #       # fixed, but not today.
+  #       run: |
+  #         git config --global core.autocrlf false
+  #         git config --global core.eol lf
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~\AppData\Local\go-build
-            ~\go\pkg\mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~\AppData\Local\go-build
+  #           ~\go\pkg\mod
+  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
 
-      - name: Install dependencies
-        run: |
-          go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+  #     - name: Install dependencies
+  #       run: |
+  #         go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
 
-      - name: Create packages
-        run: |
-          go run build.go -goarch amd64 zip
-          go run build.go -goarch arm zip
-          go run build.go -goarch arm64 zip
-          go run build.go -goarch 386 zip
-        env:
-          CGO_ENABLED: "0"
-          CODESIGN_SIGNTOOL: ${{ secrets.CODESIGN_SIGNTOOL }}
-          CODESIGN_CERTIFICATE_BASE64: ${{ secrets.CODESIGN_CERTIFICATE_BASE64 }}
-          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
-          CODESIGN_TIMESTAMP_SERVER: ${{ secrets.CODESIGN_TIMESTAMP_SERVER }}
+  #     - name: Create packages
+  #       run: |
+  #         go run build.go -goarch amd64 zip
+  #         go run build.go -goarch arm zip
+  #         go run build.go -goarch arm64 zip
+  #         go run build.go -goarch 386 zip
+  #       env:
+  #         CGO_ENABLED: "0"
+  #         CODESIGN_SIGNTOOL: ${{ secrets.CODESIGN_SIGNTOOL }}
+  #         CODESIGN_CERTIFICATE_BASE64: ${{ secrets.CODESIGN_CERTIFICATE_BASE64 }}
+  #         CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+  #         CODESIGN_TIMESTAMP_SERVER: ${{ secrets.CODESIGN_TIMESTAMP_SERVER }}
 
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages
-          path: syncthing-windows-*.zip
+  #     - name: Archive artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: packages
+  #         path: syncthing-windows-*.zip
 
   #
   # Linux
@@ -195,95 +195,95 @@ jobs:
   # macOS
   #
 
-  package-macos:
-    name: Package for macOS
-    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-    environment: signing
-    needs:
-      - build-test
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  # package-macos:
+  #   name: Package for macOS
+  #   if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+  #   environment: signing
+  #   needs:
+  #     - build-test
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
 
-      - name: Import signing certificate
-        run: |
-          # Set up a run-specific keychain, making it available for the
-          # `codesign` tool.
-          umask 066
-          KEYCHAIN_PATH=$RUNNER_TEMP/codesign.keychain
-          KEYCHAIN_PASSWORD=$(uuidgen)
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security default-keychain -s "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+  #     - name: Import signing certificate
+  #       run: |
+  #         # Set up a run-specific keychain, making it available for the
+  #         # `codesign` tool.
+  #         umask 066
+  #         KEYCHAIN_PATH=$RUNNER_TEMP/codesign.keychain
+  #         KEYCHAIN_PASSWORD=$(uuidgen)
+  #         security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+  #         security default-keychain -s "$KEYCHAIN_PATH"
+  #         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+  #         security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
 
-          # Import the certificate
-          CERTIFICATE_PATH=$RUNNER_TEMP/codesign.p12
-          echo "$DEVELOPER_ID_CERTIFICATE_BASE64" | base64 -d -o "$CERTIFICATE_PATH"
-          security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$DEVELOPER_ID_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
-          security set-key-partition-list -S apple-tool:,apple: -s -k actions "$KEYCHAIN_PATH"
+  #         # Import the certificate
+  #         CERTIFICATE_PATH=$RUNNER_TEMP/codesign.p12
+  #         echo "$DEVELOPER_ID_CERTIFICATE_BASE64" | base64 -d -o "$CERTIFICATE_PATH"
+  #         security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$DEVELOPER_ID_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
+  #         security set-key-partition-list -S apple-tool:,apple: -s -k actions "$KEYCHAIN_PATH"
 
-          # Set the codesign identity for following steps
-          echo "CODESIGN_IDENTITY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
-        env:
-          DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.DEVELOPER_ID_CERTIFICATE_BASE64 }}
-          DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}
-          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+  #         # Set the codesign identity for following steps
+  #         echo "CODESIGN_IDENTITY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
+  #       env:
+  #         DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.DEVELOPER_ID_CERTIFICATE_BASE64 }}
+  #         DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+  #         CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
 
-      - name: Create package (amd64)
-        run: |
-          go run build.go -goarch amd64 zip
-        env:
-          CGO_ENABLED: "1"
+  #     - name: Create package (amd64)
+  #       run: |
+  #         go run build.go -goarch amd64 zip
+  #       env:
+  #         CGO_ENABLED: "1"
 
-      - name: Create package (arm64 cross)
-        run: |
-          cat <<EOT > xgo.sh
-          #!/bin/bash
-          CGO_ENABLED=1 \
-            CGO_CFLAGS="-target arm64-apple-macos10.15" \
-            CGO_LDFLAGS="-target arm64-apple-macos10.15" \
-            go "\$@"
-          EOT
-          chmod 755 xgo.sh
-          go run build.go -gocmd ./xgo.sh -goarch arm64 zip
-        env:
-          CGO_ENABLED: "1"
+  #     - name: Create package (arm64 cross)
+  #       run: |
+  #         cat <<EOT > xgo.sh
+  #         #!/bin/bash
+  #         CGO_ENABLED=1 \
+  #           CGO_CFLAGS="-target arm64-apple-macos10.15" \
+  #           CGO_LDFLAGS="-target arm64-apple-macos10.15" \
+  #           go "\$@"
+  #         EOT
+  #         chmod 755 xgo.sh
+  #         go run build.go -gocmd ./xgo.sh -goarch arm64 zip
+  #       env:
+  #         CGO_ENABLED: "1"
 
-      - name: Create package (universal)
-        run: |
-          rm -rf _tmp
-          mkdir _tmp
-          pushd _tmp
+  #     - name: Create package (universal)
+  #       run: |
+  #         rm -rf _tmp
+  #         mkdir _tmp
+  #         pushd _tmp
 
-          unzip ../syncthing-macos-amd64-*.zip
-          unzip ../syncthing-macos-arm64-*.zip
-          lipo -create syncthing-macos-amd64-*/syncthing syncthing-macos-arm64-*/syncthing -o syncthing
+  #         unzip ../syncthing-macos-amd64-*.zip
+  #         unzip ../syncthing-macos-arm64-*.zip
+  #         lipo -create syncthing-macos-amd64-*/syncthing syncthing-macos-arm64-*/syncthing -o syncthing
 
-          amd64=(syncthing-macos-amd64-*)
-          universal="${amd64/amd64/universal}"
-          mv "$amd64" "$universal"
-          mv syncthing "$universal"
-          zip -r "../$universal.zip" "$universal"
+  #         amd64=(syncthing-macos-amd64-*)
+  #         universal="${amd64/amd64/universal}"
+  #         mv "$amd64" "$universal"
+  #         mv syncthing "$universal"
+  #         zip -r "../$universal.zip" "$universal"
 
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages
-          path: syncthing-*.zip
+  #     - name: Archive artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: packages
+  #         path: syncthing-*.zip
 
   #
   # Cross compile other unixes
@@ -382,8 +382,9 @@ jobs:
           path: syncthing-source-*.tar.gz
 
   docker-syncthing:
-    matrix: 
-      program: [strelaysrv, stdiscosrv]
+    strategy:
+      matrix: 
+        program: [strelaysrv, stdiscosrv]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -388,7 +388,7 @@ jobs:
         program: [strelaysrv, stdiscosrv]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set variables
         id: vars
         run: |

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -410,7 +410,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.${{ matrix.program }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/riscv64,linux/arm/v6,linux/arm/v7
           # push: ${{ github.event_name != 'pull_request' }}
           tags: migel0/syncthing-${{ matrix.program }}:latest
  

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -427,3 +427,28 @@ jobs:
           # tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:${{ env.PKGVER }},${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest
           
  
+  docker-syncthing:
+    needs: build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push syncthing
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing:latest
+ 

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -385,7 +385,7 @@ jobs:
     # needs: build-test
     strategy:
       matrix: 
-        program: [strelaysrv, stdiscosrv]
+        program: [stcrashreceiver, stdiscosrv, strelaypoolsrv, strelaysrv, stupgrades]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -381,7 +381,7 @@ jobs:
           name: packages
           path: syncthing-source-*.tar.gz
 
-  docker-syncthing:
+  docker-syncthing-programs:
     needs: build-test
     strategy:
       matrix: 
@@ -405,12 +405,23 @@ jobs:
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       -
-        name: Build and push
+        name: Build and push syncthing
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          # ,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing:latest
+      -
+        name: Build and push syncthing programs
         uses: docker/build-push-action@v4
         with:
           context: .
           file: ./Dockerfile.${{ matrix.program }}
-          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64
+          # ,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest
           # tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:${{ env.PKGVER }},${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -410,7 +410,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.${{ matrix.program }}
-          platforms: linux/amd64,linux/arm64,linux/riscv64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7
           # push: ${{ github.event_name != 'pull_request' }}
           tags: migel0/syncthing-${{ matrix.program }}:latest
  

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        runner: ["ubuntu-latest",]
         # The oldest version in this list should match what we have in our go.mod.
         # Variables don't seem to be supported here, or we could have done something nice.
         go: ["1.19"] # Skip Go 1.20 for now, https://github.com/syncthing/syncthing/issues/8799
@@ -380,3 +380,37 @@ jobs:
         with:
           name: packages
           path: syncthing-source-*.tar.gz
+
+  docker-syncthing:
+    matrix: 
+      program: [strelaysrv, stdiscosrv]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set variables
+        id: vars
+        run: |
+          PKGVER=$(grep ENV Dockerfile | cut -d" " -f 3)
+          echo "PKGVER=$PKGVER" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v3
+      -
+        name: Login to Docker Hub
+        # if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      -
+        name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile.${{ matrix.program }}
+          platforms: linux/amd64,linux/arm64
+          # push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:${{ env.PKGVER }},${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -395,9 +395,6 @@ jobs:
           PKGVER=$(grep ENV Dockerfile | cut -d" " -f 3)
           echo "PKGVER=$PKGVER" >> $GITHUB_ENV
       -
-        name: Checkout
-        uses: actions/checkout@v3
-      -
         name: Login to Docker Hub
         # if: github.event_name != 'pull_request'
         uses: docker/login-action@v2

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: ["ubuntu-latest",]
+        runner: ["windows-latest", "ubuntu-latest", "macos-latest"]
         # The oldest version in this list should match what we have in our go.mod.
         # Variables don't seem to be supported here, or we could have done something nice.
         go: ["1.19"] # Skip Go 1.20 for now, https://github.com/syncthing/syncthing/issues/8799
@@ -74,9 +74,9 @@ jobs:
         run: |
           go run build.go test
 
-  
+  #
   # Meta checks for formatting, copyright, etc
-  
+  #
 
   correctness:
     name: Check correctness
@@ -96,290 +96,290 @@ jobs:
   # Windows
   #
 
-  # package-windows:
-  #   name: Package for Windows
-  #   if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-  #   environment: signing
-  #   needs:
-  #     - build-test
-  #   runs-on: windows-latest
-  #   steps:
-  #     - name: Set git to use LF
-  #       # Without this, the checkout will happen with CRLF line endings,
-  #       # which is fine for the source code but messes up tests that depend
-  #       # on data on disk being as expected. Ideally, those tests should be
-  #       # fixed, but not today.
-  #       run: |
-  #         git config --global core.autocrlf false
-  #         git config --global core.eol lf
+  package-windows:
+    name: Package for Windows
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+    environment: signing
+    needs:
+      - build-test
+    runs-on: windows-latest
+    steps:
+      - name: Set git to use LF
+        # Without this, the checkout will happen with CRLF line endings,
+        # which is fine for the source code but messes up tests that depend
+        # on data on disk being as expected. Ideally, those tests should be
+        # fixed, but not today.
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ env.GO_VERSION }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~\AppData\Local\go-build
-  #           ~\go\pkg\mod
-  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~\AppData\Local\go-build
+            ~\go\pkg\mod
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
 
-  #     - name: Install dependencies
-  #       run: |
-  #         go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
+      - name: Install dependencies
+        run: |
+          go install github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.4.0
 
-  #     - name: Create packages
-  #       run: |
-  #         go run build.go -goarch amd64 zip
-  #         go run build.go -goarch arm zip
-  #         go run build.go -goarch arm64 zip
-  #         go run build.go -goarch 386 zip
-  #       env:
-  #         CGO_ENABLED: "0"
-  #         CODESIGN_SIGNTOOL: ${{ secrets.CODESIGN_SIGNTOOL }}
-  #         CODESIGN_CERTIFICATE_BASE64: ${{ secrets.CODESIGN_CERTIFICATE_BASE64 }}
-  #         CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
-  #         CODESIGN_TIMESTAMP_SERVER: ${{ secrets.CODESIGN_TIMESTAMP_SERVER }}
+      - name: Create packages
+        run: |
+          go run build.go -goarch amd64 zip
+          go run build.go -goarch arm zip
+          go run build.go -goarch arm64 zip
+          go run build.go -goarch 386 zip
+        env:
+          CGO_ENABLED: "0"
+          CODESIGN_SIGNTOOL: ${{ secrets.CODESIGN_SIGNTOOL }}
+          CODESIGN_CERTIFICATE_BASE64: ${{ secrets.CODESIGN_CERTIFICATE_BASE64 }}
+          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
+          CODESIGN_TIMESTAMP_SERVER: ${{ secrets.CODESIGN_TIMESTAMP_SERVER }}
 
-  #     - name: Archive artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: packages
-  #         path: syncthing-windows-*.zip
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: syncthing-windows-*.zip
 
   #
   # Linux
   #
 
-  # package-linux:
-  #   name: Package for Linux
-  #   needs:
-  #     - build-test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+  package-linux:
+    name: Package for Linux
+    needs:
+      - build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ env.GO_VERSION }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cache/go-build
-  #           ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
 
-  #     - name: Create packages
-  #       run: |
-  #         archs=$(go tool dist list | grep linux | sed 's#linux/##')
-  #         for goarch in $archs ; do
-  #           go run build.go -goarch "$goarch" tar
-  #         done
-  #       env:
-  #         CGO_ENABLED: "0"
+      - name: Create packages
+        run: |
+          archs=$(go tool dist list | grep linux | sed 's#linux/##')
+          for goarch in $archs ; do
+            go run build.go -goarch "$goarch" tar
+          done
+        env:
+          CGO_ENABLED: "0"
 
-  #     - name: Archive artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: packages
-  #         path: syncthing-linux-*.tar.gz
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: syncthing-linux-*.tar.gz
 
   #
   # macOS
   #
 
-  # package-macos:
-  #   name: Package for macOS
-  #   if: github.event_name == 'push' && github.ref == 'refs/heads/release'
-  #   environment: signing
-  #   needs:
-  #     - build-test
-  #   runs-on: macos-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+  package-macos:
+    name: Package for macOS
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+    environment: signing
+    needs:
+      - build-test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ env.GO_VERSION }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cache/go-build
-  #           ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
 
-  #     - name: Import signing certificate
-  #       run: |
-  #         # Set up a run-specific keychain, making it available for the
-  #         # `codesign` tool.
-  #         umask 066
-  #         KEYCHAIN_PATH=$RUNNER_TEMP/codesign.keychain
-  #         KEYCHAIN_PASSWORD=$(uuidgen)
-  #         security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-  #         security default-keychain -s "$KEYCHAIN_PATH"
-  #         security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-  #         security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+      - name: Import signing certificate
+        run: |
+          # Set up a run-specific keychain, making it available for the
+          # `codesign` tool.
+          umask 066
+          KEYCHAIN_PATH=$RUNNER_TEMP/codesign.keychain
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
 
-  #         # Import the certificate
-  #         CERTIFICATE_PATH=$RUNNER_TEMP/codesign.p12
-  #         echo "$DEVELOPER_ID_CERTIFICATE_BASE64" | base64 -d -o "$CERTIFICATE_PATH"
-  #         security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$DEVELOPER_ID_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
-  #         security set-key-partition-list -S apple-tool:,apple: -s -k actions "$KEYCHAIN_PATH"
+          # Import the certificate
+          CERTIFICATE_PATH=$RUNNER_TEMP/codesign.p12
+          echo "$DEVELOPER_ID_CERTIFICATE_BASE64" | base64 -d -o "$CERTIFICATE_PATH"
+          security import "$CERTIFICATE_PATH" -k "$KEYCHAIN_PATH" -P "$DEVELOPER_ID_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productsign
+          security set-key-partition-list -S apple-tool:,apple: -s -k actions "$KEYCHAIN_PATH"
 
-  #         # Set the codesign identity for following steps
-  #         echo "CODESIGN_IDENTITY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
-  #       env:
-  #         DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.DEVELOPER_ID_CERTIFICATE_BASE64 }}
-  #         DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}
-  #         CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+          # Set the codesign identity for following steps
+          echo "CODESIGN_IDENTITY=$CODESIGN_IDENTITY" >> $GITHUB_ENV
+        env:
+          DEVELOPER_ID_CERTIFICATE_BASE64: ${{ secrets.DEVELOPER_ID_CERTIFICATE_BASE64 }}
+          DEVELOPER_ID_CERTIFICATE_PASSWORD: ${{ secrets.DEVELOPER_ID_CERTIFICATE_PASSWORD }}
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
 
-  #     - name: Create package (amd64)
-  #       run: |
-  #         go run build.go -goarch amd64 zip
-  #       env:
-  #         CGO_ENABLED: "1"
+      - name: Create package (amd64)
+        run: |
+          go run build.go -goarch amd64 zip
+        env:
+          CGO_ENABLED: "1"
 
-  #     - name: Create package (arm64 cross)
-  #       run: |
-  #         cat <<EOT > xgo.sh
-  #         #!/bin/bash
-  #         CGO_ENABLED=1 \
-  #           CGO_CFLAGS="-target arm64-apple-macos10.15" \
-  #           CGO_LDFLAGS="-target arm64-apple-macos10.15" \
-  #           go "\$@"
-  #         EOT
-  #         chmod 755 xgo.sh
-  #         go run build.go -gocmd ./xgo.sh -goarch arm64 zip
-  #       env:
-  #         CGO_ENABLED: "1"
+      - name: Create package (arm64 cross)
+        run: |
+          cat <<EOT > xgo.sh
+          #!/bin/bash
+          CGO_ENABLED=1 \
+            CGO_CFLAGS="-target arm64-apple-macos10.15" \
+            CGO_LDFLAGS="-target arm64-apple-macos10.15" \
+            go "\$@"
+          EOT
+          chmod 755 xgo.sh
+          go run build.go -gocmd ./xgo.sh -goarch arm64 zip
+        env:
+          CGO_ENABLED: "1"
 
-  #     - name: Create package (universal)
-  #       run: |
-  #         rm -rf _tmp
-  #         mkdir _tmp
-  #         pushd _tmp
+      - name: Create package (universal)
+        run: |
+          rm -rf _tmp
+          mkdir _tmp
+          pushd _tmp
 
-  #         unzip ../syncthing-macos-amd64-*.zip
-  #         unzip ../syncthing-macos-arm64-*.zip
-  #         lipo -create syncthing-macos-amd64-*/syncthing syncthing-macos-arm64-*/syncthing -o syncthing
+          unzip ../syncthing-macos-amd64-*.zip
+          unzip ../syncthing-macos-arm64-*.zip
+          lipo -create syncthing-macos-amd64-*/syncthing syncthing-macos-arm64-*/syncthing -o syncthing
 
-  #         amd64=(syncthing-macos-amd64-*)
-  #         universal="${amd64/amd64/universal}"
-  #         mv "$amd64" "$universal"
-  #         mv syncthing "$universal"
-  #         zip -r "../$universal.zip" "$universal"
+          amd64=(syncthing-macos-amd64-*)
+          universal="${amd64/amd64/universal}"
+          mv "$amd64" "$universal"
+          mv syncthing "$universal"
+          zip -r "../$universal.zip" "$universal"
 
-  #     - name: Archive artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: packages
-  #         path: syncthing-*.zip
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: syncthing-*.zip
 
   #
   # Cross compile other unixes
   #
 
-  # package-cross:
-  #   name: Package cross compiled
-  #   needs:
-  #     - build-test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+  package-cross:
+    name: Package cross compiled
+    needs:
+      - build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ env.GO_VERSION }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ~/.cache/go-build
-  #           ~/go/pkg/mod
-  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cross-${{ hashFiles('**/go.sum') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cross-${{ hashFiles('**/go.sum') }}
 
-  #     - name: Create packages
-  #       run: |
-  #         platforms=$(go tool dist list \
-  #           | grep -v aix/ppc64 \
-  #           | grep -v android/ \
-  #           | grep -v darwin/ \
-  #           | grep -v ios/ \
-  #           | grep -v js/ \
-  #           | grep -v linux/ \
-  #           | grep -v nacl/ \
-  #           | grep -v openbsd/arm\$ \
-  #           | grep -v openbsd/arm64 \
-  #           | grep -v openbsd/mips \
-  #           | grep -v plan9/ \
-  #           | grep -v windows/ \
-  #         )
+      - name: Create packages
+        run: |
+          platforms=$(go tool dist list \
+            | grep -v aix/ppc64 \
+            | grep -v android/ \
+            | grep -v darwin/ \
+            | grep -v ios/ \
+            | grep -v js/ \
+            | grep -v linux/ \
+            | grep -v nacl/ \
+            | grep -v openbsd/arm\$ \
+            | grep -v openbsd/arm64 \
+            | grep -v openbsd/mips \
+            | grep -v plan9/ \
+            | grep -v windows/ \
+          )
 
-  #         for plat in $platforms; do
-  #           goos="${plat%/*}"
-  #           goarch="${plat#*/}"
-  #           go run build.go -goos "$goos" -goarch "$goarch" tar
-  #         done
-  #       env:
-  #         CGO_ENABLED: "0"
+          for plat in $platforms; do
+            goos="${plat%/*}"
+            goarch="${plat#*/}"
+            go run build.go -goos "$goos" -goarch "$goarch" tar
+          done
+        env:
+          CGO_ENABLED: "0"
 
-  #     - name: Archive artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: packages
-  #         path: syncthing-*.tar.gz
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: syncthing-*.tar.gz
 
   #
   # Source
   #
 
-  # package-source:
-  #   name: Package source code
-  #   needs:
-  #     - build-test
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
+  package-source:
+    name: Package source code
+    needs:
+      - build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ env.GO_VERSION }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-  #     - name: Package source
-  #       run: |
-  #         version=$(go run build.go version)
-  #         echo "$version" > RELEASE
+      - name: Package source
+        run: |
+          version=$(go run build.go version)
+          echo "$version" > RELEASE
 
-  #         go mod vendor
-  #         go run build.go assets
+          go mod vendor
+          go run build.go assets
 
-  #         cd ..
+          cd ..
 
-  #         tar c -z -f "syncthing-source-$version.tar.gz" \
-  #           --exclude .git \
-  #           syncthing
+          tar c -z -f "syncthing-source-$version.tar.gz" \
+            --exclude .git \
+            syncthing
 
-  #         mv "syncthing-source-$version.tar.gz" syncthing
+          mv "syncthing-source-$version.tar.gz" syncthing
 
-  #     - name: Archive artifacts
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: packages
-  #         path: syncthing-source-*.tar.gz
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: syncthing-source-*.tar.gz
 
   docker-syncthing:
     needs: build-test
@@ -389,17 +389,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set variables
-        id: vars
-        run: |
-          PKGVER=$(grep ENV Dockerfile | cut -d" " -f 3)
-          echo "PKGVER=$PKGVER" >> $GITHUB_ENV
+      # - name: Set variables
+      #   id: vars
+      #   run: |
+      #     PKGVER=$(grep ENV Dockerfile | cut -d" " -f 3)
+      #     echo "PKGVER=$PKGVER" >> $GITHUB_ENV
       -
         name: Login to Docker Hub
-        # if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: migel0
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
@@ -411,6 +411,8 @@ jobs:
           context: .
           file: ./Dockerfile.${{ matrix.program }}
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/arm/v6,linux/arm/v7
-          # push: ${{ github.event_name != 'pull_request' }}
-          tags: migel0/syncthing-${{ matrix.program }}:latest
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest
+          # tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:${{ env.PKGVER }},${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest
+          
  

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -414,3 +414,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           # push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:${{ env.PKGVER }},${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest
+ 

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -382,6 +382,7 @@ jobs:
           path: syncthing-source-*.tar.gz
 
   docker-syncthing:
+    # needs: build-test
     strategy:
       matrix: 
         program: [strelaysrv, stdiscosrv]

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -399,7 +399,7 @@ jobs:
         # if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: migel0
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Set up Docker Buildx
@@ -412,5 +412,5 @@ jobs:
           file: ./Dockerfile.${{ matrix.program }}
           platforms: linux/amd64,linux/arm64
           # push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:${{ env.PKGVER }},${{ secrets.DOCKERHUB_USERNAME }}/syncthing-${{ matrix.program }}:latest
+          tags: migel0/syncthing-${{ matrix.program }}:${{ env.PKGVER }},migel0/syncthing-${{ matrix.program }}:latest
  

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -34,63 +34,63 @@ jobs:
   # with the list of expected supported Go versions (current, previous).
   #
 
-  build-test:
-    name: Build and test
-    strategy:
-      fail-fast: false
-      matrix:
-        runner: ["ubuntu-latest",]
-        # The oldest version in this list should match what we have in our go.mod.
-        # Variables don't seem to be supported here, or we could have done something nice.
-        go: ["1.19"] # Skip Go 1.20 for now, https://github.com/syncthing/syncthing/issues/8799
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: Set git to use LF
-        if: matrix.runner == 'windows-latest'
-        # Without this, the Windows checkout will happen with CRLF line
-        # endings, which is fine for the source code but messes up tests
-        # that depend on data on disk being as expected. Ideally, those
-        # tests should be fixed, but not today.
-        run: |
-          git config --global core.autocrlf false
-          git config --global core.eol lf
+  # build-test:
+  #   name: Build and test
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       runner: ["ubuntu-latest",]
+  #       # The oldest version in this list should match what we have in our go.mod.
+  #       # Variables don't seem to be supported here, or we could have done something nice.
+  #       go: ["1.19"] # Skip Go 1.20 for now, https://github.com/syncthing/syncthing/issues/8799
+  #   runs-on: ${{ matrix.runner }}
+  #   steps:
+  #     - name: Set git to use LF
+  #       if: matrix.runner == 'windows-latest'
+  #       # Without this, the Windows checkout will happen with CRLF line
+  #       # endings, which is fine for the source code but messes up tests
+  #       # that depend on data on disk being as expected. Ideally, those
+  #       # tests should be fixed, but not today.
+  #       run: |
+  #         git config --global core.autocrlf false
+  #         git config --global core.eol lf
 
-      - uses: actions/checkout@v3
+  #     - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ matrix.go }}
-          cache: true
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ matrix.go }}
+  #         cache: true
 
-      - name: Build
-        run: |
-          go run build.go
+  #     - name: Build
+  #       run: |
+  #         go run build.go
 
-      - name: Test
-        # Our Windows tests currently don't work on Go 1.20
-        # https://github.com/syncthing/syncthing/issues/8779
-        # https://github.com/syncthing/syncthing/issues/8778
-        if: "!(matrix.go == '1.20' && matrix.runner == 'windows-latest')"
-        run: |
-          go run build.go test
+  #     - name: Test
+  #       # Our Windows tests currently don't work on Go 1.20
+  #       # https://github.com/syncthing/syncthing/issues/8779
+  #       # https://github.com/syncthing/syncthing/issues/8778
+  #       if: "!(matrix.go == '1.20' && matrix.runner == 'windows-latest')"
+  #       run: |
+  #         go run build.go test
 
   #
   # Meta checks for formatting, copyright, etc
   #
 
-  correctness:
-    name: Check correctness
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
+  # correctness:
+  #   name: Check correctness
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
 
-      - name: Check correctness
-        run: |
-          go test -v ./meta
+  #     - name: Check correctness
+  #       run: |
+  #         go test -v ./meta
 
   #
   # Windows
@@ -155,41 +155,41 @@ jobs:
   # Linux
   #
 
-  package-linux:
-    name: Package for Linux
-    needs:
-      - build-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  # package-linux:
+  #   name: Package for Linux
+  #   needs:
+  #     - build-test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-package-${{ hashFiles('**/go.sum') }}
 
-      - name: Create packages
-        run: |
-          archs=$(go tool dist list | grep linux | sed 's#linux/##')
-          for goarch in $archs ; do
-            go run build.go -goarch "$goarch" tar
-          done
-        env:
-          CGO_ENABLED: "0"
+  #     - name: Create packages
+  #       run: |
+  #         archs=$(go tool dist list | grep linux | sed 's#linux/##')
+  #         for goarch in $archs ; do
+  #           go run build.go -goarch "$goarch" tar
+  #         done
+  #       env:
+  #         CGO_ENABLED: "0"
 
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages
-          path: syncthing-linux-*.tar.gz
+  #     - name: Archive artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: packages
+  #         path: syncthing-linux-*.tar.gz
 
   #
   # macOS
@@ -289,97 +289,97 @@ jobs:
   # Cross compile other unixes
   #
 
-  package-cross:
-    name: Package cross compiled
-    needs:
-      - build-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  # package-cross:
+  #   name: Package cross compiled
+  #   needs:
+  #     - build-test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cross-${{ hashFiles('**/go.sum') }}
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cache/go-build
+  #           ~/go/pkg/mod
+  #         key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-cross-${{ hashFiles('**/go.sum') }}
 
-      - name: Create packages
-        run: |
-          platforms=$(go tool dist list \
-            | grep -v aix/ppc64 \
-            | grep -v android/ \
-            | grep -v darwin/ \
-            | grep -v ios/ \
-            | grep -v js/ \
-            | grep -v linux/ \
-            | grep -v nacl/ \
-            | grep -v openbsd/arm\$ \
-            | grep -v openbsd/arm64 \
-            | grep -v openbsd/mips \
-            | grep -v plan9/ \
-            | grep -v windows/ \
-          )
+  #     - name: Create packages
+  #       run: |
+  #         platforms=$(go tool dist list \
+  #           | grep -v aix/ppc64 \
+  #           | grep -v android/ \
+  #           | grep -v darwin/ \
+  #           | grep -v ios/ \
+  #           | grep -v js/ \
+  #           | grep -v linux/ \
+  #           | grep -v nacl/ \
+  #           | grep -v openbsd/arm\$ \
+  #           | grep -v openbsd/arm64 \
+  #           | grep -v openbsd/mips \
+  #           | grep -v plan9/ \
+  #           | grep -v windows/ \
+  #         )
 
-          for plat in $platforms; do
-            goos="${plat%/*}"
-            goarch="${plat#*/}"
-            go run build.go -goos "$goos" -goarch "$goarch" tar
-          done
-        env:
-          CGO_ENABLED: "0"
+  #         for plat in $platforms; do
+  #           goos="${plat%/*}"
+  #           goarch="${plat#*/}"
+  #           go run build.go -goos "$goos" -goarch "$goarch" tar
+  #         done
+  #       env:
+  #         CGO_ENABLED: "0"
 
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages
-          path: syncthing-*.tar.gz
+  #     - name: Archive artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: packages
+  #         path: syncthing-*.tar.gz
 
   #
   # Source
   #
 
-  package-source:
-    name: Package source code
-    needs:
-      - build-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+  # package-source:
+  #   name: Package source code
+  #   needs:
+  #     - build-test
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
 
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ${{ env.GO_VERSION }}
+  #     - uses: actions/setup-go@v3
+  #       with:
+  #         go-version: ${{ env.GO_VERSION }}
 
-      - name: Package source
-        run: |
-          version=$(go run build.go version)
-          echo "$version" > RELEASE
+  #     - name: Package source
+  #       run: |
+  #         version=$(go run build.go version)
+  #         echo "$version" > RELEASE
 
-          go mod vendor
-          go run build.go assets
+  #         go mod vendor
+  #         go run build.go assets
 
-          cd ..
+  #         cd ..
 
-          tar c -z -f "syncthing-source-$version.tar.gz" \
-            --exclude .git \
-            syncthing
+  #         tar c -z -f "syncthing-source-$version.tar.gz" \
+  #           --exclude .git \
+  #           syncthing
 
-          mv "syncthing-source-$version.tar.gz" syncthing
+  #         mv "syncthing-source-$version.tar.gz" syncthing
 
-      - name: Archive artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages
-          path: syncthing-source-*.tar.gz
+  #     - name: Archive artifacts
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: packages
+  #         path: syncthing-source-*.tar.gz
 
   docker-syncthing:
     # needs: build-test

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -412,5 +412,5 @@ jobs:
           file: ./Dockerfile.${{ matrix.program }}
           platforms: linux/amd64,linux/arm64
           # push: ${{ github.event_name != 'pull_request' }}
-          tags: migel0/syncthing-${{ matrix.program }}:${{ env.PKGVER }},migel0/syncthing-${{ matrix.program }}:latest
+          tags: migel0/syncthing-${{ matrix.program }}:latest
  

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -34,63 +34,63 @@ jobs:
   # with the list of expected supported Go versions (current, previous).
   #
 
-  # build-test:
-  #   name: Build and test
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       runner: ["ubuntu-latest",]
-  #       # The oldest version in this list should match what we have in our go.mod.
-  #       # Variables don't seem to be supported here, or we could have done something nice.
-  #       go: ["1.19"] # Skip Go 1.20 for now, https://github.com/syncthing/syncthing/issues/8799
-  #   runs-on: ${{ matrix.runner }}
-  #   steps:
-  #     - name: Set git to use LF
-  #       if: matrix.runner == 'windows-latest'
-  #       # Without this, the Windows checkout will happen with CRLF line
-  #       # endings, which is fine for the source code but messes up tests
-  #       # that depend on data on disk being as expected. Ideally, those
-  #       # tests should be fixed, but not today.
-  #       run: |
-  #         git config --global core.autocrlf false
-  #         git config --global core.eol lf
+  build-test:
+    name: Build and test
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["ubuntu-latest",]
+        # The oldest version in this list should match what we have in our go.mod.
+        # Variables don't seem to be supported here, or we could have done something nice.
+        go: ["1.19"] # Skip Go 1.20 for now, https://github.com/syncthing/syncthing/issues/8799
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Set git to use LF
+        if: matrix.runner == 'windows-latest'
+        # Without this, the Windows checkout will happen with CRLF line
+        # endings, which is fine for the source code but messes up tests
+        # that depend on data on disk being as expected. Ideally, those
+        # tests should be fixed, but not today.
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
 
-  #     - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ matrix.go }}
-  #         cache: true
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+          cache: true
 
-  #     - name: Build
-  #       run: |
-  #         go run build.go
+      - name: Build
+        run: |
+          go run build.go
 
-  #     - name: Test
-  #       # Our Windows tests currently don't work on Go 1.20
-  #       # https://github.com/syncthing/syncthing/issues/8779
-  #       # https://github.com/syncthing/syncthing/issues/8778
-  #       if: "!(matrix.go == '1.20' && matrix.runner == 'windows-latest')"
-  #       run: |
-  #         go run build.go test
+      - name: Test
+        # Our Windows tests currently don't work on Go 1.20
+        # https://github.com/syncthing/syncthing/issues/8779
+        # https://github.com/syncthing/syncthing/issues/8778
+        if: "!(matrix.go == '1.20' && matrix.runner == 'windows-latest')"
+        run: |
+          go run build.go test
 
-  #
+  
   # Meta checks for formatting, copyright, etc
-  #
+  
 
-  # correctness:
-  #   name: Check correctness
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
+  correctness:
+    name: Check correctness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-  #     - uses: actions/setup-go@v3
-  #       with:
-  #         go-version: ${{ env.GO_VERSION }}
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
-  #     - name: Check correctness
-  #       run: |
-  #         go test -v ./meta
+      - name: Check correctness
+        run: |
+          go test -v ./meta
 
   #
   # Windows
@@ -382,7 +382,7 @@ jobs:
   #         path: syncthing-source-*.tar.gz
 
   docker-syncthing:
-    # needs: build-test
+    needs: build-test
     strategy:
       matrix: 
         program: [stcrashreceiver, stdiscosrv, strelaypoolsrv, strelaysrv, stupgrades]


### PR DESCRIPTION
### Purpose

As discussed in  #8691 I started updating the build system to automatically build syncthing and related programs and publish them to dockerhub.

### Testing

I used the working gh actions from my [docker-syncthing-relay repo](https://github.com/Migelo/docker-syncthing-relay).
You can also check my fork and the finished action where all arches successfully finished building [here](https://github.com/Migelo/syncthing/actions/runs/4479225264).

Or the latest one where I only build for `amd64` so we can iterate more quickly on this PR.

### Todo

1. How to implement automatic tagging of docker images with the correct version. The commented out portion of my changes are how I deal with automatic versioning by setting it manually in `Dockerfile` and then greping it from there and into gh actions.
2. The repo owner has to add their `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` under `Settings->Security->Secrets and variables->Actions`


