### PR TITLE
lib/connections: Make assumptions about isLAN when interface address listing fails

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -798,10 +798,11 @@ func (s *lanChecker) isLAN(addr net.Addr) bool {
 	}
 
 	lans, err := osutil.GetLans()
-
 	if err != nil {
 		l.Debugln("Failed to retrieve interface IPs:", err)
-		return ip.IsPrivate()
+		priv := ip.IsPrivate()
+		l.Debugf("Assuming isLAN=%v for IP %v", priv, ip)
+		return priv
 	}
 
 	for _, lan := range lans {

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -793,7 +793,12 @@ func (s *lanChecker) isLAN(addr net.Addr) bool {
 		}
 	}
 
-	lans, _ := osutil.GetLans()
+	lans, err := osutil.GetLans()
+
+	if err != nil {
+		return ip.IsPrivate() || ip.IsLinkLocalUnicast()
+	}
+
 	for _, lan := range lans {
 		if lan.Contains(ip) {
 			return true

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -782,6 +782,10 @@ func (s *lanChecker) isLAN(addr net.Addr) bool {
 		return true
 	}
 
+	if ip.IsLinkLocalUnicast() {
+		return true
+	}
+
 	for _, lan := range s.cfg.Options().AlwaysLocalNets {
 		_, ipnet, err := net.ParseCIDR(lan)
 		if err != nil {
@@ -796,7 +800,8 @@ func (s *lanChecker) isLAN(addr net.Addr) bool {
 	lans, err := osutil.GetLans()
 
 	if err != nil {
-		return ip.IsPrivate() || ip.IsLinkLocalUnicast()
+		l.Debugln("Failed to retrieve interface IPs:", err)
+		return ip.IsPrivate()
 	}
 
 	for _, lan := range lans {


### PR DESCRIPTION
### Purpose

* always treat link-local IPs as LAN
* if we're unable to determine our local networks, simply treat private IPs as LAN

### Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

