### PR TITLE
lib/versioner: support tilde shortcut in external versioner command

### DIFF
--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -87,7 +87,7 @@ func (v external) Archive(filePath string) error {
 		words[i] = word
 	}
 
-	if expanded, err := fs.ExpandTilde(words[0]); err == nil {
+	if expanded, err := ExpandTilde(words[0]); err == nil {
 		words[0] = expanded
 	}
 
@@ -130,4 +130,18 @@ func (external) Restore(_ string, _ time.Time) error {
 
 func (external) Clean(_ context.Context) error {
 	return nil
+}
+
+// Replace leading tilde with user home directory
+func ExpandTilde(path string) (string, error) {
+	if !strings.HasPrefix(path, fmt.Sprintf("~%c", os.PathSeparator)) {
+		return path, nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return home + path[1:], nil
 }

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -39,10 +39,6 @@ func newExternal(cfg config.FolderConfiguration) Versioner {
 		command = strings.ReplaceAll(command, `\`, `\\`)
 	}
 
-	if expanded, err := fs.ExpandTilde(command); err == nil {
-		command = expanded
-	}
-
 	s := external{
 		command:    command,
 		filesystem: cfg.Filesystem(nil),
@@ -90,6 +86,12 @@ func (v external) Archive(filePath string) error {
 
 		words[i] = word
 	}
+
+	if expanded, err := fs.ExpandTilde(words[0]); err == nil {
+		words[0] = expanded
+	}
+
+	l.Debugf("executing command \"%s\" with arguments: %v", words[0], words[1:])
 
 	cmd := exec.Command(words[0], words[1:]...)
 	env := os.Environ()

--- a/lib/versioner/external.go
+++ b/lib/versioner/external.go
@@ -39,6 +39,10 @@ func newExternal(cfg config.FolderConfiguration) Versioner {
 		command = strings.ReplaceAll(command, `\`, `\\`)
 	}
 
+	if expanded, err := fs.ExpandTilde(command); err == nil {
+		command = expanded
+	}
+
 	s := external{
 		command:    command,
 		filesystem: cfg.Filesystem(nil),


### PR DESCRIPTION
### Purpose

The tilde character is commonly used as a reference to the user's home directory and already supported in other parts of syncthing. This change allows to configure portable external versioner commands that call scripts located in the user's home directory.

### Testing

I built the syncthing binary, configured an external versioner command to start with a tilde instead of my actual home directory and deleted a file on another device.

Additionally, I started syncthing with  `STTRACE=versioner` and verified that the leading `~` in the external versioner command was replaced with my home directory path  in the debug output.

### Documentation

I will create the corresponding pull request if the PR gets approved and you think it is necessary.

