### PR TITLE
build.go: validate -version argument against regex from lib/build

### DIFF
--- a/build.go
+++ b/build.go
@@ -272,7 +272,7 @@ func main() {
 
 	initTargets()
 
-	if !buildpkg.AllowedVersionExp.MatchString(version) {
+	if version != "unknown-dev" && !buildpkg.AllowedVersionExp.MatchString(version) {
 		// app with unallowed versions shouldn't be built because it won't run
 		log.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", version, buildpkg.AllowedVersionExp)
 	}

--- a/build.go
+++ b/build.go
@@ -272,6 +272,17 @@ func main() {
 
 	initTargets()
 
+	// we assume that getVersion should return valid version,
+	// so only validate version override
+	if version != "" {
+		if !buildpkg.AllowedVersionExp.MatchString(version) {
+			// app with unallowed versions shouldn't be built because it won't run
+			log.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", version, buildpkg.AllowedVersionExp)
+		}
+	} else {
+		version = getVersion()
+	}
+
 	// Invoking build.go with no parameters at all builds everything (incrementally),
 	// which is what you want for maximum error checking during development.
 	if flag.NArg() == 0 {
@@ -386,7 +397,7 @@ func parseFlags() {
 	flag.StringVar(&goos, "goos", runtime.GOOS, "GOOS")
 	flag.StringVar(&goCmd, "gocmd", "go", "Specify `go` command")
 	flag.BoolVar(&noupgrade, "no-upgrade", noupgrade, "Disable upgrade functionality")
-	flag.StringVar(&version, "version", getVersion(), "Set compiled in version string")
+	flag.StringVar(&version, "version", "", "Set compiled in version string")
 	flag.BoolVar(&race, "race", race, "Use race detector")
 	flag.StringVar(&extraTags, "tags", extraTags, "Extra tags, space separated")
 	flag.StringVar(&installSuffix, "installsuffix", installSuffix, "Install suffix, optional")

--- a/build.go
+++ b/build.go
@@ -272,15 +272,9 @@ func main() {
 
 	initTargets()
 
-	// we assume that getVersion should return valid version,
-	// so only validate version override
-	if version != "" {
-		if !buildpkg.AllowedVersionExp.MatchString(version) {
-			// app with unallowed versions shouldn't be built because it won't run
-			log.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", version, buildpkg.AllowedVersionExp)
-		}
-	} else {
-		version = getVersion()
+	if !buildpkg.AllowedVersionExp.MatchString(version) {
+		// app with unallowed versions shouldn't be built because it won't run
+		log.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", version, buildpkg.AllowedVersionExp)
 	}
 
 	// Invoking build.go with no parameters at all builds everything (incrementally),
@@ -397,7 +391,7 @@ func parseFlags() {
 	flag.StringVar(&goos, "goos", runtime.GOOS, "GOOS")
 	flag.StringVar(&goCmd, "gocmd", "go", "Specify `go` command")
 	flag.BoolVar(&noupgrade, "no-upgrade", noupgrade, "Disable upgrade functionality")
-	flag.StringVar(&version, "version", "", "Set compiled in version string")
+	flag.StringVar(&version, "version", getVersion(), "Set compiled in version string")
 	flag.BoolVar(&race, "race", race, "Use race detector")
 	flag.StringVar(&extraTags, "tags", extraTags, "Extra tags, space separated")
 	flag.StringVar(&installSuffix, "installsuffix", installSuffix, "Install suffix, optional")

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -36,7 +36,7 @@ var (
 	LongVersion string
 	Extra       string
 
-	allowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+|\+[0-9a-z]+)?(-[^\s]+)?$`)
+	AllowedVersionExp = regexp.MustCompile(`^v\d+\.\d+\.\d+(-[a-z0-9]+)*(\.\d+)*(\+\d+-g[0-9a-f]+|\+[0-9a-z]+)?(-[^\s]+)?$`)
 
 	envTags = []string{
 		"STGUIASSETS",
@@ -51,8 +51,8 @@ const versionExtraAllowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST
 func init() {
 	if Version != "unknown-dev" {
 		// If not a generic dev build, version string should come from git describe
-		if !allowedVersionExp.MatchString(Version) {
-			log.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", Version, allowedVersionExp)
+		if !AllowedVersionExp.MatchString(Version) {
+			log.Fatalf("Invalid version string %q;\n\tdoes not match regexp %v", Version, AllowedVersionExp)
 		}
 	}
 	setBuildData()

--- a/lib/build/build_test.go
+++ b/lib/build/build_test.go
@@ -35,7 +35,7 @@ func TestAllowedVersions(t *testing.T) {
 	}
 
 	for i, c := range testcases {
-		if allowed := allowedVersionExp.MatchString(c.ver); allowed != c.allowed {
+		if allowed := AllowedVersionExp.MatchString(c.ver); allowed != c.allowed {
 			t.Errorf("%d: incorrect result %v != %v for %q", i, allowed, c.allowed, c.ver)
 		}
 	}


### PR DESCRIPTION
In #9267 it was mentioned that binaries built with incompatible versions can't be run.  
To avoid situations like this completely, same regex is used to validate manually provided versions.

