### PR TITLE
gui: Show if device is untrusted in the main GUI

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -909,7 +909,7 @@
                         </td>
                       </tr>
                       <tr ng-if="deviceCfg.untrusted">
-                        <th><span class="fa fa-fw fa-lock"></span>&nbsp;<span translate>Untrusted</span></th>
+                        <th><span class="fa fa-fw fa-user-secret"></span>&nbsp;<span translate>Untrusted</span></th>
                         <td translate class="text-right">Yes</td>
                       </tr>
                       <tr ng-if="connections[deviceCfg.deviceID].clientVersion">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -908,6 +908,10 @@
                           </span>
                         </td>
                       </tr>
+                      <tr ng-if="deviceCfg.untrusted">
+                        <th><span class="fa fa-fw fa-lock"></span>&nbsp;<span translate>Untrusted</span></th>
+                        <td translate class="text-right">Yes</td>
+                      </tr>
                       <tr ng-if="connections[deviceCfg.deviceID].clientVersion">
                         <th><span class="fas fa-fw fa-tag"></span>&nbsp;<span translate>Version</span></th>
                         <td class="text-right">{{connections[deviceCfg.deviceID].clientVersion}}</td>


### PR DESCRIPTION
gui: Show if device is untrusted in the main GUI

Add a new entry to the unfolded device info to inform the user that the
device has been marked as "untrusted" and all folders shared with it
have to be password-protected or already Receive Encrypted.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

![image](https://github.com/syncthing/syncthing/assets/5626656/661411f1-78cb-4c4a-9914-e58d3273a063)
