### PR TITLE
lib/scanner: Fix ticker leak in scanner (fixes #9417)

### DIFF
--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -142,8 +142,6 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 		w.ProgressTickIntervalS = 2
 	}
 
-	ticker := time.NewTicker(time.Duration(w.ProgressTickIntervalS) * time.Second)
-
 	// We need to emit progress events, hence we create a routine which buffers
 	// the list of files to be hashed, counts the total number of
 	// bytes to hash, and once no more files need to be hashed (chan gets closed),
@@ -188,17 +186,17 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 				})
 			}
 
+			ticker := time.NewTicker(time.Duration(w.ProgressTickIntervalS) * time.Second)
+			defer ticker.Stop()
 			for {
 				select {
 				case <-done:
 					emitProgressEvent()
 					l.Debugln(w, "Walk progress done", w.Folder, w.Subs, w.Matcher)
-					ticker.Stop()
 					return
 				case <-ticker.C:
 					emitProgressEvent()
 				case <-ctx.Done():
-					ticker.Stop()
 					return
 				}
 			}


### PR DESCRIPTION
Move the ticker closer to where it's used and defer stop it to avoid missing a branch.

Fixes regression introduced in https://github.com/syncthing/syncthing/commit/2f3eacdb6c1c33650ccdd91f42e842c116200d92

Fixes https://github.com/syncthing/syncthing/issues/9417
