### PR TITLE
lib/ignore: Remove unused patterns in cache

### DIFF
--- a/lib/ignore/cache.go
+++ b/lib/ignore/cache.go
@@ -19,8 +19,7 @@ type nower interface {
 var clock = nower(defaultClock{})
 
 type cache struct {
-	patterns []Pattern
-	entries  map[string]cacheEntry
+	entries map[string]cacheEntry
 }
 
 type cacheEntry struct {
@@ -28,10 +27,9 @@ type cacheEntry struct {
 	access int64 // Unix nanosecond count. Sufficient until the year 2262.
 }
 
-func newCache(patterns []Pattern) *cache {
+func newCache() *cache {
 	return &cache{
-		patterns: patterns,
-		entries:  make(map[string]cacheEntry),
+		entries: make(map[string]cacheEntry),
 	}
 }
 

--- a/lib/ignore/cache_test.go
+++ b/lib/ignore/cache_test.go
@@ -21,7 +21,7 @@ func TestCache(t *testing.T) {
 		clock = oldClock
 	}()
 
-	c := newCache(nil)
+	c := newCache()
 
 	res, ok := c.get("nonexistent")
 	if res.IsIgnored() || res.IsDeletable() || ok {

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -205,7 +205,7 @@ func (m *Matcher) parseLocked(r io.Reader, file string) error {
 	m.curHash = newHash
 	m.patterns = patterns
 	if m.withCache {
-		m.matches = newCache(patterns)
+		m.matches = newCache()
 	}
 
 	return err


### PR DESCRIPTION
Tiny cleanup I noticed while trying to fix/test another issue (https://github.com/syncthing/syncthing/pull/9600). I shortly tried to figure out what it was used for in the past, but gave up without results.