### PR TITLE
gui, lib/api: Add possibility to feed through extra version information

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3051,7 +3051,11 @@ angular.module('syncthing.core')
                 arch += " Container";
             }
 
-            return $scope.version.version + ', ' + os + ' (' + arch + ')';
+            var verStr = $scope.version.version;
+            if ($scope.version.extra) {
+                verStr += ' (' + $scope.version.extra + ')';
+            }
+            return verStr + ', ' + os + ' (' + arch + ')';
         };
 
         $scope.versionBase = function () {

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -713,6 +713,7 @@ func (*service) getSystemVersion(w http.ResponseWriter, _ *http.Request) {
 		"version":     build.Version,
 		"codename":    build.Codename,
 		"longVersion": build.LongVersion,
+		"extra":       build.Extra,
 		"os":          runtime.GOOS,
 		"arch":        runtime.GOARCH,
 		"isBeta":      build.IsBeta,

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -47,7 +47,7 @@ var (
 	}
 )
 
-const versionExtraAllowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-., "
+const versionExtraAllowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-. "
 
 func init() {
 	if Version != "unknown-dev" {
@@ -94,7 +94,6 @@ func LongVersionFor(program string) string {
 	if tags := TagsList(); len(tags) > 0 {
 		v = fmt.Sprintf("%s [%s]", v, strings.Join(tags, ", "))
 	}
-
 	return v
 }
 

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -89,15 +89,12 @@ func setBuildData() {
 func LongVersionFor(program string) string {
 	// This string and date format is essentially part of our external API. Never change it.
 	date := Date.UTC().Format("2006-01-02 15:04:05 MST")
-	versionExtra := ""
-	if Extra != "" {
-		versionExtra = " (" + Extra + ")"
-	}
-	v := fmt.Sprintf(`%s %s%s "%s" (%s %s-%s) %s@%s %s`, program, Version, versionExtra, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
+	v := fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
 
 	if tags := TagsList(); len(tags) > 0 {
 		v = fmt.Sprintf("%s [%s]", v, strings.Join(tags, ", "))
 	}
+
 	return v
 }
 
@@ -110,6 +107,9 @@ func TagsList() []string {
 		if os.Getenv(envVar) != "" {
 			tags = append(tags, strings.ToLower(envVar))
 		}
+	}
+	if Extra != "" {
+		tags = append(tags, Extra)
 	}
 
 	sort.Strings(tags)

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -47,6 +47,8 @@ var (
 	}
 )
 
+const versionExtraAllowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-., "
+
 func init() {
 	if Version != "unknown-dev" {
 		// If not a generic dev build, version string should come from git describe
@@ -76,7 +78,7 @@ func setBuildData() {
 	IsRelease = exp.MatchString(Version)
 	IsCandidate = strings.Contains(Version, "-rc.")
 	IsBeta = strings.Contains(Version, "-")
-	Extra = os.Getenv("STVERSIONEXTRA")
+	Extra = filterString(os.Getenv("STVERSIONEXTRA"), versionExtraAllowedChars)
 
 	stamp, _ := strconv.Atoi(Stamp)
 	Date = time.Unix(int64(stamp), 0)
@@ -112,4 +114,16 @@ func TagsList() []string {
 
 	sort.Strings(tags)
 	return tags
+}
+
+// filterString returns a copy of s with all characters not in allowedChars
+// removed.
+func filterString(s, allowedChars string) string {
+	var res strings.Builder
+	for _, c := range s {
+		if strings.ContainsRune(allowedChars, c) {
+			res.WriteRune(c)
+		}
+	}
+	return res.String()
 }

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -35,6 +35,7 @@ var (
 	IsCandidate bool
 	IsBeta      bool
 	LongVersion string
+	Extra       string
 
 	allowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-[^\s]+)?$`)
 
@@ -75,6 +76,7 @@ func setBuildData() {
 	IsRelease = exp.MatchString(Version)
 	IsCandidate = strings.Contains(Version, "-rc.")
 	IsBeta = strings.Contains(Version, "-")
+	Extra = os.Getenv("STVERSIONEXTRA")
 
 	stamp, _ := strconv.Atoi(Stamp)
 	Date = time.Unix(int64(stamp), 0)
@@ -85,7 +87,11 @@ func setBuildData() {
 func LongVersionFor(program string) string {
 	// This string and date format is essentially part of our external API. Never change it.
 	date := Date.UTC().Format("2006-01-02 15:04:05 MST")
-	v := fmt.Sprintf(`%s %s "%s" (%s %s-%s) %s@%s %s`, program, Version, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
+	versionExtra := ""
+	if Extra != "" {
+		versionExtra = " (" + Extra + ")"
+	}
+	v := fmt.Sprintf(`%s %s%s "%s" (%s %s-%s) %s@%s %s`, program, Version, versionExtra, Codename, runtime.Version(), runtime.GOOS, runtime.GOARCH, User, Host, date)
 
 	if tags := TagsList(); len(tags) > 0 {
 		v = fmt.Sprintf("%s [%s]", v, strings.Join(tags, ", "))

--- a/lib/build/build_test.go
+++ b/lib/build/build_test.go
@@ -35,3 +35,23 @@ func TestAllowedVersions(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterString(t *testing.T) {
+	cases := []struct {
+		input  string
+		filter string
+		output string
+	}{
+		{"abcba", "abc", "abcba"},
+		{"abcba", "ab", "abba"},
+		{"abcba", "c", "c"},
+		{"abcba", "!", ""},
+		{"Foo (v1.5)", versionExtraAllowedChars, "Foo v1.5"},
+	}
+
+	for i, c := range cases {
+		if out := filterString(c.input, c.filter); out != c.output {
+			t.Errorf("%d: %q != %q", i, out, c.output)
+		}
+	}
+}


### PR DESCRIPTION
This adds an environment variable STVERSIONEXTRA that, when set, gets added to the version information in the API and GUI. In the CLI we see the following:

    % STVERSIONEXTRA=foo ./bin/syncthing --version
    syncthing v1.23.7-rc.1 (foo) "Fermium Flea" (go1.20.5 darwin...etc

In the GUI it's shown similarly in the About screen and in the local device box.

The purpose of all this is to be able to communicate something about the bundling or packaging, through the log & GUI and the end user, to the potential person supporting it -- i.e., us. :) A wrapper can set this variable to indicate that Syncthing is being run via `SyncTrayzor`, `Syncthing-macOS`, etc., and thus indicate to the end user that the GUI they are looking at is perhaps not the only source of truth and management for this instance.
