### PR TITLE
cmd/strelaysrv: Add '-max-connections', '-limit-interval' and '-unlimited-devices' flag

### DIFF
--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -313,8 +313,9 @@ func monitorLimits() {
 	limitCheckTimer = time.NewTimer(time.Minute)
 	for range limitCheckTimer.C {
 		if numConnections.Load()+numProxies.Load() > descriptorLimit {
-			overLimit.Store(true)
-			log.Println("Gone past our connection limits. Starting to refuse new/drop idle connections.")
+			if !overLimit.Swap(true) {
+				log.Println("Gone past our connection limits. Starting to refuse new/drop idle connections.")
+			}
 		} else if overLimit.CompareAndSwap(true, false) {
 			log.Println("Dropped below our connection limits. Accepting new connections.")
 		}

--- a/cmd/strelaysrv/session.go
+++ b/cmd/strelaysrv/session.go
@@ -25,6 +25,7 @@ var (
 	pendingSessions = make(map[string]*session)
 	numProxies      atomic.Int64
 	bytesProxied    atomic.Int64
+	totalSessions   atomic.Int64
 )
 
 func newSession(serverid, clientid syncthingprotocol.DeviceID, sessionRateLimit, globalRateLimit *rate.Limiter) *session {
@@ -58,6 +59,8 @@ func newSession(serverid, clientid syncthingprotocol.DeviceID, sessionRateLimit,
 	pendingSessions[string(ses.serverkey)] = ses
 	pendingSessions[string(ses.clientkey)] = ses
 	sessionMut.Unlock()
+
+	totalSessions.Add(1)
 
 	return ses
 }

--- a/cmd/strelaysrv/status.go
+++ b/cmd/strelaysrv/status.go
@@ -54,6 +54,7 @@ func getStatus(w http.ResponseWriter, _ *http.Request) {
 	status["numConnections"] = numConnections.Load()
 	status["numProxies"] = numProxies.Load()
 	status["bytesProxied"] = bytesProxied.Load()
+	status["totalSessions"] = totalSessions.Load()
 	status["goVersion"] = runtime.Version()
 	status["goOS"] = runtime.GOOS
 	status["goArch"] = runtime.GOARCH
@@ -73,6 +74,7 @@ func getStatus(w http.ResponseWriter, _ *http.Request) {
 		"message-timeout":  messageTimeout / time.Second,
 		"per-session-rate": sessionLimitBps,
 		"global-rate":      globalLimitBps,
+		"max-connection":   descriptorLimit,
 		"pools":            pools,
 		"provided-by":      providedBy,
 	}


### PR DESCRIPTION
I noticed that the number of connections significantly affects the latency on some relay servers with poor performance. On my own simple application server, about a few thousand connections can cause a TLS handshake to take more than 20 seconds, while syncthing only allows [10 seconds of timeout](https://github.com/syncthing/syncthing/blob/716b42103a7296c6a5ebcb0886c43666d2278ae4/lib/connections/service.go#L70), directly causing each session to terminate with "Listen (BEP/relay): TLS handshake: i/o timeout".

This pull request limits the maximum number of connections for the relay server, and allows setting the interval for checking whether the number of connections is exceeded, and the device list that is exempt from the limit.