### PR TITLE
lib/connections: allow IPv6 ULA in discovery

### DIFF
--- a/lib/connections/util.go
+++ b/lib/connections/util.go
@@ -71,12 +71,10 @@ func getHostPortsForAllAdapters(port int) []string {
 	portStr := strconv.Itoa(port)
 
 	for _, network := range nets {
-		// Only IPv4 addresses, as v6 link local require an interface identifiers to work correctly
-		// And non link local in theory are globally routable anyway.
-		if network.IP.To4() == nil {
-			continue
-		}
-		if network.IP.IsLinkLocalUnicast() || (isV4Local(network.IP) && network.IP.IsGlobalUnicast()) {
+		// Only accept IPv4 link-local unicast and the private ranges defined in RFC 1918 and RFC 4193
+		// IPv6 link-local addresses require an interface identifier to work correctly
+		if (network.IP.To4() != nil && network.IP.IsLinkLocalUnicast()) ||
+			(network.IP.IsPrivate() && network.IP.IsGlobalUnicast()) {
 			hostPorts = append(hostPorts, net.JoinHostPort(network.IP.String(), portStr))
 		}
 	}
@@ -105,17 +103,6 @@ func resolve(network, hostPort string) (net.IP, int, error) {
 		}
 	}
 	return net.IPv4zero, 0, net.UnknownNetworkError(network)
-}
-
-func isV4Local(ip net.IP) bool {
-	// See https://go-review.googlesource.com/c/go/+/162998/
-	// We only take the V4 part of that.
-	if ip4 := ip.To4(); ip4 != nil {
-		return ip4[0] == 10 ||
-			(ip4[0] == 172 && ip4[1]&0xf0 == 16) ||
-			(ip4[0] == 192 && ip4[1] == 168)
-	}
-	return false
 }
 
 func maybeReplacePort(uri *url.URL, laddr net.Addr) *url.URL {

--- a/lib/connections/util.go
+++ b/lib/connections/util.go
@@ -73,8 +73,7 @@ func getHostPortsForAllAdapters(port int) []string {
 	for _, network := range nets {
 		// Only accept IPv4 link-local unicast and the private ranges defined in RFC 1918 and RFC 4193
 		// IPv6 link-local addresses require an interface identifier to work correctly
-		if (network.IP.To4() != nil && network.IP.IsLinkLocalUnicast()) ||
-			(network.IP.IsPrivate() && network.IP.IsGlobalUnicast()) {
+		if (network.IP.To4() != nil && network.IP.IsLinkLocalUnicast()) || network.IP.IsPrivate() {
 			hostPorts = append(hostPorts, net.JoinHostPort(network.IP.String(), portStr))
 		}
 	}


### PR DESCRIPTION
### Purpose

Fixes #7456

The allowed IPv4 ranges are the same as before. But we now also accept IPv6 addresses in the ULA range `FC00::/7`. These addresses don't require an interface identifier and are roughly equivalent to the IPv4 private ranges.

Typical usecases:

* VPN interface IPs: Wireguard, OpenVPN, Tailscale, ...
* fixed IPv6 LAN addressing while the provider assigns a dynamic prefix. e.g used by pihole

https://cs.opensource.google/go/go/+/refs/tags/go1.21.0:src/net/ip.go;l=146

### Testing

I checked the output of https://discovery.syncthing.net/?device=xxxxxxxxxxxxxxxxxxxx and my local `fd00::` IPs were listed. 
