### PR TITLE
gui: Use nested namespace for theme name translation keys

### DIFF
--- a/gui/default/assets/lang/lang-bg.json
+++ b/gui/default/assets/lang/lang-bg.json
@@ -538,10 +538,14 @@
     "modified": "променено",
     "permit": "разрешаване",
     "seconds": "секунди",
-    "theme-name-black": "Черна",
-    "theme-name-dark": "Тъмна",
-    "theme-name-default": "По подразбиране",
-    "theme-name-light": "Светла",
+    "theme": {
+        "name": {
+            "black": "Черна",
+            "dark": "Тъмна",
+            "default": "По подразбиране",
+            "light": "Светла"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} споделя папката „{{folder}}“.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} споделя папката „{{folderlabel}}“ ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "Поръчителят {{reintroducer}} може отново да предложи това устройство."

--- a/gui/default/assets/lang/lang-ca.json
+++ b/gui/default/assets/lang/lang-ca.json
@@ -518,10 +518,14 @@
     "modified": "modificat",
     "permit": "permís",
     "seconds": "segons",
-    "theme-name-black": "Negre",
-    "theme-name-dark": "Fosc",
-    "theme-name-default": "Per defecte",
-    "theme-name-light": "Clar",
+    "theme": {
+        "name": {
+            "black": "Negre",
+            "dark": "Fosc",
+            "default": "Per defecte",
+            "light": "Clar"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} vol compartir la carpeta \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} vol compartir la carpeta \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} podria tornar a introduir aquest dispositiu."

--- a/gui/default/assets/lang/lang-ca@valencia.json
+++ b/gui/default/assets/lang/lang-ca@valencia.json
@@ -518,10 +518,14 @@
     "modified": "modificat",
     "permit": "permís",
     "seconds": "segons",
-    "theme-name-black": "Negre",
-    "theme-name-dark": "Fosc",
-    "theme-name-default": "Per defecte",
-    "theme-name-light": "Clar",
+    "theme": {
+        "name": {
+            "black": "Negre",
+            "dark": "Fosc",
+            "default": "Per defecte",
+            "light": "Clar"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} vol compartit la carpeta \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} vol compartir la carpeta \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} podria tornar a introduir aquest dispositiu."

--- a/gui/default/assets/lang/lang-cs.json
+++ b/gui/default/assets/lang/lang-cs.json
@@ -499,10 +499,14 @@
     "full documentation": "úplná dokumentace",
     "items": "položky",
     "seconds": "sekund",
-    "theme-name-black": "Černý",
-    "theme-name-dark": "Tmavý",
-    "theme-name-default": "Výchozí",
-    "theme-name-light": "Světlý",
+    "theme": {
+        "name": {
+            "black": "Černý",
+            "dark": "Tmavý",
+            "default": "Výchozí",
+            "light": "Světlý"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} chce sdílet složku „{{folder}}“.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} chce sdílet složku „{{folderlabel}}“ ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} může toto zařízení znovu uvést."

--- a/gui/default/assets/lang/lang-da.json
+++ b/gui/default/assets/lang/lang-da.json
@@ -538,10 +538,14 @@
     "modified": "ændret",
     "permit": "tillad",
     "seconds": "sekunder",
-    "theme-name-black": "Sort",
-    "theme-name-dark": "Mørk",
-    "theme-name-default": "Standard",
-    "theme-name-light": "Lys",
+    "theme": {
+        "name": {
+            "black": "Sort",
+            "dark": "Mørk",
+            "default": "Standard",
+            "light": "Lys"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} ønsker at dele mappen “{{folder}}”.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} ønsker at dele mappen “{{folderlabel}}” ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} vil muligvis genindføre denne enhed."

--- a/gui/default/assets/lang/lang-de.json
+++ b/gui/default/assets/lang/lang-de.json
@@ -538,10 +538,14 @@
     "modified": "geändert",
     "permit": "erlauben",
     "seconds": "Sekunden",
-    "theme-name-black": "Schwarz",
-    "theme-name-dark": "Dunkel",
-    "theme-name-default": "Standard",
-    "theme-name-light": "Hell",
+    "theme": {
+        "name": {
+            "black": "Schwarz",
+            "dark": "Dunkel",
+            "default": "Standard",
+            "light": "Hell"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} möchte den Ordner „{{folder}}“ teilen.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} möchte den Ordner „{{folderlabel}}“ ({{folder}}) teilen.",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} könnte dieses Gerät wieder einführen."

