### PR TITLE
all: Use Linux container CPU quota (fixes #9357, fixes #9435)

### DIFF
--- a/build.go
+++ b/build.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	buildpkg "github.com/syncthing/syncthing/lib/build"
+	_ "go.uber.org/automaxprocs"
 )
 
 var (

--- a/cmd/stcompdirs/main.go
+++ b/cmd/stcompdirs/main.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 
 	"github.com/syncthing/syncthing/lib/sha256"
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/cmd/stcrashreceiver/main.go
+++ b/cmd/stcrashreceiver/main.go
@@ -23,11 +23,11 @@ import (
 	"path/filepath"
 
 	"github.com/alecthomas/kong"
+	raven "github.com/getsentry/raven-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/syncthing/syncthing/lib/sha256"
 	"github.com/syncthing/syncthing/lib/ur"
-
-	raven "github.com/getsentry/raven-go"
+	_ "go.uber.org/automaxprocs"
 )
 
 const maxRequestSize = 1 << 20 // 1 MiB

--- a/cmd/stdisco/main.go
+++ b/cmd/stdisco/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/syncthing/syncthing/lib/beacon"
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/protocol"
+	_ "go.uber.org/automaxprocs"
 )
 
 var (

--- a/cmd/stdiscosrv/main.go
+++ b/cmd/stdiscosrv/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syndtr/goleveldb/leveldb/opt"
 	"github.com/thejerf/suture/v4"
+	_ "go.uber.org/automaxprocs"
 )
 
 const (

--- a/cmd/stevents/main.go
+++ b/cmd/stevents/main.go
@@ -14,6 +14,8 @@ import (
 	"net/http"
 	"os"
 	"time"
+
+	_ "go.uber.org/automaxprocs"
 )
 
 type event struct {

--- a/cmd/stfileinfo/main.go
+++ b/cmd/stfileinfo/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/scanner"
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/cmd/stfinddevice/main.go
+++ b/cmd/stfinddevice/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/syncthing/syncthing/lib/discover"
 	"github.com/syncthing/syncthing/lib/events"
 	"github.com/syncthing/syncthing/lib/protocol"
+	_ "go.uber.org/automaxprocs"
 )
 
 var timeout = 5 * time.Second

--- a/cmd/stfindignored/main.go
+++ b/cmd/stfindignored/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/ignore"
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/cmd/stgenfiles/main.go
+++ b/cmd/stgenfiles/main.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/cmd/strelaypoolsrv/main.go
+++ b/cmd/strelaypoolsrv/main.go
@@ -21,18 +21,18 @@ import (
 	"time"
 
 	lru "github.com/hashicorp/golang-lru/v2"
-	"github.com/syncthing/syncthing/lib/httpcache"
-	"github.com/syncthing/syncthing/lib/protocol"
-
 	"github.com/oschwald/geoip2-golang"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/syncthing/syncthing/cmd/strelaypoolsrv/auto"
 	"github.com/syncthing/syncthing/lib/assets"
+	"github.com/syncthing/syncthing/lib/httpcache"
+	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/relay/client"
 	"github.com/syncthing/syncthing/lib/sync"
 	"github.com/syncthing/syncthing/lib/tlsutil"
+	_ "go.uber.org/automaxprocs"
 )
 
 type location struct {

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -20,18 +20,17 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/build"
+	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/nat"
 	"github.com/syncthing/syncthing/lib/osutil"
+	_ "github.com/syncthing/syncthing/lib/pmp"
+	syncthingprotocol "github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/relay/protocol"
 	"github.com/syncthing/syncthing/lib/tlsutil"
-	"golang.org/x/time/rate"
-
-	"github.com/syncthing/syncthing/lib/config"
-	"github.com/syncthing/syncthing/lib/nat"
-	_ "github.com/syncthing/syncthing/lib/pmp"
 	_ "github.com/syncthing/syncthing/lib/upnp"
-
-	syncthingprotocol "github.com/syncthing/syncthing/lib/protocol"
+	_ "go.uber.org/automaxprocs"
+	"golang.org/x/time/rate"
 )
 
 var (

--- a/cmd/strelaysrv/testutil/main.go
+++ b/cmd/strelaysrv/testutil/main.go
@@ -17,6 +17,7 @@ import (
 	syncthingprotocol "github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/relay/client"
 	"github.com/syncthing/syncthing/lib/relay/protocol"
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/cmd/stsigtool/main.go
+++ b/cmd/stsigtool/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/syncthing/syncthing/lib/signature"
 	"github.com/syncthing/syncthing/lib/upgrade"
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/cmd/stupgrades/main.go
+++ b/cmd/stupgrades/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/syncthing/syncthing/lib/httpcache"
 	"github.com/syncthing/syncthing/lib/upgrade"
+	_ "go.uber.org/automaxprocs"
 )
 
 type cli struct {

--- a/cmd/stvanity/main.go
+++ b/cmd/stvanity/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/protocol"
+	_ "go.uber.org/automaxprocs"
 )
 
 type result struct {

--- a/cmd/stwatchfile/main.go
+++ b/cmd/stwatchfile/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/lib/sha256"
+	_ "go.uber.org/automaxprocs"
 )
 
 func main() {

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/thejerf/suture/v4"
 	"github.com/willabides/kongplete"
+	_ "go.uber.org/automaxprocs"
 
 	"github.com/syncthing/syncthing/cmd/syncthing/cli"
 	"github.com/syncthing/syncthing/cmd/syncthing/cmdutil"

--- a/cmd/ursrv/main.go
+++ b/cmd/ursrv/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/alecthomas/kong"
 	"github.com/syncthing/syncthing/cmd/ursrv/aggregate"
 	"github.com/syncthing/syncthing/cmd/ursrv/serve"
+	_ "go.uber.org/automaxprocs"
 )
 
 type CLI struct {

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/urfave/cli v1.22.14
 	github.com/vitrun/qart v0.0.0-20160531060029-bf64b92db6b0
 	github.com/willabides/kongplete v0.4.0
+	go.uber.org/automaxprocs v1.5.3
 	golang.org/x/crypto v0.19.0
 	golang.org/x/net v0.21.0
 	golang.org/x/sys v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -170,6 +170,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b h1:0LFwY6Q3gMACTjAbMZBjXAqTOzOwFaj2Ld6cjeQ7Rig=
 github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v1.18.0 h1:HzFfmkOzH5Q8L8G+kSJKUx5dtG87sewO+FoDDqP5Tbk=
 github.com/prometheus/client_golang v1.18.0/go.mod h1:T+GXkCk5wSJyOqMIzVgvvjFDlkOQntgjkJWKrN5txjA=
 github.com/prometheus/client_model v0.5.0 h1:VQw1hfvPvk3Uv6Qf29VrPF32JB6rtbgI6cYPYQjL0Qw=
@@ -229,6 +231,8 @@ github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5t
 github.com/yusufpapurcu/wmi v1.2.3/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
Go is not cgroup aware and by default will set GOMAXPROCS to the number of available threads, regardless of whether it is within the allocated quota. This behaviour causes high amount of CPU throttling and degraded application performance.

Fixes: #9435
