### PR TITLE
index.html: Add one-click access to #folder-sharing & #device-sharing (fixes #8972)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -584,7 +584,7 @@
                         </td>
                       </tr>
                       <tr>
-                        <th><span class="fas fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span></th>
+                        <th><span class="fas fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span>&nbsp;<span class="fas fa-pencil-alt"></span>&nbsp;<a href="" ng-click="editFolderExisting(folder, '#folder-sharing')"><i class="small">...</i></a>
                         <td class="text-right no-overflow-ellipse overflow-break-word">
                           <span ng-repeat="device in otherDevices(folder.devices)">
                             <span ng-if="folder.type !== 'receiveencrypted' && device.encryptionPassword" class="text-nowrap">
@@ -943,7 +943,7 @@
                         <td class="text-right">{{connections[deviceCfg.deviceID].clientVersion}}</td>
                       </tr>
                       <tr ng-if="deviceFolders(deviceCfg).length > 0">
-                        <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folders</span></th>
+                        <th><span class="fas fa-fw fa-folder"></span>&nbsp;<span translate>Folders</span>&nbsp;<span class="fas fa-pencil-alt"></span>&nbsp;<a href="" ng-click="editDeviceExisting(deviceCfg, '#device-sharing')"><i class="small">...</i></a></th>
                         <td class="text-right no-overflow-ellipse overflow-break-word">
                           <span ng-repeat="folderID in deviceFolders(deviceCfg)">
                             <span ng-if="folderIsSharedEncrypted(folderID, deviceCfg.deviceID)" class="text-nowrap">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -584,7 +584,7 @@
                         </td>
                       </tr>
                       <tr>
-                        <th><span class="fas fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span>&nbsp;<span class="fas fa-pencil-alt"></span>&nbsp;<a href="" ng-click="editFolderExisting(folder, '#folder-sharing')"><i class="small">...</i></a>
+                        <th><span class="fas fa-fw fa-share-alt"></span>&nbsp;<span translate>Shared With</span>&nbsp;<span class="fas fa-pencil-alt"></span>&nbsp;<a href="" ng-click="editFolderExisting(folder, '#folder-sharing')"><i class="small">...</i></a></th>
                         <td class="text-right no-overflow-ellipse overflow-break-word">
                           <span ng-repeat="device in otherDevices(folder.devices)">
                             <span ng-if="folder.type !== 'receiveencrypted' && device.encryptionPassword" class="text-nowrap">


### PR DESCRIPTION
### Purpose

Add links to quick access from a Folder to its members edit screen (#folder-sharing) and from a RemoteDevice to the list of folders they are enrolled edit screen (#device-sharing).

### Testing

Open a folder in the GUI. A link beside "Shared With" item will bring you to direct membership edition.
Open a device in the GUI. A link beside "Folders" item **would** bring you to direct edition of clusters list for this device... although this last won't do the job fully because it only displays the #device-general dialog.. I don't understand why... please advise a newb


### Screenshots
![image](https://github.com/syncthing/syncthing/assets/6240207/549c18e1-3112-4fba-ba9a-d4d996a9df1c)
![image](https://github.com/syncthing/syncthing/assets/6240207/91351b92-977a-41d5-9951-f1b4ffb7c282)


## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

