### PR TITLE
lib/scanner: Prevent sync-conflict for receive-only local modifications 

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -534,9 +534,9 @@ func TestRecvOnlyLocalChangeDoesNotCauseConflict(t *testing.T) {
 		t.Fatalf("Receive only: expected 1 file: %+v", size)
 	}
 
-	  // Perform another modification. This should not cause the file to be needed.
-	  // This is a regression test: Previously on scan the file version was changed to conflict with the global
-	  // version, thus being needed and creating a conflict copy on next pull.
+	// Perform another modification. This should not cause the file to be needed.
+	// This is a regression test: Previously on scan the file version was changed to conflict with the global
+	// version, thus being needed and creating a conflict copy on next pull.
 
 	writeFilePerm(t, ffs, "knownDir/knownFile", []byte("change2\n"), 0o644)
 

--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -534,7 +534,9 @@ func TestRecvOnlyLocalChangeDoesNotCauseConflict(t *testing.T) {
 		t.Fatalf("Receive only: expected 1 file: %+v", size)
 	}
 
-	// Perform another modification. This should not trigger the creation of a conflict file.
+	  // Perform another modification. This should not cause the file to be needed.
+	  // This is a regression test: Previously on scan the file version was changed to conflict with the global
+	  // version, thus being needed and creating a conflict copy on next pull.
 
 	writeFilePerm(t, ffs, "knownDir/knownFile", []byte("change2\n"), 0o644)
 

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -416,12 +416,14 @@ func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileIn
 			l.Debugln(w, "unchanged:", curFile)
 			return nil
 		}
-		if curFile.ShouldConflict() {
+		if curFile.ShouldConflict() && !f.ShouldConflict() {
 			// The old file was invalid for whatever reason and probably not
 			// up to date with what was out there in the cluster. Drop all
 			// others from the version vector to indicate that we haven't
 			// taken their version into account, and possibly cause a
-			// conflict.
+			// conflict. However, only do this if the new file is not also
+			// invalid. This would indicate that the new file is not part
+			// of the cluster, but e.g. a local change.
 			f.Version = f.Version.DropOthers(w.ShortID)
 		}
 		l.Debugln(w, "rescan:", curFile)
@@ -461,12 +463,14 @@ func (w *walker) walkDir(ctx context.Context, relPath string, info fs.FileInfo, 
 			l.Debugln(w, "unchanged:", curFile)
 			return nil
 		}
-		if curFile.ShouldConflict() {
+		if curFile.ShouldConflict() && !f.ShouldConflict() {
 			// The old file was invalid for whatever reason and probably not
 			// up to date with what was out there in the cluster. Drop all
 			// others from the version vector to indicate that we haven't
 			// taken their version into account, and possibly cause a
-			// conflict.
+			// conflict. However, only do this if the new file is not also
+			// invalid. This would indicate that the new file is not part
+			// of the cluster, but e.g. a local change.
 			f.Version = f.Version.DropOthers(w.ShortID)
 		}
 		l.Debugln(w, "rescan:", curFile)
@@ -514,12 +518,14 @@ func (w *walker) walkSymlink(ctx context.Context, relPath string, info fs.FileIn
 			l.Debugln(w, "unchanged:", curFile, info.ModTime().Unix(), info.Mode()&fs.ModePerm)
 			return nil
 		}
-		if curFile.ShouldConflict() {
+		if curFile.ShouldConflict() && !f.ShouldConflict() {
 			// The old file was invalid for whatever reason and probably not
 			// up to date with what was out there in the cluster. Drop all
 			// others from the version vector to indicate that we haven't
 			// taken their version into account, and possibly cause a
-			// conflict.
+			// conflict. However, only do this if the new file is not also
+			// invalid. This would indicate that the new file is not part
+			// of the cluster, but e.g. a local change.
 			f.Version = f.Version.DropOthers(w.ShortID)
 		}
 		l.Debugln(w, "rescan:", curFile)


### PR DESCRIPTION
### Purpose

This PR changes behaviour of syncthing related to `receive-only` folders, which I believe to be a bug since I wouldn't expect the current behaviour. With the current syncthing codebase, a file of a `receive-only` folder that is only modified locally can cause the creation of a `.sync-conflict` file.

### Testing

Consider this szenario: Setup two paired clients that sync a folder with a given file (e.g. `Test.txt`). One of the clients configures the folder to be `receive-only`. Now, change the contents of the file for the receive-only client **_twice_**.

With the current syncthing codebase, this leads to the creation of a `.sync-conflict` file that contains the modified contents, while the regular `Test.txt` file is reset to the cluster's provided contents. This is due to a `protocol.FileInfo#ShouldConflict` check, that is succeeding on the locally modified file.

This PR changes this behaviour to not reset the file and not cause the creation of a `.sync-conflict`. Instead, the second content update is treated the same as the first content update.

This PR also contains a test that fails on the current codebase and succeeds with the changes introduced in this PR.

### Screenshots

This is not a GUI change

### Documentation

This is not a user visible change.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

#### Thanks to all the syncthing folks for this awesome piece of software!