### PR TITLE
lib/model: Acquire fmut lock in ensureIndexHandler (fixes #9234)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1346,6 +1346,9 @@ func (m *model) ensureIndexHandler(conn protocol.Connection) *indexHandlerRegist
 	deviceID := conn.DeviceID()
 	connID := conn.ConnectionID()
 
+	// We must acquire fmut first when acquiring both locks.
+	m.fmut.RLock()
+	defer m.fmut.RUnlock()
 	m.pmut.Lock()
 	defer m.pmut.Unlock()
 


### PR DESCRIPTION
Towards the end of the function f.folderCfgs and f.folderRunners are read without the lock.