### PR TITLE
lib/ur: Don't report uptime if start time is in the past (fixes #7698)

### DIFF
--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -328,7 +328,8 @@ func (s *Service) reportData(ctx context.Context, urVersion int, preview bool) (
 }
 
 func (*Service) UptimeS() int {
-	// Handle nonexistent or wildly incorrect system clock. This code was written in 2023, it can't run in the past.
+	// Handle nonexistent or wildly incorrect system clock.
+	// This code was written in 2023, it can't run in the past.
 	if StartTime.Year() < 2023 {
 		return 0
 	}

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -330,9 +330,8 @@ func (s *Service) reportData(ctx context.Context, urVersion int, preview bool) (
 func (*Service) UptimeS() int {
 	if StartTime.Year() < 2023 {
 		return 0
-	} else {
-		return int(time.Since(StartTime).Seconds())
 	}
+	return int(time.Since(StartTime).Seconds())
 }
 
 func (s *Service) sendUsageReport(ctx context.Context) error {

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -328,7 +328,11 @@ func (s *Service) reportData(ctx context.Context, urVersion int, preview bool) (
 }
 
 func (*Service) UptimeS() int {
-	return int(time.Since(StartTime).Seconds())
+	if StartTime.Year() < 2023 {
+		return 0
+	} else {
+		return int(time.Since(StartTime).Seconds())
+	}
 }
 
 func (s *Service) sendUsageReport(ctx context.Context) error {

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -328,6 +328,7 @@ func (s *Service) reportData(ctx context.Context, urVersion int, preview bool) (
 }
 
 func (*Service) UptimeS() int {
+	// Handle nonexistent or wildly incorrect system clock. This code was written in 2023, it can't run in the past.
 	if StartTime.Year() < 2023 {
 		return 0
 	}


### PR DESCRIPTION
lib/ur: Don't report uptime if start time is in the past (fixes #7698)

Currently, because of devices with unset RTC clock, the 100% percentile
for Uptime on [1] is calculated since the Unix epoch which is useless as
far as usage statistics are concerned. Thus, if the Syncthing start time
is set to a past date, assume that the clock is wrong and do not even
try to report the uptime.

[1] https://data.syncthing.net

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>