### PR TITLE
lib/model: Only handle relevant folder summaries (kqueue) (fixes #9183)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -1065,7 +1065,7 @@ func (f *folder) monitorWatch(ctx context.Context) {
 		case ev := <-summaryChan:
 			if data, ok := ev.Data.(FolderSummaryEventData); !ok {
 				f.evLogger.Log(events.Failure, "Unexpected type of folder-summary event in folder.monitorWatch")
-			} else if data.Summary.LocalTotalItems-data.Summary.LocalDeleted > kqueueItemCountThreshold {
+			} else if data.Folder == f.folderID && data.Summary.LocalTotalItems-data.Summary.LocalDeleted > kqueueItemCountThreshold {
 				f.warnedKqueue = true
 				summarySub.Unsubscribe()
 				summaryChan = nil


### PR DESCRIPTION
On kqueue-systems, folders listen for folder summaries to (be able to) warn for potential high resource usage. However, it listened for any folder summary and not for the summary which matches the folder it's about. This could cause that an unwatched folder causes a folder summary containing more files than the threshold (10k), and the listening folder (with the watcher enabled) triggers the warning.

This makes sure that only the folder summaries which are relevant to the specific folder are being handled.

### Testing

- Fire up some kqueue-system (freebsd, I used).
- add folder A, disable the watcher, add 10001 files
- add folder B with the watcher enabled, no files are needed here

Before the change:
- add an item to folder A, trigger a rescan to speed up the process
- wait some seconds...warning triggered by folder B's summarySubscription

After the change:
- Only a warning is triggered if the received folder summary matches the folder which listens for the summaries


