### PR TITLE
etc: Use 7MiB buffer size

### DIFF
--- a/etc/linux-sysctl/30-syncthing.conf
+++ b/etc/linux-sysctl/30-syncthing.conf
@@ -1,4 +1,4 @@
-# Increase maximum socket buffer sizes to 2.5MiB for QUIC connections
+# Increase maximum socket buffer sizes to 7MiB for QUIC connections
 # see https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
-net.core.rmem_max = 2621440
-net.core.wmem_max = 2621440
+net.core.rmem_max = 7340032
+net.core.wmem_max = 7340032


### PR DESCRIPTION
### Purpose

In preparation for quic-go v0.43.0. see https://github.com/quic-go/quic-go/pull/4455