### PR TITLE
Update sysctl configs

### DIFF
--- a/etc/linux-sysctl/30-syncthing.conf
+++ b/etc/linux-sysctl/30-syncthing.conf
@@ -1,3 +1,4 @@
 # Increase maximum receive socket buffer size to 2MiB for QUIC connections
 # see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 net.core.rmem_max = 2097152
+net.core.wmem_max = 2097152

--- a/etc/linux-sysctl/30-syncthing.conf
+++ b/etc/linux-sysctl/30-syncthing.conf
@@ -1,4 +1,4 @@
-# Increase maximum receive socket buffer size to 2.5MiB for QUIC connections
+# Increase maximum socket buffer sizes to 2.5MiB for QUIC connections
 # see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 net.core.rmem_max = 2621440
 net.core.wmem_max = 2621440

--- a/etc/linux-sysctl/30-syncthing.conf
+++ b/etc/linux-sysctl/30-syncthing.conf
@@ -1,3 +1,3 @@
 # Increase maximum receive socket buffer size to 2MiB for QUIC connections
-# see https://github.com/quic-go/quic-go/wiki/UDP-Receive-Buffer-Size
+# see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 net.core.rmem_max = 2097152

--- a/etc/linux-sysctl/30-syncthing.conf
+++ b/etc/linux-sysctl/30-syncthing.conf
@@ -1,4 +1,4 @@
-# Increase maximum receive socket buffer size to 2MiB for QUIC connections
+# Increase maximum receive socket buffer size to 2.5MiB for QUIC connections
 # see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
-net.core.rmem_max = 2097152
-net.core.wmem_max = 2097152
+net.core.rmem_max = 2621440
+net.core.wmem_max = 2621440


### PR DESCRIPTION
### Purpose

quic-go v0.35.0+ tries to use a larger send buffer. This raises the necessary sysctl limit and follows the wikis recommendation of a 2.5MiB limit.