### PR TITLE
lib/model, gui: properly handle reverting receive-encrypted folders (fixes #8196)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -612,10 +612,10 @@
                   <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('override', folder.id)" ng-if="folderStatus(folder) == 'outofsync' && folder.type == 'sendonly'">
                     <span class="fas fa-arrow-circle-up"></span>&nbsp;<span translate>Override Changes</span>
                   </button>
-                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('revert', folder.id)" ng-if="hasReceiveOnlyChanged(folder)">
+                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('revert', folder.id)" ng-if="folder.type == 'receiveonly' && hasReceiveOnlyChanged(folder)">
                     <span class="fa fa-arrow-circle-down"></span>&nbsp;<span translate>Revert Local Changes</span>
                   </button>
-                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('deleteEnc', folder.id)" ng-if="hasReceiveEncryptedItems(folder)">
+                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('deleteEnc',folder.id)" ng-if="folder.type == 'receiveencrypted' && hasReceiveOnlyChanged(folder)">
                     <span class="fa fa-minus-circle"></span>&nbsp;<span translate>Delete Unexpected Items</span>
                   </button>
                   <span class="pull-right">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -615,7 +615,7 @@
                   <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('revert', folder.id)" ng-if="folder.type == 'receiveonly' && hasReceiveOnlyChanged(folder)">
                     <span class="fa fa-arrow-circle-down"></span>&nbsp;<span translate>Revert Local Changes</span>
                   </button>
-                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('deleteEnc',folder.id)" ng-if="folder.type == 'receiveencrypted' && hasReceiveOnlyChanged(folder)">
+                  <button type="button" class="btn btn-sm btn-danger pull-left" ng-click="revertOverrideConfirmationModal('deleteEnc', folder.id)" ng-if="folder.type == 'receiveencrypted' && hasReceiveOnlyChanged(folder)">
                     <span class="fa fa-minus-circle"></span>&nbsp;<span translate>Delete Unexpected Items</span>
                   </button>
                   <span class="pull-right">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3081,7 +3081,13 @@ angular.module('syncthing.core')
                 return false;
             }
             var counts = $scope.model[folderCfg.id];
-            return counts && counts.receiveOnlyTotalItems > 0;
+            if (!counts) return false;
+            if (folderCfg.type == 'receiveencrypted') {
+                // Deleting unexpected items won't trigger an index update.
+                // Subtract the deleted items from the total changed items.
+                return counts.receiveOnlyTotalItems - counts.receiveOnlyChangedDeletes > 0;
+            }
+            return counts.receiveOnlyTotalItems > 0;
         };
 
         $scope.revertOverride = function () {

--- a/lib/model/folder_recvenc.go
+++ b/lib/model/folder_recvenc.go
@@ -102,6 +102,7 @@ func (f *receiveEncryptedFolder) revert() error {
 			ModifiedBy: f.shortID,
 			Deleted:    true,
 			Version:    protocol.Vector{},
+			LocalFlags: protocol.FlagLocalReceiveOnly,
 		})
 	}
 


### PR DESCRIPTION
### Purpose

Take deleted items into account when checking for changed receive-only items in receive-encrypted folders, as these don't trigger an index update. Cleaning up unexpected folders didn't trigger a local-state change at all, so this was adjusted as well.

In addition, specific headers and messages/labels existed in the GUI for the event of unexpected items in receive-encrypted folders specifically, but these were never triggered. A minor tweak was added to handle this (again, I guess).

### Testing

- Create some receive-encrypted folder.
- Optionally (for completeness) sync some items
- On the receiving end, add some files or folders
- Press the fancy red button in the gui
- That button (and the 'Unexpected items' state) no longer gets stuck while the reverting was properly performed.