### PR TITLE
lib/ignore: properly handle non-existing included ignore-files (fixes #8764)

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -411,6 +411,7 @@ func loadParseIncludeFile(filesystem fs.Filesystem, file string, cd ChangeDetect
 
 	fd, info, err := loadIgnoreFile(filesystem, file)
 	if err != nil {
+		err = parseError(fmt.Errorf("could not load included ignore file: %v", err))
 		return nil, err
 	}
 	defer fd.Close()

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -406,7 +406,7 @@ func loadParseIncludeFile(filesystem fs.Filesystem, file string, cd ChangeDetect
 	}
 
 	if cd.Seen(filesystem, file) {
-		return nil, fmt.Errorf("multiple include of ignore file %q", file)
+		return nil, errors.New("multiple include")
 	}
 
 	fd, info, err := loadIgnoreFile(filesystem, file)

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -411,8 +411,7 @@ func loadParseIncludeFile(filesystem fs.Filesystem, file string, cd ChangeDetect
 
 	fd, info, err := loadIgnoreFile(filesystem, file)
 	if err != nil {
-		err = parseError(fmt.Errorf("could not load included ignore file: %v", err))
-		return nil, err
+		return nil, parseError(fmt.Errorf("could not load included ignore file: %v", err))
 	}
 	defer fd.Close()
 

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -197,6 +197,11 @@ func TestBadPatterns(t *testing.T) {
 		if !IsParseError(err) {
 			t.Error("Should have been a parse error:", err)
 		}
+		if strings.HasPrefix(pat, "#include") {
+			if fs.IsNotExist(err) {
+				t.Error("Includes should not toss a regular isNotExist error")
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
In the sequence of loading ignores, the error `no such file or directory` is not being considered a fatal  error, since the `.stignore` file is allowed to not exist. However, included ignore files also tossed that same error in case those did not exist while in those cases it's actually considered an error that should impact the running-status of the folder. Changing the error when opening an included ignore file to something manually defined does fix this issue, as in it now works again as described in the Documentation.

### Testing

Add/edit a folder. Add ignore-lines with `#include .somethingnonexisting` and it should now error out properly and the folder should be stopped, instead of having the ignores not being loaded and the folder remain in a running state.