### PR TITLE
lib/osutil: Skip setLowPriority in Windows if already lower (fixes #6597)

### DIFF
--- a/lib/osutil/lowprio_windows.go
+++ b/lib/osutil/lowprio_windows.go
@@ -21,6 +21,11 @@ func SetLowPriority() error {
 	}
 	defer windows.CloseHandle(handle)
 
+	if cur, err := windows.GetPriorityClass(handle); err == nil && (cur == windows.IDLE_PRIORITY_CLASS || cur == windows.BELOW_NORMAL_PRIORITY_CLASS) {
+		// We're done here.
+		return nil
+	}
+
 	if err := windows.SetPriorityClass(handle, windows.BELOW_NORMAL_PRIORITY_CLASS); err != nil {
 		return fmt.Errorf("set priority class: %w", err)
 	}


### PR DESCRIPTION
lib/osutil: Skip setLowPriority in Windows if already lower (fixes #6597)

Currently, setLowPriority always changes the process priority to "below
normal" even if the current priority is already equal or lower than
that. With this change, the process priority is changed only if the
current priority is higher than "below normal".
