### PR TITLE
lib/model: Don't bump seq on error in index handler

### DIFF
--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -293,7 +293,9 @@ func (s *indexHandler) sendIndexTo(ctx context.Context, fset *db.FileSet) error 
 		return err
 	}
 
-	err = batch.Flush()
+	if err := batch.Flush(); err != nil {
+		return err
+	}
 
 	// Use the sequence of the snapshot we iterated as a starting point for the
 	// next run. Previously we used the sequence of the last file we sent,
@@ -302,7 +304,7 @@ func (s *indexHandler) sendIndexTo(ctx context.Context, fset *db.FileSet) error 
 	// reverted). No point trying to send nothing again.
 	s.prevSequence = snap.Sequence(protocol.LocalDeviceID)
 
-	return err
+	return nil
 }
 
 func (s *indexHandler) receive(fs []protocol.FileInfo, update bool, op string) error {


### PR DESCRIPTION
This likely doesn't matter, as if the batch flush fails, the connection likely failed. So we'll get a new connection with a new cluster config and a new sequence to start from, thus it doesn't matter that we bump the sequence even though we didn't actually successfully sent the indexes. It's still wrong though :)
