### PR TITLE
lib: replace `Readdir(-1)` with `os.ReadDir`

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1865,13 +1865,7 @@ func (v jsonVersionVector) MarshalJSON() ([]byte, error) {
 }
 
 func dirNames(dir string) []string {
-	fd, err := os.Open(dir)
-	if err != nil {
-		return nil
-	}
-	defer fd.Close()
-
-	fis, err := fd.Readdir(-1)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
 	}

--- a/lib/db/backend/leveldb_open.go
+++ b/lib/db/backend/leveldb_open.go
@@ -200,20 +200,19 @@ func dbIsLarge(location string) bool {
 		return false
 	}
 
-	dir, err := os.Open(location)
-	if err != nil {
-		return false
-	}
-
-	fis, err := dir.Readdir(-1)
+	entries, err := os.ReadDir(location)
 	if err != nil {
 		return false
 	}
 
 	var size int64
-	for _, fi := range fis {
-		if fi.Name() == "LOG" {
+	for _, entry := range entries {
+		if entry.Name() == "LOG" {
 			// don't count the size
+			continue
+		}
+		fi, err := entry.Info()
+		if err != nil {
 			continue
 		}
 		size += fi.Size()


### PR DESCRIPTION
### Purpose

We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `os.ReadDir(dirname)`. `os.ReadDir` is recommended over `Readdir()`, as stated in the official doc [^1]

[^1]: "Most clients are better served by the more efficient ReadDir method." https://pkg.go.dev/os#File.Readdir

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

