### PR TITLE
Hide log out button when auth is not enabled

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -126,6 +126,8 @@
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
+
+              <li ng-if="authenticated && isAuthEnabled()" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
 
               <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -126,7 +126,7 @@
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
-              <li ng-if="authenticated && isAuthEnabled(config)"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
+              <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
 
               <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
               <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -126,7 +126,7 @@
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
-              <li ng-if="authenticated && config.gui.isAuthEnabled"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
+              <li ng-if="authenticated && isAuthEnabled(config)"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
 
               <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
               <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -126,7 +126,7 @@
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
-              <li ng-if="authenticated"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
+              <li ng-if="authenticated && config.gui.isAuthEnabled"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
 
               <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
               <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -127,11 +127,11 @@
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
 
-              <li ng-if="authenticated && isAuthEnabled()" class="divider" aria-hidden="true"></li>
-              <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>
-
               <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
               <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
+
+              <li ng-if="authenticated && isAuthEnabled()" class="divider" aria-hidden="true"></li>
+              <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>
             </ul>
           </li>
         </ul>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -128,7 +128,7 @@
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
 
               <li ng-if="authenticated && isAuthEnabled()" class="divider" aria-hidden="true"></li>
-              <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-ban"></span>&nbsp;<span translate>Log Out</span></a></li>
+              <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>
 
               <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
               <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -565,10 +565,11 @@ angular.module('syncthing.core')
             }).error($scope.emitHTTPError);
         }
 
