### PR TITLE
lib/connections: Add syncthing_connections_active metric (fixes #9527)

### DIFF
--- a/lib/connections/metrics.go
+++ b/lib/connections/metrics.go
@@ -16,7 +16,7 @@ var (
 		Namespace: "syncthing",
 		Subsystem: "connections",
 		Name:      "active",
-		Help:      "Amount of currently active connections, per device. If value is 0, the device is disconnected.",
+		Help:      "Number of currently active connections, per device. If value is 0, the device is disconnected.",
 	}, []string{"device"})
 )
 

--- a/lib/connections/metrics.go
+++ b/lib/connections/metrics.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2024 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package connections
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	metricDeviceActiveConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "syncthing",
+		Subsystem: "connections",
+		Name:      "active",
+		Help:      "Amount of currently active connections, per device. If value is 0, the device is disconnected.",
+	}, []string{"device"})
+)
+
+func registerDeviceMetrics(deviceID string) {
+	// Register metrics for this device, so that counters & gauges are present even
+	// when zero.
+	metricDeviceActiveConnections.WithLabelValues(deviceID)
+}

--- a/lib/protocol/metrics.go
+++ b/lib/protocol/metrics.go
@@ -58,5 +58,6 @@ func registerDeviceMetrics(deviceID string) {
 	metricDeviceSentUncompressedBytes.WithLabelValues(deviceID)
 	metricDeviceSentMessages.WithLabelValues(deviceID)
 	metricDeviceRecvBytes.WithLabelValues(deviceID)
+	metricDeviceRecvDecompressedBytes.WithLabelValues(deviceID)
 	metricDeviceRecvMessages.WithLabelValues(deviceID)
 }


### PR DESCRIPTION
### Purpose

Adds a new metric `syncthing_connections_active` which equals to the amount of active connections per device.

Fixes #9527 

<!--
Describe the purpose of this change. If there is an existing issue that is
resolved by this pull request, ensure that the commit subject is on the form
`Some short description (fixes #1234)` where 1234 is the issue number.
-->

### Testing

I've manually tested it by running syncthing with these changes locally and examining the returned metrics from `/metrics`.
I've done the following things:
- Connect & disconnect a device
- Increase & decrease the number of connections and verify that the value of the metric matches with the amount displayed in the GUI.

### Documentation

https://github.com/syncthing/docs/blob/main/includes/metrics-list.rst needs to be regenerated with [find-metrics.go](https://github.com/syncthing/docs/blob/main/_script/find-metrics/find-metrics.go)

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

