### PR TITLE
cmd/ursrv: Add FreeBSD detection 

### DIFF
--- a/cmd/ursrv/serve/serve.go
+++ b/cmd/ursrv/serve/serve.go
@@ -75,6 +75,7 @@ var (
 		{regexp.MustCompile(`@fedora`), "Fedora (3rd party)"},
 		{regexp.MustCompile(`\sbrew@`), "Homebrew (3rd party)"},
 		{regexp.MustCompile(`\sroot@buildkitsandbox`), "LinuxServer.io (3rd party)"},
+		{regexp.MustCompile(`\sports@freebsd`), "FreeBSD (3rd party)"},
 		{regexp.MustCompile(`.`), "Others"},
 	}
 )


### PR DESCRIPTION
### Purpose

Classify `ports@freebsd` as `FreeBSD (3rd party)`