### PR TITLE
lib/model: Correct locking when removing folder runner (fixes #9269)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -464,9 +464,9 @@ func (m *model) warnAboutOverwritingProtectedFiles(cfg config.FolderConfiguratio
 }
 
 func (m *model) removeFolder(cfg config.FolderConfiguration) {
-	m.fmut.RLock()
+	m.fmut.Lock()
 	wait := m.folderRunners.RemoveAndWaitChan(cfg.ID, 0)
-	m.fmut.RUnlock()
+	m.fmut.Unlock()
 	<-wait
 
 	// We need to hold both fmut and pmut and must acquire locks in the same
@@ -535,9 +535,9 @@ func (m *model) restartFolder(from, to config.FolderConfiguration, cacheIgnoredF
 	restartMut.Lock()
 	defer restartMut.Unlock()
 
-	m.fmut.RLock()
+	m.fmut.Lock()
 	wait := m.folderRunners.RemoveAndWaitChan(from.ID, 0)
-	m.fmut.RUnlock()
+	m.fmut.Unlock()
 	<-wait
 
 	m.fmut.Lock()


### PR DESCRIPTION
A read lock is insufficient because the remove of the map entry happens in the RemoveAndWait call, where previously it didn't. Previously, we had a split of sorts where the runner was still present in the map while being stopped and then removed later, or replaced without a visible "nil" state in the case of a restart.

This makes it so that we reinstate that behaviour by splitting the "stop and wait" and the "delete from map" operations like it was previously. I think that solves the problem, hopefully?

Ideally, we'd be able to call RemoveAndWait under fmut, but we can't do that since the runners may be calling into functions that need an fmut of their own (I think... at least that was the previous reasoning for not waiting under the lock).