--- a/gui/default/assets/lang/lang-en-AU.json
+++ b/gui/default/assets/lang/lang-en-AU.json
@@ -518,10 +518,14 @@
     "modified": "modified",
     "permit": "permit",
     "seconds": "seconds",
-    "theme-name-black": "Black",
-    "theme-name-dark": "Dark",
-    "theme-name-default": "Default",
-    "theme-name-light": "Light",
+    "theme": {
+        "name": {
+            "black": "Black",
+            "dark": "Dark",
+            "default": "Default",
+            "light": "Light"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} wants to share folder \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} wants to share folder \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} might reintroduce this device."

--- a/gui/default/assets/lang/lang-en-GB.json
+++ b/gui/default/assets/lang/lang-en-GB.json
@@ -538,10 +538,14 @@
     "modified": "modified",
     "permit": "permit",
     "seconds": "seconds",
-    "theme-name-black": "Black",
-    "theme-name-dark": "Dark",
-    "theme-name-default": "Default",
-    "theme-name-light": "Light",
+    "theme": {
+        "name": {
+            "black": "Black",
+            "dark": "Dark",
+            "default": "Default",
+            "light": "Light"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} wants to share folder \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} wants to share folder \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} might reintroduce this device."

--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -543,10 +543,14 @@
             "dummy": "(This is just a test string for nested translation namespaces. This does not need to be translated.)"
         }
     },
-    "theme-name-black": "Black",
-    "theme-name-dark": "Dark",
-    "theme-name-default": "Default",
-    "theme-name-light": "Light",
+    "theme": {
+        "name": {
+            "black": "Black",
+            "dark": "Dark",
+            "default": "Default",
+            "light": "Light"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} wants to share folder \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} wants to share folder \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} might reintroduce this device."

--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -538,11 +538,6 @@
     "modified": "modified",
     "permit": "permit",
     "seconds": "seconds",
-    "test": {
-        "translation": {
-            "dummy": "(This is just a test string for nested translation namespaces. This does not need to be translated.)"
-        }
-    },
     "theme": {
         "name": {
             "black": "Black",

--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -304,7 +304,6 @@
     "QR code": "QR code",
     "QUIC LAN": "QUIC LAN",
     "QUIC WAN": "QUIC WAN",
-    "QUIC connections are in most cases considered suboptimal": "QUIC connections are in most cases considered suboptimal",
     "Quick guide to supported patterns": "Quick guide to supported patterns",
     "Random": "Random",
     "Receive Encrypted": "Receive Encrypted",

--- a/gui/default/assets/lang/lang-es.json
+++ b/gui/default/assets/lang/lang-es.json
@@ -538,10 +538,14 @@
     "modified": "modificado",
     "permit": "permiso",
     "seconds": "segundos",
-    "theme-name-black": "Negro",
-    "theme-name-dark": "Oscuro",
-    "theme-name-default": "Por Defecto",
-    "theme-name-light": "Claro",
+    "theme": {
+        "name": {
+            "black": "Negro",
+            "dark": "Oscuro",
+            "default": "Por Defecto",
+            "light": "Claro"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} quiere compartir la carpeta \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} quiere compartir la carpeta \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} puede reintroducir este dispositivo."

--- a/gui/default/assets/lang/lang-fi.json
+++ b/gui/default/assets/lang/lang-fi.json
@@ -376,10 +376,14 @@
     "files": "tiedostot",
     "full documentation": "täysi dokumentaatio",
     "items": "kohteet",
-    "theme-name-black": "Musta",
-    "theme-name-dark": "Tumma",
-    "theme-name-default": "Oletus",
-    "theme-name-light": "Vaalea",
+    "theme": {
+        "name": {
+            "black": "Musta",
+            "dark": "Tumma",
+            "default": "Oletus",
+            "light": "Vaalea"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} haluaa jakaa kansion \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} haluaa jakaa kansion \"{{folderlabel}}\" ({{folder}})."
 }

--- a/gui/default/assets/lang/lang-fr.json
+++ b/gui/default/assets/lang/lang-fr.json
@@ -538,10 +538,14 @@
     "modified": "modifié",
     "permit": "partager tous les attributs",
     "seconds": "secondes",
