### PR TITLE
Check basic auth (and set session cookie) before noauth exceptions

### DIFF
--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -35,7 +35,6 @@ func emitLoginAttempt(success bool, username, address string, evLogger events.Lo
 	})
 	if !success {
 		l.Infof("Wrong credentials supplied during API authorization from %s", address)
-		antiBruteForceSleep()
 	}
 }
 
@@ -140,6 +139,7 @@ func passwordAuthHandler(cookieName string, guiCfg config.GUIConfiguration, ldap
 		}
 
 		emitLoginAttempt(false, req.Username, r.RemoteAddr, evLogger)
+		antiBruteForceSleep()
 		forbidden(w)
 	})
 }
@@ -163,6 +163,7 @@ func attemptBasicAuth(r *http.Request, guiCfg config.GUIConfiguration, ldapCfg c
 	}
 
 	emitLoginAttempt(false, username, r.RemoteAddr, evLogger)
+	antiBruteForceSleep()
 	return "", false
 }
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -35,6 +35,7 @@ func emitLoginAttempt(success bool, username, address string, evLogger events.Lo
 	})
 	if !success {
 		l.Infof("Wrong credentials supplied during API authorization from %s", address)
+		antiBruteForceSleep()
 	}
 }
 
@@ -139,7 +140,6 @@ func passwordAuthHandler(cookieName string, guiCfg config.GUIConfiguration, ldap
 		}
 
 		emitLoginAttempt(false, req.Username, r.RemoteAddr, evLogger)
-		antiBruteForceSleep()
 		forbidden(w)
 	})
 }
@@ -163,7 +163,6 @@ func attemptBasicAuth(r *http.Request, guiCfg config.GUIConfiguration, ldapCfg c
 	}
 
 	emitLoginAttempt(false, username, r.RemoteAddr, evLogger)
-	antiBruteForceSleep()
 	return "", false
 }
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -164,6 +164,7 @@ func attemptBasicAuth(r *http.Request, guiCfg config.GUIConfiguration, ldapCfg c
 	}
 
 	emitLoginAttempt(false, username, r.RemoteAddr, evLogger)
+	antiBruteForceSleep()
 	return "", false
 }
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -87,12 +87,6 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 			return
 		}
 
-		// Exception for static assets and REST calls that don't require authentication.
-		if isNoAuthPath(r.URL.Path) {
-			next.ServeHTTP(w, r)
-			return
-		}
-
 		cookie, err := r.Cookie(cookieName)
 		if err == nil && cookie != nil {
 			sessionsMut.Lock()
@@ -107,6 +101,12 @@ func basicAuthAndSessionMiddleware(cookieName string, guiCfg config.GUIConfigura
 		// Fall back to Basic auth if provided
 		if username, ok := attemptBasicAuth(r, guiCfg, ldapCfg, evLogger); ok {
 			createSession(cookieName, username, guiCfg, evLogger, w, r)
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Exception for static assets and REST calls that don't require authentication.
+		if isNoAuthPath(r.URL.Path) {
 			next.ServeHTTP(w, r)
 			return
 		}

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -43,13 +43,11 @@ func antiBruteForceSleep() {
 }
 
 func unauthorized(w http.ResponseWriter) {
-	antiBruteForceSleep()
 	w.Header().Set("WWW-Authenticate", "Basic realm=\"Authorization Required\"")
 	http.Error(w, "Not Authorized", http.StatusUnauthorized)
 }
 
 func forbidden(w http.ResponseWriter) {
-	antiBruteForceSleep()
 	http.Error(w, "Forbidden", http.StatusForbidden)
 }
 
@@ -141,6 +139,7 @@ func passwordAuthHandler(cookieName string, guiCfg config.GUIConfiguration, ldap
 		}
 
 		emitLoginAttempt(false, req.Username, r.RemoteAddr, evLogger)
+		antiBruteForceSleep()
 		forbidden(w)
 	})
 }

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -649,6 +649,9 @@ func TestHTTPLogin(t *testing.T) {
 				if resp.StatusCode != expectedFailStatus {
 					t.Errorf("Unexpected non-%d return code %d for unauthed request", expectedFailStatus, resp.StatusCode)
 				}
+				if hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Unexpected session cookie for unauthed request")
+				}
 			})
 
 			t.Run("incorrect password is rejected", func(t *testing.T) {
@@ -656,6 +659,9 @@ func TestHTTPLogin(t *testing.T) {
 				resp := httpGetBasicAuth(url, "üser", "rksmrgs")
 				if resp.StatusCode != expectedFailStatus {
 					t.Errorf("Unexpected non-%d return code %d for incorrect password", expectedFailStatus, resp.StatusCode)
+				}
+				if hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Unexpected session cookie for incorrect password")
 				}
 			})
 
