### PR TITLE
gui: Fix Firefox bookmark favicon (fixes #9506)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -12,8 +12,7 @@
   <meta charset="utf-8"/>
   <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <link rel="shortcut icon" href="assets/img/favicon-default.png" type="image/x-icon"/>
-  <link rel="shortcut icon" href="assets/img/favicon-{{syncthingStatus()}}.png" type="image/x-icon"/>
+  <link rel="shortcut icon" href="assets/img/favicon-default.png" ng-href="assets/img/favicon-{{syncthingStatus()}}.png" type="image/x-icon"/>
   <link rel="mask-icon" href="assets/img/safari-pinned-tab.svg" color="#0882c8"/>
 
   <title ng-bind="thisDeviceName() + ' | Syncthing'"></title>


### PR DESCRIPTION
### Purpose

Firefox uses the last specified favicon link for bookmarks, but only if it is available on initial page load.
Remove the second link and use ng-href to change the icon instead.

I'm not really familiar with AngularJS, feel free to offer suggestions for improvements.

### Testing

Briefly tested on Firefox 124.0.2 and Chrome 123.0.6312.105.

