### PR TITLE
all: Refactor the protocol/model interface a bit (ref #8981)

### DIFF
--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -58,7 +58,7 @@ var (
 
 func init() {
 	dev1, _ = protocol.DeviceIDFromString("AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR")
-	apiCfg.GUIReturns(config.GUIConfiguration{APIKey: testAPIKey})
+	apiCfg.GUIReturns(config.GUIConfiguration{APIKey: testAPIKey, RawAddress: "127.0.0.1:0"})
 }
 
 func TestMain(m *testing.M) {
@@ -496,7 +496,9 @@ func TestAPIServiceRequests(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc
 		t.Run(cases[0].URL, func(t *testing.T) {
+			t.Parallel()
 			testHTTPRequest(t, baseURL, tc, testAPIKey)
 		})
 	}
@@ -557,9 +559,10 @@ func TestHTTPLogin(t *testing.T) {
 
 	cfg := newMockedConfig()
 	cfg.GUIReturns(config.GUIConfiguration{
-		User:     "üser",
-		Password: "$2a$10$IdIZTxTg/dCNuNEGlmLynOjqg4B1FvDKuIV5e0BB3pnWVHNb8.GSq", // bcrypt of "räksmörgås" in UTF-8
-		APIKey:   testAPIKey,
+		User:       "üser",
+		Password:   "$2a$10$IdIZTxTg/dCNuNEGlmLynOjqg4B1FvDKuIV5e0BB3pnWVHNb8.GSq", // bcrypt of "räksmörgås" in UTF-8
+		RawAddress: "127.0.0.1:0",
+		APIKey:     testAPIKey,
 	})
 	baseURL, cancel, err := startHTTP(cfg)
 	if err != nil {
@@ -1050,30 +1053,31 @@ func TestHostCheck(t *testing.T) {
 		t.Error("Incorrect host header, check disabled: expected 200 OK, not", resp.Status)
 	}
 
-	// A server bound to a wildcard address also doesn't do the check
+	if !testing.Short() {
+		// A server bound to a wildcard address also doesn't do the check
 
-	cfg = newMockedConfig()
-	cfg.GUIReturns(config.GUIConfiguration{
-		RawAddress:            "0.0.0.0:0",
-		InsecureSkipHostCheck: true,
-	})
-	baseURL, cancel, err = startHTTP(cfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cancel()
+		cfg = newMockedConfig()
+		cfg.GUIReturns(config.GUIConfiguration{
+			RawAddress: "0.0.0.0:0",
+		})
+		baseURL, cancel, err = startHTTP(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer cancel()
 
-	// A request with a suspicious Host header should be allowed
+		// A request with a suspicious Host header should be allowed
 
-	req, _ = http.NewRequest("GET", baseURL, nil)
-	req.Host = "example.com"
-	resp, err = http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Error("Incorrect host header, wildcard bound: expected 200 OK, not", resp.Status)
+		req, _ = http.NewRequest("GET", baseURL, nil)
+		req.Host = "example.com"
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Error("Incorrect host header, wildcard bound: expected 200 OK, not", resp.Status)
+		}
 	}
 
 	// This should all work over IPv6 as well

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -30,7 +30,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 	defer wcfgCancel()
 	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
-	addFakeConn(m, device1, f.ID)
+	conn := addFakeConn(m, device1, f.ID)
 
 	// Create some test data
 
@@ -45,7 +45,7 @@ func TestRecvOnlyRevertDeletes(t *testing.T) {
 
 	// Send and index update for the known stuff
 
-	must(t, m.Index(device1, "ro", knownFiles))
+	must(t, m.Index(conn, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	size := globalSize(t, m, "ro")
@@ -112,7 +112,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	defer wcfgCancel()
 	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
-	addFakeConn(m, device1, f.ID)
+	conn := addFakeConn(m, device1, f.ID)
 
 	// Create some test data
 
@@ -122,7 +122,7 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 
 	// Send and index update for the known stuff
 
-	must(t, m.Index(device1, "ro", knownFiles))
+	must(t, m.Index(conn, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -202,7 +202,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 	defer wcfgCancel()
 	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
-	addFakeConn(m, device1, f.ID)
+	conn := addFakeConn(m, device1, f.ID)
 
 	// Create some test data
 
@@ -212,7 +212,7 @@ func TestRecvOnlyUndoChanges(t *testing.T) {
 
 	// Send an index update for the known stuff
 
-	must(t, m.Index(device1, "ro", knownFiles))
+	must(t, m.Index(conn, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -272,7 +272,7 @@ func TestRecvOnlyDeletedRemoteDrop(t *testing.T) {
 	defer wcfgCancel()
 	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
-	addFakeConn(m, device1, f.ID)
+	conn := addFakeConn(m, device1, f.ID)
 
 	// Create some test data
 
@@ -282,7 +282,7 @@ func TestRecvOnlyDeletedRemoteDrop(t *testing.T) {
 
 	// Send an index update for the known stuff
 
-	must(t, m.Index(device1, "ro", knownFiles))
+	must(t, m.Index(conn, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -337,7 +337,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 	defer wcfgCancel()
 	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
-	addFakeConn(m, device1, f.ID)
+	conn := addFakeConn(m, device1, f.ID)
 
 	// Create some test data
 
@@ -347,7 +347,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 
 	// Send an index update for the known stuff
 
-	must(t, m.Index(device1, "ro", knownFiles))
+	must(t, m.Index(conn, "ro", knownFiles))
 	f.updateLocalsFromScanning(knownFiles)
 
 	// Scan the folder.
@@ -402,7 +402,7 @@ func TestRecvOnlyRemoteUndoChanges(t *testing.T) {
 		return true
 	})
 	snap.Release()
-	must(t, m.IndexUpdate(device1, "ro", files))
+	must(t, m.IndexUpdate(conn, "ro", files))
 
 	// Ensure the pull to resolve conflicts (content identical) happened
 	must(t, f.doInSync(func() error {
@@ -427,7 +427,7 @@ func TestRecvOnlyRevertOwnID(t *testing.T) {
 	defer wcfgCancel()
 	ffs := f.Filesystem(nil)
 	defer cleanupModel(m)
-	addFakeConn(m, device1, f.ID)
+	conn := addFakeConn(m, device1, f.ID)
 
 	// Create some test data
 
@@ -470,7 +470,7 @@ func TestRecvOnlyRevertOwnID(t *testing.T) {
 	}()
 
 	// Receive an index update with an older version, but valid and then revert
-	must(t, m.Index(device1, f.ID, []protocol.FileInfo{fi}))
+	must(t, m.Index(conn, f.ID, []protocol.FileInfo{fi}))
 	f.Revert()
 
 	select {

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -1278,7 +1278,7 @@ func TestPullSymlinkOverExistingWindows(t *testing.T) {
 
 	m, f, wcfgCancel := setupSendReceiveFolder(t)
 	defer wcfgCancel()
-	addFakeConn(m, device1, f.ID)
+	conn := addFakeConn(m, device1, f.ID)
 
 	name := "foo"
 	if fd, err := f.mtimefs.Create(name); err != nil {
@@ -1296,7 +1296,7 @@ func TestPullSymlinkOverExistingWindows(t *testing.T) {
 	if !ok {
 		t.Fatal("file missing")
 	}
-	must(t, m.Index(device1, f.ID, []protocol.FileInfo{{Name: name, Type: protocol.FileInfoTypeSymlink, Version: file.Version.Update(device1.Short())}}))
+	must(t, m.Index(conn, f.ID, []protocol.FileInfo{{Name: name, Type: protocol.FileInfoTypeSymlink, Version: file.Version.Update(device1.Short())}}))
 
 	scanChan := make(chan string)
 

--- a/lib/model/mocks/model.go
+++ b/lib/model/mocks/model.go
@@ -44,16 +44,16 @@ type Model struct {
 		arg1 string
 		arg2 string
 	}
-	ClosedStub        func(protocol.DeviceID, error)
+	ClosedStub        func(protocol.Connection, error)
 	closedMutex       sync.RWMutex
 	closedArgsForCall []struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 error
 	}
-	ClusterConfigStub        func(protocol.DeviceID, protocol.ClusterConfig) error
+	ClusterConfigStub        func(protocol.Connection, protocol.ClusterConfig) error
 	clusterConfigMutex       sync.RWMutex
 	clusterConfigArgsForCall []struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 protocol.ClusterConfig
 	}
 	clusterConfigReturns struct {
@@ -200,10 +200,10 @@ type Model struct {
 	dismissPendingFolderReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DownloadProgressStub        func(protocol.DeviceID, string, []protocol.FileDownloadProgressUpdate) error
+	DownloadProgressStub        func(protocol.Connection, string, []protocol.FileDownloadProgressUpdate) error
 	downloadProgressMutex       sync.RWMutex
 	downloadProgressArgsForCall []struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 []protocol.FileDownloadProgressUpdate
 	}
@@ -303,10 +303,10 @@ type Model struct {
 		result1 []*model.TreeEntry
 		result2 error
 	}
-	IndexStub        func(protocol.DeviceID, string, []protocol.FileInfo) error
+	IndexStub        func(protocol.Connection, string, []protocol.FileInfo) error
 	indexMutex       sync.RWMutex
 	indexArgsForCall []struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 []protocol.FileInfo
 	}
@@ -316,10 +316,10 @@ type Model struct {
 	indexReturnsOnCall map[int]struct {
 		result1 error
 	}
-	IndexUpdateStub        func(protocol.DeviceID, string, []protocol.FileInfo) error
+	IndexUpdateStub        func(protocol.Connection, string, []protocol.FileInfo) error
 	indexUpdateMutex       sync.RWMutex
 	indexUpdateArgsForCall []struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 []protocol.FileInfo
 	}
@@ -447,10 +447,10 @@ type Model struct {
 		result1 []db.FileInfoTruncated
 		result2 error
 	}
-	RequestStub        func(protocol.DeviceID, string, string, int32, int32, int64, []byte, uint32, bool) (protocol.RequestResponse, error)
+	RequestStub        func(protocol.Connection, string, string, int32, int32, int64, []byte, uint32, bool) (protocol.RequestResponse, error)
 	requestMutex       sync.RWMutex
 	requestArgsForCall []struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 string
 		arg4 int32
@@ -728,10 +728,10 @@ func (fake *Model) BringToFrontArgsForCall(i int) (string, string) {
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Model) Closed(arg1 protocol.DeviceID, arg2 error) {
+func (fake *Model) Closed(arg1 protocol.Connection, arg2 error) {
 	fake.closedMutex.Lock()
 	fake.closedArgsForCall = append(fake.closedArgsForCall, struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 error
 	}{arg1, arg2})
 	stub := fake.ClosedStub
@@ -748,24 +748,24 @@ func (fake *Model) ClosedCallCount() int {
 	return len(fake.closedArgsForCall)
 }
 
-func (fake *Model) ClosedCalls(stub func(protocol.DeviceID, error)) {
+func (fake *Model) ClosedCalls(stub func(protocol.Connection, error)) {
 	fake.closedMutex.Lock()
 	defer fake.closedMutex.Unlock()
 	fake.ClosedStub = stub
 }
 
-func (fake *Model) ClosedArgsForCall(i int) (protocol.DeviceID, error) {
+func (fake *Model) ClosedArgsForCall(i int) (protocol.Connection, error) {
 	fake.closedMutex.RLock()
 	defer fake.closedMutex.RUnlock()
 	argsForCall := fake.closedArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *Model) ClusterConfig(arg1 protocol.DeviceID, arg2 protocol.ClusterConfig) error {
+func (fake *Model) ClusterConfig(arg1 protocol.Connection, arg2 protocol.ClusterConfig) error {
 	fake.clusterConfigMutex.Lock()
 	ret, specificReturn := fake.clusterConfigReturnsOnCall[len(fake.clusterConfigArgsForCall)]
 	fake.clusterConfigArgsForCall = append(fake.clusterConfigArgsForCall, struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 protocol.ClusterConfig
 	}{arg1, arg2})
 	stub := fake.ClusterConfigStub
@@ -787,13 +787,13 @@ func (fake *Model) ClusterConfigCallCount() int {
 	return len(fake.clusterConfigArgsForCall)
 }
 
-func (fake *Model) ClusterConfigCalls(stub func(protocol.DeviceID, protocol.ClusterConfig) error) {
+func (fake *Model) ClusterConfigCalls(stub func(protocol.Connection, protocol.ClusterConfig) error) {
 	fake.clusterConfigMutex.Lock()
 	defer fake.clusterConfigMutex.Unlock()
 	fake.ClusterConfigStub = stub
 }
 
-func (fake *Model) ClusterConfigArgsForCall(i int) (protocol.DeviceID, protocol.ClusterConfig) {
+func (fake *Model) ClusterConfigArgsForCall(i int) (protocol.Connection, protocol.ClusterConfig) {
 	fake.clusterConfigMutex.RLock()
 	defer fake.clusterConfigMutex.RUnlock()
 	argsForCall := fake.clusterConfigArgsForCall[i]
@@ -1484,7 +1484,7 @@ func (fake *Model) DismissPendingFolderReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Model) DownloadProgress(arg1 protocol.DeviceID, arg2 string, arg3 []protocol.FileDownloadProgressUpdate) error {
+func (fake *Model) DownloadProgress(arg1 protocol.Connection, arg2 string, arg3 []protocol.FileDownloadProgressUpdate) error {
 	var arg3Copy []protocol.FileDownloadProgressUpdate
 	if arg3 != nil {
 		arg3Copy = make([]protocol.FileDownloadProgressUpdate, len(arg3))
@@ -1493,7 +1493,7 @@ func (fake *Model) DownloadProgress(arg1 protocol.DeviceID, arg2 string, arg3 []
 	fake.downloadProgressMutex.Lock()
 	ret, specificReturn := fake.downloadProgressReturnsOnCall[len(fake.downloadProgressArgsForCall)]
 	fake.downloadProgressArgsForCall = append(fake.downloadProgressArgsForCall, struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 []protocol.FileDownloadProgressUpdate
 	}{arg1, arg2, arg3Copy})
@@ -1516,13 +1516,13 @@ func (fake *Model) DownloadProgressCallCount() int {
 	return len(fake.downloadProgressArgsForCall)
 }
 
-func (fake *Model) DownloadProgressCalls(stub func(protocol.DeviceID, string, []protocol.FileDownloadProgressUpdate) error) {
+func (fake *Model) DownloadProgressCalls(stub func(protocol.Connection, string, []protocol.FileDownloadProgressUpdate) error) {
 	fake.downloadProgressMutex.Lock()
 	defer fake.downloadProgressMutex.Unlock()
 	fake.DownloadProgressStub = stub
 }
 
-func (fake *Model) DownloadProgressArgsForCall(i int) (protocol.DeviceID, string, []protocol.FileDownloadProgressUpdate) {
+func (fake *Model) DownloadProgressArgsForCall(i int) (protocol.Connection, string, []protocol.FileDownloadProgressUpdate) {
 	fake.downloadProgressMutex.RLock()
 	defer fake.downloadProgressMutex.RUnlock()
 	argsForCall := fake.downloadProgressArgsForCall[i]
@@ -1990,7 +1990,7 @@ func (fake *Model) GlobalDirectoryTreeReturnsOnCall(i int, result1 []*model.Tree
 	}{result1, result2}
 }
 
-func (fake *Model) Index(arg1 protocol.DeviceID, arg2 string, arg3 []protocol.FileInfo) error {
+func (fake *Model) Index(arg1 protocol.Connection, arg2 string, arg3 []protocol.FileInfo) error {
 	var arg3Copy []protocol.FileInfo
 	if arg3 != nil {
 		arg3Copy = make([]protocol.FileInfo, len(arg3))
@@ -1999,7 +1999,7 @@ func (fake *Model) Index(arg1 protocol.DeviceID, arg2 string, arg3 []protocol.Fi
 	fake.indexMutex.Lock()
 	ret, specificReturn := fake.indexReturnsOnCall[len(fake.indexArgsForCall)]
 	fake.indexArgsForCall = append(fake.indexArgsForCall, struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 []protocol.FileInfo
 	}{arg1, arg2, arg3Copy})
@@ -2022,13 +2022,13 @@ func (fake *Model) IndexCallCount() int {
 	return len(fake.indexArgsForCall)
 }
 
-func (fake *Model) IndexCalls(stub func(protocol.DeviceID, string, []protocol.FileInfo) error) {
+func (fake *Model) IndexCalls(stub func(protocol.Connection, string, []protocol.FileInfo) error) {
 	fake.indexMutex.Lock()
 	defer fake.indexMutex.Unlock()
 	fake.IndexStub = stub
 }
 
-func (fake *Model) IndexArgsForCall(i int) (protocol.DeviceID, string, []protocol.FileInfo) {
+func (fake *Model) IndexArgsForCall(i int) (protocol.Connection, string, []protocol.FileInfo) {
 	fake.indexMutex.RLock()
 	defer fake.indexMutex.RUnlock()
 	argsForCall := fake.indexArgsForCall[i]
@@ -2058,7 +2058,7 @@ func (fake *Model) IndexReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Model) IndexUpdate(arg1 protocol.DeviceID, arg2 string, arg3 []protocol.FileInfo) error {
+func (fake *Model) IndexUpdate(arg1 protocol.Connection, arg2 string, arg3 []protocol.FileInfo) error {
 	var arg3Copy []protocol.FileInfo
 	if arg3 != nil {
 		arg3Copy = make([]protocol.FileInfo, len(arg3))
@@ -2067,7 +2067,7 @@ func (fake *Model) IndexUpdate(arg1 protocol.DeviceID, arg2 string, arg3 []proto
 	fake.indexUpdateMutex.Lock()
 	ret, specificReturn := fake.indexUpdateReturnsOnCall[len(fake.indexUpdateArgsForCall)]
 	fake.indexUpdateArgsForCall = append(fake.indexUpdateArgsForCall, struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 []protocol.FileInfo
 	}{arg1, arg2, arg3Copy})
@@ -2090,13 +2090,13 @@ func (fake *Model) IndexUpdateCallCount() int {
 	return len(fake.indexUpdateArgsForCall)
 }
 
-func (fake *Model) IndexUpdateCalls(stub func(protocol.DeviceID, string, []protocol.FileInfo) error) {
+func (fake *Model) IndexUpdateCalls(stub func(protocol.Connection, string, []protocol.FileInfo) error) {
 	fake.indexUpdateMutex.Lock()
 	defer fake.indexUpdateMutex.Unlock()
 	fake.IndexUpdateStub = stub
 }
 
-func (fake *Model) IndexUpdateArgsForCall(i int) (protocol.DeviceID, string, []protocol.FileInfo) {
+func (fake *Model) IndexUpdateArgsForCall(i int) (protocol.Connection, string, []protocol.FileInfo) {
 	fake.indexUpdateMutex.RLock()
 	defer fake.indexUpdateMutex.RUnlock()
 	argsForCall := fake.indexUpdateArgsForCall[i]
@@ -2666,7 +2666,7 @@ func (fake *Model) RemoteNeedFolderFilesReturnsOnCall(i int, result1 []db.FileIn
 	}{result1, result2}
 }
 
-func (fake *Model) Request(arg1 protocol.DeviceID, arg2 string, arg3 string, arg4 int32, arg5 int32, arg6 int64, arg7 []byte, arg8 uint32, arg9 bool) (protocol.RequestResponse, error) {
+func (fake *Model) Request(arg1 protocol.Connection, arg2 string, arg3 string, arg4 int32, arg5 int32, arg6 int64, arg7 []byte, arg8 uint32, arg9 bool) (protocol.RequestResponse, error) {
 	var arg7Copy []byte
 	if arg7 != nil {
 		arg7Copy = make([]byte, len(arg7))
@@ -2675,7 +2675,7 @@ func (fake *Model) Request(arg1 protocol.DeviceID, arg2 string, arg3 string, arg
 	fake.requestMutex.Lock()
 	ret, specificReturn := fake.requestReturnsOnCall[len(fake.requestArgsForCall)]
 	fake.requestArgsForCall = append(fake.requestArgsForCall, struct {
-		arg1 protocol.DeviceID
+		arg1 protocol.Connection
 		arg2 string
 		arg3 string
 		arg4 int32
@@ -2704,13 +2704,13 @@ func (fake *Model) RequestCallCount() int {
 	return len(fake.requestArgsForCall)
 }
 
-func (fake *Model) RequestCalls(stub func(protocol.DeviceID, string, string, int32, int32, int64, []byte, uint32, bool) (protocol.RequestResponse, error)) {
+func (fake *Model) RequestCalls(stub func(protocol.Connection, string, string, int32, int32, int64, []byte, uint32, bool) (protocol.RequestResponse, error)) {
 	fake.requestMutex.Lock()
 	defer fake.requestMutex.Unlock()
 	fake.RequestStub = stub
 }
 
-func (fake *Model) RequestArgsForCall(i int) (protocol.DeviceID, string, string, int32, int32, int64, []byte, uint32, bool) {
+func (fake *Model) RequestArgsForCall(i int) (protocol.Connection, string, string, int32, int32, int64, []byte, uint32, bool) {
 	fake.requestMutex.RLock()
 	defer fake.requestMutex.RUnlock()
 	argsForCall := fake.requestArgsForCall[i]

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -847,7 +847,7 @@ func (comp *FolderCompletion) setComplectionPct() {
 }
 
 // Map returns the members as a map, e.g. used in api to serialize as JSON.
-func (comp FolderCompletion) Map() map[string]interface{} {
+func (comp *FolderCompletion) Map() map[string]interface{} {
 	return map[string]interface{}{
 		"completion":  comp.CompletionPct,
 		"globalBytes": comp.GlobalBytes,
@@ -1110,22 +1110,23 @@ func (p *pager) done() bool {
 
 // Index is called when a new device is connected and we receive their full index.
 // Implements the protocol.Model interface.
-func (m *model) Index(deviceID protocol.DeviceID, folder string, fs []protocol.FileInfo) error {
-	return m.handleIndex(deviceID, folder, fs, false)
+func (m *model) Index(conn protocol.Connection, folder string, fs []protocol.FileInfo) error {
+	return m.handleIndex(conn, folder, fs, false)
 }
 
 // IndexUpdate is called for incremental updates to connected devices' indexes.
 // Implements the protocol.Model interface.
-func (m *model) IndexUpdate(deviceID protocol.DeviceID, folder string, fs []protocol.FileInfo) error {
-	return m.handleIndex(deviceID, folder, fs, true)
+func (m *model) IndexUpdate(conn protocol.Connection, folder string, fs []protocol.FileInfo) error {
+	return m.handleIndex(conn, folder, fs, true)
 }
 
-func (m *model) handleIndex(deviceID protocol.DeviceID, folder string, fs []protocol.FileInfo, update bool) error {
+func (m *model) handleIndex(conn protocol.Connection, folder string, fs []protocol.FileInfo, update bool) error {
 	op := "Index"
 	if update {
 		op += " update"
 	}
 
+	deviceID := conn.DeviceID()
 	l.Debugf("%v (in): %s / %q: %d files", op, deviceID, folder, len(fs))
 
 	if cfg, ok := m.cfg.Folder(folder); !ok || !cfg.SharedWith(deviceID) {
@@ -1159,12 +1160,13 @@ type ClusterConfigReceivedEventData struct {
 	Device protocol.DeviceID `json:"device"`
 }
 
-func (m *model) ClusterConfig(deviceID protocol.DeviceID, cm protocol.ClusterConfig) error {
+func (m *model) ClusterConfig(conn protocol.Connection, cm protocol.ClusterConfig) error {
 	// Check the peer device's announced folders against our own. Emits events
 	// for folders that we don't expect (unknown or not shared).
 	// Also, collect a list of folders we do share, and if he's interested in
 	// temporary indexes, subscribe the connection.
 
+	deviceID := conn.DeviceID()
 	l.Debugf("Handling ClusterConfig from %v", deviceID.Short())
 
 	m.pmut.RLock()
@@ -1544,7 +1546,7 @@ func (m *model) sendClusterConfig(ids []protocol.DeviceID) {
 	m.pmut.RUnlock()
 	// Generating cluster-configs acquires fmut -> must happen outside of pmut.
 	for _, conn := range ccConns {
-		cm, passwords := m.generateClusterConfig(conn.ID())
+		cm, passwords := m.generateClusterConfig(conn.DeviceID())
 		conn.SetFolderPasswords(passwords)
 		go conn.ClusterConfig(cm)
 	}
@@ -1774,7 +1776,8 @@ func (m *model) introduceDevice(device protocol.Device, introducerCfg config.Dev
 }
 
 // Closed is called when a connection has been closed
-func (m *model) Closed(device protocol.DeviceID, err error) {
+func (m *model) Closed(conn protocol.Connection, err error) {
+	device := conn.DeviceID()
 	m.pmut.Lock()
 	conn, ok := m.conn[device]
 	if !ok {
@@ -1834,10 +1837,12 @@ func (r *requestResponse) Wait() {
 
 // Request returns the specified data segment by reading it from local disk.
 // Implements the protocol.Model interface.
-func (m *model) Request(deviceID protocol.DeviceID, folder, name string, _, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (out protocol.RequestResponse, err error) {
+func (m *model) Request(conn protocol.Connection, folder, name string, _, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (out protocol.RequestResponse, err error) {
 	if size < 0 || offset < 0 {
 		return nil, protocol.ErrInvalid
 	}
+
+	deviceID := conn.DeviceID()
 
 	m.fmut.RLock()
 	folderCfg, ok := m.folderCfgs[folder]
@@ -2214,7 +2219,7 @@ func (m *model) GetHello(id protocol.DeviceID) protocol.HelloIntf {
 // be sent to the connected peer, thereafter index updates whenever the local
 // folder changes.
 func (m *model) AddConnection(conn protocol.Connection, hello protocol.Hello) {
-	deviceID := conn.ID()
+	deviceID := conn.DeviceID()
 	device, ok := m.cfg.Device(deviceID)
 	if !ok {
 		l.Infoln("Trying to add connection to unknown device")
@@ -2303,11 +2308,12 @@ func (m *model) AddConnection(conn protocol.Connection, hello protocol.Hello) {
 	m.deviceWasSeen(deviceID)
 }
 
-func (m *model) DownloadProgress(device protocol.DeviceID, folder string, updates []protocol.FileDownloadProgressUpdate) error {
+func (m *model) DownloadProgress(conn protocol.Connection, folder string, updates []protocol.FileDownloadProgressUpdate) error {
 	m.fmut.RLock()
 	cfg, ok := m.folderCfgs[folder]
 	m.fmut.RUnlock()
 
+	device := conn.DeviceID()
 	if !ok || cfg.DisableTempIndexes || !cfg.SharedWith(device) {
 		return nil
 	}

--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -315,15 +315,15 @@ func (t *ProgressEmitter) emptyLocked() bool {
 func (t *ProgressEmitter) temporaryIndexSubscribe(conn protocol.Connection, folders []string) {
 	t.mut.Lock()
 	defer t.mut.Unlock()
-	t.connections[conn.ID()] = conn
-	t.foldersByConns[conn.ID()] = folders
+	t.connections[conn.DeviceID()] = conn
+	t.foldersByConns[conn.DeviceID()] = folders
 }
 
 func (t *ProgressEmitter) temporaryIndexUnsubscribe(conn protocol.Connection) {
 	t.mut.Lock()
 	defer t.mut.Unlock()
-	delete(t.connections, conn.ID())
-	delete(t.foldersByConns, conn.ID())
+	delete(t.connections, conn.DeviceID())
+	delete(t.foldersByConns, conn.DeviceID())
 }
 
 func (t *ProgressEmitter) clearLocked() {

--- a/lib/model/progressemitter_test.go
+++ b/lib/model/progressemitter_test.go
@@ -463,7 +463,7 @@ func TestSendDownloadProgressMessages(t *testing.T) {
 	p.temporaryIndexUnsubscribe(fc)
 
 	sendMsgs(p)
-	_, ok := p.sentDownloadStates[fc.ID()]
+	_, ok := p.sentDownloadStates[fc.DeviceID()]
 	if ok {
 		t.Error("Should not be there")
 	}

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -107,7 +107,7 @@ func TestSymlinkTraversalRead(t *testing.T) {
 	<-done
 
 	// Request a file by traversing the symlink
-	res, err := m.Request(device1, "default", "symlink/requests_test.go", 0, 10, 0, nil, 0, false)
+	res, err := m.Request(device1Conn, "default", "symlink/requests_test.go", 0, 10, 0, nil, 0, false)
 	if err == nil || res != nil {
 		t.Error("Managed to traverse symlink")
 	}
@@ -439,7 +439,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 		t.Fatalf("unexpected weak hash: %d != 103547413", f.Blocks[0].WeakHash)
 	}
 
-	res, err := m.Request(device1, "default", "foo", 0, int32(len(payload)), 0, f.Blocks[0].Hash, f.Blocks[0].WeakHash, false)
+	res, err := m.Request(device1Conn, "default", "foo", 0, int32(len(payload)), 0, f.Blocks[0].Hash, f.Blocks[0].WeakHash, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -453,7 +453,7 @@ func TestRescanIfHaveInvalidContent(t *testing.T) {
 
 	writeFile(t, tfs, "foo", payload)
 
-	_, err = m.Request(device1, "default", "foo", 0, int32(len(payload)), 0, f.Blocks[0].Hash, f.Blocks[0].WeakHash, false)
+	_, err = m.Request(device1Conn, "default", "foo", 0, int32(len(payload)), 0, f.Blocks[0].Hash, f.Blocks[0].WeakHash, false)
 	if err == nil {
 		t.Fatalf("expected failure")
 	}
@@ -1122,7 +1122,7 @@ func TestRequestIndexSenderPause(t *testing.T) {
 
 	cc := basicClusterConfig(device1, myID, fcfg.ID)
 	cc.Folders[0].Paused = true
-	m.ClusterConfig(device1, cc)
+	m.ClusterConfig(fc, cc)
 
 	seq++
 	files[0].Sequence = seq
@@ -1143,7 +1143,7 @@ func TestRequestIndexSenderPause(t *testing.T) {
 	// Remote unpaused
 
 	cc.Folders[0].Paused = false
-	m.ClusterConfig(device1, cc)
+	m.ClusterConfig(fc, cc)
 	select {
 	case <-time.After(5 * time.Second):
 		t.Fatal("timed out before receiving index")
@@ -1168,12 +1168,12 @@ func TestRequestIndexSenderPause(t *testing.T) {
 	// Local and remote paused, then first resume remote, then local
 
 	cc.Folders[0].Paused = true
-	m.ClusterConfig(device1, cc)
+	m.ClusterConfig(fc, cc)
 
 	pauseFolder(t, m.cfg, fcfg.ID, true)
 
 	cc.Folders[0].Paused = false
-	m.ClusterConfig(device1, cc)
+	m.ClusterConfig(fc, cc)
 
 	pauseFolder(t, m.cfg, fcfg.ID, false)
 
@@ -1190,7 +1190,7 @@ func TestRequestIndexSenderPause(t *testing.T) {
 	// Folder removed on remote
 
 	cc = protocol.ClusterConfig{}
-	m.ClusterConfig(device1, cc)
+	m.ClusterConfig(fc, cc)
 
 	seq++
 	files[0].Sequence = seq
@@ -1304,7 +1304,7 @@ func TestRequestReceiveEncrypted(t *testing.T) {
 		return nil
 	})
 	m.AddConnection(fc, protocol.Hello{})
-	m.ClusterConfig(device1, protocol.ClusterConfig{
+	m.ClusterConfig(fc, protocol.ClusterConfig{
 		Folders: []protocol.Folder{
 			{
 				ID: "default",
@@ -1354,7 +1354,7 @@ func TestRequestReceiveEncrypted(t *testing.T) {
 	}
 
 	// Simulate request from device that is untrusted too, i.e. with non-empty, but garbage hash
-	_, err := m.Request(device1, fcfg.ID, name, 0, 1064, 0, []byte("garbage"), 0, false)
+	_, err := m.Request(fc, fcfg.ID, name, 0, 1064, 0, []byte("garbage"), 0, false)
 	must(t, err)
 
 	changed, err := m.LocalChangedFolderFiles(fcfg.ID, 1, 10)
@@ -1380,7 +1380,7 @@ func TestRequestGlobalInvalidToValid(t *testing.T) {
 	})
 	must(t, err)
 	waiter.Wait()
-	addFakeConn(m, device2, fcfg.ID)
+	conn := addFakeConn(m, device2, fcfg.ID)
 	tfs := fcfg.Filesystem(nil)
 	defer cleanupModelAndRemoveDir(m, tfs.URI())
 
@@ -1405,7 +1405,7 @@ func TestRequestGlobalInvalidToValid(t *testing.T) {
 	file := fc.files[0]
 	fc.mut.Unlock()
 	file.SetIgnored()
-	m.IndexUpdate(device2, fcfg.ID, []protocol.FileInfo{prepareFileInfoForIndex(file)})
+	m.IndexUpdate(conn, fcfg.ID, []protocol.FileInfo{prepareFileInfoForIndex(file)})
 
 	// Wait for the ignored file to be received and possible pulled
 	timeout := time.After(10 * time.Second)

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/protocol/mocks"
 	"github.com/syncthing/syncthing/lib/rand"
 )
 
@@ -29,12 +30,16 @@ var (
 	defaultFolderConfig     config.FolderConfiguration
 	defaultCfg              config.Configuration
 	defaultAutoAcceptCfg    config.Configuration
+	device1Conn             = &mocks.Connection{}
+	device2Conn             = &mocks.Connection{}
 )
 
 func init() {
 	myID, _ = protocol.DeviceIDFromString("ZNWFSWE-RWRV2BD-45BLMCV-LTDE2UR-4LJDW6J-R5BPWEB-TXD27XJ-IZF5RA4")
 	device1, _ = protocol.DeviceIDFromString("AIR6LPZ-7K4PTTV-UXQSMUU-CPQ5YWH-OEDFIIQ-JUG777G-2YQXXR5-YD6AWQR")
 	device2, _ = protocol.DeviceIDFromString("GYRZZQB-IRNPV4Z-T7TC52W-EQYJ3TT-FDQW6MW-DFLMU42-SSSU6EM-FBK2VAY")
+	device1Conn.DeviceIDReturns(device1)
+	device2Conn.DeviceIDReturns(device2)
 
 	cfg := config.New(myID)
 	cfg.Options.MinHomeDiskFree.Value = 0 // avoids unnecessary free space checks

--- a/lib/protocol/benchmark_test.go
+++ b/lib/protocol/benchmark_test.go
@@ -167,15 +167,15 @@ func negotiateTLS(cert tls.Certificate, conn0, conn1 net.Conn) (net.Conn, net.Co
 
 type fakeModel struct{}
 
-func (*fakeModel) Index(_ DeviceID, _ string, _ []FileInfo) error {
+func (*fakeModel) Index(Connection, string, []FileInfo) error {
 	return nil
 }
 
-func (*fakeModel) IndexUpdate(_ DeviceID, _ string, _ []FileInfo) error {
+func (*fakeModel) IndexUpdate(Connection, string, []FileInfo) error {
 	return nil
 }
 
-func (*fakeModel) Request(_ DeviceID, _, _ string, _, size int32, offset int64, _ []byte, _ uint32, _ bool) (RequestResponse, error) {
+func (*fakeModel) Request(_ Connection, _, _ string, _, size int32, offset int64, _ []byte, _ uint32, _ bool) (RequestResponse, error) {
 	// We write the offset to the end of the buffer, so the receiver
 	// can verify that it did in fact get some data back over the
 	// connection.
@@ -184,13 +184,13 @@ func (*fakeModel) Request(_ DeviceID, _, _ string, _, size int32, offset int64, 
 	return &fakeRequestResponse{buf}, nil
 }
 
-func (*fakeModel) ClusterConfig(_ DeviceID, _ ClusterConfig) error {
+func (*fakeModel) ClusterConfig(Connection, ClusterConfig) error {
 	return nil
 }
 
-func (*fakeModel) Closed(DeviceID, error) {
+func (*fakeModel) Closed(Connection, error) {
 }
 
-func (*fakeModel) DownloadProgress(_ DeviceID, _ string, _ []FileDownloadProgressUpdate) error {
+func (*fakeModel) DownloadProgress(Connection, string, []FileDownloadProgressUpdate) error {
 	return nil
 }

--- a/lib/protocol/common_test.go
+++ b/lib/protocol/common_test.go
@@ -13,8 +13,8 @@ type TestModel struct {
 	hash          []byte
 	weakHash      uint32
 	fromTemporary bool
-	indexFn       func(DeviceID, string, []FileInfo)
-	ccFn          func(DeviceID, ClusterConfig)
+	indexFn       func(string, []FileInfo)
+	ccFn          func(ClusterConfig)
 	closedCh      chan struct{}
 	closedErr     error
 }
@@ -25,18 +25,18 @@ func newTestModel() *TestModel {
 	}
 }
 
-func (t *TestModel) Index(deviceID DeviceID, folder string, files []FileInfo) error {
+func (t *TestModel) Index(_ Connection, folder string, files []FileInfo) error {
 	if t.indexFn != nil {
-		t.indexFn(deviceID, folder, files)
+		t.indexFn(folder, files)
 	}
 	return nil
 }
 
-func (*TestModel) IndexUpdate(_ DeviceID, _ string, _ []FileInfo) error {
+func (*TestModel) IndexUpdate(Connection, string, []FileInfo) error {
 	return nil
 }
 
-func (t *TestModel) Request(_ DeviceID, folder, name string, _, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error) {
+func (t *TestModel) Request(_ Connection, folder, name string, _, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error) {
 	t.folder = folder
 	t.name = name
 	t.offset = offset
@@ -49,19 +49,19 @@ func (t *TestModel) Request(_ DeviceID, folder, name string, _, size int32, offs
 	return &fakeRequestResponse{buf}, nil
 }
 
-func (t *TestModel) Closed(_ DeviceID, err error) {
+func (t *TestModel) Closed(_ Connection, err error) {
 	t.closedErr = err
 	close(t.closedCh)
 }
 
-func (t *TestModel) ClusterConfig(deviceID DeviceID, config ClusterConfig) error {
+func (t *TestModel) ClusterConfig(_ Connection, config ClusterConfig) error {
 	if t.ccFn != nil {
-		t.ccFn(deviceID, config)
+		t.ccFn(config)
 	}
 	return nil
 }
 
-func (*TestModel) DownloadProgress(DeviceID, string, []FileDownloadProgressUpdate) error {
+func (*TestModel) DownloadProgress(Connection, string, []FileDownloadProgressUpdate) error {
 	return nil
 }
 

--- a/lib/protocol/mocks/connection.go
+++ b/lib/protocol/mocks/connection.go
@@ -41,6 +41,16 @@ type Connection struct {
 	cryptoReturnsOnCall map[int]struct {
 		result1 string
 	}
+	DeviceIDStub        func() protocol.DeviceID
+	deviceIDMutex       sync.RWMutex
+	deviceIDArgsForCall []struct {
+	}
+	deviceIDReturns struct {
+		result1 protocol.DeviceID
+	}
+	deviceIDReturnsOnCall map[int]struct {
+		result1 protocol.DeviceID
+	}
 	DownloadProgressStub        func(context.Context, string, []protocol.FileDownloadProgressUpdate)
 	downloadProgressMutex       sync.RWMutex
 	downloadProgressArgsForCall []struct {
@@ -57,16 +67,6 @@ type Connection struct {
 	}
 	establishedAtReturnsOnCall map[int]struct {
 		result1 time.Time
-	}
-	IDStub        func() protocol.DeviceID
-	iDMutex       sync.RWMutex
-	iDArgsForCall []struct {
-	}
-	iDReturns struct {
-		result1 protocol.DeviceID
-	}
-	iDReturnsOnCall map[int]struct {
-		result1 protocol.DeviceID
 	}
 	IndexStub        func(context.Context, string, []protocol.FileInfo) error
 	indexMutex       sync.RWMutex
@@ -368,6 +368,59 @@ func (fake *Connection) CryptoReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
+func (fake *Connection) DeviceID() protocol.DeviceID {
+	fake.deviceIDMutex.Lock()
+	ret, specificReturn := fake.deviceIDReturnsOnCall[len(fake.deviceIDArgsForCall)]
+	fake.deviceIDArgsForCall = append(fake.deviceIDArgsForCall, struct {
+	}{})
+	stub := fake.DeviceIDStub
+	fakeReturns := fake.deviceIDReturns
+	fake.recordInvocation("DeviceID", []interface{}{})
+	fake.deviceIDMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *Connection) DeviceIDCallCount() int {
+	fake.deviceIDMutex.RLock()
+	defer fake.deviceIDMutex.RUnlock()
+	return len(fake.deviceIDArgsForCall)
+}
+
+func (fake *Connection) DeviceIDCalls(stub func() protocol.DeviceID) {
+	fake.deviceIDMutex.Lock()
+	defer fake.deviceIDMutex.Unlock()
+	fake.DeviceIDStub = stub
+}
+
+func (fake *Connection) DeviceIDReturns(result1 protocol.DeviceID) {
+	fake.deviceIDMutex.Lock()
+	defer fake.deviceIDMutex.Unlock()
+	fake.DeviceIDStub = nil
+	fake.deviceIDReturns = struct {
+		result1 protocol.DeviceID
+	}{result1}
+}
+
+func (fake *Connection) DeviceIDReturnsOnCall(i int, result1 protocol.DeviceID) {
+	fake.deviceIDMutex.Lock()
+	defer fake.deviceIDMutex.Unlock()
+	fake.DeviceIDStub = nil
+	if fake.deviceIDReturnsOnCall == nil {
+		fake.deviceIDReturnsOnCall = make(map[int]struct {
+			result1 protocol.DeviceID
+		})
+	}
+	fake.deviceIDReturnsOnCall[i] = struct {
+		result1 protocol.DeviceID
+	}{result1}
+}
+
 func (fake *Connection) DownloadProgress(arg1 context.Context, arg2 string, arg3 []protocol.FileDownloadProgressUpdate) {
 	var arg3Copy []protocol.FileDownloadProgressUpdate
 	if arg3 != nil {
@@ -457,59 +510,6 @@ func (fake *Connection) EstablishedAtReturnsOnCall(i int, result1 time.Time) {
 	}
 	fake.establishedAtReturnsOnCall[i] = struct {
 		result1 time.Time
-	}{result1}
-}
-
-func (fake *Connection) ID() protocol.DeviceID {
-	fake.iDMutex.Lock()
-	ret, specificReturn := fake.iDReturnsOnCall[len(fake.iDArgsForCall)]
-	fake.iDArgsForCall = append(fake.iDArgsForCall, struct {
-	}{})
-	stub := fake.IDStub
-	fakeReturns := fake.iDReturns
-	fake.recordInvocation("ID", []interface{}{})
-	fake.iDMutex.Unlock()
-	if stub != nil {
-		return stub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *Connection) IDCallCount() int {
-	fake.iDMutex.RLock()
-	defer fake.iDMutex.RUnlock()
-	return len(fake.iDArgsForCall)
-}
-
-func (fake *Connection) IDCalls(stub func() protocol.DeviceID) {
-	fake.iDMutex.Lock()
-	defer fake.iDMutex.Unlock()
-	fake.IDStub = stub
-}
-
-func (fake *Connection) IDReturns(result1 protocol.DeviceID) {
-	fake.iDMutex.Lock()
-	defer fake.iDMutex.Unlock()
-	fake.IDStub = nil
-	fake.iDReturns = struct {
-		result1 protocol.DeviceID
-	}{result1}
-}
-
-func (fake *Connection) IDReturnsOnCall(i int, result1 protocol.DeviceID) {
-	fake.iDMutex.Lock()
-	defer fake.iDMutex.Unlock()
-	fake.IDStub = nil
-	if fake.iDReturnsOnCall == nil {
-		fake.iDReturnsOnCall = make(map[int]struct {
-			result1 protocol.DeviceID
-		})
-	}
-	fake.iDReturnsOnCall[i] = struct {
-		result1 protocol.DeviceID
 	}{result1}
 }
 
@@ -1164,12 +1164,12 @@ func (fake *Connection) Invocations() map[string][][]interface{} {
 	defer fake.clusterConfigMutex.RUnlock()
 	fake.cryptoMutex.RLock()
 	defer fake.cryptoMutex.RUnlock()
+	fake.deviceIDMutex.RLock()
+	defer fake.deviceIDMutex.RUnlock()
 	fake.downloadProgressMutex.RLock()
 	defer fake.downloadProgressMutex.RUnlock()
 	fake.establishedAtMutex.RLock()
 	defer fake.establishedAtMutex.RUnlock()
-	fake.iDMutex.RLock()
-	defer fake.iDMutex.RUnlock()
 	fake.indexMutex.RLock()
 	defer fake.indexMutex.RUnlock()
 	fake.indexUpdateMutex.RLock()

--- a/lib/protocol/nativemodel_darwin.go
+++ b/lib/protocol/nativemodel_darwin.go
@@ -9,27 +9,27 @@ package protocol
 
 import "golang.org/x/text/unicode/norm"
 
-func makeNative(m Model) Model { return nativeModel{m} }
+func makeNative(m contextLessModel) contextLessModel { return nativeModel{m} }
 
 type nativeModel struct {
-	Model
+	contextLessModel
 }
 
-func (m nativeModel) Index(deviceID DeviceID, folder string, files []FileInfo) error {
+func (m nativeModel) Index(folder string, files []FileInfo) error {
 	for i := range files {
 		files[i].Name = norm.NFD.String(files[i].Name)
 	}
-	return m.Model.Index(deviceID, folder, files)
+	return m.contextLessModel.Index(folder, files)
 }
 
-func (m nativeModel) IndexUpdate(deviceID DeviceID, folder string, files []FileInfo) error {
+func (m nativeModel) IndexUpdate(folder string, files []FileInfo) error {
 	for i := range files {
 		files[i].Name = norm.NFD.String(files[i].Name)
 	}
-	return m.Model.IndexUpdate(deviceID, folder, files)
+	return m.contextLessModel.IndexUpdate(folder, files)
 }
 
-func (m nativeModel) Request(deviceID DeviceID, folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error) {
+func (m nativeModel) Request(folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error) {
 	name = norm.NFD.String(name)
-	return m.Model.Request(deviceID, folder, name, blockNo, size, offset, hash, weakHash, fromTemporary)
+	return m.contextLessModel.Request(folder, name, blockNo, size, offset, hash, weakHash, fromTemporary)
 }

--- a/lib/protocol/nativemodel_unix.go
+++ b/lib/protocol/nativemodel_unix.go
@@ -7,4 +7,4 @@ package protocol
 
 // Normal Unixes uses NFC and slashes, which is the wire format.
 
-func makeNative(m Model) Model { return m }
+func makeNative(m contextLessModel) contextLessModel { return m }

--- a/lib/protocol/nativemodel_windows.go
+++ b/lib/protocol/nativemodel_windows.go
@@ -13,30 +13,30 @@ import (
 	"strings"
 )
 
-func makeNative(m Model) Model { return nativeModel{m} }
+func makeNative(m contextLessModel) contextLessModel { return nativeModel{m} }
 
 type nativeModel struct {
-	Model
+	contextLessModel
 }
 
-func (m nativeModel) Index(deviceID DeviceID, folder string, files []FileInfo) error {
+func (m nativeModel) Index(folder string, files []FileInfo) error {
 	files = fixupFiles(files)
-	return m.Model.Index(deviceID, folder, files)
+	return m.contextLessModel.Index(folder, files)
 }
 
-func (m nativeModel) IndexUpdate(deviceID DeviceID, folder string, files []FileInfo) error {
+func (m nativeModel) IndexUpdate(folder string, files []FileInfo) error {
 	files = fixupFiles(files)
-	return m.Model.IndexUpdate(deviceID, folder, files)
+	return m.contextLessModel.IndexUpdate(folder, files)
 }
 
-func (m nativeModel) Request(deviceID DeviceID, folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error) {
+func (m nativeModel) Request(folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error) {
 	if strings.Contains(name, `\`) {
 		l.Warnf("Dropping request for %s, contains invalid path separator", name)
 		return nil, ErrNoSuchFile
 	}
 
 	name = filepath.FromSlash(name)
-	return m.Model.Request(deviceID, folder, name, blockNo, size, offset, hash, weakHash, fromTemporary)
+	return m.contextLessModel.Request(folder, name, blockNo, size, offset, hash, weakHash, fromTemporary)
 }
 
 func fixupFiles(files []FileInfo) []FileInfo {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -960,11 +960,7 @@ func (c *rawConnection) internalClose(err error) {
 		}
 		c.awaitingMut.Unlock()
 
-		if !c.startTime.IsZero() {
-			// Wait for the dispatcher loop to exit, if it was started to
-			// begin with.
-			<-c.dispatcherLoopStopped
-		}
+		<-c.dispatcherLoopStopped
 
 		c.model.Closed(err)
 	})

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -121,21 +121,6 @@ var (
 	errFileHasNoBlocks    = errors.New("file with empty block list")
 )
 
-type contextLessModel interface {
-	// An index was received from the peer device
-	Index(folder string, files []FileInfo) error
-	// An index update was received from the peer device
-	IndexUpdate(folder string, files []FileInfo) error
-	// A request was made by the peer device
-	Request(folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error)
-	// A cluster configuration message was received
-	ClusterConfig(config ClusterConfig) error
-	// The peer device closed the connection or an error occurred
-	Closed(err error)
-	// The peer device sent progress updates for the files it is currently downloading
-	DownloadProgress(folder string, updates []FileDownloadProgressUpdate) error
-}
-
 type Model interface {
 	// An index was received from the peer device
 	Index(conn Connection, folder string, files []FileInfo) error
@@ -149,6 +134,17 @@ type Model interface {
 	Closed(conn Connection, err error)
 	// The peer device sent progress updates for the files it is currently downloading
 	DownloadProgress(conn Connection, folder string, updates []FileDownloadProgressUpdate) error
+}
+
+// contextLessModel is the Model interface, but without the initial
+// Connection parameter. Internal use only.
+type contextLessModel interface {
+	Index(folder string, files []FileInfo) error
+	IndexUpdate(folder string, files []FileInfo) error
+	Request(folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error)
+	ClusterConfig(config ClusterConfig) error
+	Closed(err error)
+	DownloadProgress(folder string, updates []FileDownloadProgressUpdate) error
 }
 
 type RequestResponse interface {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -121,19 +121,34 @@ var (
 	errFileHasNoBlocks    = errors.New("file with empty block list")
 )
 
+type contextLessModel interface {
+	// An index was received from the peer device
+	Index(folder string, files []FileInfo) error
+	// An index update was received from the peer device
+	IndexUpdate(folder string, files []FileInfo) error
+	// A request was made by the peer device
+	Request(folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error)
+	// A cluster configuration message was received
+	ClusterConfig(config ClusterConfig) error
+	// The peer device closed the connection or an error occurred
+	Closed(err error)
+	// The peer device sent progress updates for the files it is currently downloading
+	DownloadProgress(folder string, updates []FileDownloadProgressUpdate) error
+}
+
 type Model interface {
 	// An index was received from the peer device
-	Index(deviceID DeviceID, folder string, files []FileInfo) error
+	Index(conn Connection, folder string, files []FileInfo) error
 	// An index update was received from the peer device
-	IndexUpdate(deviceID DeviceID, folder string, files []FileInfo) error
+	IndexUpdate(conn Connection, folder string, files []FileInfo) error
 	// A request was made by the peer device
-	Request(deviceID DeviceID, folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error)
+	Request(conn Connection, folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error)
 	// A cluster configuration message was received
-	ClusterConfig(deviceID DeviceID, config ClusterConfig) error
+	ClusterConfig(conn Connection, config ClusterConfig) error
 	// The peer device closed the connection or an error occurred
-	Closed(device DeviceID, err error)
+	Closed(conn Connection, err error)
 	// The peer device sent progress updates for the files it is currently downloading
-	DownloadProgress(deviceID DeviceID, folder string, updates []FileDownloadProgressUpdate) error
+	DownloadProgress(conn Connection, folder string, updates []FileDownloadProgressUpdate) error
 }
 
 type RequestResponse interface {
@@ -146,7 +161,7 @@ type Connection interface {
 	Start()
 	SetFolderPasswords(passwords map[string]string)
 	Close(err error)
-	ID() DeviceID
+	DeviceID() DeviceID
 	Index(ctx context.Context, folder string, files []FileInfo) error
 	IndexUpdate(ctx context.Context, folder string, files []FileInfo) error
 	Request(ctx context.Context, folder string, name string, blockNo int, offset int64, size int, hash []byte, weakHash uint32, fromTemporary bool) ([]byte, error)
@@ -171,8 +186,8 @@ type ConnectionInfo interface {
 type rawConnection struct {
 	ConnectionInfo
 
-	id        DeviceID
-	receiver  Model
+	deviceID  DeviceID
+	model     contextLessModel
 	startTime time.Time
 
 	cr     *countingReader
@@ -229,10 +244,16 @@ const (
 // Should not be modified in production code, just for testing.
 var CloseTimeout = 10 * time.Second
 
-func NewConnection(deviceID DeviceID, reader io.Reader, writer io.Writer, closer io.Closer, receiver Model, connInfo ConnectionInfo, compress Compression, passwords map[string]string, keyGen *KeyGenerator) Connection {
+func NewConnection(deviceID DeviceID, reader io.Reader, writer io.Writer, closer io.Closer, model Model, connInfo ConnectionInfo, compress Compression, passwords map[string]string, keyGen *KeyGenerator) Connection {
+	// We create the wrapper for the model first, as it needs to be passed
+	// in at the lowest level in the stack. At the end of construction,
+	// before returning, we add the connection to cwm so that it can be used
+	// by the model.
+	cwm := &connectionWrappingModel{model: model}
+
 	// Encryption / decryption is first (outermost) before conversion to
 	// native path formats.
-	nm := makeNative(receiver)
+	nm := makeNative(cwm)
 	em := newEncryptedModel(nm, newFolderKeyRegistry(keyGen, passwords), keyGen)
 
 	// We do the wire format conversion first (outermost) so that the
@@ -241,17 +262,18 @@ func NewConnection(deviceID DeviceID, reader io.Reader, writer io.Writer, closer
 	ec := newEncryptedConnection(rc, rc, em.folderKeys, keyGen)
 	wc := wireFormatConnection{ec}
 
+	cwm.conn = wc
 	return wc
 }
 
-func newRawConnection(deviceID DeviceID, reader io.Reader, writer io.Writer, closer io.Closer, receiver Model, connInfo ConnectionInfo, compress Compression) *rawConnection {
+func newRawConnection(deviceID DeviceID, reader io.Reader, writer io.Writer, closer io.Closer, receiver contextLessModel, connInfo ConnectionInfo, compress Compression) *rawConnection {
 	cr := &countingReader{Reader: reader}
 	cw := &countingWriter{Writer: writer}
 
 	return &rawConnection{
 		ConnectionInfo:        connInfo,
-		id:                    deviceID,
-		receiver:              receiver,
+		deviceID:              deviceID,
+		model:                 receiver,
 		cr:                    cr,
 		cw:                    cw,
 		closer:                closer,
@@ -295,8 +317,8 @@ func (c *rawConnection) Start() {
 	c.startTime = time.Now().Truncate(time.Second)
 }
 
-func (c *rawConnection) ID() DeviceID {
-	return c.id
+func (c *rawConnection) DeviceID() DeviceID {
+	return c.deviceID
 }
 
 // Index writes the list of file information to the connected peer device
@@ -462,7 +484,7 @@ func (c *rawConnection) dispatcherLoop() (err error) {
 
 		switch msg := msg.(type) {
 		case *ClusterConfig:
-			err = c.receiver.ClusterConfig(c.id, *msg)
+			err = c.model.ClusterConfig(*msg)
 
 		case *Index:
 			err = c.handleIndex(*msg)
@@ -477,7 +499,7 @@ func (c *rawConnection) dispatcherLoop() (err error) {
 			c.handleResponse(*msg)
 
 		case *DownloadProgress:
-			err = c.receiver.DownloadProgress(c.id, msg.Folder, msg.Updates)
+			err = c.model.DownloadProgress(msg.Folder, msg.Updates)
 		}
 		if err != nil {
 			return newHandleError(err, msgContext)
@@ -579,13 +601,13 @@ func (c *rawConnection) readHeader(fourByteBuf []byte) (Header, error) {
 }
 
 func (c *rawConnection) handleIndex(im Index) error {
-	l.Debugf("Index(%v, %v, %d file)", c.id, im.Folder, len(im.Files))
-	return c.receiver.Index(c.id, im.Folder, im.Files)
+	l.Debugf("Index(%v, %v, %d file)", c.deviceID, im.Folder, len(im.Files))
+	return c.model.Index(im.Folder, im.Files)
 }
 
 func (c *rawConnection) handleIndexUpdate(im IndexUpdate) error {
-	l.Debugf("queueing IndexUpdate(%v, %v, %d files)", c.id, im.Folder, len(im.Files))
-	return c.receiver.IndexUpdate(c.id, im.Folder, im.Files)
+	l.Debugf("queueing IndexUpdate(%v, %v, %d files)", c.deviceID, im.Folder, len(im.Files))
+	return c.model.IndexUpdate(im.Folder, im.Files)
 }
 
 // checkIndexConsistency verifies a number of invariants on FileInfos received in
@@ -651,7 +673,7 @@ func checkFilename(name string) error {
 }
 
 func (c *rawConnection) handleRequest(req Request) {
-	res, err := c.receiver.Request(c.id, req.Folder, req.Name, int32(req.BlockNo), int32(req.Size), req.Offset, req.Hash, req.WeakHash, req.FromTemporary)
+	res, err := c.model.Request(req.Folder, req.Name, int32(req.BlockNo), int32(req.Size), req.Offset, req.Hash, req.WeakHash, req.FromTemporary)
 	if err != nil {
 		c.send(context.Background(), &Response{
 			ID:   req.ID,
@@ -925,7 +947,7 @@ func (c *rawConnection) internalClose(err error) {
 	c.closeOnce.Do(func() {
 		l.Debugln("close due to", err)
 		if cerr := c.closer.Close(); cerr != nil {
-			l.Debugln(c.id, "failed to close underlying conn:", cerr)
+			l.Debugln(c.deviceID, "failed to close underlying conn:", cerr)
 		}
 		close(c.closed)
 
@@ -938,9 +960,13 @@ func (c *rawConnection) internalClose(err error) {
 		}
 		c.awaitingMut.Unlock()
 
-		<-c.dispatcherLoopStopped
+		if !c.startTime.IsZero() {
+			// Wait for the dispatcher loop to exit, if it was started to
+			// begin with.
+			<-c.dispatcherLoopStopped
+		}
 
-		c.receiver.Closed(c.ID(), err)
+		c.model.Closed(err)
 	})
 }
 
@@ -958,11 +984,11 @@ func (c *rawConnection) pingSender() {
 		case <-ticker.C:
 			d := time.Since(c.cw.Last())
 			if d < PingSendInterval/2 {
-				l.Debugln(c.id, "ping skipped after wr", d)
+				l.Debugln(c.deviceID, "ping skipped after wr", d)
 				continue
 			}
 
-			l.Debugln(c.id, "ping -> after", d)
+			l.Debugln(c.deviceID, "ping -> after", d)
 			c.ping()
 
 		case <-c.closed:
@@ -983,11 +1009,11 @@ func (c *rawConnection) pingReceiver() {
 		case <-ticker.C:
 			d := time.Since(c.cr.Last())
 			if d > ReceiveTimeout {
-				l.Debugln(c.id, "ping timeout", d)
+				l.Debugln(c.deviceID, "ping timeout", d)
 				c.internalClose(ErrTimeout)
 			}
 
-			l.Debugln(c.id, "last read within", d)
+			l.Debugln(c.deviceID, "last read within", d)
 
 		case <-c.closed:
 			return
@@ -1067,4 +1093,36 @@ func messageContext(msg message) (string, error) {
 	default:
 		return "", errors.New("unknown or empty message")
 	}
+}
+
+// connectionWrappingModel takes the Model interface from the model package,
+// which expects the Connection as the first parameter in all methods, and
+// wraps it to conform to the protocol.Model interface.
+type connectionWrappingModel struct {
+	conn  Connection
+	model Model
+}
+
+func (c *connectionWrappingModel) Index(folder string, files []FileInfo) error {
+	return c.model.Index(c.conn, folder, files)
+}
+
+func (c *connectionWrappingModel) IndexUpdate(folder string, files []FileInfo) error {
+	return c.model.IndexUpdate(c.conn, folder, files)
+}
+
+func (c *connectionWrappingModel) Request(folder, name string, blockNo, size int32, offset int64, hash []byte, weakHash uint32, fromTemporary bool) (RequestResponse, error) {
+	return c.model.Request(c.conn, folder, name, blockNo, size, offset, hash, weakHash, fromTemporary)
+}
+
+func (c *connectionWrappingModel) ClusterConfig(config ClusterConfig) error {
+	return c.model.ClusterConfig(c.conn, config)
+}
+
+func (c *connectionWrappingModel) Closed(err error) {
+	c.model.Closed(c.conn, err)
+}
+
+func (c *connectionWrappingModel) DownloadProgress(folder string, updates []FileDownloadProgressUpdate) error {
+	return c.model.DownloadProgress(c.conn, folder, updates)
 }

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -1097,7 +1097,7 @@ func messageContext(msg message) (string, error) {
 
 // connectionWrappingModel takes the Model interface from the model package,
 // which expects the Connection as the first parameter in all methods, and
-// wraps it to conform to the protocol.Model interface.
+// wraps it to conform to the protocol.contextLessModel interface.
 type connectionWrappingModel struct {
 	conn  Connection
 	model Model

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -145,7 +145,7 @@ func TestCloseRace(t *testing.T) {
 	indexReceived := make(chan struct{})
 	unblockIndex := make(chan struct{})
 	m0 := newTestModel()
-	m0.indexFn = func(_ DeviceID, _ string, _ []FileInfo) {
+	m0.indexFn = func(string, []FileInfo) {
 		close(indexReceived)
 		<-unblockIndex
 	}
@@ -924,7 +924,7 @@ func TestDispatcherToCloseDeadlock(t *testing.T) {
 	m := newTestModel()
 	rw := testutils.NewBlockingRW()
 	c := getRawConnection(NewConnection(c0ID, rw, &testutils.NoopRW{}, testutils.NoopCloser{}, m, new(mockedConnectionInfo), CompressionAlways, nil, testKeyGen))
-	m.ccFn = func(devID DeviceID, cc ClusterConfig) {
+	m.ccFn = func(ClusterConfig) {
 		c.Close(errManual)
 	}
 	c.Start()


### PR DESCRIPTION
These are refactoring changes made in the multiple-connection PR (#8918), broken out to reduce the noise there. Hence reviewing it requires some suspension of disbelief in terms of whether these changes are necessary -- they are, over there, but not necessarily by themselves over here... :) The changes are:

- In `lib/protocol`, `func (Connection) ID() DeviceID` is now called `func (Connection) DeviceID() DeviceID()` to disambiguate it from future other kind of IDs (the connection ID).
- Also in `lib/protocol`, all the callbacks used to take the device ID as the first parameter to explain where they came from. These now get the actual Connection instead, which is more specific and enables things like replying on the same connection. There's some juggling to accomplish this, because the actual protocol code that does the callbacks (`rawConnection`) doesn't have a clue about a "connection", it just has a reader and a writer for the bytes. Thus the callback interface is split up -- inside the protocol, it doesn't take a connection or device ID as parameter (`contextLessModel`), it is assumed that whoever created the connection knows what the callbacks refer to. Then there is a small wrapper (`connectionWrappingModel`) struct that does precisely this: intercepts the callbacks, adds the connection info, and then calls them again upwards. 
- Changes in model to the new signatures.
- Changes in all the tests for the new signatures.
- Minor tweaks to some tests while I was anywhere there... (parallelization, listening on 127.0.0.1 instead of 0.0.0.0 when possible.)
- Harmonized log lines from showing full device ID to just short ID in places where I saw it and were anyway touching stuff...
