### PR TITLE
lib/model: Prevent infinite index sending loop (fixes #9407)

### DIFF
--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -295,12 +295,13 @@ func (s *indexHandler) sendIndexTo(ctx context.Context, fset *db.FileSet) error 
 
 	err = batch.Flush()
 
-	// True if there was nothing to be sent
-	if f.Sequence == 0 {
-		return err
-	}
+	// Use the sequence of the snapshot we iterated as a starting point for the
+	// next run. Previously we used the sequence of the last file we sent,
+	// however it's possible that a higher sequence exists, just doesn't need to
+	// be sent (e.g. in a receive-only folder, when a local change was
+	// reverted). No point trying to send nothing again.
+	s.prevSequence = snap.Sequence(protocol.LocalDeviceID)
 
-	s.prevSequence = f.Sequence
 	return err
 }
 


### PR DESCRIPTION
Explanation of what/why in a code comment.

Fixes https://github.com/syncthing/syncthing/issues/9407