### PR TITLE
Don't add empty device to config on init

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -268,6 +268,9 @@ func (cfg *Configuration) prepare(myID protocol.DeviceID) error {
 }
 
 func (cfg *Configuration) ensureMyDevice(myID protocol.DeviceID) {
+	if myID == protocol.EmptyDeviceID {
+		return
+	}
 	for _, device := range cfg.Devices {
 		if device.DeviceID == myID {
 			return
@@ -483,6 +486,9 @@ func (cfg *Configuration) SetFolders(folders []FolderConfiguration) {
 }
 
 func ensureDevicePresent(devices []FolderDeviceConfiguration, myID protocol.DeviceID) []FolderDeviceConfiguration {
+	if myID == protocol.EmptyDeviceID {
+		return devices
+	}
 	for _, device := range devices {
 		if device.DeviceID.Equals(myID) {
 			return devices

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1489,6 +1489,7 @@ func TestXattrFilter(t *testing.T) {
 	}
 }
 
+// Verify that opening a config with myID == protocol.EmptyDeviceID doesn't add that ID to the config.
 // Done in various places where config is needed, but the device ID isn't known.
 func TestLoadEmptyDeviceID(t *testing.T) {
 	temp, err := copyToTmp(testFs, "example.xml")

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1489,6 +1489,35 @@ func TestXattrFilter(t *testing.T) {
 	}
 }
 
+// Done in various places where config is needed, but the device ID isn't known.
+func TestLoadEmptyDeviceID(t *testing.T) {
+	temp, err := copyToTmp(testFs, "example.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fd, err := testFs.Open(temp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer fd.Close()
+	cfg, _, err := ReadXML(fd, protocol.EmptyDeviceID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, devCfg := range cfg.Devices {
+		if devCfg.DeviceID == protocol.EmptyDeviceID {
+			t.Fatal("Device with empty ID")
+		}
+	}
+	for _, folderCfg := range cfg.Folders {
+		for _, devCfg := range folderCfg.Devices {
+			if devCfg.DeviceID == protocol.EmptyDeviceID {
+				t.Fatalf("Device with empty ID in folder %v", folderCfg.Description())
+			}
+		}
+	}
+}
+
 func loadTestFiles() {
 	entries, err := os.ReadDir("testdata")
 	if err != nil {


### PR DESCRIPTION
We usually want to ensure that our own device is present. However if the given device ID is the empty ID, we shouldn't do that. This is a legimate (though way too non-obvious) use-case when opening the config without knowing/caring about the device ID.
