### PR TITLE
Add support for custom ALPN

### DIFF
--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"log"
 	"net"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -82,7 +83,7 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config, token strin
 	}
 
 	state := conn.ConnectionState()
-	if debug && state.NegotiatedProtocol != protocol.ProtocolName {
+	if debug && !slices.Contains(config.NextProtos, state.NegotiatedProtocol) {
 		log.Println("Protocol negotiation error")
 	}
 

--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -78,7 +78,7 @@ var httpClient = &http.Client{
 func main() {
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
 
-	var dir, extAddress, proto string
+	var dir, extAddress, proto, nextProto string
 
 	flag.StringVar(&listen, "listen", ":22067", "Protocol listen address")
 	flag.StringVar(&dir, "keys", ".", "Directory where cert.pem and key.pem is stored")
@@ -94,6 +94,7 @@ func main() {
 	flag.StringVar(&providedBy, "provided-by", "", "An optional description about who provides the relay")
 	flag.StringVar(&extAddress, "ext-address", "", "An optional address to advertise as being available on.\n\tAllows listening on an unprivileged port with port forwarding from e.g. 443, and be connected to on port 443.")
 	flag.StringVar(&proto, "protocol", "tcp", "Protocol used for listening. 'tcp' for IPv4 and IPv6, 'tcp4' for IPv4, 'tcp6' for IPv6")
+	flag.StringVar(&nextProto, "alpn", protocol.ProtocolName, "Next protocol (ALPN) used for connection. Multiple values are separated by a comma.")
 	flag.BoolVar(&natEnabled, "nat", false, "Use UPnP/NAT-PMP to acquire external port mapping")
 	flag.IntVar(&natLease, "nat-lease", 60, "NAT lease length in minutes")
 	flag.IntVar(&natRenewal, "nat-renewal", 30, "NAT renewal frequency in minutes")
@@ -165,7 +166,7 @@ func main() {
 
 	tlsCfg := &tls.Config{
 		Certificates:           []tls.Certificate{cert},
-		NextProtos:             []string{protocol.ProtocolName},
+		NextProtos:             strings.Split(nextProto, ","),
 		ClientAuth:             tls.RequestClientCert,
 		SessionTicketsDisabled: true,
 		InsecureSkipVerify:     true,


### PR DESCRIPTION
Use "bep-relay" as default but allow custom ALPNs if the relay server is used for something unrelated to "bep-relay".

### Purpose
This allows to use the perfect syncthing-relay for another usage for different applications without to have conflicts with syncthing application itself and custom application.

### Testing
Used "testutil" of strelaysrv and saw that it shows an error in log output if the ALPN does not match. Also used wireshark to see the TLS alert "No application protocol".

## Authorship
André Klitzing <aklitzing@gmail.com>
