### PR TITLE
gui: Fix lastSeenDays error due to undefined deviceStats when adding new devices (ref #8730)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1090,7 +1090,7 @@ angular.module('syncthing.core')
             }
 
             // Disconnected
-            if (!unused && $scope.deviceStats[deviceCfg.deviceID].lastSeenDays && $scope.deviceStats[deviceCfg.deviceID].lastSeenDays >= 7) {
+            if (!unused && $scope.deviceStats[deviceCfg.deviceID] && $scope.deviceStats[deviceCfg.deviceID].lastSeenDays && $scope.deviceStats[deviceCfg.deviceID].lastSeenDays >= 7) {
                 return status + 'disconnected-inactive';
             } else {
                 return status + 'disconnected';


### PR DESCRIPTION
gui: Fix lastSeenDays error due to undefined deviceStats when adding new devices (ref #8730)

When adding new devices, the GUI may throw errors about being unable to
read properties of undefined when trying to read lastSeenDays. This is
because deviceStats may not yet exist at the very moment of adding a new
device. To prevent the error, add yet another check to see whether
deviceStats exists before trying to read lastSeenDays.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

The GUI sometimes gets flooded with these errors right after adding a new device. I've experienced the problem for a long time, however I'm still unable to reproduce it at will. It seems to only happen in existing installations, only after running for some time, and still not always, so I'm not really sure why `deviceStats[deviceCfg.deviceID]` sometimes returns `undefined` and sometimes just works. Nevertheless, I think that this code change should at least get rid of the error.

![image](https://github.com/syncthing/syncthing/assets/5626656/547c5a61-4753-4b11-bbe7-4b19eb4ee064)
![image](https://github.com/syncthing/syncthing/assets/5626656/3eaabef8-50de-4dcc-9847-12220bfb1442)
