### PR TITLE
all: Prevent directory undeletion on macOS 14.3+ when syncXattrs is enabled (fixes #9371)

### DIFF
--- a/lib/fs/platform_common.go
+++ b/lib/fs/platform_common.go
@@ -46,15 +46,17 @@ func unixPlatformData(fs Filesystem, name string, userCache *userCache, groupCac
 		} else if ud.GID == 0 {
 			ud.GroupName = "root"
 		}
-
+		l.Debugf("unixPlatformData: %s ownership: UID=%d (%s), GID=%d (%s)", name, ud.UID, ud.OwnerName, ud.GID, ud.GroupName)
 		pd.Unix = &ud
 	}
 
 	if scanXattrs {
 		xattrs, err := fs.GetXattr(name, xattrFilter)
 		if err != nil {
+			l.Warnf("unixPlatformData: Failed to get xattrs for %s: %v", name, err)
 			return protocol.PlatformData{}, err
 		}
+		l.Debugf("unixPlatformData: %s xattrs: %v", name, xattrs)
 		pd.SetXattrs(xattrs)
 	}
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -2087,17 +2087,20 @@ func (f *sendReceiveFolder) scanIfItemChanged(name string, stat fs.FileInfo, ite
 		return fmt.Errorf("comparing item on disk to db: %w", err)
 	}
 
-	if !statItem.IsEquivalentOptional(item, protocol.FileInfoComparison{
+	comparisonResult := statItem.IsEquivalentOptional(item, protocol.FileInfoComparison{
 		ModTimeWindow:   f.modTimeWindow,
 		IgnorePerms:     f.IgnorePerms,
 		IgnoreBlocks:    true,
 		IgnoreFlags:     protocol.LocalAllFlags,
 		IgnoreOwnership: !f.SyncOwnership,
 		IgnoreXattrs:    !f.SyncXattrs,
-	}) {
+	})
+	if !comparisonResult {
+		l.Debugf("scanIfItemChanged: %s not equivalent to db version. ModTimeWindow: %v, IgnorePerms: %v, IgnoreBlocks: true, IgnoreFlags: %v, IgnoreOwnership: %v, IgnoreXattrs: %v", name, f.modTimeWindow, f.IgnorePerms, protocol.LocalAllFlags, !f.SyncOwnership, !f.SyncXattrs)
 		return errModified
 	}
 
+	l.Debugf("scanIfItemChanged: %s matches db version", name)
 	return nil
 }
 


### PR DESCRIPTION
### Purpose

This is my attempt at fixing (fix may be a strong word, more of a workaround) the "deleted folder snapback" issue described in great lengths at #9371. I have limited experience with the Syncthing codebase, and with Go in general, so this really needs some more 👀 !

I _believe_ the root cause of this "bug" is either:

- macOS is not permitting the `syncthing` binary to properly set the folder modification timestamps (even when granted Full Disk Access TCC/PPPC permissions)
—or—
- macOS is delaying or queueing writes related to xattrs / timestamps. The timestamp that gets recorded in Syncthing's db is offset by some unknown amount due to this.

The result is the directory inode modtimes in the db become "out of sync" with what later gets read back from the filesystem. This causes hysteresis when a folder is deleted: the receiving side thinks it's been changed and forces a rescan, defers the deletion, which is then picked up by the sender, and the folder is "put back" (sans all contained files however...)

### Testing

I tried to take a conservative approach—this only targets macOS for now (not sure if this issue is confirmed to occur on other platforms). I added a bit of debug logging.

Tested on:
- my 2 Macs (M1 Mini/M2 MacBook Air) both running 14.4 dev beta 3 (23E5196e)
- [Syncthing macOS](https://github.com/syncthing/syncthing-macos) bundle v1.27.3
- custom-compiled `syncthing` binary replacing the one from the app bundle (based on [`1.27.4-rc1`](https://github.com/syncthing/syncthing/releases/tag/v1.27.4-rc.1) + 3e8ec950a)
- Compiled with `go1.22.0`

In addition to many hours of manual testing, I ran the following simple shell script, which repeatedly creates a folder, dumps some files into it, and then deletes the folder—over and over. Before this patch, the `xyzzy` folder would almost immediately snap back on Mac-A.

```bash
#!/usr/bin/env bash

DELAY=10
TESTDIR="$HOME/Sync/xyzzy"
while true; do
  echo "creating dir: $TESTDIR"
  mkdir -p "$TESTDIR"
  cd "$TESTDIR" || exit 1
  echo "creating files"
  for n in {1..20}; do echo $n >$n.txt; done
  cd
  echo "sleeping ${DELAY}s"
  sleep $DELAY
  echo
  echo "deleting $TESTDIR"
  rm -r "${TESTDIR:?}"
  echo "sleeping ${DELAY}s"
  sleep $DELAY
  echo
done
```

When run with the `STTRACE` env var set e.g. `STTRACE=all`, you will see log entries like the one below when this code path is hit:

```
[AL47A] 2024/02/18 01:07:37.138658 bep_extensions.go:259: DEBUG: isEquivalent: skipping modtime check due to platform bug
```
