### PR TITLE
lib/api: Improve ignore loading error handling (fixes #9253)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -47,7 +47,6 @@ import (
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
-	"github.com/syncthing/syncthing/lib/ignore"
 	"github.com/syncthing/syncthing/lib/locations"
 	"github.com/syncthing/syncthing/lib/logger"
 	"github.com/syncthing/syncthing/lib/model"
@@ -1349,11 +1348,6 @@ func (s *service) getDBIgnores(w http.ResponseWriter, r *http.Request) {
 	folder := qs.Get("folder")
 
 	lines, patterns, err := s.model.LoadIgnores(folder)
-	if err != nil && !ignore.IsParseError(err) {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
 	sendJSON(w, map[string]interface{}{
 		"ignore":   lines,
 		"expanded": patterns,


### PR DESCRIPTION
Any errors that were not a ParseError were returned as an API failure rather than an error with the ignore file. This was quite limiting and short sighted, since there may be permission errors, path format errors, and possibly other things that are in fact legitimate problems with loading the ignore file and not a bug or connection problem.

Returning a 500 error to the GUI causes the GUI to display a connection error, which is never desirable here.
