### PR TITLE
lib/db: Drop indexes for outgoing data to force refresh (ref #9496)

### DIFF
--- a/lib/db/keyer.go
+++ b/lib/db/keyer.go
@@ -103,6 +103,7 @@ type keyer interface {
 	// index IDs
 	GenerateIndexIDKey(key, device, folder []byte) (indexIDKey, error)
 	FolderFromIndexIDKey(key []byte) ([]byte, bool)
+	DeviceFromIndexIDKey(key []byte) ([]byte, bool)
 
 	// Mtimes
 	GenerateMtimesKey(key, folder []byte) (mtimesKey, error)
@@ -306,6 +307,10 @@ func (k defaultKeyer) GenerateIndexIDKey(key, device, folder []byte) (indexIDKey
 
 func (k defaultKeyer) FolderFromIndexIDKey(key []byte) ([]byte, bool) {
 	return k.folderIdx.Val(binary.BigEndian.Uint32(key[keyPrefixLen+keyDeviceLen:]))
+}
+
+func (k defaultKeyer) DeviceFromIndexIDKey(key []byte) ([]byte, bool) {
+	return k.folderIdx.Val(binary.BigEndian.Uint32(key[keyPrefixLen : keyPrefixLen+keyDeviceLen]))
 }
 
 type mtimesKey []byte


### PR DESCRIPTION
### Purpose

Resend our indexes since we fixed that index-sending issue.

I made a new thing to only drop the non-local-device index IDs, i.e., those for other devices. This means we will see a mismatch and resend all indexes, but they will not. This is somewhat cleaner as it avoids resending everything twice when two devices are upgraded, and in any case, we have no reason to force a resend of incoming indexes here.

### Testing

It happens on my computer...