### PR TITLE
 Support explicit translation ID and dotted namespaces in translation extraction 

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -538,6 +538,11 @@
     "modified": "modified",
     "permit": "permit",
     "seconds": "seconds",
+    "test": {
+        "translation": {
+            "dummy": "(This is just a test string for nested translation namespaces. This does not need to be translated.)"
+        }
+    },
     "theme-name-black": "Black",
     "theme-name-dark": "Dark",
     "theme-name-default": "Default",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -1091,5 +1091,6 @@
   <script type="text/javascript" src="syncthing/app.js"></script>
   <!-- / gui application code -->
 
+  <div translate="test.translation.dummy" style="display: none;">(This is just a test string for nested translation namespaces. This does not need to be translated.)</div>
 </body>
 </html>

--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -26,6 +26,7 @@ syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvi
         prefix: 'assets/lang/lang-',
         suffix: '.json'
     });
+    $translateProvider.fallbackLanguage('en');
 
     LocaleServiceProvider.setAvailableLocales(validLangs);
     LocaleServiceProvider.setDefaultLocale('en');

--- a/script/translate.go
+++ b/script/translate.go
@@ -104,45 +104,20 @@ func inTranslate(n *html.Node, translationId string, filename string) {
 	}
 }
 
-func isNamespacedTranslationId(id string) bool {
-	if !strings.Contains(id, ".") {
-		return false
-	}
-
-	if id[len(id)-1] == '.' {
-		// Last section of namespaced ID must not be empty
-		return false
-	}
-
-	if strings.Contains(id, " ") {
-		// Probably a sentence
-		return false
-	}
-
-	if strings.Contains(id, "..") {
-		// Probably something like "Loading..."
-		return false
-	}
-
-	return true
-}
-
 func translation(id string, v string) {
+	namespace := trans
+	idParts := strings.Split(id, ".")
+	id = idParts[len(idParts)-1]
+	for _, subNamespace := range idParts[0 : len(idParts)-1] {
+		if _, ok := namespace[subNamespace]; !ok {
+			namespace[subNamespace] = make(map[string]interface{})
+		}
+		namespace = namespace[subNamespace].(map[string]interface{})
+	}
+
 	v = strings.TrimSpace(v)
 	if id == "" {
 		id = v
-	}
-
-	namespace := trans
-	if isNamespacedTranslationId(id) {
-		idParts := strings.Split(id, ".")
-		id = idParts[len(idParts)-1]
-		for _, subNamespace := range idParts[0 : len(idParts)-1] {
-			if _, ok := namespace[subNamespace]; !ok {
-				namespace[subNamespace] = make(map[string]interface{})
-			}
-			namespace = namespace[subNamespace].(map[string]interface{})
-		}
 	}
 
 	if _, ok := namespace[id]; !ok {


### PR DESCRIPTION
### Purpose

This was extracted from PR #9175 as requested in https://github.com/syncthing/syncthing/pull/9175#discussion_r1370183132 .

In summary: some translations, especially single words or other short labels for buttons and the like, may not be transferable between contexts even if they happen to be equal in English. In these cases, setting an explicit translation ID is important for context separation. Angular Translate also supports nested JSON in translation tables, addressed using `.` as namespace separator; this enhancement makes use of this when extracting translation with an explicit translation ID.

See also the motivation I laid out in https://github.com/syncthing/syncthing/pull/9175#discussion_r1369930826 :

>```diff
>+<th><label translate="settings.webauthn.credentials.columnHeading.name">Name</label></th>
>+<th><label translate="settings.webauthn.credentials.columnHeading.createTime">Created</label></th>
>+<th><label translate="settings.webauthn.credentials.columnHeading.lastUseTime">Last used</label></th>
>+<th><label translate="settings.webauthn.credentials.columnHeading.requireUserVerification">Require UV</label></th>
>```
>
>By the way, I've used namespaced translation IDs here and in a few other places because the inferred ones don't work across languages and contexts. For example: in Swedish, "Created" could be translated as "Skapades" (was created), "Skapad" (is created, common) or "Skapat" (is created, neuter). So a single "Created" translation key would fairly likely be translated incorrectly if the translator sees no other context, and almost certainly if it's used in more than one place.
>
>Similarly, "Require UV" is difficult to translate at all without the context of what "UV" expands to, but it's also not appropriate to spell out "Require user verification" here since that would make the column heading far too wide.

I'm not sure how this - especially nested JSON - interacts with ~~Transifex~~ Weblate, though. ~~It could be that the translation ID isn't shown in the user interface. I'd be happy to investigate that if possible.~~ If Weblate does not support nested JSON, it is easy to drop the nested namespace parsing part.


### Testing

PR #9175 has a few commits, such as https://github.com/syncthing/syncthing/pull/9175/commits/a0b8407acbedd7b62d4f212083744973816275a2 and https://github.com/syncthing/syncthing/pull/9175/commits/1c131a34383d5edc220fdd5a0f3e47fb93c1a75d, demonstrating what kinds of usage this would enable.

To test this you can edit any `translate` attribute in the HTML sources to `translate="<id>"` and then run `go run build.go translate`. You should then see `<id>` used as the extracted translation key. If `<id>` contains any `.` characters, the extracted translations JSON will be nested with namespaces separated by `.`. Any translations that do not explicitly specify the translation ID are unaffected, and continue to use the original English text as the translation key.
