### PR TITLE
lib/fs: Add ASCII fastpath for normalization

### DIFF
--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -35,6 +35,9 @@ func UnicodeLowercaseNormalized(s string) string {
 }
 
 func toLower(r rune) rune {
+	if r <= unicode.MaxASCII && (r < 'A' || 'Z' < r) {
+		return r
+	}
 	return unicode.ToLower(unicode.ToUpper(r))
 }
 

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -58,7 +58,7 @@ func toLowerASCII(s string) string {
 		pos = i + 1
 		c += 'a' - 'A'
 		b.WriteByte(c)
-		}
+	}
 	if pos != len(s) {
 		b.WriteString(s[pos:])
 	}
@@ -77,5 +77,5 @@ func toLower(r rune) rune {
 		}
 		return r + 'a' - 'A'
 	}
-	return unicode.ToLower(unicode.ToUpper(r))
+	return unicode.To(unicode.LowerCase, unicode.To(unicode.UpperCase, r))
 }

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -36,7 +36,12 @@ func UnicodeLowercaseNormalized(s string) string {
 	rs.WriteString(s[:i])
 
 	for _, r := range s[i:] {
-		rs.WriteRune(unicode.ToLower(unicode.ToUpper(r)))
+		r = unicode.ToLower(unicode.ToUpper(r))
+		if r < utf8.RuneSelf {
+			rs.WriteByte(byte(r))
+		} else {
+			rs.WriteRune(r)
+		}
 	}
 	return norm.NFC.String(rs.String())
 }

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -49,15 +49,16 @@ func toLowerASCII(s string) string {
 	b.Grow(len(s))
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if 'A' <= c && c <= 'Z' {
-			if pos != i {
-				b.WriteString(s[pos:i])
-			}
-			pos = i + 1
-			c += 'a' - 'A'
-			b.WriteByte(c)
+		if c < 'A' || 'Z' < c {
+			continue
 		}
-	}
+		if pos < i {
+			b.WriteString(s[pos:i])
+		}
+		pos = i + 1
+		c += 'a' - 'A'
+		b.WriteByte(c)
+		}
 	if pos != len(s) {
 		b.WriteString(s[pos:])
 	}

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -9,7 +9,6 @@ package fs
 import (
 	"strings"
 	"unicode"
-	"unicode/utf8"
 
 	"golang.org/x/text/unicode/norm"
 )
