### PR TITLE
lib/nat: Don't crash on empty address list (fixes #9503)

### DIFF
--- a/lib/nat/service.go
+++ b/lib/nat/service.go
@@ -233,9 +233,8 @@ func (s *Service) verifyExistingLocked(ctx context.Context, mapping *Mapping, na
 		default:
 		}
 
-		// Delete addresses for NATDevice's that do not exist anymore
-		nat, ok := nats[id]
-		if !ok {
+		if nat, ok := nats[id]; !ok || len(extAddrs) == 0 {
+			// Delete addresses for NATDevice's that do not exist anymore
 			mapping.removeAddressLocked(id)
 			change = true
 			continue


### PR DESCRIPTION
I don't particularly know this piece of code, but this appears to me like it would handle the crash and do the right thing...
