### PR TITLE
gui: Remove non-functional HTML from External Versioning tooltip (ref #8923)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -561,7 +561,7 @@
                             <span ng-switch-when="trashcan" translate>Trash Can</span>
                             <span ng-switch-when="simple" translate>Simple</span>
                             <span ng-switch-when="staggered" translate>Staggered</span>
-                            <span ng-switch-when="external" tooltip data-original-title="<span class='text-monospace'>{{folder.versioning.params.command}}</span>" translate>External</span>
+                            <span ng-switch-when="external" tooltip data-original-title="{{folder.versioning.params.command}}" translate>External</span>
                           </span>
                           <span ng-if="folder.versioning.type != 'external'">
                             <span ng-if="(folder.versioning.type == 'trashcan' || folder.versioning.type == 'simple')" tooltip data-original-title="{{'Clean out after' | translate}}">


### PR DESCRIPTION
gui: Remove non-functional HTML from External Versioning tooltip (ref #8923)

Since [1], it is no longer possible to use HTML in tooltips. This was
addressed in [2], however the commit missed one instance of HTML that
was used to change the font type of the External versioning command
tooltip. This remaining HTML is removed in this commit.

[1] f5e5af391a6583047c64ef8c51642003a79b75cf
[2] 73c52eafb6566435dffd979c3c49562b6d5a4238

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>

### Screenshots

![image](https://github.com/syncthing/syncthing/assets/5626656/d5f6c553-35cb-48c2-b654-809d8bbe93b8)