-    "theme-name-black": "Noir",
-    "theme-name-dark": "Sombre",
-    "theme-name-default": "Par défaut (système)",
-    "theme-name-light": "Clair",
+    "theme": {
+        "name": {
+            "black": "Noir",
+            "dark": "Sombre",
+            "default": "Par défaut (système)",
+            "light": "Clair"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} vous invite au partage \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} vous invite au partage \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} pourrait ré-enrôler cet appareil."

--- a/gui/default/assets/lang/lang-hu.json
+++ b/gui/default/assets/lang/lang-hu.json
@@ -507,10 +507,14 @@
     "items": "elem",
     "modified": "módosított",
     "seconds": "másodperc",
-    "theme-name-black": "Fekete",
-    "theme-name-dark": "Sötét",
-    "theme-name-default": "Alapértelmezett",
-    "theme-name-light": "Világos",
+    "theme": {
+        "name": {
+            "black": "Fekete",
+            "dark": "Sötét",
+            "default": "Alapértelmezett",
+            "light": "Világos"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} szeretné megosztani a mappát: „{{folder}}”.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} szeretné megosztani a mappát: „{{folderlabel}}” ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} újra bevezetheti ezt az eszközt."

--- a/gui/default/assets/lang/lang-id.json
+++ b/gui/default/assets/lang/lang-id.json
@@ -452,10 +452,14 @@
     "full documentation": "dokumentasi penuh",
     "items": "berkas",
     "seconds": "detik",
-    "theme-name-black": "Hitam",
-    "theme-name-dark": "Gelap",
-    "theme-name-default": "Bawaan",
-    "theme-name-light": "Terang",
+    "theme": {
+        "name": {
+            "black": "Hitam",
+            "dark": "Gelap",
+            "default": "Bawaan",
+            "light": "Terang"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} ingin berbagi folder \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} ingin berbagi folder \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} mungkin memperkenalkan ulang perangkat ini."

--- a/gui/default/assets/lang/lang-it.json
+++ b/gui/default/assets/lang/lang-it.json
@@ -537,10 +537,14 @@
     "modified": "modificato",
     "permit": "permettere",
     "seconds": "secondi",
-    "theme-name-black": "Nero",
-    "theme-name-dark": "Scuro",
-    "theme-name-default": "Predefinito",
-    "theme-name-light": "Chiaro",
+    "theme": {
+        "name": {
+            "black": "Nero",
+            "dark": "Scuro",
+            "default": "Predefinito",
+            "light": "Chiaro"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} vuole condividere la cartella \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} vuole condividere la cartella \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} potrebbe reintrodurre questo dispositivo."

--- a/gui/default/assets/lang/lang-ja.json
+++ b/gui/default/assets/lang/lang-ja.json
@@ -440,10 +440,14 @@
     "items": "項目",
     "modified": "更新",
     "seconds": "秒",
-    "theme-name-black": "ブラック",
-    "theme-name-dark": "ダーク",
-    "theme-name-default": "デフォルト",
-    "theme-name-light": "ライト",
+    "theme": {
+        "name": {
+            "black": "ブラック",
+            "dark": "ダーク",
+            "default": "デフォルト",
+            "light": "ライト"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} がフォルダー \"{{folder}}\" を共有するよう求めています。",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} がフォルダー「{{folderlabel}}」 ({{folder}}) を共有するよう求めています。"
 }

--- a/gui/default/assets/lang/lang-ko-KR.json
+++ b/gui/default/assets/lang/lang-ko-KR.json
@@ -538,10 +538,14 @@
     "modified": "수정됨",
     "permit": "허용",
     "seconds": "초",
-    "theme-name-black": "검은색",
-    "theme-name-dark": "어두운 색",
-    "theme-name-default": "기본 색",
-    "theme-name-light": "밝은 색",
+    "theme": {
+        "name": {
+            "black": "검은색",
+            "dark": "어두운 색",
+            "default": "기본 색",
+            "light": "밝은 색"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} 기기가 \"{{folder}}\" 폴더를 공유하길 원합니다.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} 기기가 \"{{folderlabel}}\" ({{folder}}) 폴더를 공유하길 원합니다.",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} 기기에서 이 기기를 다시 소개할 수 있습니다."

--- a/gui/default/assets/lang/lang-nl.json
+++ b/gui/default/assets/lang/lang-nl.json
@@ -538,10 +538,14 @@
     "modified": "gewijzigd",
     "permit": "toestaan",
     "seconds": "seconden",
