### PR TITLE
gui: Scroll to bottom by clicking message in log viewer

### DIFF
--- a/gui/default/syncthing/core/logViewerModalView.html
+++ b/gui/default/syncthing/core/logViewerModalView.html
@@ -9,7 +9,7 @@
       <div id="log-viewer-log" class="tab-pane in active">
         <label translate ng-if="logging.logEntries.length == 0">Loading...</label>
         <textarea id="logViewerText" class="form-control" rows="20" ng-if="logging.logEntries.length != 0" readonly style="font-family: Consolas, monospace; font-size: 11px; overflow: auto;">{{ logging.content() }}</textarea>
-        <p translate class="help-block" ng-style="{'visibility': logging.paused ? 'visible' : 'hidden'}">Log tailing paused. Scroll to the bottom to continue.</p>
+        <a href="" translate class="help-block" ng-style="{'visibility': logging.paused ? 'visible' : 'hidden'}" ng-click="logging.scrollToBottom()" style="text-decoration: none">Log tailing paused. Scroll to the bottom to continue.</a>
       </div>
 
       <div id="log-viewer-facilities" class="tab-pane">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1429,6 +1429,11 @@ angular.module('syncthing.core')
                 // Browser events do not cause redraw, trigger manually.
                 $scope.$apply();
             },
+            scrollToBottom: function () {
+                var textArea = $('#logViewerText');
+                var scrollHeight = textArea.prop('scrollHeight');
+                textArea.prop('scrollTop', scrollHeight);
+            },
             timer: null,
             entries: [],
             paused: false,


### PR DESCRIPTION
### Purpose

That's a small usability feature enabling to scroll to the bottom in the log viewer by clicking 'Log tailing paused. Scroll to the bottom to continue.' (in the respective language).


### Screenshots

![23-09-25-syncthing-feature-log-scroll](https://github.com/syncthing/syncthing/assets/49024624/8dbfa235-847d-4e25-998c-1809a00bc41d)