@@ -31,7 +30,7 @@ func isASCII(s string) (bool, bool) {
 	isLower := true
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if c >= utf8.RuneSelf {
+		if c > unicode.MaxASCII {
 			return false, isLower
 		}
 		if 'A' <= c && c <= 'Z' {

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -35,8 +35,11 @@ func UnicodeLowercaseNormalized(s string) string {
 }
 
 func toLower(r rune) rune {
-	if r <= unicode.MaxASCII && (r < 'A' || 'Z' < r) {
-		return r
+	if r <= unicode.MaxASCII {
+		if r < 'A' || 'Z' < r {
+			return r
+		}
+		return r + 'a' - 'A'
 	}
 	return unicode.ToLower(unicode.ToUpper(r))
 }

--- a/lib/fs/folding.go
+++ b/lib/fs/folding.go
@@ -77,5 +77,8 @@ func toLower(r rune) rune {
 		}
 		return r + 'a' - 'A'
 	}
+	if r <= unicode.MaxLatin1 && r != 'µ' {
+		return unicode.To(unicode.LowerCase, r)
+	}
 	return unicode.To(unicode.LowerCase, unicode.To(unicode.UpperCase, r))
 }

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -56,7 +56,9 @@ var asciiCases = []struct {
 }{
 	{"img_202401241010.jpg", asciiLower, "lowercase ASCII"},
 	{"IMG_202401241010.jpg", asciiMixed, "mixedcase ASCII"},
-	{"收购要约_2024.xlsx", nonAscii, "unicode"},
+	{"übernahme angebot.xlsx", nonAscii, "lowercase unicode"},
+	{"Übernahme Angebot.xlsx", nonAscii, "mixedcase unicode"},
+	{"ウェブの国際化.html", nonAscii, "multibyte unicode"},
 }
 
 func TestCheckCase(t *testing.T) {
@@ -65,11 +67,6 @@ func TestCheckCase(t *testing.T) {
 		if res != ac.result {
 			t.Errorf("checkCase(%q) => %d, expected %d (%s)", ac.name, res, ac.result, ac.resultName)
 		}
-	if checkCase("MiXeD") != asciiMixed {
-		t.Errorf("Expected asciiMixed")
-	}
-	if checkCase("文字化け") != nonAscii {
-		t.Errorf("Expected nonAscii")
 	}
 }
 
@@ -82,22 +79,13 @@ func TestUnicodeLowercaseNormalized(t *testing.T) {
 	}
 }
 
-func BenchmarkUnicodeLowercaseMaybeChange(b *testing.B) {
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		for _, s := range caseCases {
-			UnicodeLowercaseNormalized(s[0])
-		}
-	}
-}
-
-func BenchmarkUnicodeLowercaseNoChange(b *testing.B) {
-	b.ReportAllocs()
-
-	for i := 0; i < b.N; i++ {
-		for _, s := range caseCases {
-			UnicodeLowercaseNormalized(s[1])
-		}
+func BenchmarkUnicodeLowercase(b *testing.B) {
+	for _, c := range asciiCases {
+		b.Run(c.resultName, func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				UnicodeLowercaseNormalized(c.name)
+			}
+		})
 	}
 }

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -49,10 +49,22 @@ var caseCases = [][2]string{
 	{"a\xCC\x88", "\xC3\xA4"}, // ä
 }
 
+var asciiCases = []struct {
+	name       string
+	result     caseType
+	resultName string
+}{
+	{"img_202401241010.jpg", asciiLower, "lowercase ASCII"},
+	{"IMG_202401241010.jpg", asciiMixed, "mixedcase ASCII"},
+	{"收购要约_2024.xlsx", nonAscii, "unicode"},
+}
+
 func TestCheckCase(t *testing.T) {
-	if checkCase("lower") != asciiLower {
-		t.Errorf("Expected asciiLower")
-	}
+	for _, ac := range asciiCases {
+		res := checkCase(ac.name)
+		if res != ac.result {
+			t.Errorf("checkCase(%q) => %d, expected %d (%s)", ac.name, res, ac.result, ac.resultName)
+		}
 	if checkCase("MiXeD") != asciiMixed {
 		t.Errorf("Expected asciiMixed")
 	}

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -49,25 +49,12 @@ var caseCases = [][2]string{
 	{"a\xCC\x88", "\xC3\xA4"}, // ä
 }
 
-var asciiCases = []struct {
-	name       string
-	result     caseType
-	resultName string
-}{
-	{"img_202401241010.jpg", asciiLower, "ASCII lowercase"},
-	{"IMG_202401241010.jpg", asciiMixed, "ASCII mixedcase"},
-	{"übernahme angebot.xlsx", nonAscii, "Unicode lowercase"},
-	{"Übernahme Angebot.xlsx", nonAscii, "Unicode mixedcase"},
-	{"ウェブの国際化.html", nonAscii, "Unicode multibyte"},
-}
-
-func TestCheckCase(t *testing.T) {
-	for _, ac := range asciiCases {
-		res := checkCase(ac.name)
-		if res != ac.result {
-			t.Errorf("checkCase(%q) => %d, expected %d (%s)", ac.name, res, ac.result, ac.resultName)
-		}
-	}
+var benchmarkCases = [][2]string{
+	{"img_202401241010.jpg", "ASCII lowercase"},
+	{"IMG_202401241010.jpg", "ASCII mixedcase"},
+	{"übernahme angebot.xlsx", "Unicode lowercase"},
+	{"Übernahme Angebot.xlsx", "Unicode mixedcase"},
+	{"ウェブの国際化.html", "Unicode multibyte"},
 }
 
 func TestUnicodeLowercaseNormalized(t *testing.T) {
@@ -80,11 +67,11 @@ func TestUnicodeLowercaseNormalized(t *testing.T) {
 }
 
 func BenchmarkUnicodeLowercase(b *testing.B) {
-	for _, c := range asciiCases {
-		b.Run(c.resultName, func(b *testing.B) {
+	for _, c := range benchmarkCases {
+		b.Run(c[1], func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				UnicodeLowercaseNormalized(c.name)
+				UnicodeLowercaseNormalized(c[0])
 			}
 		})
 	}

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -51,10 +51,14 @@ var caseCases = [][2]string{
 
 var benchmarkCases = [][2]string{
 	{"img_202401241010.jpg", "ASCII lowercase"},
-	{"IMG_202401241010.jpg", "ASCII mixedcase"},
-	{"übernahme angebot.xlsx", "Unicode lowercase"},
-	{"Übernahme Angebot.xlsx", "Unicode mixedcase"},
-	{"ウェブの国際化.html", "Unicode multibyte"},
+	{"IMG_202401241010.jpg", "ASCII mixedcase start"},
+	{"img_202401241010.JPG", "ASCII mixedcase end"},
+	{"wir_kinder_aus_bullerbü.epub", "Unicode lowercase"},
+	{"Wir_Kinder_aus_Bullerbü.epub", "Unicode mixedcase start"},
+	{"wir_kinder_aus_bullerbü.EPUB", "Unicode mixedcase end"},
+	{"translated_ウェブの国際化.html", "Multibyte Unicode lowercase"},
+	{"Translated_ウェブの国際化.html", "Multibyte Unicode mixedcase start"},
+	{"translated_ウェブの国際化.HTML", "Multibyte Unicode mixedcase end"},
 }
 
 func TestUnicodeLowercaseNormalized(t *testing.T) {

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -54,11 +54,11 @@ var asciiCases = []struct {
 	result     caseType
 	resultName string
 }{
-	{"img_202401241010.jpg", asciiLower, "lowercase ASCII"},
-	{"IMG_202401241010.jpg", asciiMixed, "mixedcase ASCII"},
-	{"übernahme angebot.xlsx", nonAscii, "lowercase unicode"},
-	{"Übernahme Angebot.xlsx", nonAscii, "mixedcase unicode"},
-	{"ウェブの国際化.html", nonAscii, "multibyte unicode"},
+	{"img_202401241010.jpg", asciiLower, "ASCII lowercase"},
+	{"IMG_202401241010.jpg", asciiMixed, "ASCII mixedcase"},
+	{"übernahme angebot.xlsx", nonAscii, "Unicode lowercase"},
+	{"Übernahme Angebot.xlsx", nonAscii, "Unicode mixedcase"},
+	{"ウェブの国際化.html", nonAscii, "Unicode multibyte"},
 }
 
 func TestCheckCase(t *testing.T) {

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -49,6 +49,18 @@ var caseCases = [][2]string{
 	{"a\xCC\x88", "\xC3\xA4"}, // ä
 }
 
+func TestCheckCase(t *testing.T) {
+	if checkCase("lower") != asciiLower {
+		t.Errorf("Expected asciiLower")
+	}
+	if checkCase("MiXeD") != asciiMixed {
+		t.Errorf("Expected asciiMixed")
+	}
+	if checkCase("文字化け") != nonAscii {
+		t.Errorf("Expected nonAscii")
+	}
+}
+
 func TestUnicodeLowercaseNormalized(t *testing.T) {
 	for _, tc := range caseCases {
 		res := UnicodeLowercaseNormalized(tc[0])

--- a/lib/fs/folding_test.go
+++ b/lib/fs/folding_test.go
@@ -53,12 +53,12 @@ var benchmarkCases = [][2]string{
 	{"img_202401241010.jpg", "ASCII lowercase"},
 	{"IMG_202401241010.jpg", "ASCII mixedcase start"},
 	{"img_202401241010.JPG", "ASCII mixedcase end"},
-	{"wir_kinder_aus_bullerbü.epub", "Unicode lowercase"},
-	{"Wir_Kinder_aus_Bullerbü.epub", "Unicode mixedcase start"},
-	{"wir_kinder_aus_bullerbü.EPUB", "Unicode mixedcase end"},
-	{"translated_ウェブの国際化.html", "Multibyte Unicode lowercase"},
-	{"Translated_ウェブの国際化.html", "Multibyte Unicode mixedcase start"},
-	{"translated_ウェブの国際化.HTML", "Multibyte Unicode mixedcase end"},
+	{"wir_kinder_aus_bullerbü.epub", "Latin1 lowercase"},
+	{"Wir_Kinder_aus_Bullerbü.epub", "Latin1 mixedcase start"},
+	{"wir_kinder_aus_bullerbü.EPUB", "Latin1 mixedcase end"},
+	{"translated_ウェブの国際化.html", "Unicode lowercase"},
+	{"Translated_ウェブの国際化.html", "Unicode mixedcase start"},
+	{"translated_ウェブの国際化.HTML", "Unicode mixedcase end"},
 }
 
 func TestUnicodeLowercaseNormalized(t *testing.T) {


### PR DESCRIPTION
### Purpose

Avoids `unicode.ToLower(unicode.ToUpper(r))` and `norm.NFC.String(s)` for simple ASCII filenames.