-    "theme-name-black": "Zwart",
-    "theme-name-dark": "Donker",
-    "theme-name-default": "Standaard",
-    "theme-name-light": "Licht",
+    "theme": {
+        "name": {
+            "black": "Zwart",
+            "dark": "Donker",
+            "default": "Standaard",
+            "light": "Licht"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} wil map \"{{folder}}\" delen.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} wil map \"{{folderlabel}}\" ({{folder}}) delen.",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} kan dit apparaat mogelijk opnieuw introduceren."

--- a/gui/default/assets/lang/lang-pl.json
+++ b/gui/default/assets/lang/lang-pl.json
@@ -538,10 +538,14 @@
     "modified": "modyfikacja",
     "permit": "zezwól",
     "seconds": "sekundy",
-    "theme-name-black": "Czarny",
-    "theme-name-dark": "Ciemny",
-    "theme-name-default": "Domyślny",
-    "theme-name-light": "Jasny",
+    "theme": {
+        "name": {
+            "black": "Czarny",
+            "dark": "Ciemny",
+            "default": "Domyślny",
+            "light": "Jasny"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "Urządzenie {{device}} chce współdzielić folder \"{{folder}}\"",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "Urządzenie {{device}} chce współdzielić folder \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "Urządzenie {{reintroducer}} może ponownie wprowadzić to urządzenie."

--- a/gui/default/assets/lang/lang-pt-BR.json
+++ b/gui/default/assets/lang/lang-pt-BR.json
@@ -536,10 +536,14 @@
     "modified": "modificado",
     "permit": "permitir",
     "seconds": "segundos",
-    "theme-name-black": "Preto",
-    "theme-name-dark": "Escuro",
-    "theme-name-default": "Padrão",
-    "theme-name-light": "Claro",
+    "theme": {
+        "name": {
+            "black": "Preto",
+            "dark": "Escuro",
+            "default": "Padrão",
+            "light": "Claro"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} quer compartilhar a pasta \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} quer compartilhar a pasta \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} pode reintroduzir este dispositivo."

--- a/gui/default/assets/lang/lang-pt-PT.json
+++ b/gui/default/assets/lang/lang-pt-PT.json
@@ -538,10 +538,14 @@
     "modified": "modificado",
     "permit": "permitir",
     "seconds": "segundos",
-    "theme-name-black": "Preto",
-    "theme-name-dark": "Escuro",
-    "theme-name-default": "Predefinido",
-    "theme-name-light": "Claro",
+    "theme": {
+        "name": {
+            "black": "Preto",
+            "dark": "Escuro",
+            "default": "Predefinido",
+            "light": "Claro"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} quer partilhar a pasta \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} quer partilhar a pasta \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} poderá reintroduzir este dispositivo."

--- a/gui/default/assets/lang/lang-ru.json
+++ b/gui/default/assets/lang/lang-ru.json
@@ -497,10 +497,14 @@
     "items": "элементы",
     "modified": "изменено",
     "seconds": "сек.",
-    "theme-name-black": "Чёрная",
-    "theme-name-dark": "Тёмная",
-    "theme-name-default": "По умолчанию",
-    "theme-name-light": "Светлая",
+    "theme": {
+        "name": {
+            "black": "Чёрная",
+            "dark": "Тёмная",
+            "default": "По умолчанию",
+            "light": "Светлая"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} хочет поделиться папкой «{{folder}}».",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} хочет поделиться папкой «{{folderlabel}}» ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} может повторно рекомендовать это устройство."

--- a/gui/default/assets/lang/lang-si.json
+++ b/gui/default/assets/lang/lang-si.json
@@ -502,10 +502,14 @@
     "modified": "සංශෝධිතයි",
     "permit": "අවසරය",
     "seconds": "තත්පර",
-    "theme-name-black": "කළු",
-    "theme-name-dark": "අඳුරු",
-    "theme-name-default": "පෙරනිමි",
-    "theme-name-light": "දීප්ත",
+    "theme": {
+        "name": {
+            "black": "කළු",
+            "dark": "අඳුරු",
+            "default": "පෙරනිමි",
+            "light": "දීප්ත"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} ට \"{{folder}}\" ෆෝල්ඩරය බෙදා ගැනීමට අවශ්‍යයි.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} ට \"{{folderlabel}}\" ({{folder}}) ෆෝල්ඩරය බෙදා ගැනීමට අවශ්‍යයි.",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} මෙම උපාංගය නැවත හඳුන්වා දිය හැක."

--- a/gui/default/assets/lang/lang-sk.json
+++ b/gui/default/assets/lang/lang-sk.json
@@ -538,10 +538,14 @@
     "modified": "zmenené",
     "permit": "povolenie",
     "seconds": "sekúnd",
-    "theme-name-black": "Čierna",
-    "theme-name-dark": "Tmavé",
-    "theme-name-default": "Predvolené",
-    "theme-name-light": "Svetlá",
+    "theme": {
+        "name": {
+            "black": "Čierna",
+            "dark": "Tmavé",
+            "default": "Predvolené",
+            "light": "Svetlá"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} chce zdieľať adresár \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} chce zdieľať adresár \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} môže znova uviesť toto zariadenie."

