### PR TITLE
adding exe files and .vscode to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ stdiscosrv.exe
 *.zip
 *.asc
 *.deb
+*.exe
 .jshintrc
 coverage.out
 files/pidx
@@ -20,3 +21,4 @@ deb
 /proto/scripts/protoc-gen-gosyncthing
 /gui/next-gen-gui
 .idea
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,3 @@ deb
 /repos
 /proto/scripts/protoc-gen-gosyncthing
 /gui/next-gen-gui
-.idea
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 /syncthing
 /stdiscosrv
-syncthing.exe
-stdiscosrv.exe
 *.tar.gz
 *.zip
 *.asc


### PR DESCRIPTION
### Purpose

Ignore *.exe files by git.

After PR discussion .idea and .vscode removed from .gitignore.

### Testing

Tested using git.

### Documentation

No changes.

