### PR TITLE
Removed no longer relevant Bountysource link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ implementations][11] for Windows, Mac, and Linux.
 
 To run Syncthing in Docker, see [the Docker README][16].
 
-## Vote on features/bugs
-
-We'd like to encourage you to [vote][12] on issues that matter to you.
-This helps the team understand what are the biggest pain points for our
-users, and could potentially influence what is being worked on next.
-
 ## Getting in Touch
 
 The first and best point of contact is the [Forum][8].
@@ -111,7 +105,6 @@ All code is licensed under the [MPLv2 License][7].
 [8]: https://forum.syncthing.net/
 [10]: https://github.com/syncthing/syncthing/issues
 [11]: https://docs.syncthing.net/users/contrib.html#gui-wrappers
-[12]: https://www.bountysource.com/teams/syncthing/issues
 [13]: https://github.com/syncthing/syncthing/blob/main/GOALS.md
 [14]: assets/logo-text-128.png
 [15]: https://syncthing.net/


### PR DESCRIPTION
### Purpose

Bountysource no longer exists and the readme link 404s. This removes the Bountysource link and corresponding readme section.

Perhaps the section should instead be replaced by other instructions for voting on features.