### PR TITLE
cmd/syncthing: Add environment variables for --home, --conf, and --data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,5 +44,6 @@ HEALTHCHECK --interval=1m --timeout=10s \
   CMD curl -fkLsS -m 2 127.0.0.1:8384/rest/noauth/health | grep -o --color=never OK || exit 1
 
 ENV STGUIADDRESS=0.0.0.0:8384
+ENV STHOMEDIR=/var/syncthing/config
 RUN chmod 755 /bin/entrypoint.sh
-ENTRYPOINT ["/bin/entrypoint.sh", "/bin/syncthing", "-home", "/var/syncthing/config"]
+ENTRYPOINT ["/bin/entrypoint.sh", "/bin/syncthing"]

--- a/cmd/syncthing/cmdutil/options_common.go
+++ b/cmd/syncthing/cmdutil/options_common.go
@@ -9,8 +9,8 @@ package cmdutil
 // CommonOptions are reused among several subcommands
 type CommonOptions struct {
 	buildCommonOptions
-	ConfDir         string `name:"config" placeholder:"PATH" help:"Set configuration directory (config and keys)"`
-	HomeDir         string `name:"home" placeholder:"PATH" help:"Set configuration and data directory"`
+	ConfDir         string `name:"config" placeholder:"PATH" env:"STCONFDIR" help:"Set configuration directory (config and keys)"`
+	HomeDir         string `name:"home" placeholder:"PATH" env:"STHOMEDIR" help:"Set configuration and data directory"`
 	NoDefaultFolder bool   `env:"STNODEFAULTFOLDER" help:"Don't create the \"default\" folder on first startup"`
 	SkipPortProbing bool   `help:"Don't try to find free ports for GUI and listen addresses on first startup"`
 }

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -144,9 +144,9 @@ type serveOptions struct {
 	Audit            bool   `help:"Write events to audit file"`
 	AuditFile        string `name:"auditfile" placeholder:"PATH" help:"Specify audit file (use \"-\" for stdout, \"--\" for stderr)"`
 	BrowserOnly      bool   `help:"Open GUI in browser"`
-	DataDir          string `name:"data" placeholder:"PATH" help:"Set data directory (database and logs)"`
+	DataDir          string `name:"data" placeholder:"PATH" env:"STDATADIR" help:"Set data directory (database and logs)"`
 	DeviceID         bool   `help:"Show the device ID"`
-	GenerateDir      string `name:"generate" placeholder:"PATH" help:"Generate key and config in specified dir, then exit"` //DEPRECATED: replaced by subcommand!
+	GenerateDir      string `name:"generate" placeholder:"PATH" help:"Generate key and config in specified dir, then exit"` // DEPRECATED: replaced by subcommand!
 	GUIAddress       string `name:"gui-address" placeholder:"URL" help:"Override GUI address (e.g. \"http://192.0.2.42:8443\")"`
 	GUIAPIKey        string `name:"gui-apikey" placeholder:"API-KEY" help:"Override GUI API key"`
 	LogFile          string `name:"logfile" default:"${logFile}" placeholder:"PATH" help:"Log file name (see below)"`
@@ -354,7 +354,7 @@ func (options serveOptions) Run() error {
 	}
 
 	// Ensure that our home directory exists.
-	if err := syncthing.EnsureDir(locations.GetBaseDir(locations.ConfigBaseDir), 0700); err != nil {
+	if err := syncthing.EnsureDir(locations.GetBaseDir(locations.ConfigBaseDir), 0o700); err != nil {
 		l.Warnln("Failure on home directory:", err)
 		os.Exit(svcutil.ExitError.AsInt())
 	}
@@ -722,7 +722,6 @@ func setupSignalHandling(app *syncthing.App) {
 func loadOrDefaultConfig() (config.Wrapper, error) {
 	cfgFile := locations.Get(locations.ConfigFile)
 	cfg, _, err := config.Load(cfgFile, protocol.EmptyDeviceID, events.NoopLogger)
-
 	if err != nil {
 		newCfg := config.New(protocol.EmptyDeviceID)
 		return config.Wrap(cfgFile, newCfg, protocol.EmptyDeviceID, events.NoopLogger), nil
@@ -750,7 +749,7 @@ func auditWriter(auditFile string) io.Writer {
 		} else {
 			auditFlags = os.O_WRONLY | os.O_CREATE | os.O_APPEND
 		}
-		fd, err = os.OpenFile(auditFile, auditFlags, 0600)
+		fd, err = os.OpenFile(auditFile, auditFlags, 0o600)
 		if err != nil {
 			l.Warnln("Audit:", err)
 			os.Exit(svcutil.ExitError.AsInt())


### PR DESCRIPTION
This allows environment overrides for our directories. This is advantageous because, apart from the obvious, it means we can set it in the Docker file and not add command line options there. Having the command line option as we did meant that it was impossible to use the Docker image for other commands than `serve` (because that is implied when we see other options on the command line).
