### PR TITLE
gui: Show in GUI if limitBandwidthInLan is enabled

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -30,6 +30,7 @@
     "An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.": "An external command handles the versioning. It has to remove the file from the shared folder. If the path to the application contains spaces, it should be quoted.",
     "Anonymous Usage Reporting": "Anonymous Usage Reporting",
     "Anonymous usage report format has changed. Would you like to move to the new format?": "Anonymous usage report format has changed. Would you like to move to the new format?",
+    "Applied to LAN": "Applied to LAN",
     "Apply": "Apply",
     "Are you sure you want to override all remote changes?": "Are you sure you want to override all remote changes?",
     "Are you sure you want to permanently delete all these files?": "Are you sure you want to permanently delete all these files?",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -661,6 +661,9 @@
                             <i class="text-muted"><span translate>Limit</span>:
                               <span ng-if="!metricRates">{{config.options.maxRecvKbps*1024 | binary}}B/s</span>
                               <span ng-if="metricRates">{{config.options.maxRecvKbps*1024*8 | metric}}bps</span>
+                              <span ng-if="config.options.limitBandwidthInLan">
+                                (<span translate>Applied to LAN</span>)
+                              </span>
                             </i>
                           </small>
                         </a>
@@ -677,6 +680,9 @@
                             <i class="text-muted"><span translate>Limit</span>:
                               <span ng-if="!metricRates">{{config.options.maxSendKbps*1024 | binary}}B/s</span>
                               <span ng-if="metricRates">{{config.options.maxSendKbps*1024*8 | metric}}bps</span>
+                              <span ng-if="config.options.limitBandwidthInLan">
+                                (<span translate>Applied to LAN</span>)
+                              </span>
                             </i>
                           </small>
                         </a>


### PR DESCRIPTION
gui: Show in GUI if limitBandwidthInLan is enabled

Currently, it is impossible to know whether the limitBandwidthInLan
option is enabled without going into the Advanced Configuration. With
this change, a note is added next to the bandwidth limit information
that informs the user that the limits are applied to LAN connections
too.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

![image](https://github.com/syncthing/syncthing/assets/5626656/206c8f0b-c949-45a6-b5e5-39db976e1ec0)
