### PR TITLE
lib/model: Reinstate setting folder idle state

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -163,7 +163,10 @@ func (f *sendReceiveFolder) pull() (bool, error) {
 
 	scanChan := make(chan string)
 	go f.pullScannerRoutine(scanChan)
-	defer close(scanChan)
+	defer func() {
+		close(scanChan)
+		f.setState(FolderIdle)
+	}()
 
 	metricFolderPulls.WithLabelValues(f.ID).Inc()
 	ctx, cancel := context.WithCancel(f.ctx)


### PR DESCRIPTION
The call to set state to idle was removed in
https://github.com/syncthing/syncthing/commit/b9c08d3814685bc8c4a322756e042b9852e321b4#diff-8581eb7670c1f6463c9d9254d863d9137906c6055baeb124b9518ddabfc94167 for no reason I can discern. This results in folders apparently stuck "preparing to sync" when there is nothing for them to sync (they are actually idle). This reinstates it.
