### PR TITLE
lib/model: Set enc. trailer size on pull (ref #8563, #8556)

### DIFF
--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -357,6 +357,7 @@ func (s *sharedPullerState) finalizeEncrypted() error {
 		return err
 	}
 	s.file.Size += trailerSize
+	s.file.EncryptionTrailerSize = int(trailerSize)
 	return nil
 }
 


### PR DESCRIPTION
In the original fix in #8563 I simply forgot this. Which meant #8556 wasn't actually fixed, as the trialer size would have been 0 (default), and thus we would have still sent the inflated size to encrypted peers.