### PR TITLE
lib/config, lib/model: Better error message for insufficient space

### DIFF
--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -278,7 +278,7 @@ func (f *FolderConfiguration) CheckAvailableSpace(req uint64) error {
 		return nil
 	}
 	if err := checkAvailableSpace(req, f.MinDiskFree, usage); err != nil {
-		return fmt.Errorf("insufficient space in folder %v (%v): %w", f.Description(), fs.URI(), err)
+		return fmt.Errorf("insufficient space in folder %v (%v) - %w", f.Description(), fs.URI(), err)
 	}
 	return nil
 }

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -333,7 +333,7 @@ func (f *folder) getHealthErrorWithoutIgnores() error {
 		dbPath := locations.Get(locations.Database)
 		if usage, err := fs.NewFilesystem(fs.FilesystemTypeBasic, dbPath).Usage("."); err == nil {
 			if err = config.CheckFreeSpace(minFree, usage); err != nil {
-				return fmt.Errorf("insufficient space on disk for database (%v): %w", dbPath, err)
+				return fmt.Errorf("insufficient space on disk for database (%v) - %w", dbPath, err)
 			}
 		}
 	}


### PR DESCRIPTION
By not using a colon, the error doesn't get prematurely cut off in the GUI.

<img width="920" alt="Screenshot 2023-07-19 at 22 23 00" src="https://github.com/syncthing/syncthing/assets/125426/00f0b57d-0f64-4d55-b145-449a99cf8bac">
