### PR TITLE
build: Tests should run with Go 1.20 on Windows

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -67,10 +67,6 @@ jobs:
           go run build.go
 
       - name: Test
-        # Our Windows tests currently don't work on Go 1.20
-        # https://github.com/syncthing/syncthing/issues/8779
-        # https://github.com/syncthing/syncthing/issues/8778
-        if: "!(matrix.go == '1.20' && matrix.runner == 'windows-latest')"
         run: |
           go run build.go test
 

--- a/lib/fs/basicfs_windows_test.go
+++ b/lib/fs/basicfs_windows_test.go
@@ -12,7 +12,6 @@ package fs
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -35,14 +34,6 @@ func TestWindowsPaths(t *testing.T) {
 		{`e:\x\`, `\\?\e:\x`, `e:\x`},
 		{`e:\x\\`, `\\?\e:\x`, `e:\x`},
 		{`\\192.0.2.22\network\share`, `\\192.0.2.22\network\share`, `\\192.0.2.22\network\share`},
-	}
-
-	if runtime.Version() >= "go1.20" {
-		testCases = append(testCases,
-			testCase{`\\.\e:`, `\\.\e:\`, `e:\`},
-			testCase{`\\.\e:\`, `\\.\e:\`, `e:\`},
-			testCase{`\\.\e:\\`, `\\.\e:\`, `e:\`},
-		)
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
Despite the discussion in #8889 we missed to actually enable the test runs on Go 1.20, and when you do we can see that the additional tests added there do not, in fact, pass. This (`\\.\...` paths) isn't something we tested before and I'm not really sure what they're supposed to mean anyway, so ...