@@ -665,6 +671,9 @@ func TestHTTPLogin(t *testing.T) {
 				if resp.StatusCode != expectedFailStatus {
 					t.Errorf("Unexpected non-%d return code %d for incorrect username", expectedFailStatus, resp.StatusCode)
 				}
+				if hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Unexpected session cookie for incorrect username")
+				}
 			})
 
 			t.Run("UTF-8 auth works", func(t *testing.T) {
@@ -672,6 +681,9 @@ func TestHTTPLogin(t *testing.T) {
 				resp := httpGetBasicAuth(url, "üser", "räksmörgås") // string literals in Go source code are in UTF-8
 				if resp.StatusCode != expectedOkStatus {
 					t.Errorf("Unexpected non-%d return code %d for authed request (UTF-8)", expectedOkStatus, resp.StatusCode)
+				}
+				if !hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Expected session cookie for authed request (UTF-8)")
 				}
 			})
 
@@ -681,6 +693,9 @@ func TestHTTPLogin(t *testing.T) {
 				if resp.StatusCode != expectedOkStatus {
 					t.Errorf("Unexpected non-%d return code %d for authed request (ISO-8859-1)", expectedOkStatus, resp.StatusCode)
 				}
+				if !hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Expected session cookie for authed request (ISO-8859-1)")
+				}
 			})
 
 			t.Run("bad X-API-Key is rejected", func(t *testing.T) {
@@ -688,6 +703,9 @@ func TestHTTPLogin(t *testing.T) {
 				resp := httpGetXapikey(url, testAPIKey+"X")
 				if resp.StatusCode != expectedFailStatus {
 					t.Errorf("Unexpected non-%d return code %d for bad API key", expectedFailStatus, resp.StatusCode)
+				}
+				if hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Unexpected session cookie for bad API key")
 				}
 			})
 
@@ -697,13 +715,19 @@ func TestHTTPLogin(t *testing.T) {
 				if resp.StatusCode != expectedOkStatus {
 					t.Errorf("Unexpected non-%d return code %d for API key", expectedOkStatus, resp.StatusCode)
 				}
+				if hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Unexpected session cookie for API key")
+				}
 			})
 
 			t.Run("bad Bearer is rejected", func(t *testing.T) {
 				t.Parallel()
 				resp := httpGetAuthorizationBearer(url, testAPIKey+"X")
 				if resp.StatusCode != expectedFailStatus {
-					t.Errorf("Unexpected non-%d return code %d for bad API key", expectedFailStatus, resp.StatusCode)
+					t.Errorf("Unexpected non-%d return code %d for bad Authorization: Bearer", expectedFailStatus, resp.StatusCode)
+				}
+				if hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Unexpected session cookie for bad Authorization: Bearer")
 				}
 			})
 
@@ -711,7 +735,10 @@ func TestHTTPLogin(t *testing.T) {
 				t.Parallel()
 				resp := httpGetAuthorizationBearer(url, testAPIKey)
 				if resp.StatusCode != expectedOkStatus {
-					t.Errorf("Unexpected non-%d return code %d for API key", expectedOkStatus, resp.StatusCode)
+					t.Errorf("Unexpected non-%d return code %d for Authorization: Bearer", expectedOkStatus, resp.StatusCode)
+				}
+				if hasSessionCookie(resp.Cookies()) {
+					t.Errorf("Unexpected session cookie for bad Authorization: Bearer")
 				}
 			})
 		})

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -744,9 +744,11 @@ func TestHTTPLogin(t *testing.T) {
 		})
 	}
 
+	testWith(true, http.StatusOK, http.StatusOK, "/")
 	testWith(true, http.StatusOK, http.StatusUnauthorized, "/meta.js")
 	testWith(true, http.StatusNotFound, http.StatusUnauthorized, "/any-path/that/does/nooooooot/match-any/noauth-pattern")
 
+	testWith(false, http.StatusOK, http.StatusOK, "/")
 	testWith(false, http.StatusOK, http.StatusForbidden, "/meta.js")
 	testWith(false, http.StatusNotFound, http.StatusForbidden, "/any-path/that/does/nooooooot/match-any/noauth-pattern")
 }


### PR DESCRIPTION
### Purpose

This is motivated by the Android app: https://github.com/syncthing/syncthing-android/pull/1982#issuecomment-1752042554

The planned fix in response to basic auth behaviour changing in #8757 was to add the `Authorization` header when opening the WebView, but it turns out the function used only applies the header to the initial page load, not any subsequent script loads or AJAX calls. The `basicAuthAndSessionMiddleware` checks for no-auth exceptions before checking the `Authorization` header, so the header has no effect on the initial page load since the `/` path is a no-auth exception. Thus the Android app fails to log in when opening the WebView.

This changes the order of checks in `basicAuthAndSessionMiddleware` so that the `Authorization` header is always checked if present, and a session cookie is set if it is valid. Only after that does the middleware fall back to checking for no-auth exceptions.


### Testing

`api_test.go` has been expanded with additional checks:
- Check that a session cookie is set whenever correct basic auth is provided.
- Check that a session cookie is not set when basic auth is incorrect.
- Check that a session cookie is not set when authenticating with an API token (either via `X-Api-Key` or `Authorization: Bearer`).

And an additional test case:
- Check that requests to `/` always succeed, but receive a session cookie when correct basic auth is provided.

I have manually verified that
- The new assertions fail if the `createSession` call is removed in `basicAuthAndSessionMiddleware`.
- The new test cases in e6e4df4d7034302b729ada6d91cff6e2b29678da fail before the change in 0e47d37e738d4c15736c496e01cd949afb372e71 is applied.


### Documentation

No changes needed.
