### PR TITLE
chore: staticcheck fix

### DIFF
--- a/lib/db/meta.go
+++ b/lib/db/meta.go
@@ -391,9 +391,7 @@ func (m *metadataTracker) Snapshot() *countsMap {
 	for k, v := range m.indexes {
 		c.indexes[k] = v
 	}
-	for i := range m.counts.Counts {
-		c.counts.Counts[i] = m.counts.Counts[i]
-	}
+	copy(c.counts.Counts, m.counts.Counts)
 
 	return c
 }

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -609,10 +609,10 @@ func TestRequestSymlinkWindows(t *testing.T) {
 
 func equalContents(fs fs.Filesystem, path string, contents []byte) error {
 	fd, err := fs.Open(path)
-	defer fd.Close()
 	if err != nil {
 		return err
 	}
+	defer fd.Close()
 	bs, err := io.ReadAll(fd)
 	if err != nil {
 		return err

--- a/lib/versioner/trashcan_test.go
+++ b/lib/versioner/trashcan_test.go
@@ -8,7 +8,6 @@ package versioner
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -227,7 +226,7 @@ func TestTrashcanCleanOut(t *testing.T) {
 		".stversions/remove/removesubdir/file1": true,
 	}
 
-	t.Run(fmt.Sprintf("trashcan versioner trashcan clean up"), func(t *testing.T) {
+	t.Run("trashcan versioner trashcan clean up", func(t *testing.T) {
 		oldTime := time.Now().Add(-8 * 24 * time.Hour)
 		for file, shouldRemove := range testcases {
 			fs.MkdirAll(filepath.Dir(file), 0777)


### PR DESCRIPTION
### Purpose
staticcheck fix
should check returned error before deferring fd.Close()
unnecessary use of fmt.Sprintf
should use copy(to, from) instead of a loop



### Testing

Describe what testing has been done, and how the reviewer can test the change
if new tests are not included.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