--- a/gui/default/assets/lang/lang-sl.json
+++ b/gui/default/assets/lang/lang-sl.json
@@ -456,10 +456,14 @@
     "items": "predmeti",
     "modified": "spremenjeno",
     "seconds": "sekunde",
-    "theme-name-black": "Črna",
-    "theme-name-dark": "Temno",
-    "theme-name-default": "Privzeto",
-    "theme-name-light": "Svetlo",
+    "theme": {
+        "name": {
+            "black": "Črna",
+            "dark": "Temno",
+            "default": "Privzeto",
+            "light": "Svetlo"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} želi deliti mapo \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} želi deliti mapo \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} bo morda znova predstavil to napravo."

--- a/gui/default/assets/lang/lang-sv.json
+++ b/gui/default/assets/lang/lang-sv.json
@@ -538,10 +538,14 @@
     "modified": "ändrad",
     "permit": "tillåt",
     "seconds": "sekunder",
-    "theme-name-black": "Svart",
-    "theme-name-dark": "Mörkt",
-    "theme-name-default": "Standard",
-    "theme-name-light": "Ljust",
+    "theme": {
+        "name": {
+            "black": "Svart",
+            "dark": "Mörkt",
+            "default": "Standard",
+            "light": "Ljust"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} vill dela mapp \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} vill dela mapp \"{{folderlabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} kan återinföra denna enhet."

--- a/gui/default/assets/lang/lang-tr.json
+++ b/gui/default/assets/lang/lang-tr.json
@@ -538,10 +538,14 @@
     "modified": "değiştirildi",
     "permit": "izin ver",
     "seconds": "saniye",
-    "theme-name-black": "Siyah",
-    "theme-name-dark": "Koyu",
-    "theme-name-default": "Varsayılan",
-    "theme-name-light": "Açık",
+    "theme": {
+        "name": {
+            "black": "Siyah",
+            "dark": "Koyu",
+            "default": "Varsayılan",
+            "light": "Açık"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}}, \"{{folder}}\" klasörünü paylaşmak istiyor.",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}}, \"{{folderlabel}}\" ({{folder}}) klasörünü paylaşmak istiyor.",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} bu cihazı yeniden tanıtabilir."

--- a/gui/default/assets/lang/lang-uk.json
+++ b/gui/default/assets/lang/lang-uk.json
@@ -507,10 +507,14 @@
     "items": "елементи",
     "modified": "змінено",
     "seconds": "секунд",
-    "theme-name-black": "Чорна",
-    "theme-name-dark": "Темна",
-    "theme-name-default": "Стандартна",
-    "theme-name-light": "Світла",
+    "theme": {
+        "name": {
+            "black": "Чорна",
+            "dark": "Темна",
+            "default": "Стандартна",
+            "light": "Світла"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} хоче поділитися папкою \"{{folder}}\".",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} хоче поділитися папкою \"{{folderLabel}}\" ({{folder}}).",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} може повторно порекомендувати цей пристрій."

--- a/gui/default/assets/lang/lang-zh-CN.json
+++ b/gui/default/assets/lang/lang-zh-CN.json
@@ -538,10 +538,14 @@
     "modified": "已修改",
     "permit": "允许",
     "seconds": "秒",
