### PR TITLE
gui: Remove unused hard-coded styles from Recent Changes modal

### DIFF
--- a/gui/default/syncthing/device/globalChangesModalView.html
+++ b/gui/default/syncthing/device/globalChangesModalView.html
@@ -1,4 +1,3 @@
-<style> th, td { padding: 6px; } </style>
 <modal id="globalChanges" status="default" icon="fas fa-info-circle" heading="{{'Recent Changes' | translate}}" large="yes" closeable="yes">
   <div class="modal-body">
     <div class="table-responsive">


### PR DESCRIPTION
gui: Remove unused hard-coded styles from Recent Changes modal

Currently, the Recent Changes modal has hardcoded th and td
styles. However, they are not even used in the modal itself, because
Bootstrap overrides them with its own styles for these elements in the
same modal. Yet, when hard-coded like that, these styles can conflict
with other table elements in the GUI. Thus, remove them completely.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

As seen below, the styles are overridden by Bootstrap in multiple places. I only found them, because they were messing up my table from https://github.com/syncthing/syncthing/pull/9094.

![image](https://github.com/syncthing/syncthing/assets/5626656/a34d7c3d-5899-455f-b769-0270c6c0c070)
