### PR TITLE
lib/model: Deflake new IndexHandlerTest

### DIFF
--- a/lib/model/indexhandler_test.go
+++ b/lib/model/indexhandler_test.go
@@ -57,9 +57,9 @@ func TestIndexhandlerConcurrency(t *testing.T) {
 				t.Error("wrong filename", n)
 			}
 			recvdEntries++
-			wg.Done()
 		}
 		recvdBatches++
+		wg.Done()
 		return nil
 	})
 
@@ -74,8 +74,8 @@ func TestIndexhandlerConcurrency(t *testing.T) {
 				Blocks: []protocol.BlockInfo{{Hash: make([]byte, 32)}},
 			})
 			sentEntries++
-			wg.Add(1)
 		}
+		wg.Add(1)
 		if err := b1.Flush(); err != nil {
 			t.Fatal(err)
 		}

--- a/lib/model/indexhandler_test.go
+++ b/lib/model/indexhandler_test.go
@@ -66,14 +66,14 @@ func TestIndexhandlerConcurrency(t *testing.T) {
 	b1 := db.NewFileInfoBatch(func(fs []protocol.FileInfo) error {
 		return c1.IndexUpdate(ctx, "foo", fs)
 	})
-	sentBatches := 0
+	sentEntries := 0
 	for i := 0; i < msgs; i++ {
 		for j := 0; j < files; j++ {
 			b1.Append(protocol.FileInfo{
 				Name:   fmt.Sprintf("f%d-%d", i, j),
 				Blocks: []protocol.BlockInfo{{Hash: make([]byte, 32)}},
 			})
-			sentBatches++
+			sentEntries++
 			wg.Add(1)
 		}
 		if err := b1.Flush(); err != nil {
@@ -93,7 +93,7 @@ func TestIndexhandlerConcurrency(t *testing.T) {
 	<-c1.Closed()
 	<-c2.Closed()
 
-	if recvdEntries != sentBatches {
-		t.Error("didn't receive all expected messages", recvdEntries, sentBatches)
+	if recvdEntries != sentEntries {
+		t.Error("didn't receive all expected messages", recvdEntries, sentEntries)
 	}
 }


### PR DESCRIPTION
The new test has a flakiness factor on slow platforms, where the close on the sending connection races with the last index message, potentially messing up the count. This adds a wait to ensure that all sent messages are received, or the test will eventually fail with a timeout.