-    "theme-name-black": "黑色",
-    "theme-name-dark": "深色",
-    "theme-name-default": "默认",
-    "theme-name-light": "浅色",
+    "theme": {
+        "name": {
+            "black": "黑色",
+            "dark": "深色",
+            "default": "默认",
+            "light": "浅色"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} 想将 “{{folder}}” 文件夹共享给您。",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} 想要共享 \"{{folderlabel}}\" ({{folder}}) 文件夹给您。",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}}可能会重新引入此设备。"

--- a/gui/default/assets/lang/lang-zh-HK.json
+++ b/gui/default/assets/lang/lang-zh-HK.json
@@ -498,10 +498,6 @@
     "full documentation": "完整文檔",
     "items": "條目",
     "seconds": "秒",
-    "theme-name-black": "theme-name-black",
-    "theme-name-dark": "theme-name-dark",
-    "theme-name-default": "theme-name-default",
-    "theme-name-light": "theme-name-light",
     "{%device%} wants to share folder \"{%folder%}\".": "{%device%} 想將 「{%folder%}」 文件夾共享給您。",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{%device%} 想要共享 \"{%folderlabel%}\" ({%folder%}) 文件夾給您。",
     "{%reintroducer%} might reintroduce this device.": "{%reintroducer%} 可能會重新引入此設備。"

--- a/gui/default/assets/lang/lang-zh-TW.json
+++ b/gui/default/assets/lang/lang-zh-TW.json
@@ -456,10 +456,14 @@
     "full documentation": "完整說明文件",
     "items": "個項目",
     "seconds": "秒",
-    "theme-name-black": "黑色",
-    "theme-name-dark": "深色",
-    "theme-name-default": "預設",
-    "theme-name-light": "淺色",
+    "theme": {
+        "name": {
+            "black": "黑色",
+            "dark": "深色",
+            "default": "預設",
+            "light": "淺色"
+        }
+    },
     "{%device%} wants to share folder \"{%folder%}\".": "{{device}} 想要共享資料夾 \"{{folder}}\"。",
     "{%device%} wants to share folder \"{%folderlabel%}\" ({%folder%}).": "{{device}} 想要共享資料夾 \"{{folderlabel}}\" ({{folder}})。",
     "{%reintroducer%} might reintroduce this device.": "{{reintroducer}} 可能會重新引入此裝置。"

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -1091,6 +1091,5 @@
   <script type="text/javascript" src="syncthing/app.js"></script>
   <!-- / gui application code -->
 
-  <div translate="test.translation.dummy" style="display: none;">(This is just a test string for nested translation namespaces. This does not need to be translated.)</div>
 </body>
 </html>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3215,8 +3215,8 @@ angular.module('syncthing.core')
         };
 
         $scope.themeName = function (theme) {
-            var translation = $translate.instant("theme-name-" + theme);
-            if (translation.indexOf("theme-name-") == 0) {
+            var translation = $translate.instant("theme.name." + theme);
+            if (translation.indexOf("theme.name.") == 0) {
                 // Fall back to simple Title Casing on missing translation
                 translation = theme.toLowerCase().replace(/(?:^|\s)\S/g, function (a) {
                     return a.toUpperCase();

--- a/script/translate.go
+++ b/script/translate.go
@@ -104,6 +104,21 @@ func inTranslate(n *html.Node, translationId string, filename string) {
 	}
 }
 
+func isTranslated(id string) bool {
+	namespace := trans
+	idParts := strings.Split(id, ".")
+	id = idParts[len(idParts)-1]
+	for _, subNamespace := range idParts[0 : len(idParts)-1] {
+		if _, ok := namespace[subNamespace]; !ok {
+			return false
+		}
+		namespace = namespace[subNamespace].(map[string]interface{})
+	}
+
+	_, ok := namespace[id]
+	return ok
+}
+
 func translation(id string, v string) {
 	namespace := trans
 	idParts := strings.Split(id, ".")
@@ -169,10 +184,10 @@ func collectThemes(basePath string) {
 	}
 	for _, f := range files {
 		if f.IsDir() {
-			key := "theme-name-" + f.Name()
-			if _, ok := trans[key]; !ok {
+			key := "theme.name." + f.Name()
+			if !isTranslated(key) {
 				name := strings.Title(f.Name())
-				trans[key] = name
+				translation(key, name)
 			}
 		}
 	}


### PR DESCRIPTION
Following up on #9192, this makes use of the new mechanism for the theme names.

The dummy string added for testing is removed again here.  All translations are updated to the new nested syntax, except Chinese (zh-HK) where the string weren't actually translated.