### PR TITLE
gui, lib/scanner: Improve scan progress indication (ref #8331)

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1039,17 +1039,28 @@ angular.module('syncthing.core')
                 // Do the same thing in case we only have zero byte files to sync.
                 return 95;
             }
-            var pct = 100 * $scope.model[folder].inSyncBytes / $scope.model[folder].globalBytes;
-            return Math.floor(pct);
+            return progressIntegerPercentage($scope.model[folder].inSyncBytes, $scope.model[folder].globalBytes);
         };
 
         $scope.scanPercentage = function (folder) {
             if (!$scope.scanProgress[folder]) {
                 return undefined;
             }
-            var pct = 100 * $scope.scanProgress[folder].current / $scope.scanProgress[folder].total;
-            return Math.floor(pct);
+            return progressIntegerPercentage($scope.scanProgress[folder].current, $scope.scanProgress[folder].total);
         };
+
+        function progressIntegerPercentage(current, total) {
+            // Even after whatever is being tracked (e.g. hashed or synced
+            // bytes) is completed, there's likely some more work to be done to
+            // fully finish the process (db updates, ...). Users apparently
+            // don't like seeing 100%, so give them 99% to indicate "about to be
+            // finished".
+            if (current === total) {
+                return 99;
+            }
+            var pct = 100 * current / total;
+            return Math.floor(pct);
+        }
 
         $scope.scanRate = function (folder) {
             if (!$scope.scanProgress[folder]) {


### PR DESCRIPTION
This adresses a few things that came up in issue #8331. It might fix the issue, or it might not - it's not that clear-cut what exactly is happening there.

This avoids sending progress updates when there is nothing to hash. And ensures we send a final progress update when things are done. And in that latter case, avoid showing 100% in the UI while the scan is wrapping up.