### PR TITLE
cmd/ursrv: Add linuxserver.io detection

### DIFF
--- a/cmd/ursrv/serve/serve.go
+++ b/cmd/ursrv/serve/serve.go
@@ -72,6 +72,7 @@ var (
 		{regexp.MustCompile(`@debian`), "Debian (3rd party)"},
 		{regexp.MustCompile(`@fedora`), "Fedora (3rd party)"},
 		{regexp.MustCompile(`\bbrew@`), "Homebrew (3rd party)"},
+		{regexp.MustCompile(`root@buildkitsandbox`), "LinuxServer.io (3rd party)"},
 		{regexp.MustCompile(`.`), "Others"},
 	}
 )


### PR DESCRIPTION
### Purpose

See https://github.com/syncthing/syncthing/issues/9140#issuecomment-1741070101

### Testing

Found a reddit [thread](https://old.reddit.com/r/docker/comments/13vq2ka/my_syncthing_container_refuses_to_write_to_my/) that confirmed my suspicion that `root@buildkitsandbox` is used by LinuxServer.io images.

https://docs.linuxserver.io/images/docker-syncthing

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

