### PR TITLE
gui: Use case-insensive and backslash-agnostic versions filter (fixes #7973)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2783,10 +2783,11 @@ angular.module('syncthing.core')
                     // Use case-insensitive filter.
                     var filterText = $scope.restoreVersions.filters.text.toLowerCase();
                     var versionPath = node.key.toLowerCase();
-                    // Allow backslashes on Windows as filter path separators.
+                    // Convert backslashes to forward slashes on Windows
+                    // to allow using them as path separators.
                     if ($scope.version.os == 'windows') {
-                        filterText = filterText.replace(/\//g, '\\');
-                        versionPath = versionPath.replace(/\//g, '\\');
+                        filterText = filterText.replace(/\\/g, '/');
+                        versionPath = versionPath.replace(/\\/g, '/');
                     }
                     if (versionPath.indexOf(filterText) < 0) {
                         return false;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2778,9 +2778,21 @@ angular.module('syncthing.core')
 
             $scope.restoreVersions.tree.filterNodes(function (node) {
                 if (node.folder) return false;
-                if ($scope.restoreVersions.filters.text && node.key.indexOf($scope.restoreVersions.filters.text) < 0) {
-                    return false;
+
+                if ($scope.restoreVersions.filters.text) {
+                    // Use case-insensitive filter.
+                    var filterText = $scope.restoreVersions.filters.text.toLowerCase();
+                    var versionPath = node.key.toLowerCase();
+                    // Allow backslashes on Windows as filter path separators.
+                    if ($scope.version.os == 'windows') {
+                        filterText = filterText.replace(/\//g, '\\');
+                        versionPath = versionPath.replace(/\//g, '\\');
+                    }
+                    if (versionPath.indexOf(filterText) < 0) {
+                        return false;
+                    }
                 }
+
                 if ($scope.restoreVersions.filterVersions(node.data.versions).length == 0) {
                     return false;
                 }

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2780,15 +2780,10 @@ angular.module('syncthing.core')
                 if (node.folder) return false;
 
                 if ($scope.restoreVersions.filters.text) {
-                    // Use case-insensitive filter.
-                    var filterText = $scope.restoreVersions.filters.text.toLowerCase();
-                    var versionPath = node.key.toLowerCase();
-                    // Convert backslashes to forward slashes on Windows
-                    // to allow using them as path separators.
-                    if ($scope.version.os == 'windows') {
-                        filterText = filterText.replace(/\\/g, '/');
-                        versionPath = versionPath.replace(/\\/g, '/');
-                    }
+                    // Use case-insensitive filter and convert backslashes to
+                    // forward slashes to allow using them as path separators.
+                    var filterText = $scope.restoreVersions.filters.text.toLowerCase().replace(/\\/g, '/');
+                    var versionPath = node.key.toLowerCase().replace(/\\/g, '/');
                     if (versionPath.indexOf(filterText) < 0) {
                         return false;
                     }


### PR DESCRIPTION
gui: Use case-insensive versions filter and allow backslashes as path separators (fixes #7973)

Currently, the versions filter is case-sensitive regardless of the
underlying OS. With this change, the filter becomes case-insensitive
everywhere, which is more user-friendly and makes it easier to search
for files whose exact case the user may not remember.

In addition, allow backslashes to be used as filter path separators.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>
