### PR TITLE
Add `org.opencontainers.image.source` to Dockerfiles

### DIFF
--- a/.github/workflows/build-infra-dockers.yaml
+++ b/.github/workflows/build-infra-dockers.yaml
@@ -6,23 +6,22 @@ on:
       - infrastructure
 
 env:
-    GO_VERSION: "~1.21.1"
-    CGO_ENABLED: "0"
-    BUILD_USER: docker
-    BUILD_HOST: github.syncthing.net
+  GO_VERSION: "~1.21.1"
+  CGO_ENABLED: "0"
+  BUILD_USER: docker
+  BUILD_HOST: github.syncthing.net
 
 jobs:
-
   docker-syncthing:
     name: Build and push Docker images
     runs-on: ubuntu-latest
     environment: docker
     strategy:
-        matrix:
-            pkg:
-                - stcrashreceiver
-                - strelaypoolsrv
-                - stupgrades
+      matrix:
+        pkg:
+          - stcrashreceiver
+          - strelaypoolsrv
+          - stupgrades
     steps:
       - uses: actions/checkout@v4
         with:
@@ -52,3 +51,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: syncthing/${{ matrix.pkg }}:latest,syncthing/${{ matrix.pkg }}:${{ github.sha }}
+          outputs: |
+            annotation.org.opencontainers.image.revision="${{ github.sha }}"

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -762,6 +762,7 @@ jobs:
             tags=${{ matrix.image }}:edge
           fi
           echo "DOCKER_TAGS=$tags" >> $GITHUB_ENV
+          echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -771,6 +772,9 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/7
           push: ${{ env.DOCKER_PUSH == 'true' }}
           tags: ${{ env.DOCKER_TAGS }}
+          outputs: |
+            annotation.org.opencontainers.image.version="${{ env.VERSION }}"
+            annotation.org.opencontainers.image.revision="${{ github.sha }}"
 
   #
   # Check for known vulnerabilities in Go dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,14 @@ RUN if [ ! -f syncthing-linux-$TARGETARCH ] ; then \
 FROM alpine
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.authors="The Syncthing Project" \
+      org.opencontainers.image.url="https://syncthing.net" \
+      org.opencontainers.image.documentation="https://docs.syncthing.net" \
+      org.opencontainers.image.source="https://github.com/syncthing/syncthing" \
+      org.opencontainers.image.vendor="The Syncthing Project"
+      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.title="Syncthing"
+
 EXPOSE 8384 22000/tcp 22000/udp 21027/udp
 
 VOLUME ["/var/syncthing"]

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,6 +1,14 @@
 ARG GOVERSION=latest
 FROM golang:$GOVERSION
 
+LABEL org.opencontainers.image.authors="The Syncthing Project" \
+      org.opencontainers.image.url="https://syncthing.net" \
+      org.opencontainers.image.documentation="https://docs.syncthing.net" \
+      org.opencontainers.image.source="https://github.com/syncthing/syncthing" \
+      org.opencontainers.image.vendor="The Syncthing Project"
+      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.title="Syncthing Builder"
+
 # FPM to build Debian packages
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	locales rubygems ruby-dev build-essential git \

--- a/Dockerfile.stcrashreceiver
+++ b/Dockerfile.stcrashreceiver
@@ -1,6 +1,14 @@
 FROM alpine
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.authors="The Syncthing Project" \
+      org.opencontainers.image.url="https://syncthing.net" \
+      org.opencontainers.image.documentation="https://docs.syncthing.net" \
+      org.opencontainers.image.source="https://github.com/syncthing/syncthing" \
+      org.opencontainers.image.vendor="The Syncthing Project"
+      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.title="Syncthing Crash Receiver"
+
 EXPOSE 8080
 
 COPY stcrashreceiver-linux-${TARGETARCH} /bin/stcrashreceiver

--- a/Dockerfile.stdiscosrv
+++ b/Dockerfile.stdiscosrv
@@ -16,6 +16,14 @@ RUN if [ ! -f stdiscosrv-linux-$TARGETARCH ] ; then \
 FROM alpine
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.authors="The Syncthing Project" \
+      org.opencontainers.image.url="https://syncthing.net" \
+      org.opencontainers.image.documentation="https://docs.syncthing.net" \
+      org.opencontainers.image.source="https://github.com/syncthing/syncthing" \
+      org.opencontainers.image.vendor="The Syncthing Project"
+      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.title="Syncthing Discovery Server"
+
 EXPOSE 19200 8443
 
 VOLUME ["/var/stdiscosrv"]

--- a/Dockerfile.strelaypoolsrv
+++ b/Dockerfile.strelaypoolsrv
@@ -1,6 +1,14 @@
 FROM alpine
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.authors="The Syncthing Project" \
+      org.opencontainers.image.url="https://syncthing.net" \
+      org.opencontainers.image.documentation="https://docs.syncthing.net" \
+      org.opencontainers.image.source="https://github.com/syncthing/syncthing" \
+      org.opencontainers.image.vendor="The Syncthing Project"
+      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.title="Syncthing Relay Pool Server"
+
 EXPOSE 8080
 
 RUN apk add --no-cache ca-certificates su-exec curl

--- a/Dockerfile.strelaysrv
+++ b/Dockerfile.strelaysrv
@@ -16,6 +16,14 @@ RUN if [ ! -f strelaysrv-linux-$TARGETARCH ] ; then \
 FROM alpine
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.authors="The Syncthing Project" \
+      org.opencontainers.image.url="https://syncthing.net" \
+      org.opencontainers.image.documentation="https://docs.syncthing.net" \
+      org.opencontainers.image.source="https://github.com/syncthing/syncthing" \
+      org.opencontainers.image.vendor="The Syncthing Project"
+      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.title="Syncthing Relay Server"
+
 EXPOSE 22067 22070
 
 VOLUME ["/var/strelaysrv"]

--- a/Dockerfile.stupgrades
+++ b/Dockerfile.stupgrades
@@ -1,6 +1,14 @@
 FROM alpine
 ARG TARGETARCH
 
+LABEL org.opencontainers.image.authors="The Syncthing Project" \
+      org.opencontainers.image.url="https://syncthing.net" \
+      org.opencontainers.image.documentation="https://docs.syncthing.net" \
+      org.opencontainers.image.source="https://github.com/syncthing/syncthing" \
+      org.opencontainers.image.vendor="The Syncthing Project"
+      org.opencontainers.image.licenses="MPL-2.0"
+      org.opencontainers.image.title="Syncthing Upgrades"
+
 EXPOSE 8080
 
 COPY stupgrades-linux-${TARGETARCH} /bin/stupgrades


### PR DESCRIPTION
### Purpose

The OCI image spec specifies well-defined [annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md) that can be added to images.
Theses annotations can then be used by other tools to gather more information of an image.

This PR adds the `org.opencontainers.image.source` to allow tools such as [renovate](https://github.com/renovatebot/renovate) to find the release notes of a give version.

~~I've only done this change for `Dockerfile`. Should I also add the label to the other dockerfiles?~~
I've now added the source annotations to all `Dockerfile`s & action workflows.

### Testing

None, change was done by following the [renovate documentation](https://docs.renovatebot.com/modules/datasource/docker/).

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

