### PR TITLE
Consider `HOME` environment variable on Windows

### DIFF
--- a/lib/fs/util.go
+++ b/lib/fs/util.go
@@ -37,9 +37,15 @@ func ExpandTilde(path string) (string, error) {
 
 func getHomeDir() (string, error) {
 	if build.IsWindows {
+		// to fancy a random dude on the internet, we prioritize HOME:
+		home, ok := os.LookupEnv("HOME")
+		if ok && home != "" {
+			return home, nil
+		}
+
 		// Legacy -- we prioritize this for historical reasons, whereas
 		// os.UserHomeDir uses %USERPROFILE% always.
-		home := filepath.Join(os.Getenv("HomeDrive"), os.Getenv("HomePath"))
+		home = filepath.Join(os.Getenv("HomeDrive"), os.Getenv("HomePath"))
 		if home != "" {
 			return home, nil
 		}


### PR DESCRIPTION
Prioritizing `HOME` environment variable allows for customization of the user directory. `HOME` variable has established itself amongst Unix-native Windows apps as a reasonable mechanism to let the user overwrite all the different app developers' slightly different ideas of how to map `HOME` into the Windows world.

### Purpose

On Windows `%USERPROFILE%` points to a user's home directory. [syncthing/lib/fs/util.go](https://github.com/syncthing/syncthing/blob/a28441a9bfae6d2bca84215534dc0f9faea8e4dc/lib/fs/util.go#L40) states:

>```go
>     // Legacy -- we prioritize this for historical reasons, whereas
>     // os.UserHomeDir uses %USERPROFILE% always.
>     home = filepath.Join(os.Getenv("HomeDrive"), os.Getenv("HomePath"))
> ```

In certain setups, `%HomeDrive%\%HomePath%` doesn't point to the actual home directory, rather than a network storage. In those "professional" settings, `%HomeDrive%` and `%HomePath%` are likely set via an active domain profile and not necessarily under the control of the user. Besides changing default folder options via the web UI, the user cannot affect the determination of the home folder.

Git [addresses this issue](https://github.com/git/git/commit/e12a9556602f4d94254cc4eda25b5615ff07131a) by prioritizing the `HOME` environment variable. Windows doesn't use `HOME` environment variable and if it is set anyways, it likely is to address this particular issue of enforcing a certain home location.
If `HOME` isn't set, Git uses `%HomeDrive%\%HomePath%` if it (the folder) exists, otherwise defaults to `%USERPROFILE%`. The patch I propose aligns home determination with Git except for the part of checking whether `HOME` exist as a folder. (I am foreign to Go).

### Testing

Set `HOME` environment variable to a folder different from `%HomeDrive%\%HomePath%` and check how `~` is expanded.

### Screenshots

N/A

### Documentation

Under Windows, set the HOME environment variable to alter the default home folder.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

