### PR TITLE
Fix handling of extended characters in .stignore on macOS

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -248,7 +248,7 @@ func (m *Matcher) Match(file string) (result ignoreresult.R) {
 	// allow skipping matched directories or not. As soon as we hit an
 	// exclude pattern (with some exceptions), we can't skip directories
 	// anymore.
-	file = filepath.ToSlash(file)
+	file = osutil.NormalizedFilename(file)
 	var lowercaseFile string
 	canSkipDir := true
 	for _, pattern := range m.patterns {

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -85,7 +85,7 @@ func TestIgnore(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		if r := pats.Match(tc.f); r.IsIgnored() != tc.r {
+		if r := pats.Match(osutil.NativeFilename(tc.f)); r.IsIgnored() != tc.r {
 			t.Errorf("Incorrect ignoreFile() #%d (%s); E: %v, A: %v", i, tc.f, tc.r, r)
 		}
 	}
@@ -125,7 +125,7 @@ func TestExcludes(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if r := pats.Match(tc.f); r.IsIgnored() != tc.r {
+		if r := pats.Match(osutil.NativeFilename(tc.f)); r.IsIgnored() != tc.r {
 			t.Errorf("Incorrect match for %s: %v != %v", tc.f, r, tc.r)
 		}
 	}
@@ -156,18 +156,18 @@ func TestFlagOrder(t *testing.T) {
 
 	for i := 1; i < 7; i++ {
 		pat := fmt.Sprintf("ign%d", i)
-		if r := pats.Match(pat); r.IsIgnored() || r.IsDeletable() {
+		if r := pats.Match(osutil.NativeFilename(pat)); r.IsIgnored() || r.IsDeletable() {
 			t.Errorf("incorrect %s", pat)
 		}
 	}
 	for i := 7; i < 10; i++ {
 		pat := fmt.Sprintf("ign%d", i)
-		if r := pats.Match(pat); r.IsDeletable() {
+		if r := pats.Match(osutil.NativeFilename(pat)); r.IsDeletable() {
 			t.Errorf("incorrect %s", pat)
 		}
 	}
 
-	if r := pats.Match("(?d)!ign10"); !r.IsIgnored() {
+	if r := pats.Match(osutil.NativeFilename("(?d)!ign10")); !r.IsIgnored() {
 		t.Errorf("incorrect")
 	}
 }
@@ -207,7 +207,7 @@ func TestDeletables(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if r := pats.Match(tc.f); r.IsIgnored() != tc.i || r.IsDeletable() != tc.d {
+		if r := pats.Match(osutil.NativeFilename(tc.f)); r.IsIgnored() != tc.i || r.IsDeletable() != tc.d {
 			t.Errorf("Incorrect match for %s: %v != Result{%t, %t}", tc.f, r, tc.i, tc.d)
 		}
 	}
@@ -260,13 +260,13 @@ func TestCaseSensitivity(t *testing.T) {
 	}
 
 	for _, tc := range match {
-		if !ign.Match(tc).IsIgnored() {
+		if !ign.Match(osutil.NativeFilename(tc)).IsIgnored() {
 			t.Errorf("Incorrect match for %q: should be matched", tc)
 		}
 	}
 
 	for _, tc := range dontMatch {
-		if ign.Match(tc).IsIgnored() {
+		if ign.Match(osutil.NativeFilename(tc)).IsIgnored() {
 			t.Errorf("Incorrect match for %q: should not be matched", tc)
 		}
 	}
@@ -310,7 +310,7 @@ func TestCaching(t *testing.T) {
 	// Cache some outcomes
 
 	for _, letter := range []string{"a", "b", "x", "y"} {
-		pats.Match(letter)
+		pats.Match(osutil.NativeFilename(letter))
 	}
 
 	if pats.matches.len() != 4 {
@@ -347,7 +347,7 @@ func TestCaching(t *testing.T) {
 	// Cache some outcomes again
 
 	for _, letter := range []string{"b", "x", "y"} {
-		pats.Match(letter)
+		pats.Match(osutil.NativeFilename(letter))
 	}
 
 	// Verify that outcomes preserved on next load
@@ -378,7 +378,7 @@ func TestCaching(t *testing.T) {
 	// Cache some outcomes again
 
 	for _, letter := range []string{"b", "x", "y"} {
-		pats.Match(letter)
+		pats.Match(osutil.NativeFilename(letter))
 	}
 
 	// Verify that outcomes provided on next load
@@ -442,9 +442,10 @@ flamingo
 		b.Error(err)
 	}
 
+	f := osutil.NativeFilename("filename")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		result = pats.Match("filename")
+		result = pats.Match(f)
 	}
 }
 
@@ -486,8 +487,9 @@ flamingo
 	if err != nil {
 		b.Fatal(err)
 	}
+	f := osutil.NativeFilename("filename")
 	// Cache the outcome for "filename"
-	pats.Match("filename")
+	pats.Match(f)
 
 	// This load should now load the cached outcomes as the set of patterns
 	// has not changed.
@@ -497,7 +499,7 @@ flamingo
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		result = pats.Match("filename")
+		result = pats.Match(f)
 	}
 }
 
@@ -527,13 +529,13 @@ func TestCacheReload(t *testing.T) {
 
 	// Verify that both are ignored
 
-	if !pats.Match("f1").IsIgnored() {
+	if !pats.Match(osutil.NativeFilename("f1")).IsIgnored() {
 		t.Error("Unexpected non-match for f1")
 	}
-	if !pats.Match("f2").IsIgnored() {
+	if !pats.Match(osutil.NativeFilename("f2")).IsIgnored() {
 		t.Error("Unexpected non-match for f2")
 	}
-	if pats.Match("f3").IsIgnored() {
+	if pats.Match(osutil.NativeFilename("f3")).IsIgnored() {
 		t.Error("Unexpected match for f3")
 	}
 
@@ -562,13 +564,13 @@ func TestCacheReload(t *testing.T) {
 
 	// Verify that the new patterns are in effect
 
-	if !pats.Match("f1").IsIgnored() {
+	if !pats.Match(osutil.NativeFilename("f1")).IsIgnored() {
 		t.Error("Unexpected non-match for f1")
 	}
-	if pats.Match("f2").IsIgnored() {
+	if pats.Match(osutil.NativeFilename("f2")).IsIgnored() {
 		t.Error("Unexpected match for f2")
 	}
-	if !pats.Match("f3").IsIgnored() {
+	if !pats.Match(osutil.NativeFilename("f3")).IsIgnored() {
 		t.Error("Unexpected non-match for f3")
 	}
 }
@@ -683,9 +685,9 @@ func TestWindowsPatterns(t *testing.T) {
 	}
 
 	tests := []string{`a\b`, `c\d`}
-	for _, pat := range tests {
-		if !pats.Match(pat).IsIgnored() {
-			t.Errorf("Should match %s", pat)
+	for _, tc := range tests {
+		if !pats.Match(osutil.NativeFilename(tc)).IsIgnored() {
+			t.Errorf("Should match %s", tc)
 		}
 	}
 }
@@ -711,9 +713,9 @@ func TestAutomaticCaseInsensitivity(t *testing.T) {
 	}
 
 	tests := []string{`a/B`, `C/d`}
-	for _, pat := range tests {
-		if !pats.Match(pat).IsIgnored() {
-			t.Errorf("Should match %s", pat)
+	for _, tc := range tests {
+		if !pats.Match(osutil.NativeFilename(tc)).IsIgnored() {
+			t.Errorf("Should match %s", tc)
 		}
 	}
 }
@@ -745,7 +747,7 @@ func TestCommas(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if pats.Match(tc.name).IsIgnored() != tc.match {
+		if pats.Match(osutil.NativeFilename(tc.name)).IsIgnored() != tc.match {
 			t.Errorf("Match of %s was %v, should be %v", tc.name, !tc.match, tc.match)
 		}
 	}
@@ -823,11 +825,11 @@ func TestIssue3639(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !pats.Match("foo/bar").IsIgnored() {
+	if !pats.Match(osutil.NativeFilename("foo/bar")).IsIgnored() {
 		t.Error("Should match 'foo/bar'")
 	}
 
-	if pats.Match("foo").IsIgnored() {
+	if pats.Match(osutil.NativeFilename("foo")).IsIgnored() {
 		t.Error("Should not match 'foo'")
 	}
 }
@@ -860,7 +862,7 @@ func TestIssue3674(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(tc.file).IsIgnored()
+		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -895,7 +897,7 @@ func TestGobwasGlobIssue18(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(tc.file).IsIgnored()
+		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -927,7 +929,7 @@ func TestRoot(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(tc.file).IsIgnored()
+		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -1027,7 +1029,7 @@ func TestIssue4680(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(tc.file).IsIgnored()
+		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -1122,7 +1124,7 @@ func TestIssue5009(t *testing.T) {
 	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
 		t.Fatal(err)
 	}
-	if m := pats.Match("ign2"); !m.CanSkipDir() {
+	if m := pats.Match(osutil.NativeFilename("ign2")); !m.CanSkipDir() {
 		t.Error("CanSkipDir should be true without excludes")
 	}
 
@@ -1138,7 +1140,7 @@ func TestIssue5009(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m := pats.Match("ign2"); m.CanSkipDir() {
+	if m := pats.Match(osutil.NativeFilename("ign2")); m.CanSkipDir() {
 		t.Error("CanSkipDir should not be true with excludes")
 	}
 }
@@ -1164,7 +1166,7 @@ func TestSpecialChars(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if !pats.Match(c).IsIgnored() {
+		if !pats.Match(osutil.NativeFilename(c)).IsIgnored() {
 			t.Errorf("%q should be ignored", c)
 		}
 	}
@@ -1191,7 +1193,7 @@ func TestIntlWildcards(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if !pats.Match(c).IsIgnored() {
+		if !pats.Match(osutil.NativeFilename(c)).IsIgnored() {
 			t.Errorf("%q should be ignored", c)
 		}
 	}
@@ -1272,7 +1274,7 @@ func TestSkipIgnoredDirs(t *testing.T) {
 	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
 		t.Fatal(err)
 	}
-	if m := pats.Match("whatever"); !m.CanSkipDir() {
+	if m := pats.Match(osutil.NativeFilename("whatever")); !m.CanSkipDir() {
 		t.Error("CanSkipDir should be true")
 	}
 
@@ -1283,7 +1285,7 @@ func TestSkipIgnoredDirs(t *testing.T) {
 	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
 		t.Fatal(err)
 	}
-	if m := pats.Match("whatever"); m.CanSkipDir() {
+	if m := pats.Match(osutil.NativeFilename("whatever")); m.CanSkipDir() {
 		t.Error("CanSkipDir should be false")
 	}
 }

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -85,7 +85,7 @@ func TestIgnore(t *testing.T) {
 	}
 
 	for i, tc := range tests {
-		if r := pats.Match(osutil.NativeFilename(tc.f)); r.IsIgnored() != tc.r {
+		if r := pats.Match(tc.f); r.IsIgnored() != tc.r {
 			t.Errorf("Incorrect ignoreFile() #%d (%s); E: %v, A: %v", i, tc.f, tc.r, r)
 		}
 	}
@@ -125,7 +125,7 @@ func TestExcludes(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if r := pats.Match(osutil.NativeFilename(tc.f)); r.IsIgnored() != tc.r {
+		if r := pats.Match(tc.f); r.IsIgnored() != tc.r {
 			t.Errorf("Incorrect match for %s: %v != %v", tc.f, r, tc.r)
 		}
 	}
@@ -156,18 +156,18 @@ func TestFlagOrder(t *testing.T) {
 
 	for i := 1; i < 7; i++ {
 		pat := fmt.Sprintf("ign%d", i)
-		if r := pats.Match(osutil.NativeFilename(pat)); r.IsIgnored() || r.IsDeletable() {
+		if r := pats.Match(pat); r.IsIgnored() || r.IsDeletable() {
 			t.Errorf("incorrect %s", pat)
 		}
 	}
 	for i := 7; i < 10; i++ {
 		pat := fmt.Sprintf("ign%d", i)
-		if r := pats.Match(osutil.NativeFilename(pat)); r.IsDeletable() {
+		if r := pats.Match(pat); r.IsDeletable() {
 			t.Errorf("incorrect %s", pat)
 		}
 	}
 
-	if r := pats.Match(osutil.NativeFilename("(?d)!ign10")); !r.IsIgnored() {
+	if r := pats.Match("(?d)!ign10"); !r.IsIgnored() {
 		t.Errorf("incorrect")
 	}
 }
@@ -207,7 +207,7 @@ func TestDeletables(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if r := pats.Match(osutil.NativeFilename(tc.f)); r.IsIgnored() != tc.i || r.IsDeletable() != tc.d {
+		if r := pats.Match(tc.f); r.IsIgnored() != tc.i || r.IsDeletable() != tc.d {
 			t.Errorf("Incorrect match for %s: %v != Result{%t, %t}", tc.f, r, tc.i, tc.d)
 		}
 	}
@@ -260,13 +260,13 @@ func TestCaseSensitivity(t *testing.T) {
 	}
 
 	for _, tc := range match {
-		if !ign.Match(osutil.NativeFilename(tc)).IsIgnored() {
+		if !ign.Match(tc).IsIgnored() {
 			t.Errorf("Incorrect match for %q: should be matched", tc)
 		}
 	}
 
 	for _, tc := range dontMatch {
-		if ign.Match(osutil.NativeFilename(tc)).IsIgnored() {
+		if ign.Match(tc).IsIgnored() {
 			t.Errorf("Incorrect match for %q: should not be matched", tc)
 		}
 	}
@@ -310,7 +310,7 @@ func TestCaching(t *testing.T) {
 	// Cache some outcomes
 
 	for _, letter := range []string{"a", "b", "x", "y"} {
-		pats.Match(osutil.NativeFilename(letter))
+		pats.Match(letter)
 	}
 
 	if pats.matches.len() != 4 {
@@ -347,7 +347,7 @@ func TestCaching(t *testing.T) {
 	// Cache some outcomes again
 
 	for _, letter := range []string{"b", "x", "y"} {
-		pats.Match(osutil.NativeFilename(letter))
+		pats.Match(letter)
 	}
 
 	// Verify that outcomes preserved on next load
@@ -378,7 +378,7 @@ func TestCaching(t *testing.T) {
 	// Cache some outcomes again
 
 	for _, letter := range []string{"b", "x", "y"} {
-		pats.Match(osutil.NativeFilename(letter))
+		pats.Match(letter)
 	}
 
 	// Verify that outcomes provided on next load
@@ -442,10 +442,9 @@ flamingo
 		b.Error(err)
 	}
 
-	f := osutil.NativeFilename("filename")
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		result = pats.Match(f)
+		result = pats.Match("filename")
 	}
 }
 
@@ -487,9 +486,8 @@ flamingo
 	if err != nil {
 		b.Fatal(err)
 	}
-	f := osutil.NativeFilename("filename")
 	// Cache the outcome for "filename"
-	pats.Match(f)
+	pats.Match("filename")
 
 	// This load should now load the cached outcomes as the set of patterns
 	// has not changed.
@@ -499,7 +497,7 @@ flamingo
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		result = pats.Match(f)
+		result = pats.Match("filename")
 	}
 }
 
@@ -529,13 +527,13 @@ func TestCacheReload(t *testing.T) {
 
 	// Verify that both are ignored
 
-	if !pats.Match(osutil.NativeFilename("f1")).IsIgnored() {
+	if !pats.Match("f1").IsIgnored() {
 		t.Error("Unexpected non-match for f1")
 	}
-	if !pats.Match(osutil.NativeFilename("f2")).IsIgnored() {
+	if !pats.Match("f2").IsIgnored() {
 		t.Error("Unexpected non-match for f2")
 	}
-	if pats.Match(osutil.NativeFilename("f3")).IsIgnored() {
+	if pats.Match("f3").IsIgnored() {
 		t.Error("Unexpected match for f3")
 	}
 
@@ -564,13 +562,13 @@ func TestCacheReload(t *testing.T) {
 
 	// Verify that the new patterns are in effect
 
-	if !pats.Match(osutil.NativeFilename("f1")).IsIgnored() {
+	if !pats.Match("f1").IsIgnored() {
 		t.Error("Unexpected non-match for f1")
 	}
-	if pats.Match(osutil.NativeFilename("f2")).IsIgnored() {
+	if pats.Match("f2").IsIgnored() {
 		t.Error("Unexpected match for f2")
 	}
-	if !pats.Match(osutil.NativeFilename("f3")).IsIgnored() {
+	if !pats.Match("f3").IsIgnored() {
 		t.Error("Unexpected non-match for f3")
 	}
 }
@@ -685,9 +683,9 @@ func TestWindowsPatterns(t *testing.T) {
 	}
 
 	tests := []string{`a\b`, `c\d`}
-	for _, tc := range tests {
-		if !pats.Match(osutil.NativeFilename(tc)).IsIgnored() {
-			t.Errorf("Should match %s", tc)
+	for _, pat := range tests {
+		if !pats.Match(pat).IsIgnored() {
+			t.Errorf("Should match %s", pat)
 		}
 	}
 }
@@ -713,9 +711,9 @@ func TestAutomaticCaseInsensitivity(t *testing.T) {
 	}
 
 	tests := []string{`a/B`, `C/d`}
-	for _, tc := range tests {
-		if !pats.Match(osutil.NativeFilename(tc)).IsIgnored() {
-			t.Errorf("Should match %s", tc)
+	for _, pat := range tests {
+		if !pats.Match(pat).IsIgnored() {
+			t.Errorf("Should match %s", pat)
 		}
 	}
 }
@@ -747,7 +745,7 @@ func TestCommas(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if pats.Match(osutil.NativeFilename(tc.name)).IsIgnored() != tc.match {
+		if pats.Match(tc.name).IsIgnored() != tc.match {
 			t.Errorf("Match of %s was %v, should be %v", tc.name, !tc.match, tc.match)
 		}
 	}
@@ -825,11 +823,11 @@ func TestIssue3639(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !pats.Match(osutil.NativeFilename("foo/bar")).IsIgnored() {
+	if !pats.Match("foo/bar").IsIgnored() {
 		t.Error("Should match 'foo/bar'")
 	}
 
-	if pats.Match(osutil.NativeFilename("foo")).IsIgnored() {
+	if pats.Match("foo").IsIgnored() {
 		t.Error("Should not match 'foo'")
 	}
 }
@@ -862,7 +860,7 @@ func TestIssue3674(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
+		res := pats.Match(tc.file).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -897,7 +895,7 @@ func TestGobwasGlobIssue18(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
+		res := pats.Match(tc.file).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -929,7 +927,7 @@ func TestRoot(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
+		res := pats.Match(tc.file).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -1029,7 +1027,7 @@ func TestIssue4680(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		res := pats.Match(osutil.NativeFilename(tc.file)).IsIgnored()
+		res := pats.Match(tc.file).IsIgnored()
 		if res != tc.matches {
 			t.Errorf("Matches(%q) == %v, expected %v", tc.file, res, tc.matches)
 		}
@@ -1124,7 +1122,7 @@ func TestIssue5009(t *testing.T) {
 	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
 		t.Fatal(err)
 	}
-	if m := pats.Match(osutil.NativeFilename("ign2")); !m.CanSkipDir() {
+	if m := pats.Match("ign2"); !m.CanSkipDir() {
 		t.Error("CanSkipDir should be true without excludes")
 	}
 
@@ -1140,7 +1138,7 @@ func TestIssue5009(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if m := pats.Match(osutil.NativeFilename("ign2")); m.CanSkipDir() {
+	if m := pats.Match("ign2"); m.CanSkipDir() {
 		t.Error("CanSkipDir should not be true with excludes")
 	}
 }
@@ -1166,7 +1164,7 @@ func TestSpecialChars(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if !pats.Match(osutil.NativeFilename(c)).IsIgnored() {
+		if !pats.Match(c).IsIgnored() {
 			t.Errorf("%q should be ignored", c)
 		}
 	}
@@ -1193,7 +1191,7 @@ func TestIntlWildcards(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		if !pats.Match(osutil.NativeFilename(c)).IsIgnored() {
+		if !pats.Match(c).IsIgnored() {
 			t.Errorf("%q should be ignored", c)
 		}
 	}
@@ -1274,7 +1272,7 @@ func TestSkipIgnoredDirs(t *testing.T) {
 	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
 		t.Fatal(err)
 	}
-	if m := pats.Match(osutil.NativeFilename("whatever")); !m.CanSkipDir() {
+	if m := pats.Match("whatever"); !m.CanSkipDir() {
 		t.Error("CanSkipDir should be true")
 	}
 
@@ -1285,7 +1283,7 @@ func TestSkipIgnoredDirs(t *testing.T) {
 	if err := pats.Parse(bytes.NewBufferString(stignore), ".stignore"); err != nil {
 		t.Fatal(err)
 	}
-	if m := pats.Match(osutil.NativeFilename("whatever")); m.CanSkipDir() {
+	if m := pats.Match("whatever"); m.CanSkipDir() {
 		t.Error("CanSkipDir should be false")
 	}
 }

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -792,7 +792,7 @@ func TestIssue3164(t *testing.T) {
 	}
 }
 
-func TestIssue3174(t *testing.T) {
+func TestIssue3174AndIssue9597(t *testing.T) {
 	testFs := newTestFS()
 
 	stignore := `
@@ -805,7 +805,7 @@ func TestIssue3174(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if !pats.Match("åäö").IsIgnored() {
+	if !pats.Match(osutil.NativeFilename("åäö")).IsIgnored() {
 		t.Error("Should match")
 	}
 }


### PR DESCRIPTION
### Purpose

Normalize pathnames before comparing to ignore patterns. (issue #9597).

Added to the existing unit test. The existing unit tests covers extended character patterns, but it is when a NFD filename is matched against a NFC pattern that the an expected match did not occur.

Made the unit test more robust by passing in native-format pathnames every time Matcher.Match is invoked, to uncover potential future similar bugs.

### Testing

Updated unit test fails without fix, passes with fix. (On macOS at least).

Benchmark results:

```
Before:
BenchmarkMatch-8                 2180224               538.7 ns/op
BenchmarkMatchCached-8           9932952               119.6 ns/op

BenchmarkMatch-8                 2192263               534.9 ns/op
BenchmarkMatchCached-8           9533098               119.8 ns/op

BenchmarkMatch-8                 2171739               536.4 ns/op
BenchmarkMatchCached-8           9956037               120.5 ns/op

BenchmarkMatch-8                 2192551               538.2 ns/op
BenchmarkMatchCached-8           9385444               121.7 ns/op

BenchmarkMatch-8                 2140863               539.8 ns/op
BenchmarkMatchCached-8           9518190               122.1 ns/op

BenchmarkMatch-8                 2189522               531.4 ns/op
BenchmarkMatchCached-8           9751231               118.8 ns/op

BenchmarkMatch-8                 2192011               536.6 ns/op
BenchmarkMatchCached-8           9524190               119.8 ns/op


After:
BenchmarkMatch-8                 2164195               540.4 ns/op
BenchmarkMatchCached-8           9753216               119.9 ns/op

BenchmarkMatch-8                 2177550               540.8 ns/op
BenchmarkMatchCached-8           9671676               120.2 ns/op

BenchmarkMatch-8                 2171844               541.7 ns/op
BenchmarkMatchCached-8           9651882               119.6 ns/op

BenchmarkMatch-8                 2164958               540.8 ns/op
BenchmarkMatchCached-8           9804344               119.4 ns/op

BenchmarkMatch-8                 2141856               542.0 ns/op
BenchmarkMatchCached-8           9493785               120.3 ns/op

BenchmarkMatch-8                 2168912               539.3 ns/op
BenchmarkMatchCached-8           9555124               120.2 ns/op

BenchmarkMatch-8                 2171197               540.3 ns/op
BenchmarkMatchCached-8           9690603               119.6 ns/op
```

This shows a 0.87% mean performance degradation on `BenchmarkMatch`

I have considered how to minimise this. The normalisation could be applied only if the any of the ignore patterns contain any extended characters (detected by whether NFC-form matches NFD-form). Interested in others' thoughts on whether this needs to be optimised?

### Screenshots

N/A

### Documentation

N/A

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

