### PR TITLE
Add Docker umask Support

### DIFF
--- a/README-Docker.md
+++ b/README-Docker.md
@@ -15,6 +15,9 @@ To grant Syncthing additional capabilities without running as root, use the
 `PCAP` environment variable with the same syntax as that for `setcap(8)`.
 For example, `PCAP=cap_chown,cap_fowner+ep`.
 
+To set a different umask value, use the `UMASK` environment variable. For
+example `UMASK=002`.
+
 ## Example Usage
 
 **Docker cli**

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -2,6 +2,8 @@
 
 set -eu
 
+[ -n "${UMASK:-}" ] && umask "$UMASK"
+
 if [ "$(id -u)" = '0' ]; then
   binary="$1"
   if [ -z "${PCAP:-}" ]; then

--- a/script/docker-entrypoint.sh
+++ b/script/docker-entrypoint.sh
@@ -4,7 +4,7 @@ set -eu
 
 if [ "$(id -u)" = '0' ]; then
   binary="$1"
-  if [ "${PCAP:-}" == "" ] ; then
+  if [ -z "${PCAP:-}" ]; then
     # If Syncthing should have no extra capabilities, make sure to remove them
     # from the binary. This will fail with an error if there are no
     # capabilities to remove, hence the || true etc.


### PR DESCRIPTION
### Purpose

Add support for setting umask value in the Docker `entrypoint.sh` script. This is useful when
not syncing permissions and working with groups, and needing umask values like `002` instead of `022`.

This is vaguely related to https://github.com/syncthing/syncthing/pull/5857 but as this
is about the Docker setup I figured it might be worth trying a PR.

### Alternative

Since the current setup uses entrypoint instead of a combination of entrypoint and command,
I had to edit `entrypoint.sh`.
An alternative workaround for not adding the `UMASK` environment variable would be to set:
```dockerfile
ENTRYPOINT ["/bin/entrypoint.sh"]
CMD ["/bin/syncthing"]
```

That way it would be easier for the user to change the command in the `compose.yml` to something like:
```yml
command: "/bin/sh -c 'umask 002 && /bin/syncthing'"
```

With the current setup of the entrypoint acting as wrapper and command, the user has to change a
both settings.

Let me know if there's more interest in that, and I'd be happy to create a pull request for a change like that.

### Testing

I have tested a `compose.yml` file with and without the new `UMASK` environment variable.

### Documentation

Updated the `README-Docker.md` file.
