### PR TITLE
gui: Fix Logs modal icon to match header icon (ref #9067)

### DIFF
--- a/gui/default/syncthing/core/logViewerModalView.html
+++ b/gui/default/syncthing/core/logViewerModalView.html
@@ -1,4 +1,4 @@
-<modal id="logViewer" status="default" icon="far fa-file-alt" heading="{{'Logs' | translate}}" large="yes" closeable="yes">
+<modal id="logViewer" status="default" icon="fa fa-wrench" heading="{{'Logs' | translate}}" large="yes" closeable="yes">
   <div class="modal-body">
     <ul class="nav nav-tabs">
       <li class="active"><a data-toggle="tab" href="#log-viewer-log" translate>Log</a></li>


### PR DESCRIPTION
The Logs icon was changed in [1] in the header, however the icon used in the modal was left out. This changes it, so that the header and the modal icons match.

[1] 2abba1dfb0f3337dd1e77c6584e7d12bdba284b9