### PR TITLE
lib/model: Fix file size inconsistency due to enc. trailer

### DIFF
--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -352,8 +352,12 @@ func (s *sharedPullerState) finalizeEncrypted() error {
 			return err
 		}
 	}
-	_, err := writeEncryptionTrailer(s.file, s.writer)
-	return err
+	trailerSize, err := writeEncryptionTrailer(s.file, s.writer)
+	if err != nil {
+		return err
+	}
+	s.file.Size += trailerSize
+	return nil
 }
 
 // Returns the size of the written trailer.


### PR DESCRIPTION
Fixes a regression due to PR #8563, while arguable the bug was actually introduced in a much older PR #7155, but didn't have any bad effects so far:
We account for the encryption trailer in the db updater routine, calculating the file-info size there. However there's no guarantee that the file-info at this point is still the exact same as when it was written. It was before, but isn't anymore since introducing the new EncryptedTrailerSize field.
Fix: Adjust the size in the info at the same place where the trailer is written, i.e. we definitely have the actual size on disk.