### PR TITLE
lib/build: Allow semver build in version regex (fixes #9267)

### DIFF
--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -36,7 +36,7 @@ var (
 	LongVersion string
 	Extra       string
 
-	allowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+)?(-[^\s]+)?$`)
+	allowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+|\+[0-9a-z]+)?(-[^\s]+)?$`)
 
 	envTags = []string{
 		"STGUIASSETS",

--- a/lib/build/build_test.go
+++ b/lib/build/build_test.go
@@ -27,6 +27,11 @@ func TestAllowedVersions(t *testing.T) {
 		{"v0.13.0-some-weird-but-allowed-tag", true},
 		{"v0.13.0-allowed.to.do.this", true},
 		{"v0.13.0+not.allowed.to.do.this", false},
+		{"v1.27.0+xyz", true},
+		{"v1.27.0-abc.1+xyz", true},
+		{"v1.0.0+45", true},
+		{"v1.0.0-noupgrade", true},
+		{"v1.0.0+noupgrade", true},
 	}
 
 	for i, c := range testcases {


### PR DESCRIPTION
### Purpose

Closes #9267.
