### PR TITLE
build: Use actual Go version as cache key

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -175,6 +175,11 @@ jobs:
           cache: false
           check-latest: true
 
+      - name: Get actual Go version
+        run: |
+          go version
+          echo "GO_VERSION=$(go version | sed 's#^.*go##;s# .*##')" >> $GITHUB_ENV
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -223,6 +228,11 @@ jobs:
           cache: false
           check-latest: true
 
+      - name: Get actual Go version
+        run: |
+          go version
+          echo "GO_VERSION=$(go version | sed 's#^.*go##;s# .*##')" >> $GITHUB_ENV
+
       - uses: actions/cache@v3
         with:
           path: |
@@ -264,6 +274,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true
+
+      - name: Get actual Go version
+        run: |
+          go version
+          echo "GO_VERSION=$(go version | sed 's#^.*go##;s# .*##')" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:
@@ -386,6 +401,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true
+
+      - name: Get actual Go version
+        run: |
+          go version
+          echo "GO_VERSION=$(go version | sed 's#^.*go##;s# .*##')" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:
@@ -561,6 +581,11 @@ jobs:
           cache: false
           check-latest: true
 
+      - name: Get actual Go version
+        run: |
+          go version
+          echo "GO_VERSION=$(go version | sed 's#^.*go##;s# .*##')" >> $GITHUB_ENV
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.0'
@@ -727,6 +752,11 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true
+
+      - name: Get actual Go version
+        run: |
+          go version
+          echo "GO_VERSION=$(go version | sed 's#^.*go##;s# .*##')" >> $GITHUB_ENV
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
We use `env.GO_VERSION` as cache key for the build cache, but this is nowadays typically something like `~1.21.1` which doesn't change when 1.21.2, 1.21.3 etc are released, making the cache fairly useless as everything gets rebuilt. This re-sets the `GO_VERSION` variable after installing Go so that it contains the actual installed version.