### PR TITLE
lib/connections: fix transport type detection for QUIC

### DIFF
--- a/lib/connections/structs.go
+++ b/lib/connections/structs.go
@@ -126,7 +126,7 @@ func (c internalConn) Crypto() string {
 
 func (c internalConn) Transport() string {
 	transport := c.connType.Transport()
-	ip, err := osutil.IPFromAddr(c.LocalAddr())
+	ip, err := osutil.IPFromAddr(c.RemoteAddr())
 	if err != nil {
 		return transport
 	}


### PR DESCRIPTION
### Purpose

Fixes #8274

The actual local address is not resolved for a QUIC connection, and will always report what we've passed to the listener. A dual-stack enabled host would simply return `[::]:xxxxx`, which is interpreted as `quic6`.

The remote address doesn't suffer from this problem.

### Testing

https://github.com/syncthing/syncthing/issues/8274#issuecomment-1722490987

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

