### PR TITLE
lib/location: Fix regression of timestamp handling (ref #9180)

### DIFF
--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -285,10 +285,10 @@ func userHomeDir() string {
 }
 
 func GetTimestamped(key LocationEnum) string {
-	return getTimestamped(key, time.Now())
+	return getTimestampedAt(key, time.Now())
 }
 
-func getTimestamped(key LocationEnum, when time.Time) string {
+func getTimestampedAt(key LocationEnum, when time.Time) string {
 	// We take the roundtrip via "%{timestamp}" instead of passing the path
 	// directly through time.Format() to avoid issues when the path we are
 	// expanding contains numbers; otherwise for example

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -122,8 +122,8 @@ var locationTemplates = map[LocationEnum]string{
 	Database:      "${data}/" + LevelDBDir,
 	LogFile:       "${data}/syncthing.log", // --logfile on Windows
 	CsrfTokens:    "${data}/csrftokens.txt",
-	PanicLog:      "${data}/panic-${timestamp}.log",
-	AuditLog:      "${data}/audit-${timestamp}.log",
+	PanicLog:      "${data}/panic-%{timestamp}.log",
+	AuditLog:      "${data}/audit-%{timestamp}.log",
 	GUIAssets:     "${config}/gui",
 	DefFolder:     "${userHome}/Sync",
 }
@@ -285,14 +285,18 @@ func userHomeDir() string {
 }
 
 func GetTimestamped(key LocationEnum) string {
-	// We take the roundtrip via "${timestamp}" instead of passing the path
+	return getTimestamped(key, time.Now())
+}
+
+func getTimestamped(key LocationEnum, when time.Time) string {
+	// We take the roundtrip via "%{timestamp}" instead of passing the path
 	// directly through time.Format() to avoid issues when the path we are
 	// expanding contains numbers; otherwise for example
 	// /home/user2006/.../panic-20060102-150405.log would get both instances of
 	// 2006 replaced by 2015...
 	tpl := locations[key]
-	now := time.Now().Format("20060102-150405")
-	return strings.ReplaceAll(tpl, "${timestamp}", now)
+	timestamp := when.Format("20060102-150405")
+	return strings.ReplaceAll(tpl, "%{timestamp}", timestamp)
 }
 
 func fileExists(path string) bool {

--- a/lib/locations/locations_test.go
+++ b/lib/locations/locations_test.go
@@ -104,7 +104,7 @@ func TestUnixDataDir(t *testing.T) {
 }
 
 func TestGetTimestamped(t *testing.T) {
-	s := getTimestamped(PanicLog, time.Date(2023, 10, 25, 21, 47, 0, 0, time.UTC))
+	s := getTimestampedAt(PanicLog, time.Date(2023, 10, 25, 21, 47, 0, 0, time.UTC))
 	exp := "panic-20231025-214700.log"
 	if file := filepath.Base(s); file != exp {
 		t.Errorf("got %q, expected %q", file, exp)

--- a/lib/locations/locations_test.go
+++ b/lib/locations/locations_test.go
@@ -9,7 +9,9 @@
 package locations
 
 import (
+	"path/filepath"
 	"testing"
+	"time"
 
 	"golang.org/x/exp/slices"
 )
@@ -98,5 +100,13 @@ func TestUnixDataDir(t *testing.T) {
 		if actual != c.expected {
 			t.Errorf("unixDataDir(%q, %q, %q, %q) == %q, expected %q", c.userHome, c.configDir, c.xdgDataHome, c.xdgStateHome, actual, c.expected)
 		}
+	}
+}
+
+func TestGetTimestamped(t *testing.T) {
+	s := getTimestamped(PanicLog, time.Date(2023, 10, 25, 21, 47, 0, 0, time.UTC))
+	exp := "panic-20231025-214700.log"
+	if file := filepath.Base(s); file != exp {
+		t.Errorf("got %q, expected %q", file, exp)
 	}
 }


### PR DESCRIPTION
The new, supposedly better variable expansion would eradicate `${timestamp}` that was previously left alone. Now, instead, call it `%{timestamp}` to differentiate. Add a test to make sure it continues working.