### PR TITLE
all: More stringent timer handling (ref #9417)

### DIFF
--- a/cmd/stdiscosrv/database.go
+++ b/cmd/stdiscosrv/database.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/sliceutil"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/storage"
 	"github.com/syndtr/goleveldb/leveldb/util"
@@ -172,7 +173,7 @@ func (s *levelDBStore) get(key string) (DatabaseRecord, error) {
 
 func (s *levelDBStore) Serve(ctx context.Context) error {
 	t := time.NewTimer(0)
-	defer t.Stop()
+	defer timeutil.StopTimer(t)
 	defer s.db.Close()
 
 	// Start the statistics serve routine. It will exit with us when
@@ -196,7 +197,7 @@ loop:
 		case <-statisticsDone:
 			// The statistics routine is done with one iteratation, schedule
 			// the next.
-			t.Reset(databaseStatisticsInterval)
+			timeutil.ResetTimer(t, databaseStatisticsInterval)
 
 		case <-ctx.Done():
 			// We're done.

--- a/cmd/stdiscosrv/replication.go
+++ b/cmd/stdiscosrv/replication.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 const (
@@ -91,7 +92,7 @@ func (s *replicationSender) Serve(ctx context.Context) error {
 	}
 
 	heartBeatTicker := time.NewTicker(replicationHeartbeatInterval)
-	defer heartBeatTicker.Stop()
+	defer timeutil.StopTicker(heartBeatTicker)
 
 	// Send records.
 	buf := make([]byte, 1024)

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -23,6 +23,7 @@ import (
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/syncthing/syncthing/lib/httpcache"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/timeutil"
 
 	"github.com/oschwald/geoip2-golang"
 	"github.com/prometheus/client_golang/prometheus"
@@ -465,7 +466,7 @@ func handleRelayTest(request request) {
 		if debug {
 			log.Println("Stopping existing timer for", request.relay)
 		}
-		timer.Stop()
+		timeutil.StopTimer(timer)
 	}
 
 	for i, current := range knownRelays {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -51,6 +51,7 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/syncthing"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
 )
 
@@ -791,7 +792,7 @@ func autoUpgrade(cfg config.Wrapper, app *syncthing.App, evLogger events.Logger)
 
 		opts := cfg.Options()
 		if !opts.AutoUpgradeEnabled() {
-			timer.Reset(upgradeCheckInterval)
+			timeutil.ResetTimer(timer, upgradeCheckInterval)
 			continue
 		}
 
@@ -805,13 +806,13 @@ func autoUpgrade(cfg config.Wrapper, app *syncthing.App, evLogger events.Logger)
 			// Don't complain too loudly here; we might simply not have
 			// internet connectivity, or the upgrade server might be down.
 			l.Infoln("Automatic upgrade:", err)
-			timer.Reset(checkInterval)
+			timeutil.ResetTimer(timer, checkInterval)
 			continue
 		}
 
 		if upgrade.CompareVersions(rel.Tag, build.Version) != upgrade.Newer {
 			// Skip equal, older or majorly newer (incompatible) versions
-			timer.Reset(checkInterval)
+			timeutil.ResetTimer(timer, checkInterval)
 			continue
 		}
 
@@ -819,7 +820,7 @@ func autoUpgrade(cfg config.Wrapper, app *syncthing.App, evLogger events.Logger)
 		err = upgrade.To(rel)
 		if err != nil {
 			l.Warnln("Automatic upgrade:", err)
-			timer.Reset(checkInterval)
+			timeutil.ResetTimer(timer, checkInterval)
 			continue
 		}
 		sub.Unsubscribe()

--- a/cmd/syncthing/monitor.go
+++ b/cmd/syncthing/monitor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 var (
@@ -489,7 +490,7 @@ func (f *autoclosedFile) Write(bs []byte) (int, error) {
 	// If we haven't run into the maxOpenTime, postpone close for another
 	// closeDelay
 	if time.Since(f.opened) < f.maxOpenTime {
-		f.closeTimer.Reset(f.closeDelay)
+		timeutil.ResetTimer(f.closeTimer, f.closeDelay)
 	}
 
 	return f.fd.Write(bs)
@@ -500,7 +501,7 @@ func (f *autoclosedFile) Close() error {
 	defer f.mut.Unlock()
 
 	// Stop the timer and closerLoop() routine
-	f.closeTimer.Stop()
+	timeutil.StopTimer(f.closeTimer)
 	close(f.closed)
 
 	// Close the file, if it's open

--- a/cmd/ursrv/serve/serve.go
+++ b/cmd/ursrv/serve/serve.go
@@ -31,6 +31,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur/contract"
 )
@@ -227,7 +228,7 @@ const maxCacheTime = 15 * time.Minute
 
 func (s *server) cacheRefresher() {
 	ticker := time.NewTicker(maxCacheTime - time.Minute)
-	defer ticker.Stop()
+	defer timeutil.StopTicker(ticker)
 	for ; true; <-ticker.C {
 		s.cacheMut.Lock()
 		if err := s.refreshCacheLocked(); err != nil {

--- a/lib/api/tokenmanager.go
+++ b/lib/api/tokenmanager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 type tokenManager struct {
@@ -122,7 +123,7 @@ func (m *tokenManager) saveLocked() {
 	if m.saveTimer == nil {
 		m.saveTimer = time.AfterFunc(time.Second, m.scheduledSave)
 	} else {
-		m.saveTimer.Reset(time.Second)
+		timeutil.ResetTimer(m.saveTimer, time.Second)
 	}
 }
 

--- a/lib/config/wrapper.go
+++ b/lib/config/wrapper.go
@@ -22,6 +22,7 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sliceutil"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/thejerf/suture/v4"
 )
 
@@ -240,6 +241,7 @@ func (w *wrapper) Serve(ctx context.Context) error {
 
 	var e modifyEntry
 	saveTimer := time.NewTimer(0)
+	defer timeutil.StopTimer(saveTimer)
 	<-saveTimer.C
 	saveTimerRunning := false
 	for {
@@ -265,7 +267,7 @@ func (w *wrapper) Serve(ctx context.Context) error {
 		if !reflect.DeepEqual(w.cfg, to) {
 			waiter, err = w.replaceLocked(to)
 			if !saveTimerRunning {
-				saveTimer.Reset(minSaveInterval)
+				timeutil.ResetTimer(saveTimer, minSaveInterval)
 				saveTimerRunning = true
 			}
 		}

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -41,6 +41,7 @@ import (
 	"github.com/syncthing/syncthing/lib/stringutil"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 
 	// Registers NAT service providers
 	_ "github.com/syncthing/syncthing/lib/pmp"
@@ -518,9 +519,10 @@ func (s *service) connect(ctx context.Context) error {
 			}
 			s.dialNowDevices = make(map[protocol.DeviceID]struct{})
 			s.dialNowDevicesMut.Unlock()
-			timeout.Stop()
+			timeutil.StopTimer(timeout)
 		case <-timeout.C:
 		case <-ctx.Done():
+			timeutil.StopTimer(timeout)
 			return ctx.Err()
 		}
 	}

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -26,6 +26,7 @@ import (
 	"github.com/syncthing/syncthing/lib/stringutil"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/thejerf/suture/v4"
 )
 
@@ -705,7 +706,7 @@ func (db *Lowlevel) gcRunner(ctx context.Context) error {
 	}
 
 	t := time.NewTimer(next)
-	defer t.Stop()
+	defer timeutil.StopTimer(t)
 
 	for {
 		select {

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -23,6 +23,7 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 // A ParseError signifies an error with contents of an ignore file,
@@ -311,6 +312,7 @@ func (m *Matcher) Stop() {
 
 func (m *Matcher) clean(d time.Duration) {
 	t := time.NewTimer(d / 2)
+	defer timeutil.StopTimer(t)
 	for {
 		select {
 		case <-m.stop:

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -30,6 +30,7 @@ import (
 	"github.com/syncthing/syncthing/lib/semaphore"
 	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/syncthing/syncthing/lib/versioner"
 	"github.com/syncthing/syncthing/lib/weakhash"
 )
@@ -1726,7 +1727,7 @@ func (f *sendReceiveFolder) dbUpdaterRoutine(dbUpdateChan <-chan dbUpdateJob) {
 	found := false
 	var lastFile protocol.FileInfo
 	tick := time.NewTicker(maxBatchTime)
-	defer tick.Stop()
+	defer timeutil.StopTicker(tick)
 	batch := db.NewFileInfoBatch(func(files []protocol.FileInfo) error {
 		// sync directories
 		for dir := range changedDirs {

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -23,6 +23,7 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 type FolderSummaryService interface {
@@ -314,6 +315,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 func (c *folderSummaryService) calculateSummaries(ctx context.Context) error {
 	const pumpInterval = 2 * time.Second
 	pump := time.NewTimer(pumpInterval)
+	defer timeutil.StopTimer(pump)
 
 	for {
 		select {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -43,6 +43,7 @@ import (
 	"github.com/syncthing/syncthing/lib/stats"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/syncthing/syncthing/lib/ur/contract"
 	"github.com/syncthing/syncthing/lib/versioner"
 )
@@ -268,6 +269,7 @@ func (m *model) serve(ctx context.Context) error {
 
 	close(m.started)
 
+	defer timeutil.StopTimer(m.promotionTimer)
 	for {
 		select {
 		case <-ctx.Done():
@@ -2374,7 +2376,7 @@ func (m *model) AddConnection(conn protocol.Connection, hello protocol.Hello) {
 func (m *model) scheduleConnectionPromotion() {
 	// Keeps deferring to prevent multiple executions in quick succession,
 	// e.g. if multiple connections to a single device are closed.
-	m.promotionTimer.Reset(time.Second)
+	timeutil.ResetTimer(m.promotionTimer, time.Second)
 }
 
 // promoteConnections checks for devices that have connections, but where

--- a/lib/model/progressemitter.go
+++ b/lib/model/progressemitter.go
@@ -15,6 +15,7 @@ import (
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/sync"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 type ProgressEmitter struct {
@@ -69,6 +70,7 @@ func (t *ProgressEmitter) Serve(ctx context.Context) error {
 
 	var lastUpdate time.Time
 	var lastCount, newCount int
+	defer timeutil.StopTimer(t.timer)
 	for {
 		select {
 		case <-ctx.Done():
@@ -252,7 +254,7 @@ func (t *ProgressEmitter) Register(s *sharedPullerState) {
 	}
 	l.Debugln("progress emitter: registering", s.folder, s.file.Name)
 	if t.emptyLocked() {
-		t.timer.Reset(t.interval)
+		timeutil.ResetTimer(t.timer, t.interval)
 	}
 	if _, ok := t.registry[s.folder]; !ok {
 		t.registry[s.folder] = make(map[string]*sharedPullerState)

--- a/lib/model/util.go
+++ b/lib/model/util.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 // inWritableDir calls fn(path), while making sure that the directory
@@ -76,7 +77,7 @@ func addTimeUntilCancelled(ctx context.Context, counter prometheus.Counter) {
 	}()
 
 	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
+	defer timeutil.StopTicker(ticker)
 
 	for {
 		select {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	lz4 "github.com/pierrec/lz4/v4"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 const (
@@ -965,6 +966,7 @@ func (c *rawConnection) Close(err error) {
 	c.sendCloseOnce.Do(func() {
 		done := make(chan struct{})
 		timeout := time.NewTimer(CloseTimeout)
+		defer timeutil.StopTimer(timeout)
 		select {
 		case c.closeBox <- asyncMessage{&Close{err.Error()}, done}:
 			select {
@@ -1021,7 +1023,7 @@ func (c *rawConnection) internalClose(err error) {
 // PingSendInterval/2 and PingSendInterval.
 func (c *rawConnection) pingSender() {
 	ticker := time.NewTicker(PingSendInterval / 2)
-	defer ticker.Stop()
+	defer timeutil.StopTicker(ticker)
 
 	for {
 		select {
@@ -1046,7 +1048,7 @@ func (c *rawConnection) pingSender() {
 // ReceiveTimeout. If not, we close the connection with an ErrTimeout.
 func (c *rawConnection) pingReceiver() {
 	ticker := time.NewTicker(ReceiveTimeout / 2)
-	defer ticker.Stop()
+	defer timeutil.StopTicker(ticker)
 
 	for {
 		select {

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -15,6 +15,7 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 	syncthingprotocol "github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/relay/protocol"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 type staticClient struct {
@@ -73,11 +74,12 @@ func (c *staticClient) serve(ctx context.Context) error {
 	go messageReader(ctx, c.conn, messages, errorsc)
 
 	timeout := time.NewTimer(c.messageTimeout)
+	defer timeutil.StopTimer(timeout)
 
 	for {
 		select {
 		case message := <-messages:
-			timeout.Reset(c.messageTimeout)
+			timeutil.ResetTimer(timeout, c.messageTimeout)
 			l.Debugf("%s received message %T", c, message)
 
 			switch msg := message.(type) {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -23,6 +23,7 @@ import (
 	"github.com/syncthing/syncthing/lib/ignore"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"golang.org/x/text/unicode/norm"
 )
 
@@ -193,12 +194,12 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 				case <-done:
 					emitProgressEvent()
 					l.Debugln(w, "Walk progress done", w.Folder, w.Subs, w.Matcher)
-					ticker.Stop()
+					timeutil.StopTicker(ticker)
 					return
 				case <-ticker.C:
 					emitProgressEvent()
 				case <-ctx.Done():
-					ticker.Stop()
+					timeutil.StopTicker(ticker)
 					return
 				}
 			}
@@ -665,12 +666,12 @@ func (c *byteCounter) ticker() {
 	// The metrics.EWMA expects clock ticks every five seconds in order to
 	// decay the average properly.
 	t := time.NewTicker(5 * time.Second)
+	defer timeutil.StopTicker(t)
 	for {
 		select {
 		case <-t.C:
 			c.Tick()
 		case <-c.stop:
-			t.Stop()
 			return
 		}
 	}

--- a/lib/stun/stun.go
+++ b/lib/stun/stun.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/svcutil"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 const stunRetryInterval = 5 * time.Minute
@@ -93,6 +94,7 @@ func (s *Service) Serve(ctx context.Context) error {
 	}()
 
 	timer := time.NewTimer(time.Millisecond)
+	defer timeutil.StopTimer(timer)
 
 	for {
 	disabled:

--- a/lib/sync/sync.go
+++ b/lib/sync/sync.go
@@ -15,6 +15,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 var timeNow = time.Now
@@ -286,5 +288,5 @@ func (w *TimeoutCondWaiter) Wait() bool {
 }
 
 func (w *TimeoutCondWaiter) Stop() {
-	w.timer.Stop()
+	timeutil.StopTimer(w.timer)
 }

--- a/lib/timeutil/timeutil.go
+++ b/lib/timeutil/timeutil.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2024 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package timeutil
+
+import "time"
+
+// StopTimer stops the timer and ensures the channel is drained.
+func StopTimer(t *time.Timer) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+}
+
+// ResetTimer is timer.Stop()+timer.Reset() to properly reset the timer
+// according to the mandated pattern in https://pkg.go.dev/time#Timer.Reset:
+// timers must only be reset if they are stopped and drained. If you'rea
+// lready in a branch that just received from the timer channel you can use
+// timer.Reset() directly, otherwise this pattern must be used.
+func ResetTimer(t *time.Timer, dur time.Duration) {
+	if !t.Stop() {
+		select {
+		case <-t.C:
+		default:
+		}
+	}
+	t.Reset(dur)
+}
+
+// StopTicker stops the ticker and drains the channel to ensure the ticker
+// can be deallocated.
+func StopTicker(t *time.Ticker) {
+	t.Stop()
+	select {
+	case <-t.C:
+	default:
+	}
+}

--- a/lib/timeutil/timeutil.go
+++ b/lib/timeutil/timeutil.go
@@ -20,8 +20,8 @@ func StopTimer(t *time.Timer) {
 
 // ResetTimer is timer.Stop()+timer.Reset() to properly reset the timer
 // according to the mandated pattern in https://pkg.go.dev/time#Timer.Reset:
-// timers must only be reset if they are stopped and drained. If you'rea
-// lready in a branch that just received from the timer channel you can use
+// timers must only be reset if they are stopped and drained. If you're in a
+// branch that just received from the timer channel you can use
 // timer.Reset() directly, otherwise this pattern must be used.
 func ResetTimer(t *time.Timer, dur time.Duration) {
 	if !t.Stop() {

--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -20,6 +20,7 @@ import (
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/svcutil"
+	"github.com/syncthing/syncthing/lib/timeutil"
 
 	"github.com/thejerf/suture/v4"
 )
@@ -92,6 +93,7 @@ func (h *failureHandler) Serve(ctx context.Context) error {
 
 	var err error
 	timer := time.NewTimer(minDelay)
+	defer timeutil.StopTimer(timer)
 	resetTimer := make(chan struct{})
 	for err == nil {
 		select {
@@ -139,7 +141,7 @@ func (h *failureHandler) Serve(ctx context.Context) error {
 				timer.Reset(minDelay)
 			}
 		case <-resetTimer:
-			timer.Reset(minDelay)
+			timeutil.ResetTimer(timer, minDelay)
 		case <-ctx.Done():
 			err = ctx.Err()
 		}

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -27,6 +27,7 @@ import (
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/scanner"
+	"github.com/syncthing/syncthing/lib/timeutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur/contract"
 )
@@ -373,12 +374,13 @@ func (s *Service) Serve(ctx context.Context) error {
 	defer s.cfg.Unsubscribe(s)
 
 	t := time.NewTimer(time.Duration(s.cfg.Options().URInitialDelayS) * time.Second)
+	defer timeutil.StopTimer(t)
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-s.forceRun:
-			t.Reset(0)
+			timeutil.ResetTimer(t, 0)
 		case <-t.C:
 			if s.cfg.Options().URAccepted >= 2 {
 				err := s.sendUsageReport(ctx)

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/timeutil"
 )
 
 // Not meant to be changed, but must be changeable for tests
@@ -148,7 +149,7 @@ func Aggregate(ctx context.Context, in <-chan fs.Event, out chan<- []string, fol
 
 func (a *aggregator) mainLoop(in <-chan fs.Event, out chan<- []string, cfg config.Wrapper, evLogger events.Logger) {
 	a.notifyTimer = time.NewTimer(a.notifyDelay)
-	defer a.notifyTimer.Stop()
+	defer timeutil.StopTimer(a.notifyTimer)
 
 	inProgressItemSubscription := evLogger.Subscribe(events.ItemStarted | events.ItemFinished)
 	defer inProgressItemSubscription.Unsubscribe()
@@ -314,7 +315,7 @@ func (a *aggregator) resetNotifyTimerIfNeeded() {
 func (a *aggregator) resetNotifyTimer(duration time.Duration) {
 	l.Debugln(a, "Resetting notifyTimer to", duration.String())
 	a.notifyTimerNeedsReset = false
-	a.notifyTimer.Reset(duration)
+	timeutil.ResetTimer(a.notifyTimer, duration)
 }
 
 func (a *aggregator) actOnTimer(out chan<- []string) {


### PR DESCRIPTION
We were a bit lax in our timer and ticker handling. In some cases there were timers and tickers that weren't explicitly stopped, leading to a potential timer leak; in some cases the stop and reset didn't follow the patterns mandated in the documentation. These things are notoriously difficult to do properly due to mistakes in the original API design...

Now there is a tiny utility package for stopping and resetting timers, which should generally be used. There are specific circumstances where the "raw" methods can be used, like

```
select {
  case <-timer.C:
    timer.Reset(...) // this is fine, because we know the timer is stopped and drained
```

but in more complicated cases the wrapper functions will be safe and do the right thing.
