### PR TITLE
Set Platform Data for New Folders w/ NoPermissions Flag

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -622,13 +622,17 @@ func (f *sendReceiveFolder) handleDir(file protocol.FileInfo, snap *db.Snapshot,
 		// not MkdirAll because the parent should already exist.
 		mkdir := func(path string) error {
 			err = f.mtimefs.Mkdir(path, mode)
-			if err != nil || f.IgnorePerms || file.NoPermissions {
+			if err != nil || f.IgnorePerms {
 				return err
 			}
 
 			// Set the platform data (ownership, xattrs, etc).
 			if err := f.setPlatformData(&file, path); err != nil {
 				return err
+			}
+
+			if file.NoPermissions {
+				return nil
 			}
 
 			// Stat the directory so we can check its permissions.


### PR DESCRIPTION
### Purpose

Platform data (ownership, xattrs, etc.) is now set correctly for newly-received folders, even if the received folder has the NoPermissions flag. This fixes #8399.