### PR TITLE
etc/linux-desktop: use double dash for long options

### DIFF
--- a/etc/linux-desktop/syncthing-ui.desktop
+++ b/etc/linux-desktop/syncthing-ui.desktop
@@ -2,7 +2,7 @@
 Name=Syncthing Web UI
 GenericName=File synchronization UI
 Comment=Opens Syncthing's Web UI in the default browser (Syncthing must already be started).
-Exec=/usr/bin/syncthing -browser-only
+Exec=/usr/bin/syncthing --browser-only
 Icon=syncthing
 Terminal=false
 Type=Application


### PR DESCRIPTION
Use a style for options that is consistent with the documentation and other uses.
