### PR TITLE
gui: Add time remaining for sync (ref #899)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -860,6 +860,12 @@
                           </a>
                         </td>
                       </tr>
+                      <tr ng-if="deviceStatus(deviceCfg) == 'syncing'">
+                        <th><span class="fas fa-fw fa-hourglass-half"></span>&nbsp;<span translate>Time Remaining</span></th>
+                        <td class="text-right">
+                          <span>{{syncRemaining(deviceCfg.deviceID)}}</span>
+                        </td>
+                      </tr>
                       <tr ng-if="completion[deviceCfg.deviceID]._needItems">
                         <th><span class="fas fa-fw fa-exchange-alt"></span>&nbsp;<span translate>Out of Sync Items</span></th>
                         <td class="text-right">

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -733,6 +733,12 @@
                       </td>
                     </tr>
                     <tr>
+                      <th><span class="fas fa-fw fa-hourglass-half"></span>&nbsp;<span translate>Time Remaining</span></th>
+                      <td class="text-right">
+                        <span>{{getTotalSyncTimeRemaining()}}</span>
+                      </td>
+                    </tr>
+                    <tr>
                       <th><span class="fas fa-fw fa-sitemap"></span>&nbsp;<span translate>Listeners</span></th>
                       <td class="text-right">
                         <span class="data" tooltip data-original-title="{{'Show detailed listener status' | translate}}.">

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1070,13 +1070,52 @@ angular.module('syncthing.core')
             return $scope.scanProgress[folder].rate;
         };
 
-        $scope.syncRemaining = function (folder) {
-            if (!$scope.completion[folder]) {
+        $scope.getTotalSyncTimeRemaining = function () {
+            // "Syncing (16%, 3.8 GiB, 1m 50s)"
+            var folderList = $scope.folderList();
+
+            var totalSize = 0;
+            var totalSeconds = "";
+            var totalTimeRemaining = "";
+            var folderCount = 0;
+
+            folderList.forEach((folder) => {
+                if (folderCount != $scope.folderList().length)
+                {
+                        console.log("CURRENT FOLDER");
+                        console.log(folder);
+                        var currentFolderID = folder.id;
+                        
+                        var remainingBytes = $scope.model[currentFolderID].needBytes;
+                        var downloadSpeed = $scope.connectionsTotal.inbps*8;
+                        var seconds = remainingBytes / downloadSpeed;
+
+                        console.log("CURRENT FOLDER size: " + totalSize);
+                        console.log("CURRENT FOLDER seconds: " + seconds);
+                        // seconds = Math.ceil(seconds / 10) * 10;
+                        
+                        totalSize += remainingBytes;
+                        totalSeconds += seconds;
+                        folderCount ++;
+                }
+            })
+
+
+            totalTimeRemaining = getTimeRemaining(totalSeconds);
+            var finalSize = totalSize;
+            var syncMessage = "Syncing (" + finalSize  + "B, " + totalTimeRemaining + ")";
+            return syncMessage;
+
+            
+        }
+
+        $scope.syncRemaining = function (deviceID) {
+            if (!$scope.completion[deviceID]) {
                 return "";
             }
 
-            var remainingBytes = $scope.completion[folder]._needBytes;
-            var uploadSpeed = $scope.connections[folder].outbps*8
+            var remainingBytes = $scope.completion[deviceID]._needBytes;
+            var uploadSpeed = $scope.connections[deviceID].outbps*8;
 
             var seconds = remainingBytes / uploadSpeed;
             seconds = Math.ceil(seconds / 10) * 10;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1070,6 +1070,20 @@ angular.module('syncthing.core')
             return $scope.scanProgress[folder].rate;
         };
 
+        $scope.syncRemaining = function (folder) {
+            if (!$scope.completion[folder]) {
+                return "";
+            }
+
+            var remainingBytes = $scope.completion[folder]._needBytes;
+            var uploadSpeed = $scope.connections[folder].outbps*8
+
+            var seconds = remainingBytes / uploadSpeed;
+            seconds = Math.ceil(seconds / 10) * 10;
+            
+            return getTimeRemaining(seconds)
+        }
+
         $scope.scanRemaining = function (folder) {
             // Formats the remaining scan time as a string. Includes days and
             // hours only when relevant, resulting in time stamps like:
@@ -1094,6 +1108,10 @@ angular.module('syncthing.core')
 
             seconds = Math.ceil(seconds / 10) * 10;
 
+            return getTimeRemaining(seconds)
+        };
+
+        function getTimeRemaining(seconds){
             // Separate out the number of days.
             var days = 0;
             var res = [];
@@ -1129,7 +1147,7 @@ angular.module('syncthing.core')
             }
 
             return res.join(' ');
-        };
+        }
 
         $scope.deviceStatus = function (deviceCfg) {
             var status = '';


### PR DESCRIPTION
### Purpose

Adds a time remaining component to the devices in Remote Devices list ( fixes #9665). The time remaining updates along with the change in upload speed.

### Testing

Have tested this with a 4GB video file by syncing it  between my local machine and another device.

### Screenshots

![photo_2024-08-28 18 17 31](https://github.com/user-attachments/assets/e004f19c-a94e-4e0e-9d3a-fb87bd654c5f)

### Documentation
-

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

