### PR TITLE
Fix typos

### DIFF
--- a/cmd/stdiscosrv/main.go
+++ b/cmd/stdiscosrv/main.go
@@ -100,13 +100,13 @@ func main() {
 
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if os.IsNotExist(err) {
-		log.Println("Failed to load keypair. Generating one, this might take a while...")
+		log.Println("Failed to load key pair. Generating one, this might take a while...")
 		cert, err = tlsutil.NewCertificate(certFile, keyFile, "stdiscosrv", 20*365)
 		if err != nil {
 			log.Fatalln("Failed to generate X509 key pair:", err)
 		}
 	} else if err != nil {
-		log.Fatalln("Failed to load keypair:", err)
+		log.Fatalln("Failed to load key pair:", err)
 	}
 	devID := protocol.NewDeviceID(cert.Certificate[0])
 	log.Println("Server device ID is", devID)

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -157,7 +157,7 @@ func main() {
 	certFile, keyFile := filepath.Join(dir, "cert.pem"), filepath.Join(dir, "key.pem")
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		log.Println("Failed to load keypair. Generating one, this might take a while...")
+		log.Println("Failed to load key pair. Generating one, this might take a while...")
 		cert, err = tlsutil.NewCertificate(certFile, keyFile, "strelaysrv", 20*365)
 		if err != nil {
 			log.Fatalln("Failed to generate X509 key pair:", err)

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -55,7 +55,7 @@ var diffTestData = []struct {
 	{"", "", 1024, []protocol.BlockInfo{}},
 	{"contents", "contents", 3, []protocol.BlockInfo{}},
 	{"contents", "cantents", 3, []protocol.BlockInfo{{Offset: 0, Size: 3}}},
-	{"contents", "contants", 3, []protocol.BlockInfo{{Offset: 3, Size: 3}}},
+	{"contents", "constants", 3, []protocol.BlockInfo{{Offset: 3, Size: 3}}},
 	{"contents", "cantants", 3, []protocol.BlockInfo{{Offset: 0, Size: 3}, {Offset: 3, Size: 3}}},
 	{"contents", "", 3, []protocol.BlockInfo{{Offset: 0, Size: 0}}},
 	{"", "contents", 3, []protocol.BlockInfo{{Offset: 0, Size: 3}, {Offset: 3, Size: 3}, {Offset: 6, Size: 2}}},

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -451,7 +451,7 @@ func TestWriteCompressed(t *testing.T) {
 
 		msg := &Response{Data: make([]byte, 10240)}
 		if random {
-			// This should make the message uncompressible.
+			// This should make the message incompressible.
 			rand.Read(msg.Data)
 		}
 

--- a/man/syncthing-device-ids.7
+++ b/man/syncthing-device-ids.7
@@ -38,7 +38,7 @@ the public key in use.
 .SH KEYS
 .sp
 To understand device IDs we need to look at the underlying mechanisms. At first
-startup, Syncthing will create a public/private keypair.
+startup, Syncthing will create a public/private key pair.
 .sp
 Currently this is a 384 bit ECDSA key (3072 bit RSA prior to v0.12.5,
 which is what is used as an example in this article). The keys are saved in
@@ -97,7 +97,7 @@ public key; the serial number is zero and the Issuer and Subject are both
 “syncthing” where a qualified name might otherwise be expected.
 .sp
 An advanced user could replace the \fBkey.pem\fP and \fBcert.pem\fP files with a
-keypair generated directly by the \fBopenssl\fP utility or other mechanism.
+key pair generated directly by the \fBopenssl\fP utility or other mechanism.
 .SH DEVICE IDS
 .sp
 To form a device ID the SHA\-256 hash of the certificate data in DER form is

--- a/man/syncthing-rest-api.7
+++ b/man/syncthing-rest-api.7
@@ -1994,7 +1994,7 @@ These endpoints require the \fBgui.debugging\fP configuration option to
 be enabled and yield an access denied error code otherwise.
 .SS GET /rest/debug/peerCompletion
 .sp
-Summarizes the completion precentage for each remote device.  Returns an object
+Summarizes the completion percentage for each remote device.  Returns an object
 with device IDs as keys and an integer percentage as values.
 .SS GET /rest/debug/httpmetrics
 .sp


### PR DESCRIPTION
### Purpose

Fix typos found via `codespell -S *.js,*.json -L
lod,ot,filetest,startd,benchs,nd,fo,bu,te,ue,mye,statics,fliter,flate,symetric,hax,adn,noo,som,welp,alle`

### Testing

Describe what testing has been done, and how the reviewer can test the change
if new tests are not included.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

