### PR TITLE
Fix WANAddresses returning only unspecified IPs

### DIFF
--- a/lib/connections/tcp_listen.go
+++ b/lib/connections/tcp_listen.go
@@ -178,10 +178,10 @@ func (t *tcpListener) WANAddresses() []*url.URL {
 			// For every address with a specified IP, add one without an IP,
 			// just in case the specified IP is still internal (router behind DMZ).
 			if len(addr.IP) != 0 && !addr.IP.IsUnspecified() {
-				uri = *t.uri
+				zeroUri := *t.uri
 				addr.IP = nil
-				uri.Host = addr.String()
-				uris = append(uris, &uri)
+				zeroUri.Host = addr.String()
+				uris = append(uris, &zeroUri)
 			}
 		}
 	}


### PR DESCRIPTION
### Purpose

This PR cherry-picks the fix for the bug in tcp_listen.go discovered in #9010, which caused only `0.0.0.0` to be returned as the IP address.

### Testing

This has been tested in the context of the merge request. The code still builds with just this commit applied.
