### PR TITLE
lib/fs: Fix conflicts on Android due to fluctuating inode change time

### DIFF
--- a/lib/fs/basicfs_fileinfo_linuxish.go
+++ b/lib/fs/basicfs_fileinfo_linuxish.go
@@ -20,7 +20,7 @@ func (fi basicFileInfo) InodeChangeTime() time.Time {
 	// On Android, mtime and inode-change-time fluctuate, which can cause
 	// conflicts even when nothing has been modified on the device itself.
 	// Ref: https://forum.syncthing.net/t/keep-getting-conflicts-generated-on-android-device-for-files-modified-only-on-a-desktop-pc/19060
-	if build.IsAndroid { 
+	if build.IsAndroid {
 		return time.Time{}
 	}
 	if sys, ok := fi.FileInfo.Sys().(*syscall.Stat_t); ok {

--- a/lib/fs/basicfs_fileinfo_linuxish.go
+++ b/lib/fs/basicfs_fileinfo_linuxish.go
@@ -12,9 +12,17 @@ package fs
 import (
 	"syscall"
 	"time"
+
+	"github.com/syncthing/syncthing/lib/build"
 )
 
 func (fi basicFileInfo) InodeChangeTime() time.Time {
+	// On Android, mtime and inode-change-time fluctuate, which can cause
+	// conflicts even when nothing has been modified on the device itself.
+	// Ref: https://forum.syncthing.net/t/keep-getting-conflicts-generated-on-android-device-for-files-modified-only-on-a-desktop-pc/19060
+	if build.IsAndroid { 
+		return time.Time{}
+	}
 	if sys, ok := fi.FileInfo.Sys().(*syscall.Stat_t); ok {
 		return time.Unix(0, sys.Ctim.Nano())
 	}


### PR DESCRIPTION
lib/fs: Fix conflicts on Android due to fluctuating inode change time

[1] added inode change time to file info in order to support syncing
extended attributes. However, in the case of Android, this inode change
time fluctuates, leading to unexpected conflicts even when the user has
not even touched the files on the Android device itself. Thus, in order
to prevent those conflicts from happening, do not write inode change
time on Android.

[1] 6cac308bcdf197f4bbe8bd36725d9ac92a622559

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>