-        $scope.isAuthEnabled = function (config) {
+        $scope.isAuthEnabled = function () {
             // This function should match IsAuthEnabled() in guiconfiguration.go
-            if (config && config.gui) {
-	        return config.gui.authMode === 'ldap' || (config.gui.user && config.gui.password);
+            var guiCfg = $scope.config && $scope.config.gui;
+            if (guiCfg) {
+                return guiCfg.authMode === 'ldap' || (guiCfg.user && guiCfg.password);
             }
             return false;
         };
@@ -587,7 +588,7 @@ angular.module('syncthing.core')
             $scope.openNoAuth = addr.substr(0, 4) !== "127."
                 && addr.substr(0, 6) !== "[::1]:"
                 && addr.substr(0, 1) !== "/"
-                && !$scope.isAuthEnabled($scope.config)
+                && !$scope.isAuthEnabled()
                 && !guiCfg.insecureAdminAccess;
 
             if ((guiCfg.user && guiCfg.password) || guiCfg.authMode === 'ldap') {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -579,8 +579,7 @@ angular.module('syncthing.core')
             $scope.openNoAuth = addr.substr(0, 4) !== "127."
                 && addr.substr(0, 6) !== "[::1]:"
                 && addr.substr(0, 1) !== "/"
-                && (!guiCfg.user || !guiCfg.password)
-                && guiCfg.authMode !== 'ldap'
+                && !guiCfg.isAuthEnabled
                 && !guiCfg.insecureAdminAccess;
 
             if ((guiCfg.user && guiCfg.password) || guiCfg.authMode === 'ldap') {

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -565,6 +565,14 @@ angular.module('syncthing.core')
             }).error($scope.emitHTTPError);
         }
 
+        $scope.isAuthEnabled = function (config) {
+            // This function should match IsAuthEnabled() in guiconfiguration.go
+            if (config && config.gui) {
+	        return config.gui.authMode === 'ldap' || (config.gui.user && config.gui.password);
+            }
+            return false;
+        };
+
         function refreshNoAuthWarning() {
             if (!$scope.system || !$scope.config || !$scope.config.gui) {
                 // We need all to be able to determine the state.
@@ -579,7 +587,7 @@ angular.module('syncthing.core')
             $scope.openNoAuth = addr.substr(0, 4) !== "127."
                 && addr.substr(0, 6) !== "[::1]:"
                 && addr.substr(0, 1) !== "/"
-                && !guiCfg.isAuthEnabled
+                && !$scope.isAuthEnabled($scope.config)
                 && !guiCfg.insecureAdminAccess;
 
             if ((guiCfg.user && guiCfg.password) || guiCfg.authMode === 'ldap') {

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -41,7 +41,7 @@ func (c *configMuxBuilder) registerConfig(path string) {
 			Configuration: cfg,
 			GUI: guiCfgWithExtras{
 				GUIConfiguration: cfg.GUI,
-				IsAuthEnabled: cfg.GUI.IsAuthEnabled(),
+				IsAuthEnabled:    cfg.GUI.IsAuthEnabled(),
 			},
 		})
 	})

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -26,24 +26,7 @@ type configMuxBuilder struct {
 
 func (c *configMuxBuilder) registerConfig(path string) {
 	c.HandlerFunc(http.MethodGet, path, func(w http.ResponseWriter, _ *http.Request) {
-		cfg := c.cfg.RawCopy()
-
-		type guiCfgWithExtras struct {
-			config.GUIConfiguration
-			IsAuthEnabled bool `json:"isAuthEnabled"`
-		}
-		type configWithExtras struct {
-			config.Configuration
-			GUI guiCfgWithExtras `json:"gui"`
-		}
-
-		sendJSON(w, configWithExtras{
-			Configuration: cfg,
-			GUI: guiCfgWithExtras{
-				GUIConfiguration: cfg.GUI,
-				IsAuthEnabled:    cfg.GUI.IsAuthEnabled(),
-			},
-		})
+		sendJSON(w, c.cfg.RawCopy())
 	})
 
 	c.HandlerFunc(http.MethodPut, path, func(w http.ResponseWriter, r *http.Request) {

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -26,7 +26,24 @@ type configMuxBuilder struct {
 
 func (c *configMuxBuilder) registerConfig(path string) {
 	c.HandlerFunc(http.MethodGet, path, func(w http.ResponseWriter, _ *http.Request) {
-		sendJSON(w, c.cfg.RawCopy())
+		cfg := c.cfg.RawCopy()
+
+		type guiCfgWithExtras struct {
+			config.GUIConfiguration
+			IsAuthEnabled bool `json:"isAuthEnabled"`
+		}
+		type configWithExtras struct {
+			config.Configuration
+			GUI guiCfgWithExtras `json:"gui"`
+		}
+
+		sendJSON(w, configWithExtras{
+			Configuration: cfg,
+			GUI: guiCfgWithExtras{
+				GUIConfiguration: cfg.GUI,
+				IsAuthEnabled: cfg.GUI.IsAuthEnabled(),
+			},
+		})
 	})
 
 	c.HandlerFunc(http.MethodPut, path, func(w http.ResponseWriter, r *http.Request) {

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -19,6 +19,7 @@ import (
 )
 
 func (c GUIConfiguration) IsAuthEnabled() bool {
+	// This function should match isAuthEnabled() in syncthingController.js
 	return c.AuthMode == AuthModeLDAP || (len(c.User) > 0 && len(c.Password) > 0)
 }
 


### PR DESCRIPTION
### Purpose

This was an oversight in #8757: the new "Log out" button is always shown in the "Actions" menu, even when authentication is not enabled.


### Testing

These manual tests have been done:

1. With authentication disabled (set username to empty): click the "Actions" menu. Verify that the "Log out" button is not shown.
2. Set a username and password and log back in. Click the "Actions" menu. Verify that the "Log out" button is shown.
3. Unset the username and save the config. Click the "Actions" menu. Verify that the "Log out" button is again not shown (do not refresh the page after saving the config).


### Screenshots

Before (3d0da5ac60ab02cf47ca5cd4fada48cc70360ec9):

![Screenshot before: Log out button shown with auth not configured](https://github.com/syncthing/syncthing/assets/1367758/84979c79-1272-453c-ab6f-1771c1a1785d)

After (f032f079db283967423784ec3e3aadeb6ee2f755):

![Screenshot after: Log out button not shown when auth not configured](https://github.com/syncthing/syncthing/assets/1367758/2ba9a8cc-6a8d-4ec4-933a-1b3d0bdb57e7)


### Documentation

No changes needed.
