### PR TITLE
lib/fs: Add invalid UTF-8 guards to Matcher and Watcher (fixes #9369)

### DIFF
--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -83,7 +83,14 @@ func (f *BasicFilesystem) watchLoop(ctx context.Context, name string, roots []st
 
 		select {
 		case ev := <-backendChan:
-			relPath, err := f.unrootedChecked(ev.Path(), roots)
+			evPath := ev.Path()
+
+			if !utf8.ValidString(evPath) {
+				l.Debugln(f.Type(), f.URI(), "Watch: Ignoring invalid UTF-8")
+				return
+			}
+
+			relPath, err := f.unrootedChecked(evPath, roots)
 			if err != nil {
 				select {
 				case errChan <- err:

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -87,7 +87,7 @@ func (f *BasicFilesystem) watchLoop(ctx context.Context, name string, roots []st
 
 			if !utf8.ValidString(evPath) {
 				l.Debugln(f.Type(), f.URI(), "Watch: Ignoring invalid UTF-8")
-				return
+				continue
 			}
 
 			relPath, err := f.unrootedChecked(evPath, roots)

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -44,11 +44,9 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 		}
 
 		rel, err := f.unrootedChecked(absPath, roots)
-
 		if err != nil {
 			return true
 		}
-
 		return ignore.Match(rel).CanSkipDir()
 	}
 	err = notify.WatchWithFilter(watchPath, backendChan, absShouldIgnore, eventMask)

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -14,6 +14,7 @@ package fs
 import (
 	"context"
 	"errors"
+	"unicode/utf8"
 
 	"github.com/syncthing/notify"
 )
@@ -38,10 +39,16 @@ func (f *BasicFilesystem) Watch(name string, ignore Matcher, ctx context.Context
 	}
 
 	absShouldIgnore := func(absPath string) bool {
+		if !utf8.ValidString(absPath) {
+			return true
+		}
+
 		rel, err := f.unrootedChecked(absPath, roots)
+
 		if err != nil {
 			return true
 		}
+
 		return ignore.Match(rel).CanSkipDir()
 	}
 	err = notify.WatchWithFilter(watchPath, backendChan, absShouldIgnore, eventMask)

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -11,12 +11,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"github.com/gobwas/glob"
 	"io"
 	"path/filepath"
 	"strings"
 	"time"
-
-	"github.com/gobwas/glob"
+	"unicode/utf8"
 
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore/ignoreresult"
@@ -214,6 +214,9 @@ func (m *Matcher) parseLocked(r io.Reader, file string) error {
 // Match matches the patterns plus temporary and internal files.
 func (m *Matcher) Match(file string) (result ignoreresult.R) {
 	switch {
+	case !utf8.ValidString(file):
+		return ignoreresult.IgnoreAndSkip
+
 	case fs.IsTemporary(file):
 		return ignoreresult.IgnoreAndSkip
 

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -11,12 +11,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/gobwas/glob"
 	"io"
 	"path/filepath"
 	"strings"
 	"time"
-	"unicode/utf8"
+
+	"github.com/gobwas/glob"
 
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore/ignoreresult"
@@ -214,9 +214,6 @@ func (m *Matcher) parseLocked(r io.Reader, file string) error {
 // Match matches the patterns plus temporary and internal files.
 func (m *Matcher) Match(file string) (result ignoreresult.R) {
 	switch {
-	case !utf8.ValidString(file):
-		return ignoreresult.IgnoreAndSkip
-
 	case fs.IsTemporary(file):
 		return ignoreresult.IgnoreAndSkip
 


### PR DESCRIPTION
### Purpose

Add invalid UTF-8 guards to fix #9369. Probably not a permanent fix, but putting it up here in case someone else encounters the same panic.

### Testing

All tests pass. I was going to add a test to `basicfs_watch` but there doesn't seem to be a straightforward way to test for unexpected events.

