### PR TITLE
lib/model: Improve LastSeen handling

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -817,6 +817,11 @@ func (m *model) DeviceStatistics() (map[protocol.DeviceID]stats.DeviceStatistics
 		if err != nil {
 			return nil, err
 		}
+		if len(m.deviceConnIDs[id]) > 0 {
+			// If a device is currently connected, we can see them right
+			// now.
+			stats.LastSeen = time.Now().Truncate(time.Second)
+		}
 		res[id] = stats
 	}
 	return res, nil
@@ -2483,6 +2488,7 @@ func (m *model) deviceWasSeen(deviceID protocol.DeviceID) {
 func (m *model) deviceDidCloseFRLocked(deviceID protocol.DeviceID, duration time.Duration) {
 	if sr, ok := m.deviceStatRefs[deviceID]; ok {
 		_ = sr.LastConnectionDuration(duration)
+		_ = sr.WasSeen()
 	}
 }
 


### PR DESCRIPTION
LastSeen for a device was only updated when they connected. This now updates it when they disconnect, so that we remember the last time we actually saw them. When asking the API for current stats, currently connected devices get a last seen value of the current time.
