### PR TITLE
chore(discovery,upgrade): use regular TLS certificate verification

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -53,14 +53,14 @@ var (
 	// DefaultDiscoveryServersV4 should be substituted when the configuration
 	// contains <globalAnnounceServer>default-v4</globalAnnounceServer>.
 	DefaultDiscoveryServersV4 = []string{
-		"https://discovery.syncthing.net/v2/?noannounce&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
-		"https://discovery-v4.syncthing.net/v2/?nolookup&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
+		"https://discovery-lookup.syncthing.net/v2/?noannounce",
+		"https://discovery-announce-v4.syncthing.net/v2/?nolookup",
 	}
 	// DefaultDiscoveryServersV6 should be substituted when the configuration
 	// contains <globalAnnounceServer>default-v6</globalAnnounceServer>.
 	DefaultDiscoveryServersV6 = []string{
-		"https://discovery.syncthing.net/v2/?noannounce&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
-		"https://discovery-v6.syncthing.net/v2/?nolookup&id=LYXKCHX-VI3NYZR-ALCJBHF-WMZYSPK-QG6QJA3-MPFYMSO-U56GTUK-NA2MIAW",
+		"https://discovery-lookup.syncthing.net/v2/?noannounce",
+		"https://discovery-announce-v6.syncthing.net/v2/?nolookup",
 	}
 	// DefaultDiscoveryServers should be substituted when the configuration
 	// contains <globalAnnounceServer>default</globalAnnounceServer>.

--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -14,7 +14,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"compress/gzip"
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -61,26 +60,18 @@ const (
 	maxMetadataSize = 10 << 20 // 10 MiB
 )
 
-// This is an HTTP/HTTPS client that does *not* perform certificate
-// validation. We do this because some systems where Syncthing runs have
-// issues with old or missing CA roots. It doesn't actually matter that we
-// load the upgrade insecurely as we verify an ECDSA signature of the actual
-// binary contents before accepting the upgrade.
-var insecureHTTP = &http.Client{
+var upgradeClient = &http.Client{
 	Timeout: readTimeout,
 	Transport: &http.Transport{
 		DialContext: dialer.DialContext,
 		Proxy:       http.ProxyFromEnvironment,
-		TLSClientConfig: &tls.Config{
-			InsecureSkipVerify: true,
-		},
 	},
 }
 
 var osVersion string
 
 func init() {
-	_ = http2.ConfigureTransport(insecureHTTP.Transport.(*http.Transport))
+	_ = http2.ConfigureTransport(upgradeClient.Transport.(*http.Transport))
 	osVersion, _ = host.KernelVersion()
 	osVersion = strings.TrimSpace(osVersion)
 }
@@ -95,7 +86,7 @@ func insecureGet(url, version string) (*http.Response, error) {
 	if osVersion != "" {
 		req.Header.Set("Syncthing-Os-Version", osVersion)
 	}
-	return insecureHTTP.Do(req)
+	return upgradeClient.Do(req)
 }
 
 // FetchLatestReleases returns the latest releases. The "current" parameter
@@ -233,7 +224,7 @@ func readRelease(archiveName, dir, url string) (string, error) {
 	}
 
 	req.Header.Add("Accept", "application/octet-stream")
-	resp, err := insecureHTTP.Do(req)
+	resp, err := upgradeClient.Do(req)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This changes the two remaining instances where we use insecure HTTPS to use standard HTTPS certificate verification.

When we introduced these things, almost a decade ago, HTTPS certificates were expensive and annoying to get, much of the web was still HTTP, and many devices seemed to not have up-to-date CA bundles.

Nowadays _all_ of the web is HTTPS and I'm skeptical that any device can work well without understanding LetsEncrypt certificates in particular.

Our current discovery servers use hardcoded certificates which has several issues:
- Not great for security if it leaks as there is no way to rotate it
- Not great for infrastructure flexibility as we can't use many load balancer or TLS termination services
- The certificate is a very oddball ECDSA-SHA384 type certificate which has higher CPU cost than a more regular certificate, which has real effects on our infrastructure

Using normal TLS certificates here improves these things.

I expect there will be some very few devices out there for which this doesn't work. For the foreseeable future they can simply change the config to use the old URLs and parameters -- it'll be years before we can retire those entirely. 

For the upgrade client this simply seems like better hygiene. While our releases are signed anyway, protecting the metadata exchange is _better_ and, again, I doubt many clients will fail this today. 

