### PR TITLE
Allow BindDN to exclude any username formatting

### DIFF
--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -161,7 +161,7 @@ func authLDAP(username string, password string, cfg config.LDAPConfiguration) bo
 
 	defer connection.Close()
 
-	err = connection.Bind(fmt.Sprintf(cfg.BindDN, username), password)
+	err = connection.Bind(ldapTemplateBindDN(cfg.BindDN, username), password)
 	if err != nil {
 		l.Warnln("LDAP Bind:", err)
 		return false
@@ -197,6 +197,15 @@ func authLDAP(username string, password string, cfg config.LDAPConfiguration) bo
 	}
 
 	return true
+}
+
+func ldapTemplateBindDN(bindDN string, username string) string {
+	// Check if formatting directives are included in the ldapTemplateBindDN - if so add username.
+	// (%%s is a literal %s - unlikely for LDAP, but easy to handle here).
+	if strings.Count(bindDN, "%s") != strings.Count(bindDN, "%%s") {
+		bindDN = fmt.Sprintf(bindDN, username)
+	}
+	return bindDN
 }
 
 // Convert an ISO-8859-1 encoded byte string to UTF-8. Works by the

--- a/lib/api/api_auth_test.go
+++ b/lib/api/api_auth_test.go
@@ -45,3 +45,23 @@ func TestStaticAuthPasswordFail(t *testing.T) {
 		t.Fatalf("should fail auth")
 	}
 }
+
+func TestAuthLDAPSendsCorrectBindDNWithTemplate(t *testing.T) {
+	t.Parallel()
+
+	templatedDn := ldapTemplateBindDN("cn=%s,dc=some,dc=example,dc=com", "username")
+	expectedDn := "cn=username,dc=some,dc=example,dc=com"
+	if expectedDn != templatedDn {
+		t.Fatalf("ldapTemplateBindDN should be %s != %s", expectedDn, templatedDn)
+	}
+}
+
+func TestAuthLDAPSendsCorrectBindDNWithNoTemplate(t *testing.T) {
+	t.Parallel()
+
+	templatedDn := ldapTemplateBindDN("cn=fixedusername,dc=some,dc=example,dc=com", "username")
+	expectedDn := "cn=fixedusername,dc=some,dc=example,dc=com"
+	if expectedDn != templatedDn {
+		t.Fatalf("ldapTemplateBindDN should be %s != %s", expectedDn, templatedDn)
+	}
+}


### PR DESCRIPTION
### Purpose

Fix the error string being injected when the template variable for username is omitted in the LDAP Bind DN string (fixes #8899).

### Testing

Regression tests have been added to check the new behavior for the original use case and the new one.

### Documentation

No documentation change should be required, although the language for LDAP configuration could be changed to note that `%s` is optional. This would be in-line with the more useful use LDAP auth, which is locking a single syncthing instance to a single user account which manages it's password via LDAP.
