### PR TITLE
lib/config/config.go: Allow sharing folder with untrusted device if s…

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -556,8 +556,8 @@ loop:
 func ensureNoUntrustedTrustingSharing(f *FolderConfiguration, devices []FolderDeviceConfiguration, existingDevices map[protocol.DeviceID]*DeviceConfiguration) []FolderDeviceConfiguration {
 	for i := 0; i < len(devices); i++ {
 		dev := devices[i]
-		if dev.EncryptionPassword != "" {
-			// There's a password set, no check required
+		if dev.EncryptionPassword != "" || f.Type == FolderTypeReceiveEncrypted {
+			// There's a password set or the folder is received encrypted, no check required
 			continue
 		}
 		if devCfg := existingDevices[dev.DeviceID]; devCfg.Untrusted {


### PR DESCRIPTION
…hared as encrypted

### Purpose
Fixes #8965. 

Safety check added in v1.23.6 introduced bug. Bug unshares folders with untrusted devices if folder does not have an encryption password set, regardless of whether the folder is shared with the untrusted device as encrypted or not. Prevents sharing with untrusted devices in some cases where sharing would be encrypted.

Patch preserves safety check but permits sharing folders with untrusted devices if they are shared as encrypted.

### Testing
Tested on 2023/07/31 as follows:
- Compiled syncthing from main with and without this patch
- Ran both syncthing binaries concurrently
- Added both syncthing instances as mutually untrusted devices.
- Shared one folder per instance with the other as encrypted
As expected, the unmodified syncthing instance automatically deleted its shared folder (consistent with v1.23.6 bugged behaviour). The patched syncthing instance did not (consistent with pre-v1.23.6 behaviour before safety check and bug was introduced).

