### PR TITLE
lib/discover: Enable HTTP/2 for global discovery requests

### DIFF
--- a/lib/discover/global.go
+++ b/lib/discover/global.go
@@ -112,6 +112,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: opts.insecure,
 			Certificates:       []tls.Certificate{cert},
+			MinVersion:         tls.VersionTLS12,
 		},
 		DisableKeepAlives: true, // announcements are few and far between, so don't keep the connection open
 	}
@@ -131,6 +132,7 @@ func NewGlobal(server string, cert tls.Certificate, addrList AddressLister, evLo
 		Proxy:       http.ProxyFromEnvironment,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: opts.insecure,
+			MinVersion:         tls.VersionTLS12,
 		},
 		IdleConnTimeout: time.Second,
 	}


### PR DESCRIPTION
By creating the http.Transport and tls.Configuration ourselves we override some default behavior and end up with a client that speaks only HTTP/1.1.

This adds a call to http.ConfigureTransport to do the relevant magic to enable HTTP/2.

Also tweaks the keepalive settings to be a little kinder to the server(s) and adds a minimum TLS version requirement of TLS/1.2.
