### PR TITLE
gui: Fix incorrect UI language auto detection (fixes #9668)

### DIFF
--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -85,7 +85,7 @@ angular.module('syncthing.core')
                                     if (character === '-') {
                                         return possibleLang.indexOf(lang) === 0;
                                     }
-                                } if (possibleLang.length < lang.length) {
+                                } else if (possibleLang.length < lang.length) {
                                     // Match "en-US" with "en" but not "fil" with "fi".
                                     character = lang.slice(0, lang.length - possibleLang.length).slice(-1);
                                     if (character === '-') {

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -64,7 +64,7 @@ angular.module('syncthing.core')
                         var i,
                             browserLang,
                             matching,
-                            locale = _defaultLocale;
+                            locale = _defaultLocale; // Fallback if nothing matched
 
                         for (i = 0; i < langs.length; i++) {
                             browserLang = langs[i];
@@ -74,19 +74,19 @@ angular.module('syncthing.core')
                             }
 
                             matching = _availableLocales.filter(function (possibleLang) {
-                                // The langs returned by the /rest/langs call will be in lower
+                                // The langs returned by the /svc/langs call will be in lower
                                 // case. We compare to the lowercase version of the language
                                 // code we have as well.
                                 possibleLang = possibleLang.toLowerCase();
                                 if (possibleLang.indexOf(browserLang) !== 0) {
-                                    // Prefix does not match.
+                                    // Prefix does not match
                                     return false;
                                 }
                                 if (possibleLang.length > browserLang.length) {
-                                    // Must match up to the next hyphen separator.
+                                    // Must match up to the next hyphen separator
                                     return possibleLang[browserLang.length] === '-';
                                 }
-                                // Same length, exact match.
+                                // Same length, exact match
                                 return true;
                             });
 
@@ -95,7 +95,6 @@ angular.module('syncthing.core')
                                 break;
                             }
                         }
-                        // Fallback if nothing matched
                         useLocale(locale);
                     });
                 }

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -82,7 +82,6 @@ angular.module('syncthing.core')
                                     // Prefix does not match.
                                     return false;
                                 }
-                                console.log("compare", browserLang, possibleLang);
                                 if (possibleLang.length > browserLang.length) {
                                     // Must match up to the next hyphen separator.
                                     return possibleLang[browserLang.length] === '-';

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -90,7 +90,7 @@ angular.module('syncthing.core')
                                 } else if (possibleLang.length > browserLang.length) {
                                     // Match "en" with "en-GB" but not "en-GB" with "en". Keep
                                     // checking even if found already, as exact match may still
-                                    // be found later.
+                                    // be found later. Otherwise, the last match will be used.
                                     possibleLang = possibleLang.replace(pattern, '');
                                     if (possibleLang === browserLang) {
                                         matchingLang = guiLang;

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -84,15 +84,12 @@ angular.module('syncthing.core')
                                 if (possibleLang.length > browserLang.length) {
                                     // Must match up to the next hyphen separator.
                                     return possibleLang[browserLang.length] === '-';
-                                    console.log("same length, exact match");
                                 }
-                                console.log("same length, exact match");
                                 // Same length, exact match.
                                 return true;
                             });
 
                             if (matching[0]) {
-                                console.log("matching", browserLang, matching[0]);
                                 locale = matching[0];
                                 break;
                             }

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -91,7 +91,7 @@ angular.module('syncthing.core')
                                 return true;
                             });
 
