### PR TITLE
docker: Allow start even if chown fails (fixes #9133)

### DIFF
--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -14,8 +14,10 @@ if [ "$(id -u)" = '0' ]; then
     setcap "$PCAP" "$binary"
   fi
 
-  chown "${PUID}:${PGID}" "${HOME}" \
-    && exec su-exec "${PUID}:${PGID}" \
+  # Chown may fail, which may cause us to be unable to start; but maybe
+  # it'll work anyway, so we the error slide.
+  chown "${PUID}:${PGID}" "${HOME}" || true
+  exec su-exec "${PUID}:${PGID}" \
        env HOME="$HOME" "$@"
 else
   exec "$@"

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -15,7 +15,7 @@ if [ "$(id -u)" = '0' ]; then
   fi
 
   # Chown may fail, which may cause us to be unable to start; but maybe
-  # it'll work anyway, so we the error slide.
+  # it'll work anyway, so we let the error slide.
   chown "${PUID}:${PGID}" "${HOME}" || true
   exec su-exec "${PUID}:${PGID}" \
        env HOME="$HOME" "$@"


### PR DESCRIPTION
Maybe it fails, maybe it doesn't. If it fails and we didn't need it we don't need to complain. If it fails and we did need it, we'll fail on the next line instead.