### PR TITLE
gui: Add help link for numConnections

### DIFF
--- a/gui/default/syncthing/device/editDeviceModalView.html
+++ b/gui/default/syncthing/device/editDeviceModalView.html
@@ -141,7 +141,10 @@
             <div class="col-md-6" ng-class="{'has-error': deviceEditor.numConnections.$invalid && deviceEditor.numConnections.$dirty}">
               <label translate>Connection Management</label>
               <div class="row">
-                <span class="col-md-8" translate>Number of Connections</span>
+                <span class="col-md-8">
+                  <span translate>Number of Connections</span>
+                  &nbsp;<a href="{{docsURL('advanced/device-numconnections')}}" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
+                </span>
                 <div class="col-md-4">
                   <input name="numConnections" id="numConnections" class="form-control" type="number" pattern="\d+" ng-model="currentDevice.numConnections" min="0" />
                 </div>


### PR DESCRIPTION
Like so:

<img width="837" alt="Screenshot 2023-09-07 at 08 03 19" src="https://github.com/syncthing/syncthing/assets/125426/9a138223-3158-443d-a64c-ef83c7e289f5">

---

(An interesting side effect of our versioned documentation switcheroo is that this link currently doesn't work. It points to `...?version=v1.24.1`, but there is no 1.24.1 so the site redirects to version 1.24.0, and there the page is 404... Maybe we should just default to latest if the requested version is > latest tagged...)