### PR TITLE
Link to data.syncthing.net source code

### DIFF
--- a/cmd/ursrv/serve/static/index.html
+++ b/cmd/ursrv/serve/static/index.html
@@ -611,6 +611,7 @@ found in the LICENSE file.
   </div>
   <hr>
   <p>
+    <a href="https://github.com/syncthing/syncthing/tree/main/cmd/ursrv">Source code</a>.
     This product includes GeoLite2 data created by MaxMind, available from
     <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
   </p>


### PR DESCRIPTION
### Purpose

To see that https://data.syncthing.net is open source, study the code and change it.

### Testing

The bottom line of the https://data.syncthing.net/ should include the link to https://github.com/syncthing/syncthing/tree/main/cmd/ursrv