### PR TITLE
gui: Fix File Versioning icon to match in all places

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -533,7 +533,7 @@
                         </td>
                       </tr>
                       <tr ng-if="folder.versioning.type">
-                        <th><span class="fa fa-fw fa-file"></span>&nbsp;<span translate>File Versioning</span></th>
+                        <th><span class="fa fa-fw fa-files-o"></span>&nbsp;<span translate>File Versioning</span></th>
                         <td class="text-right">
                           <span ng-switch="folder.versioning.type">
                             <span ng-switch-when="trashcan" translate>Trash Can</span>

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -4,7 +4,7 @@
       <ul class="nav nav-tabs" ng-init="loadFormIntoScope(folderEditor)">
         <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}" class="active"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-general'}}"><span class="fas fa-cog"></span> <span translate>General</span></a></li>
         <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-sharing'}}"><span class="fas fa-share-alt"></span> <span translate>Sharing</span></a></li>
-        <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-versioning'}}"><span class="fas fa-copy"></span> <span translate>File Versioning</span></a></li>
+        <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-versioning'}}"><span class="fa fa-files-o"></span> <span translate>File Versioning</span></a></li>
         <li ng-class="{'disabled': currentFolder._recvEnc}"><a data-toggle="tab" href="{{currentFolder._recvEnc ? '' : '#folder-ignores'}}"><span class="fas fa-filter"></span> <span translate>Ignore Patterns</span></a></li>
         <li ng-class="{'disabled': currentFolder._editing == 'new-ignores'}"><a data-toggle="tab" href="{{currentFolder._editing == 'new-ignores' ? '' : '#folder-advanced'}}"><span class="fas fa-cogs"></span> <span translate>Advanced</span></a></li>
       </ul>


### PR DESCRIPTION
Currently, different icons are used for File Versioning when displayed in the unfolded folder info in the main part of the GUI, and the icon used in the Edit Folder modal. This changes the main GUI icon to match the icon used in the modal.

### Screenshots

#### Modal icon

![image](https://github.com/syncthing/syncthing/assets/5626656/1abe130d-ad6d-404b-8377-a8dc301f5e9e)

#### Before (different icon used in the GUI)

![image](https://github.com/syncthing/syncthing/assets/5626656/6d682d8f-4527-451f-830e-f99472c03ab5)

#### After (same icon used in both places)

![image](https://github.com/syncthing/syncthing/assets/5626656/51ef8e3d-58f1-4cea-b80d-c221bad1ea38)
