### PR TITLE
lib/config: better error message for low disk space

### DIFF
--- a/lib/config/size.go
+++ b/lib/config/size.go
@@ -83,10 +83,10 @@ func CheckFreeSpace(minFree Size, usage fs.Usage) error {
 	if minFree.Percentage() {
 		freePct := (float64(usage.Free) / float64(usage.Total)) * 100
 		if freePct < val {
-			return fmt.Errorf("current %.2f %% < required %v", freePct, minFree)
+			return fmt.Errorf("Low disk space (< %v)", minFree)
 		}
 	} else if float64(usage.Free) < val {
-		return fmt.Errorf("current %sB < required %v", formatSI(usage.Free), minFree)
+		return fmt.Errorf("Low disk space (< %v)", minFree)
 	}
 
 	return nil


### PR DESCRIPTION
### Purpose

This is to improve the error message when syncing stops due to the low disk space check failing.  The reason for this is because the existing message doesn't mention disk space, just percentages.  When I saw that message it wasn't immediately obvious that it related to disk space which prompted this [forum post](https://forum.syncthing.net/t/receive-only-folder-is-stuck-out-of-sync/20534).

### Testing

I built and ran Syncthing with my changes.

### Screenshots

Here's what it looks like with my changes:

![Screenshot 2023-07-19 at 13 27 33](https://github.com/syncthing/syncthing/assets/490067/4b5542e8-b1a0-4cd1-994b-d3b918eecc63)