### PR TITLE
build: Revert specifics for Go 1.21.4, build using Go 1.21.5

### DIFF
--- a/.github/workflows/build-infra-dockers.yaml
+++ b/.github/workflows/build-infra-dockers.yaml
@@ -6,7 +6,7 @@ on:
       - infrastructure
 
 env:
-  GO_VERSION: "~1.21.1"
+  GO_VERSION: "~1.21.5"
   CGO_ENABLED: "0"
   BUILD_USER: docker
   BUILD_HOST: github.syncthing.net
@@ -27,6 +27,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -48,7 +48,7 @@ jobs:
         runner: ["windows-latest", "ubuntu-latest", "macos-latest"]
         # The oldest version in this list should match what we have in our go.mod.
         # Variables don't seem to be supported here, or we could have done something nice.
-        go: ["1.20.12", "1.21.5"]
+        go: ["~1.20.12", "~1.21.5"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Set git to use LF

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -48,7 +48,7 @@ jobs:
         runner: ["windows-latest", "ubuntu-latest", "macos-latest"]
         # The oldest version in this list should match what we have in our go.mod.
         # Variables don't seem to be supported here, or we could have done something nice.
-        go: ["1.20", "1.21.5"]
+        go: ["1.20.12", "1.21.5"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Set git to use LF

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -12,7 +12,7 @@ env:
   # The go version to use for builds. We set check-latest to true when
   # installing, so we get the latest patch version that matches the
   # expression.
-  GO_VERSION: "~1.21.1"
+  GO_VERSION: "~1.21.5"
 
   # Optimize compatibility on the slow archictures.
   GO386: softfloat
@@ -48,20 +48,7 @@ jobs:
         runner: ["windows-latest", "ubuntu-latest", "macos-latest"]
         # The oldest version in this list should match what we have in our go.mod.
         # Variables don't seem to be supported here, or we could have done something nice.
-        go: ["1.20", "1.21"]
-
-        # Don't run the Windows tests with Go 1.21.4 or 1.20.11; this can be
-        # removed when 1.21.5 and 1.20.12 is released.
-        exclude:
-          - runner: windows-latest
-            go: "1.20"
-          - runner: windows-latest
-            go: "1.21"
-        include:
-          - runner: windows-latest
-            go: "~1.20.12 || ~1.20.0 <1.20.11"
-          - runner: windows-latest
-            go: "~1.21.5 || ~1.21.1 <1.21.4"
+        go: ["1.20", "1.21.5"]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Set git to use LF
@@ -169,9 +156,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          # Temporary version constraint to avoid 1.21.4 which has a bug in
-          # path handling. This can be removed when 1.21.5 is released.
-          go-version: "~1.21.5 || ~1.21.1 <1.21.4"
+          go-version: ${{ env.GO_VERSION }}
           cache: false
           check-latest: true
 


### PR DESCRIPTION
This reverts commit e477777f49ab2dd7cf3f29b88b4254ddb7e79f9b.

In principle, we could have stayed with `~1.21.1`, but `check-latest: true` apparently checks some cache/manifest/something that is only periodically refreshed and isn't aware of 1.21.5 yet. So update the constraints to force an upgrade.

Also the infrastructure images weren't actually using the constraint since there was no `setup-go` action...
