### PR TITLE
lib/connections: fix building with `-tags noquic`

### DIFF
--- a/lib/connections/quic_unsupported.go
+++ b/lib/connections/quic_unsupported.go
@@ -9,6 +9,10 @@
 
 package connections
 
+import (
+	"fmt"
+)
+
 var errNotInBuild = fmt.Errorf("%w: disabled at build time", errUnsupported)
 
 func init() {


### PR DESCRIPTION
### Purpose

Upcoming Go 1.21 needs quic-go 0.37.0, while Syncthing is not compatible with that version yet (#8930). This fix allows building Syncthing with Go 1.21 for testing purposes.

### Testing

Building Syncthing with [go1.21rc3](https://go.dev/dl/go1.21rc3.linux-amd64.tar.gz) and run it.

### Documentation

(no documentation changes needed)

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.