### PR TITLE
Prevent Discovery from returning Nil IP (fixes #9189)

### DIFF
--- a/cmd/stdiscosrv/apisrv.go
+++ b/cmd/stdiscosrv/apisrv.go
@@ -137,10 +137,10 @@ func (s *apiSrv) handler(w http.ResponseWriter, req *http.Request) {
 
 	if s.useHTTP {
 		// X-Forwarded-For can have multiple client IPs; split using the comma separator
-		forwardIPs := strings.Split(req.Header.Get("X-Forwarded-For"), ",")
-		if len(forwardIPs) > 0 {
-			// get the originating client (left most ip) and parse
-			remoteAddr.IP = net.ParseIP(forwardIPs[0])
+		forwardIP, _, found := strings.Cut(req.Header.Get("X-Forwarded-For"), ",")
+		if found {
+			// net.ParseIP will return nil if leading/trailing whitespace exists; use strings.TrimSpace()
+			remoteAddr.IP = net.ParseIP(strings.TrimSpace(forwardIP))
 		}
 
 		if parsedPort, err := strconv.ParseInt(req.Header.Get("X-Client-Port"), 10, 0); err == nil {

--- a/cmd/stdiscosrv/apisrv.go
+++ b/cmd/stdiscosrv/apisrv.go
@@ -137,11 +137,10 @@ func (s *apiSrv) handler(w http.ResponseWriter, req *http.Request) {
 
 	if s.useHTTP {
 		// X-Forwarded-For can have multiple client IPs; split using the comma separator
-		forwardIP, _, found := strings.Cut(req.Header.Get("X-Forwarded-For"), ",")
-		if found {
-			// net.ParseIP will return nil if leading/trailing whitespace exists; use strings.TrimSpace()
-			remoteAddr.IP = net.ParseIP(strings.TrimSpace(forwardIP))
-		}
+		forwardIP, _, _ := strings.Cut(req.Header.Get("X-Forwarded-For"), ",")
+
+		// net.ParseIP will return nil if leading/trailing whitespace exists; use strings.TrimSpace()
+		remoteAddr.IP = net.ParseIP(strings.TrimSpace(forwardIP))
 
 		if parsedPort, err := strconv.ParseInt(req.Header.Get("X-Client-Port"), 10, 0); err == nil {
 			remoteAddr.Port = int(parsedPort)

--- a/cmd/stdiscosrv/apisrv_test.go
+++ b/cmd/stdiscosrv/apisrv_test.go
@@ -69,6 +69,14 @@ func TestFixupAddresses(t *testing.T) {
 			remote: addr("123.123.123.123", 9000),
 			in:     []string{"tcp://44.44.44.44:0"},
 			out:    []string{"tcp://44.44.44.44:9000"},
+		}, { // remote ip nil
+			remote: addr("", 9000),
+			in:     []string{"tcp://:22000", "tcp://44.44.44.44:9000"},
+			out:    []string{"tcp://44.44.44.44:9000"},
+		}, { // remote port 0
+			remote: addr("123.123.123.123", 0),
+			in:     []string{"tcp://:22000", "tcp://44.44.44.44"},
+			out:    []string{"tcp://123.123.123.123:22000"},
 		},
 	}
 


### PR DESCRIPTION
### Purpose

Treat X-Forwarded-For as a comma separated string to prevent Nil IP being returned by the Discovery Server
Fixes: [9189](https://github.com/syncthing/syncthing/issues/9189
)
### Testing

Unit Tests implemented

Testing with a Discovery Client can be done as follows:
```
A simple example to replicate this entails running Discovery with HTTP, use Nginx as a reverse proxy and hardcode (as an example) a list of IPs in the X-Forwarded-For header.
1. Send an Announcement with tcp://0.0.0.0:<some-port>
2. Query the DeviceID
3. Observe the returned IP Address is no longer nil; i.e.  `tcp://<nil>:<some-port>`
```

## Authorship
Vishal A. Patel