### PR TITLE
Use config.NextProtos instead of hardcoded value

### DIFF
--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"log"
 	"net"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -82,7 +83,7 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config, token strin
 	}
 
 	state := conn.ConnectionState()
-	if debug && state.NegotiatedProtocol != protocol.ProtocolName {
+	if debug && !slices.Contains(config.NextProtos, state.NegotiatedProtocol) {
 		log.Println("Protocol negotiation error")
 	}
 


### PR DESCRIPTION
### Purpose
Just a tiny change to use the "correct" value instead of hardcoded one to satisfy "one definition rule".

### Testing
Used testutil to check that connection is still possible.

## Authorship
André Klitzing <aklitzing@gmail.com>