### PR TITLE
gui: Show if device has Auto Accept enabled in the main GUI

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -900,6 +900,10 @@
                         <th><span class="far fa-fw fa-handshake-o"></span>&nbsp;<span translate>Introduced By</span></th>
                         <td class="text-right">{{ deviceName(devices[deviceCfg.introducedBy]) || deviceCfg.introducedBy.substring(0, 5) }}</td>
                       </tr>
+                      <tr ng-if="deviceCfg.autoAcceptFolders">
+                        <th><span class="fa fa-fw fa-level-down"></span>&nbsp;<span translate>Auto Accept</span></th>
+                        <td translate class="text-right">Yes</td>
+                      </tr>
                       <tr>
                         <th><span class="fas fa-fw fa-qrcode"></span>&nbsp;<span translate>Identification</span></th>
                         <td class="text-right">


### PR DESCRIPTION
gui: Show if device has Auto Accept enabled in GUI

Add a new entry to the unfolded device info to inform the user that the
device has Auto Accept enabled.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

![image](https://github.com/syncthing/syncthing/assets/5626656/e3c67f5e-ac5b-4408-8077-224dd0ae79e6)
