### PR TITLE
lib/fs, lib/model: Be careful about potentially negative durations (fixes #9112)

### DIFF
--- a/lib/fs/metrics.go
+++ b/lib/fs/metrics.go
@@ -92,7 +92,9 @@ func (m *metricsFS) account(op string) func(bytes int) {
 	t0 := time.Now()
 	root := m.next.URI()
 	return func(bytes int) {
-		metricTotalOperationSeconds.WithLabelValues(root, op).Add(time.Since(t0).Seconds())
+		if dur := time.Since(t0).Seconds(); dur > 0 {
+			metricTotalOperationSeconds.WithLabelValues(root, op).Add(dur)
+		}
 		metricTotalOperationsCount.WithLabelValues(root, op).Inc()
 		if bytes >= 0 {
 			metricTotalBytesCount.WithLabelValues(root, op).Add(float64(bytes))

--- a/lib/model/util.go
+++ b/lib/model/util.go
@@ -158,7 +158,9 @@ func inWritableDir(fn func(string) error, targetFs fs.Filesystem, path string, i
 func addTimeUntilCancelled(ctx context.Context, counter prometheus.Counter) {
 	t0 := time.Now()
 	defer func() {
-		counter.Add(time.Since(t0).Seconds())
+		if dur := time.Since(t0).Seconds(); dur > 0 {
+			counter.Add(dur)
+		}
 	}()
 
 	ticker := time.NewTicker(time.Second)
@@ -167,7 +169,9 @@ func addTimeUntilCancelled(ctx context.Context, counter prometheus.Counter) {
 	for {
 		select {
 		case t := <-ticker.C:
-			counter.Add(t.Sub(t0).Seconds())
+			if dur := t.Sub(t0).Seconds(); dur > 0 {
+				counter.Add(dur)
+			}
 			t0 = t
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
I don't really understand under what circumstances, but sometimes these calls panic with a "panic: counter cannot decrease in value" because the value passed to Add() was negative.
