### PR TITLE
gui: Remove Twitter link from footer

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -448,7 +448,6 @@
     "Today": "Today",
     "Trash Can": "Trash Can",
     "Trash Can File Versioning": "Trash Can File Versioning",
-    "Twitter": "Twitter",
     "Type": "Type",
     "UNIX Permissions": "UNIX Permissions",
     "Unavailable": "Unavailable",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -963,7 +963,6 @@
         <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/releases" target="_blank"><span class="far fa-file-alt"></span>&nbsp;<span translate>Changelog</span></a></li>
         <li><a class="navbar-link" href="https://github.com/syncthing/syncthing/issues" target="_blank"><span class="fas fa-bug"></span>&nbsp;<span translate>Bugs</span></a></li>
         <li><a class="navbar-link" href="https://github.com/syncthing/syncthing" target="_blank"><span class="fas fa-wrench"></span>&nbsp;<span translate>Source Code</span></a></li>
-        <li><a class="navbar-link" href="https://twitter.com/syncthing" target="_blank"><span class="fab fa-twitter"></span>&nbsp;<span translate>Twitter</span></a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
gui: Remove Twitter link from footer

There is a Twitter link at the very bottom of the GUI. However, the page
seems rather dead, as almost no updates or information have been posted
there for a long time. On top of that, Twitter has recently switched to
a login wall, meaning that without logging in, people cannot even access
the site.

Because of the above, remove the Twitter link from the GUI altogether.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>