### PR TITLE
lib/locations: Change default config/data location to new XDG recommendation (fixes #9178, fixes #9179)

### DIFF
--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -191,7 +191,10 @@ func defaultConfigDir(userHome string) string {
 		return filepath.Join(userHome, "Library/Application Support/Syncthing")
 
 	default:
-		// Legacy: if our config exists under $XDG_CONFIG_HOME/syncthing, use that
+		// Legacy: if our config exists under $XDG_CONFIG_HOME/syncthing,
+		// use that. The variable should be set to an absolute path or be
+		// ignored, but that's not what we did previously, so we retain the
+		// old behavior.
 		if xdgCfg := os.Getenv("XDG_CONFIG_HOME"); xdgCfg != "" {
 			candidate := filepath.Join(xdgCfg, "syncthing")
 			if _, err := os.Lstat(filepath.Join(candidate, configFileName)); err == nil {
@@ -203,8 +206,8 @@ func defaultConfigDir(userHome string) string {
 		if _, err := os.Lstat(filepath.Join(candidate, configFileName)); err == nil {
 			return candidate
 		}
-		// If XDG_STATE_HOME is set, use that
-		if xdgState := os.Getenv("XDG_STATE_HOME"); xdgState != "" {
+		// If XDG_STATE_HOME is set to an absolute path, use that
+		if xdgState := os.Getenv("XDG_STATE_HOME"); filepath.IsAbs(xdgState) {
 			return filepath.Join(xdgState, "syncthing")
 		}
 		// Use our default
@@ -223,7 +226,9 @@ func defaultDataDir(userHome, config string) string {
 	if _, err := os.Lstat(filepath.Join(config, LevelDBDir)); err == nil {
 		return config
 	}
-	// Legacy: if a database exists under $XDG_DATA_HOME/syncthing, use that
+	// Legacy: if a database exists under $XDG_DATA_HOME/syncthing, use
+	// that. The variable should be set to an absolute path or be ignored,
+	// but that's not what we did previously, so we retain the old behavior.
 	if xdgData := os.Getenv("XDG_DATA_HOME"); xdgData != "" {
 		candidate := filepath.Join(xdgData, "syncthing")
 		if _, err := os.Lstat(filepath.Join(candidate, LevelDBDir)); err == nil {
@@ -235,8 +240,8 @@ func defaultDataDir(userHome, config string) string {
 	if _, err := os.Lstat(filepath.Join(candidate, LevelDBDir)); err == nil {
 		return candidate
 	}
-	// If XDG_STATE_HOME is set, use that
-	if xdgState := os.Getenv("XDG_STATE_HOME"); xdgState != "" {
+	// If XDG_STATE_HOME is set to an absolute path, use that
+	if xdgState := os.Getenv("XDG_STATE_HOME"); filepath.IsAbs(xdgState) {
 		return filepath.Join(xdgState, "syncthing")
 	}
 	// Use our default

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -42,7 +42,7 @@ type BaseDirEnum string
 const (
 	// Overridden by --home flag, $STHOMEDIR, --config flag, or $STCONFDIR
 	ConfigBaseDir BaseDirEnum = "config"
-	// Overriddeb by --home flag, $STHOMEDIR, --data flag, or $STDATADIR
+	// Overridden by --home flag, $STHOMEDIR, --data flag, or $STDATADIR
 	DataBaseDir BaseDirEnum = "data"
 
 	// User's home directory, *not* --home flag

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -48,7 +48,10 @@ const (
 	// User's home directory, *not* --home flag
 	UserHomeBaseDir BaseDirEnum = "userHome"
 
-	LevelDBDir = "index-v0.14.0.db"
+	LevelDBDir          = "index-v0.14.0.db"
+	configFileName      = "config.xml"
+	defaultStateDir     = ".local/state/syncthing"
+	oldDefaultConfigDir = ".config/syncthing"
 )
 
 // Platform dependent directories
@@ -191,13 +194,13 @@ func defaultConfigDir(userHome string) string {
 		// Legacy: if our config exists under $XDG_CONFIG_HOME/syncthing, use that
 		if xdgCfg := os.Getenv("XDG_CONFIG_HOME"); xdgCfg != "" {
 			candidate := filepath.Join(xdgCfg, "syncthing")
-			if _, err := os.Lstat(filepath.Join(candidate, "config.xml")); err == nil {
+			if _, err := os.Lstat(filepath.Join(candidate, configFileName)); err == nil {
 				return candidate
 			}
 		}
 		// Legacy: if our config exists under ~/.config/syncthing, use that
-		candidate := filepath.Join(userHome, ".config/syncthing")
-		if _, err := os.Lstat(filepath.Join(candidate, "config.xml")); err == nil {
+		candidate := filepath.Join(userHome, oldDefaultConfigDir)
+		if _, err := os.Lstat(filepath.Join(candidate, configFileName)); err == nil {
 			return candidate
 		}
 		// If XDG_STATE_HOME is set, use that
@@ -205,7 +208,7 @@ func defaultConfigDir(userHome string) string {
 			return filepath.Join(xdgState, "syncthing")
 		}
 		// Use our default
-		return filepath.Join(userHome, ".local/state/syncthing")
+		return filepath.Join(userHome, defaultStateDir)
 	}
 }
 
@@ -228,7 +231,7 @@ func defaultDataDir(userHome, config string) string {
 		}
 	}
 	// Legacy: if a database exists under ~/.config/syncthing, use that
-	candidate := filepath.Join(userHome, ".config/syncthing")
+	candidate := filepath.Join(userHome, oldDefaultConfigDir)
 	if _, err := os.Lstat(filepath.Join(candidate, LevelDBDir)); err == nil {
 		return candidate
 	}
@@ -237,7 +240,7 @@ func defaultDataDir(userHome, config string) string {
 		return filepath.Join(xdgState, "syncthing")
 	}
 	// Use our default
-	return filepath.Join(userHome, ".local/state/syncthing")
+	return filepath.Join(userHome, defaultStateDir)
 }
 
 // userHomeDir returns the user's home directory, or dies trying.

--- a/lib/locations/locations_test.go
+++ b/lib/locations/locations_test.go
@@ -4,6 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at https://mozilla.org/MPL/2.0/.
 
+//go:build !windows
+
 package locations
 
 import (

--- a/lib/locations/locations_test.go
+++ b/lib/locations/locations_test.go
@@ -1,0 +1,96 @@
+package locations
+
+import (
+	"testing"
+
+	"golang.org/x/exp/slices"
+)
+
+func TestUnixConfigDir(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		userHome      string
+		xdgConfigHome string
+		xdgStateHome  string
+		filesExist    []string
+		expected      string
+	}{
+		// First some "new installations", no files exist previously.
+
+		// No variables set, use our current default
+		{"/home/user", "", "", nil, "/home/user/.local/state/syncthing"},
+		// Config home set, doesn't matter
+		{"/home/user", "/somewhere/else", "", nil, "/home/user/.local/state/syncthing"},
+		// State home set, use that
+		{"/home/user", "", "/var/state", nil, "/var/state/syncthing"},
+		// State home set, again config home doesn't matter
+		{"/home/user", "/somewhere/else", "/var/state", nil, "/var/state/syncthing"},
+
+		// Now some "upgrades", where we have files in the old locations.
+
+		// Config home set, a file exists in the default location
+		{"/home/user", "/somewhere/else", "", []string{"/home/user/.config/syncthing/config.xml"}, "/home/user/.config/syncthing"},
+		// State home set, a file exists in the default location
+		{"/home/user", "", "/var/state", []string{"/home/user/.config/syncthing/config.xml"}, "/home/user/.config/syncthing"},
+		// Both config home and state home set, a file exists in the default location
+		{"/home/user", "/somewhere/else", "/var/state", []string{"/home/user/.config/syncthing/config.xml"}, "/home/user/.config/syncthing"},
+
+		// Config home set, and a file exists at that place
+		{"/home/user", "/somewhere/else", "", []string{"/somewhere/else/syncthing/config.xml"}, "/somewhere/else/syncthing"},
+		// Config home and state home set, and a file exists in config home
+		{"/home/user", "/somewhere/else", "/var/state", []string{"/somewhere/else/syncthing/config.xml"}, "/somewhere/else/syncthing"},
+	}
+
+	for _, c := range cases {
+		fileExists := func(path string) bool { return slices.Contains(c.filesExist, path) }
+		actual := unixConfigDir(c.userHome, c.xdgConfigHome, c.xdgStateHome, fileExists)
+		if actual != c.expected {
+			t.Errorf("unixConfigDir(%q, %q, %q) == %q, expected %q", c.userHome, c.xdgConfigHome, c.xdgStateHome, actual, c.expected)
+		}
+	}
+}
+
+func TestUnixDataDir(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		userHome     string
+		configDir    string
+		xdgDataHome  string
+		xdgStateHome string
+		filesExist   []string
+		expected     string
+	}{
+		// First some "new installations", no files exist previously.
+
+		// No variables set, use our current default
+		{"/home/user", "", "", "", nil, "/home/user/.local/state/syncthing"},
+		// Config dir overridden, doesn't matter
+		{"/home/user", "/somewhere/else", "", "", nil, "/home/user/.local/state/syncthing"},
+		// Data home set, doesn't matter
+		{"/home/user", "", "/somewhere/else", "", nil, "/home/user/.local/state/syncthing"},
+		// State home set, use that
+		{"/home/user", "", "", "/var/state", nil, "/var/state/syncthing"},
+
+		// Now some "upgrades", where we have files in the old locations.
+
+		// A database exists in the old default location, use that
+		{"/home/user", "", "", "", []string{"/home/user/.config/syncthing/index-v0.14.0.db"}, "/home/user/.config/syncthing"},
+		{"/home/user", "/config/dir", "/xdg/data/home", "/xdg/state/home", []string{"/home/user/.config/syncthing/index-v0.14.0.db"}, "/home/user/.config/syncthing"},
+
+		// A database exists in the config dir, use that
+		{"/home/user", "/config/dir", "/xdg/data/home", "/xdg/state/home", []string{"/config/dir/index-v0.14.0.db"}, "/config/dir"},
+
+		// A database exists in the old xdg data home, use that
+		{"/home/user", "/config/dir", "/xdg/data/home", "/xdg/state/home", []string{"/xdg/data/home/syncthing/index-v0.14.0.db"}, "/xdg/data/home/syncthing"},
+	}
+
+	for _, c := range cases {
+		fileExists := func(path string) bool { return slices.Contains(c.filesExist, path) }
+		actual := unixDataDir(c.userHome, c.configDir, c.xdgDataHome, c.xdgStateHome, fileExists)
+		if actual != c.expected {
+			t.Errorf("unixDataDir(%q, %q, %q, %q) == %q, expected %q", c.userHome, c.configDir, c.xdgDataHome, c.xdgStateHome, actual, c.expected)
+		}
+	}
+}

--- a/lib/locations/locations_test.go
+++ b/lib/locations/locations_test.go
@@ -1,3 +1,9 @@
+// Copyright (C) 2023 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
 package locations
 
 import (
@@ -66,8 +72,6 @@ func TestUnixDataDir(t *testing.T) {
 
 		// No variables set, use our current default
 		{"/home/user", "", "", "", nil, "/home/user/.local/state/syncthing"},
-		// Config dir overridden, doesn't matter
-		{"/home/user", "/somewhere/else", "", "", nil, "/home/user/.local/state/syncthing"},
 		// Data home set, doesn't matter
 		{"/home/user", "", "/somewhere/else", "", nil, "/home/user/.local/state/syncthing"},
 		// State home set, use that


### PR DESCRIPTION
This makes the new default $XDG_STATE_HOME/syncthing or ~/.local/state/syncthing, while still looking in legacy locations first for existing installs.

Note that this does not *move* existing installs, and nor should we. Existing paths will continue to be used as-is, but the user can move the dir into the new place if they want to use it (as they could prior to this change as well, for that matter).

### Documentation

Needs update to the config docs about our default locations.