### PR TITLE
cmd/syncthing: Use correct binary when restarting monitor

### DIFF
--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -346,7 +346,7 @@ func restartMonitor(binary string, args []string) error {
 }
 
 func restartMonitorUnix(binary string, args []string) error {
-	return syscall.Exec(args[0], args, os.Environ())
+	return syscall.Exec(binary, args, os.Environ())
 }
 
 func restartMonitorWindows(binary string, args []string) error {
@@ -521,7 +521,7 @@ func (f *autoclosedFile) ensureOpenLocked() error {
 	// We open the file for write only, and create it if it doesn't exist.
 	flags := os.O_WRONLY | os.O_CREATE | os.O_APPEND
 
-	fd, err := os.OpenFile(f.name, flags, 0644)
+	fd, err := os.OpenFile(f.name, flags, 0o644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The discrepancy was flagged by DeepSource; usually this will not matter as binary == args[0] but in the case there is a difference we have the parameter for a reason.
