### PR TITLE
lib/api: Correct ordering of Accept-Language codes by weight (fixes #9670)

### DIFF
--- a/gui/default/syncthing/core/localeService.js
+++ b/gui/default/syncthing/core/localeService.js
@@ -74,9 +74,9 @@ angular.module('syncthing.core')
                             }
 
                             matching = _availableLocales.filter(function (possibleLang) {
-                                // The langs returned by the /svc/langs call will be in lower
-                                // case. We compare to the lowercase version of the language
-                                // code we have as well.
+                                // The langs returned by the /rest/svc/langs call will be in
+                                // lower case. We compare to the lowercase version of the
+                                // language code we have as well.
                                 possibleLang = possibleLang.toLowerCase();
                                 if (possibleLang.indexOf(browserLang) !== 0) {
                                     // Prefix does not match

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1492,13 +1492,14 @@ func (*service) getLang(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		weight := strings.ToLower(strings.TrimSpace(parts[1]))
-		if weight[:2] == "q=" {
-			if q, err := strconv.ParseFloat(weight[2:], 32); err != nil {
-				// Completely dismiss entries with invalid weight
-				delete(langs, code)
-			} else {
-				langs[code] = q
-			}
+		if weight[:2] != "q=" {
+			continue
+		}
+		if q, err := strconv.ParseFloat(weight[2:], 32); err != nil {
+			// Completely dismiss entries with invalid weight
+			delete(langs, code)
+		} else {
+			langs[code] = q
 		}
 	}
 	var orderedLangs = make([]string, 0, len(langs))

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1483,11 +1483,11 @@ func (*service) getDeviceID(w http.ResponseWriter, r *http.Request) {
 
 func (*service) getLang(w http.ResponseWriter, r *http.Request) {
 	lang := r.Header.Get("Accept-Language")
-	var langs = make(map[string]float64)
+	var weights = make(map[string]float64)
 	for _, l := range strings.Split(lang, ",") {
 		parts := strings.SplitN(l, ";", 2)
 		code := strings.ToLower(strings.TrimSpace(parts[0]))
-		langs[code] = 1.0
+		weights[code] = 1.0
 		if len(parts) < 2 {
 			continue
 		}
@@ -1497,20 +1497,20 @@ func (*service) getLang(w http.ResponseWriter, r *http.Request) {
 		}
 		if q, err := strconv.ParseFloat(weight[2:], 32); err != nil {
 			// Completely dismiss entries with invalid weight
-			delete(langs, code)
+			delete(weights, code)
 		} else {
-			langs[code] = q
+			weights[code] = q
 		}
 	}
-	var orderedLangs = make([]string, 0, len(langs))
-	for code := range langs {
-		orderedLangs = append(orderedLangs, code)
+	var langs = make([]string, 0, len(weights))
+	for code := range weights {
+		langs = append(langs, code)
 	}
 	// Reorder by descending q value
-	sort.SliceStable(orderedLangs, func(i, j int) bool {
-		return langs[orderedLangs[i]] > langs[orderedLangs[j]]
+	sort.SliceStable(langs, func(i, j int) bool {
+		return weights[langs[i]] > weights[langs[j]]
 	})
-	sendJSON(w, orderedLangs)
+	sendJSON(w, langs)
 }
 
 func (s *service) postSystemUpgrade(w http.ResponseWriter, _ *http.Request) {

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1492,7 +1492,7 @@ func (*service) getLang(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		weight := strings.ToLower(strings.TrimSpace(parts[1]))
-		if weight[:2] != "q=" {
+		if !strings.HasPrefix(weight, "q=") {
 			continue
 		}
 		if q, err := strconv.ParseFloat(weight[2:], 32); err != nil {


### PR DESCRIPTION
### Purpose

The preference for languages in the Accept-Language header field should not be deduced from the listed order, but from the passed "quality values", according to the HTTP specification: https://httpwg.org/specs/rfc9110.html#field.accept-language

This implements the parsing of q=values and ordering within the API backend, to not complicate things further in the GUI code.  Entries with invalid (unparseable) quality values are discarded completely.

### Testing

Example based on the RFC, modify to taste:
```
curl -X GET -H "Accept-Language: da, en-GB;q=1.8, en;q=1.0" http://localhost:8384/rest/svc/lang
```