### PR TITLE
Fix data race in TestCSRFRequired

### DIFF
--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -771,15 +771,9 @@ func TestCSRFRequired(t *testing.T) {
 		}
 	}
 
-	dataRaceSleep := func() {
-		// time.Sleep(time.Duration(50 + rand.Intn(150)) * time.Millisecond)
-		time.Sleep(time.Duration(500) * time.Millisecond)
-	}
-
 	t.Run("/rest without a token should fail", func(t *testing.T) {
 		t.Parallel()
 		resp, err := cli.Get(baseURL + "/rest/system/config")
-		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -794,7 +788,6 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-"+csrfTokenName, csrfTokenValue)
 		resp, err := cli.Do(req)
-		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -809,7 +802,6 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-API-Key", testAPIKey+"X")
 		resp, err := cli.Do(req)
-		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -824,7 +816,6 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("Authorization", "Bearer "+testAPIKey+"X")
 		resp, err := cli.Do(req)
-		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -839,7 +830,6 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-API-Key", testAPIKey)
 		resp, err := cli.Do(req)
-		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -854,7 +844,6 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("Authorization", "Bearer "+testAPIKey)
 		resp, err := cli.Do(req)
-		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -778,7 +778,7 @@ func TestCSRFRequired(t *testing.T) {
 
 	t.Run("/rest without a token should fail", func(t *testing.T) {
 		t.Parallel()
-		resp, err = cli.Get(baseURL + "/rest/system/config")
+		resp, err := cli.Get(baseURL + "/rest/system/config")
 		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
@@ -793,7 +793,7 @@ func TestCSRFRequired(t *testing.T) {
 		t.Parallel()
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-"+csrfTokenName, csrfTokenValue)
-		resp, err = cli.Do(req)
+		resp, err := cli.Do(req)
 		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
@@ -808,7 +808,7 @@ func TestCSRFRequired(t *testing.T) {
 		t.Parallel()
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-API-Key", testAPIKey+"X")
-		resp, err = cli.Do(req)
+		resp, err := cli.Do(req)
 		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
@@ -823,7 +823,7 @@ func TestCSRFRequired(t *testing.T) {
 		t.Parallel()
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("Authorization", "Bearer "+testAPIKey+"X")
-		resp, err = cli.Do(req)
+		resp, err := cli.Do(req)
 		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
@@ -838,7 +838,7 @@ func TestCSRFRequired(t *testing.T) {
 		t.Parallel()
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-API-Key", testAPIKey)
-		resp, err = cli.Do(req)
+		resp, err := cli.Do(req)
 		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
@@ -853,7 +853,7 @@ func TestCSRFRequired(t *testing.T) {
 		t.Parallel()
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("Authorization", "Bearer "+testAPIKey)
-		resp, err = cli.Do(req)
+		resp, err := cli.Do(req)
 		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -771,9 +771,15 @@ func TestCSRFRequired(t *testing.T) {
 		}
 	}
 
+	dataRaceSleep := func() {
+		// time.Sleep(time.Duration(50 + rand.Intn(150)) * time.Millisecond)
+		time.Sleep(time.Duration(500) * time.Millisecond)
+	}
+
 	t.Run("/rest without a token should fail", func(t *testing.T) {
 		t.Parallel()
 		resp, err = cli.Get(baseURL + "/rest/system/config")
+		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -788,6 +794,7 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-"+csrfTokenName, csrfTokenValue)
 		resp, err = cli.Do(req)
+		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -802,6 +809,7 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-API-Key", testAPIKey+"X")
 		resp, err = cli.Do(req)
+		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -816,6 +824,7 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("Authorization", "Bearer "+testAPIKey+"X")
 		resp, err = cli.Do(req)
+		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -830,6 +839,7 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("X-API-Key", testAPIKey)
 		resp, err = cli.Do(req)
+		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}
@@ -844,6 +854,7 @@ func TestCSRFRequired(t *testing.T) {
 		req, _ := http.NewRequest("GET", baseURL+"/rest/system/config", nil)
 		req.Header.Set("Authorization", "Bearer "+testAPIKey)
 		resp, err = cli.Do(req)
+		dataRaceSleep()
 		if err != nil {
 			t.Fatal("Unexpected error from getting /rest/system/config:", err)
 		}


### PR DESCRIPTION
### Purpose

Originally discovered on commit f71387cc841ca9f7a7c0c9aaebb9a67cd1556e9a in PR #8757. Commit 855c6dc67b96abdd1afcc66bad262bb9849d9189 introduces a data race in `TestCSRFRequired` because of how the `resp, err` variables are reused between the parallel test routines.

### Testing

- Commit 2296c387137362781f5c6d23d05f402d60410f32 should fairly reliably reveal the data race. If not, increase the delay in `dataRaceSleep` and re-run the test.
- Commit 96013c373d005d736e1c72615b219540c62df615 fixes the data race.
- Commit 61c65ff1773a197a9cbf40efd24b3c48b5fe9df2 removes the delays introduced in 2296c387137362781f5c6d23d05f402d60410f32.

### Documentation

N/A