-                            if (matching[0]) {
+                            if (matching.length >= 1) {
                                 locale = matching[0];
                                 break;
                             }

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -64,7 +64,7 @@ angular.module('syncthing.core')
                         var i,
                             lang,
                             matching,
-                            character,
+                            pattern = /-.*$/,
                             locale = _defaultLocale;
 
                         for (i = 0; i < langs.length; i++) {
@@ -79,24 +79,16 @@ angular.module('syncthing.core')
                                 // case. We compare to the lowercase version of the language
                                 // code we have as well.
                                 possibleLang = possibleLang.toLowerCase();
-                                if (possibleLang.length > lang.length) {
-                                    // Match "en" with "en-US" but not "fi" with "fil".
-                                    character = possibleLang.slice(0, possibleLang.length - lang.length).slice(-1);
-                                    if (character === '-') {
-                                        return possibleLang.indexOf(lang) === 0;
-                                    }
-                                } else if (possibleLang.length < lang.length) {
-                                    // Match "en-US" with "en" but not "fil" with "fi".
-                                    character = lang.slice(0, lang.length - possibleLang.length).slice(-1);
-                                    if (character === '-') {
-                                        return lang.indexOf(possibleLang) === 0;
-                                    }
-                                } else {
-                                    return lang.indexOf(possibleLang) === 0;
+                                // Match "en" with "en-US" but not "fi" with "fil",
+                                // and match "en-US" with "en" but not "fil" with "fi".
+                                if (possibleLang !== lang) {
+                                    lang = lang.replace(pattern, '');
+                                    possibleLang = possibleLang.replace(pattern, '');
                                 }
+                                return lang === possibleLang;
                             });
 
-                            if (matching.length >= 1) {
+                            if (matching) {
                                 locale = matching[0];
                                 break;
                             }

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -62,16 +62,8 @@ angular.module('syncthing.core')
                         // match only "zh-TW" and not "zh" or "zh-CN".
 
                         var i,
-                            // We need to reverse the order, so that "zh" matches with "zh-CN"
-                            // and not zh-TW". This is because if no exact matches are found,
-                            // the last match wins. The order needs to be reversed here and not
-                            // later in the matching loop, as the browser may request multiple
-                            // languages, and all of them should match in the reversed order.
-                            guiLangs = _availableLocales.reverse(),
                             browserLang,
-                            possibleLang,
-                            matchingLang,
-                            pattern = /-.*$/,
+                            matching,
                             locale = _defaultLocale;
 
                         for (i = 0; i < langs.length; i++) {
@@ -79,27 +71,29 @@ angular.module('syncthing.core')
                             if (browserLang.length < 2) {
                                 continue;
                             }
-                            guiLangs.filter(function (guiLang) {
+                            matching = _availableLocales.filter(function (possibleLang) {
                                 // The langs returned by the /rest/langs call will be in lower
                                 // case. We compare to the lowercase version of the language
                                 // code we have as well.
-                                possibleLang = guiLang.toLowerCase();
-                                if (possibleLang === browserLang) {
-                                    // Skip further checking if exact match found.
-                                    return matchingLang = guiLang;
-                                } else if (possibleLang.length > browserLang.length) {
-                                    // Match "en" with "en-GB" but not "en-GB" with "en". Keep
-                                    // checking even if found already, as exact match may still
-                                    // be found later. Otherwise, the last match will be used.
-                                    possibleLang = possibleLang.replace(pattern, '');
-                                    if (possibleLang === browserLang) {
-                                        matchingLang = guiLang;
-                                    }
+                                possibleLang = possibleLang.toLowerCase();
+                                if (possibleLang.indexOf(browserLang) !== 0) {
+                                    // Prefix does not match.
+                                    return false;
                                 }
+                                console.log("compare", browserLang, possibleLang);
+                                if (possibleLang.length > browserLang.length) {
+                                    // Must match up to the next hyphen separator.
+                                    return possibleLang[browserLang.length] === '-';
+                                    console.log("same length, exact match");
+                                }
+                                console.log("same length, exact match");
+                                // Same length, exact match.
+                                return true;
                             });
 
-                            if (matchingLang) {
-                                locale = matchingLang;
+                            if (matching[0]) {
+                                console.log("matching", browserLang, matching[0]);
+                                locale = matching[0];
                                 break;
                             }
                         }

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -68,9 +68,11 @@ angular.module('syncthing.core')
 
                         for (i = 0; i < langs.length; i++) {
                             browserLang = langs[i];
+
                             if (browserLang.length < 2) {
                                 continue;
                             }
+
                             matching = _availableLocales.filter(function (possibleLang) {
                                 // The langs returned by the /rest/langs call will be in lower
                                 // case. We compare to the lowercase version of the language

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -79,8 +79,7 @@ angular.module('syncthing.core')
                                 // case. We compare to the lowercase version of the language
                                 // code we have as well.
                                 possibleLang = possibleLang.toLowerCase();
-                                // Match "en" with "en-US" but not "fi" with "fil",
-                                // and match "en-US" with "en" but not "fil" with "fi".
+                                // Match "en" with "en-US" but not "fi" with "fil", and vice versa.
                                 if (possibleLang !== lang) {
                                     lang = lang.replace(pattern, '');
                                     possibleLang = possibleLang.replace(pattern, '');

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -62,6 +62,12 @@ angular.module('syncthing.core')
                         // match only "zh-TW" and not "zh" or "zh-CN".
 
                         var i,
+                            // We need to reverse the order, so that "zh" matches with "zh-CN"
+                            // and not zh-TW". This is because if no exact matches are found,
+                            // the last match wins. The order needs to be reversed here and not
+                            // later in the matching loop, as the browser may request multiple
+                            // languages, and all of them should match in the reversed order.
+                            guiLangs = _availableLocales.reverse(),
                             browserLang,
                             possibleLang,
                             matchingLang,
@@ -73,13 +79,10 @@ angular.module('syncthing.core')
                             if (browserLang.length < 2) {
                                 continue;
                             }
-
-                            _availableLocales.reverse().filter(function (guiLang) {
+                            guiLangs.filter(function (guiLang) {
                                 // The langs returned by the /rest/langs call will be in lower
                                 // case. We compare to the lowercase version of the language
-                                // code we have as well. If no exact match found, the last match
-                                // wins, so we need reverse the order to make "zh" match with
-                                // "zh-CN" and not "zh-TW".
+                                // code we have as well.
                                 possibleLang = guiLang.toLowerCase();
                                 if (possibleLang === browserLang) {
                                     // Skip further checking if exact match found.

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -45,7 +45,6 @@ angular.module('syncthing.core')
 
             function autoConfigLocale() {
                 var params = $location.search();
-                var exactMatch;
                 var savedLang;
                 if (_localStorage) {
                     savedLang = _localStorage[_SYNLANG];

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -53,8 +53,8 @@ angular.module('syncthing.core')
 
                 if (params.lang) {
                     useLocale(params.lang, true);
-                // } else if (savedLang) {
-                    // useLocale(savedLang);
+                } else if (savedLang) {
+                    useLocale(savedLang);
                 } else {
                     readBrowserLocales().success(function (langs) {
                         // Find the exact language in the list provided by the user's browser.

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -64,6 +64,7 @@ angular.module('syncthing.core')
                         var i,
                             lang,
                             matching,
+                            character,
                             locale = _defaultLocale;
 
                         for (i = 0; i < langs.length; i++) {
@@ -79,7 +80,17 @@ angular.module('syncthing.core')
                                 // code we have as well.
                                 possibleLang = possibleLang.toLowerCase();
                                 if (possibleLang.length > lang.length) {
-                                    return possibleLang.indexOf(lang) === 0;
+                                    // Match "en" with "en-US" but not "fi" with "fil".
+                                    character = possibleLang.slice(0, possibleLang.length - lang.length).slice(-1);
+                                    if (character === '-') {
+                                        return possibleLang.indexOf(lang) === 0;
+                                    }
+                                } if (possibleLang.length < lang.length) {
+                                    // Match "en-US" with "en" but not "fil" with "fi".
+                                    character = lang.slice(0, lang.length - possibleLang.length).slice(-1);
+                                    if (character === '-') {
+                                        return lang.indexOf(possibleLang) === 0;
+                                    }
                                 } else {
                                     return lang.indexOf(possibleLang) === 0;
                                 }

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -85,7 +85,7 @@ angular.module('syncthing.core')
                                     // Skip further checking if exact match found.
                                     return matchingLang = guiLang;
                                 } else if (possibleLang.length > browserLang.length) {
-                                    // Match "en-GB" with "en" but not "en" with "en-GB". Keep
+                                    // Match "en" with "en-GB" but not "en-GB" with "en". Keep
                                     // checking even if found already, as exact match may still
                                     // be found later.
                                     possibleLang = possibleLang.replace(pattern, '');

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -87,7 +87,7 @@ angular.module('syncthing.core')
                                 }
                             });
 
-                            // Only look for a prefixed or suffixed match when no exact match exists.
+                            // Only look for a suffixed match when no exact match exists.
                             if (!matching[0]) {
                                 matching = _availableLocales.filter(function (possibleLang) {
                                     possibleLang = possibleLang.toLowerCase();

--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -52,8 +52,8 @@ angular.module('syncthing.core')
 
                 if (params.lang) {
                     useLocale(params.lang, true);
-                // } else if (savedLang) {
-                    // useLocale(savedLang);
+                } else if (savedLang) {
+                    useLocale(savedLang);
                 } else {
                     readBrowserLocales().success(function (langs) {
                         // Find the first language in the list provided by the user's browser


### PR DESCRIPTION
gui: Fix incorrect UI language auto detection (fixes #9668)

Currently, the code only checks whether the detected language partially
matches one of the available languages. This means that if the detected
language is "fi" but among the available languages there is only "fil"
and no "fi", then it will match "fi" with "fil", even though the two are
completely different languages.

With this change, the matching is only done when there is a hyphen in
the language code, e.g. "en" will match with "en-US".

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>