### PR TITLE
lib/model: Remove runner during folder cleanup (fixes #9269)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -465,7 +465,7 @@ func (m *model) warnAboutOverwritingProtectedFiles(cfg config.FolderConfiguratio
 
 func (m *model) removeFolder(cfg config.FolderConfiguration) {
 	m.fmut.RLock()
-	wait := m.folderRunners.RemoveAndWaitChan(cfg.ID, 0)
+	wait := m.folderRunners.StopAndWaitChan(cfg.ID, 0)
 	m.fmut.RUnlock()
 	<-wait
 
@@ -507,6 +507,7 @@ func (m *model) removeFolder(cfg config.FolderConfiguration) {
 // Need to hold lock on m.fmut when calling this.
 func (m *model) cleanupFolderLocked(cfg config.FolderConfiguration) {
 	// clear up our config maps
+	m.folderRunners.Remove(cfg.ID)
 	delete(m.folderCfgs, cfg.ID)
 	delete(m.folderFiles, cfg.ID)
 	delete(m.folderIgnores, cfg.ID)
@@ -536,7 +537,7 @@ func (m *model) restartFolder(from, to config.FolderConfiguration, cacheIgnoredF
 	defer restartMut.Unlock()
 
 	m.fmut.RLock()
-	wait := m.folderRunners.RemoveAndWaitChan(from.ID, 0)
+	wait := m.folderRunners.StopAndWaitChan(from.ID, 0)
 	m.fmut.RUnlock()
 	<-wait
 


### PR DESCRIPTION
Before introducing the service map and using it for folder runners, the entries in folderCfgs and folderRunners for the same key/folder were removed under a single lock. Stopping the folder happens separately before that with just the read lock. Now with the service map stopping the folder and removing it from the map is a single operation. And that still happens with just a read-lock. However even with a full lock it’s still problematic: After the folder stopped, the runner isn’t present anymore while the folder-config still is and sais the folder isn't paused.

The index handler in turn looks at the folder config that is not paused, thus assumes the runner has to be present -> nil deref on the runner.

A better solution might be to push most of these fmut maps into the folder - they anyway are needed in there. Then there's just a single map/source of info that's necessarily consistent. That's quite a bit of work though, and probably/likely there will be corner cases there too.