### PR TITLE
lib/ignore: Fix caching of filenames with path separators on windows

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -231,6 +231,8 @@ func (m *Matcher) Match(file string) (result ignoreresult.R) {
 		return ignoreresult.NotIgnored
 	}
 
+	file = filepath.ToSlash(file)
+
 	if m.matches != nil {
 		// Check the cache for a known result.
 		res, ok := m.matches.get(file)
@@ -248,7 +250,6 @@ func (m *Matcher) Match(file string) (result ignoreresult.R) {
 	// allow skipping matched directories or not. As soon as we hit an
 	// exclude pattern (with some exceptions), we can't skip directories
 	// anymore.
-	file = filepath.ToSlash(file)
 	var lowercaseFile string
 	canSkipDir := true
 	for _, pattern := range m.patterns {


### PR DESCRIPTION
Previously we queried cache with backslashes, and stored entries with slashes. As in no cache hits ever for non-toplevel files. I also eventually remembered that cache is disabled by default, so this is a bit pointless, but still right :P 