### PR TITLE
lib/versioner: Don't complain when folder is stopping

### DIFF
--- a/lib/versioner/util.go
+++ b/lib/versioner/util.go
@@ -330,7 +330,9 @@ func clean(ctx context.Context, versionsFs fs.Filesystem, toRemove func([]string
 	}
 
 	if err := versionsFs.Walk(".", walkFn); err != nil {
-		l.Warnln("Versioner: error scanning versions dir", err)
+		if !errors.Is(err, context.Canceled) {
+			l.Warnln("Versioner: scanning versions dir:", err)
+		}
 		return err
 	}
 


### PR DESCRIPTION
https://forum.syncthing.net/t/versioner-error-scanning-versions-dir-context-canceled-when-trying-to-clean-versions/20778/2