### PR TITLE
gui: Add missing $scope in editDeviceUntrustedChanged function

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1711,9 +1711,9 @@ angular.module('syncthing.core')
         }
 
         $scope.editDeviceUntrustedChanged = function () {
-            if (currentDevice.untrusted) {
-                currentDevice.introducer = false;
-                currentDevice.autoAcceptFolders = false;
+            if ($scope.currentDevice.untrusted) {
+                $scope.currentDevice.introducer = false;
+                $scope.currentDevice.autoAcceptFolders = false;
             }
         }
 


### PR DESCRIPTION
gui: Add missing $scope in editDeviceUntrustedChanged function

Because $scope is missing, there are JavaScript errors when ticking and
unticking the "Untrusted" checkbox in the Advanced tab of the Edit
Device modal.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

![image](https://github.com/syncthing/syncthing/assets/5626656/58c25e90-c197-4377-8ec9-473cfeac4df2)

