### PR TITLE
lib/fs: Reproduce and fix spurious mtime changes (ref #9677)

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -50,7 +50,7 @@ type fskey struct {
 // caseFilesystemRegistry caches caseFilesystems and runs a routine to drop
 // their cache every now and then.
 type caseFilesystemRegistry struct {
-	fss          map[fskey]*caseFilesystem
+	caseCaches   map[fskey]caseCache
 	mut          sync.RWMutex
 	startCleaner sync.Once
 }
@@ -77,18 +77,15 @@ func (r *caseFilesystemRegistry) get(fs Filesystem) Filesystem {
 	// take a write lock and try again.
 
 	r.mut.RLock()
-	caseFs, ok := r.fss[k]
+	cache, ok := r.caseCaches[k]
 	r.mut.RUnlock()
 
 	if !ok {
 		r.mut.Lock()
-		caseFs, ok = r.fss[k]
+		cache, ok = r.caseCaches[k]
 		if !ok {
-			caseFs = &caseFilesystem{
-				Filesystem: fs,
-				realCaser:  newDefaultRealCaser(fs),
-			}
-			r.fss[k] = caseFs
+			cache = newCaseCache()
+			r.caseCaches[k] = cache
 			r.startCleaner.Do(func() {
 				go r.cleaner()
 			})
@@ -96,7 +93,13 @@ func (r *caseFilesystemRegistry) get(fs Filesystem) Filesystem {
 		r.mut.Unlock()
 	}
 
-	return caseFs
+	return &caseFilesystem{
+		Filesystem: fs,
+		realCaser: &defaultRealCaser{
+			fs:    fs,
+			cache: cache,
+		},
+	}
 }
 
 func (r *caseFilesystemRegistry) cleaner() {
@@ -109,19 +112,19 @@ func (r *caseFilesystemRegistry) cleaner() {
 		// within the loop.
 
 		r.mut.RLock()
-		toProcess := make([]*caseFilesystem, 0, len(r.fss))
-		for _, caseFs := range r.fss {
-			toProcess = append(toProcess, caseFs)
+		toProcess := make([]caseCache, 0, len(r.caseCaches))
+		for _, cache := range r.caseCaches {
+			toProcess = append(toProcess, cache)
 		}
 		r.mut.RUnlock()
 
-		for _, caseFs := range toProcess {
-			caseFs.dropCache()
+		for _, cache := range toProcess {
+			cache.Purge()
 		}
 	}
 }
 
-var globalCaseFilesystemRegistry = caseFilesystemRegistry{fss: make(map[fskey]*caseFilesystem)}
+var globalCaseFilesystemRegistry = caseFilesystemRegistry{caseCaches: make(map[fskey]caseCache)}
 
 // OptionDetectCaseConflicts ensures that the potentially case-insensitive filesystem
 // behaves like a case-sensitive filesystem. Meaning that it takes into account
@@ -393,20 +396,19 @@ func (f *caseFilesystem) checkCaseExisting(name string) error {
 
 type defaultRealCaser struct {
 	cache caseCache
+	fs    Filesystem
+	mut   sync.Mutex
 }
 
-func newDefaultRealCaser(fs Filesystem) *defaultRealCaser {
+type caseCache = *lru.TwoQueueCache[string, *caseNode]
+
+func newCaseCache() caseCache {
 	cache, err := lru.New2Q[string, *caseNode](caseCacheItemLimit)
 	// New2Q only errors if given invalid parameters, which we don't.
 	if err != nil {
 		panic(err)
 	}
-	return &defaultRealCaser{
-		cache: caseCache{
-			fs:            fs,
-			TwoQueueCache: cache,
-		},
-	}
+	return cache
 }
 
 func (r *defaultRealCaser) realCase(name string) (string, error) {
@@ -416,7 +418,7 @@ func (r *defaultRealCaser) realCase(name string) (string, error) {
 	}
 
 	for _, comp := range PathComponents(name) {
-		node := r.cache.getExpireAdd(realName)
+		node := r.getExpireAdd(realName)
 
 		if node.err != nil {
 			return "", node.err
@@ -440,26 +442,20 @@ func (r *defaultRealCaser) dropCache() {
 	r.cache.Purge()
 }
 
-type caseCache struct {
-	*lru.TwoQueueCache[string, *caseNode]
-	fs  Filesystem
-	mut sync.Mutex
-}
-
 // getExpireAdd gets an entry for the given key. If no entry exists, or it is
 // expired a new one is created and added to the cache.
-func (c *caseCache) getExpireAdd(key string) *caseNode {
-	c.mut.Lock()
-	defer c.mut.Unlock()
-	node, ok := c.Get(key)
+func (r *defaultRealCaser) getExpireAdd(key string) *caseNode {
+	r.mut.Lock()
+	defer r.mut.Unlock()
+	node, ok := r.cache.Get(key)
 	if !ok {
-		node := newCaseNode(key, c.fs)
-		c.Add(key, node)
+		node := newCaseNode(key, r.fs)
+		r.cache.Add(key, node)
 		return node
 	}
 	if node.expires.Before(time.Now()) {
-		node = newCaseNode(key, c.fs)
-		c.Add(key, node)
+		node = newCaseNode(key, r.fs)
+		r.cache.Add(key, node)
 	}
 	return node
 }

--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -175,7 +175,10 @@ func BenchmarkWalkCaseFakeFS100k(b *testing.B) {
 		// Construct the casefs manually or it will get cached and the benchmark is invalid.
 		casefs := &caseFilesystem{
 			Filesystem: fsys,
-			realCaser:  newDefaultRealCaser(fsys),
+			realCaser: &defaultRealCaser{
+				fs:    fsys,
+				cache: newCaseCache(),
+			},
 		}
 		var fakefs *fakeFS
 		if ffs, ok := unwrapFilesystem(fsys, filesystemWrapperTypeNone); ok {
@@ -201,7 +204,10 @@ func BenchmarkWalkCaseFakeFS100k(b *testing.B) {
 		// Construct the casefs manually or it will get cached and the benchmark is invalid.
 		casefs := &caseFilesystem{
 			Filesystem: fsys,
-			realCaser:  newDefaultRealCaser(fsys),
+			realCaser: &defaultRealCaser{
+				fs:    fsys,
+				cache: newCaseCache(),
+			},
 		}
 		var fakefs *fakeFS
 		if ffs, ok := unwrapFilesystem(fsys, filesystemWrapperTypeNone); ok {

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -54,18 +54,20 @@ const randomBlockShift = 14 // 128k
 //     latency=d  to set the amount of time each "disk" operation takes, where d is time.ParseDuration format
 //     content=true to save actual file contents instead of generating pseudorandomly; n.b. memory usage
 //     nostfolder=true skip the creation of .stfolder
+//     timeprecisionsecond=true Modification times are stored with only second precision
 //
 // - Two fakeFS:s pointing at the same root path see the same files.
 type fakeFS struct {
-	counters    fakeFSCounters
-	uri         string
-	mut         sync.Mutex
-	root        *fakeEntry
-	insens      bool
-	withContent bool
-	latency     time.Duration
-	userCache   *userCache
-	groupCache  *groupCache
+	counters            fakeFSCounters
+	uri                 string
+	mut                 sync.Mutex
+	root                *fakeEntry
+	insens              bool
+	withContent         bool
+	timePrecisionSecond bool
+	latency             time.Duration
+	userCache           *userCache
+	groupCache          *groupCache
 }
 
 type fakeFSCounters struct {
@@ -126,6 +128,7 @@ func newFakeFilesystem(rootURI string, _ ...Option) *fakeFS {
 	fs.insens = params.Get("insens") == "true"
 	fs.withContent = params.Get("content") == "true"
 	nostfolder := params.Get("nostfolder") == "true"
+	fs.timePrecisionSecond = params.Get("timeprecisionsecond") == "true"
 
 	if sizeavg == 0 {
 		sizeavg = 1 << 20
@@ -258,6 +261,9 @@ func (fs *fakeFS) Chtimes(name string, _ time.Time, mtime time.Time) error {
 	entry := fs.entryForName(name)
 	if entry == nil {
 		return os.ErrNotExist
+	}
+	if fs.timePrecisionSecond {
+		mtime = mtime.Round(time.Second)
 	}
 	entry.mtime = mtime
 	return nil

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -261,11 +261,6 @@ func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem
 		}
 	}
 
-	// Case handling is the innermost, as any filesystem calls by wrappers should be case-resolved
-	if caseOpt != nil {
-		fs = caseOpt.apply(fs)
-	}
-
 	// mtime handling should happen inside walking, as filesystem calls while
 	// walking should be mtime-resolved too
 	if mtimeOpt != nil {
@@ -274,15 +269,35 @@ func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem
 
 	fs = &metricsFS{next: fs}
 
+	layersAboveWalkFilesystem := 0
+	if caseOpt != nil {
+		// DirNames calls made to check the case of a name will also be
+		// attributed to the calling function.
+		layersAboveWalkFilesystem++
+	}
 	if l.ShouldDebug("walkfs") {
-		return NewWalkFilesystem(&logFilesystem{fs})
+		// A walkFilesystem is not a layer to skip, it embeds the underlying
+		// filesystem, passing calls directly trough. Except for calls made
+		// during walking, however those are truly originating in the walk
+		// filesystem.
+		fs = NewWalkFilesystem(newLogFilesystem(fs, layersAboveWalkFilesystem))
+	} else if l.ShouldDebug("fs") {
+		fs = newLogFilesystem(NewWalkFilesystem(fs), layersAboveWalkFilesystem)
+	} else {
+		fs = NewWalkFilesystem(fs)
 	}
 
-	if l.ShouldDebug("fs") {
-		return &logFilesystem{NewWalkFilesystem(fs)}
+	// Case handling is at the outermost layer to resolve all input names.
+	// Reason being is that the only names/paths that are potentially "wrong"
+	// come from outside the fs package. Any paths that result from filesystem
+	// operations itself already have the correct case. Thus there's e.g. no
+	// point to check the case on all the stating the walk filesystem does, it
+	// just adds overhead.
+	if caseOpt != nil {
+		fs = caseOpt.apply(fs)
 	}
 
-	return NewWalkFilesystem(fs)
+	return fs
 }
 
 // IsInternal returns true if the file, as a path relative to the folder

--- a/lib/fs/filesystem_test.go
+++ b/lib/fs/filesystem_test.go
@@ -213,7 +213,7 @@ func TestRepro9677(t *testing.T) {
 
 	// Now syncthing gets upgraded (or even just restarted), which resets the
 	// case FS registry as it lives in memory.
-	globalCaseFilesystemRegistry = caseFilesystemRegistry{fss: make(map[fskey]*caseFilesystem)}
+	globalCaseFilesystemRegistry = caseFilesystemRegistry{caseCaches: make(map[fskey]caseCache)}
 
 	// This time we first create some filesystem without a database and thus no
 	// mtime-FS, which is used in various places outside of the folder code. We

--- a/lib/fs/logfs.go
+++ b/lib/fs/logfs.go
@@ -16,10 +16,20 @@ import (
 
 type logFilesystem struct {
 	Filesystem
+	// Number of filesystem layers on top of logFilesystem to skip when looking
+	// for the true caller of the filesystem
+	layers int
 }
 
-func getCaller() string {
-	_, file, line, ok := runtime.Caller(2)
+func newLogFilesystem(fs Filesystem, layers int) *logFilesystem {
+	return &logFilesystem{
+		Filesystem: fs,
+		layers:     layers,
+	}
+}
+
+func (fs *logFilesystem) getCaller() string {
+	_, file, line, ok := runtime.Caller(fs.layers + 1)
 	if !ok {
 		return "unknown"
 	}
@@ -28,139 +38,139 @@ func getCaller() string {
 
 func (fs *logFilesystem) Chmod(name string, mode FileMode) error {
 	err := fs.Filesystem.Chmod(name, mode)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Chmod", name, mode, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Chmod", name, mode, err)
 	return err
 }
 
 func (fs *logFilesystem) Chtimes(name string, atime time.Time, mtime time.Time) error {
 	err := fs.Filesystem.Chtimes(name, atime, mtime)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Chtimes", name, atime, mtime, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Chtimes", name, atime, mtime, err)
 	return err
 }
 
 func (fs *logFilesystem) Create(name string) (File, error) {
 	file, err := fs.Filesystem.Create(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Create", name, file, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Create", name, file, err)
 	return file, err
 }
 
 func (fs *logFilesystem) CreateSymlink(target, name string) error {
 	err := fs.Filesystem.CreateSymlink(target, name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "CreateSymlink", target, name, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "CreateSymlink", target, name, err)
 	return err
 }
 
 func (fs *logFilesystem) DirNames(name string) ([]string, error) {
 	names, err := fs.Filesystem.DirNames(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "DirNames", name, names, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "DirNames", name, names, err)
 	return names, err
 }
 
 func (fs *logFilesystem) Lstat(name string) (FileInfo, error) {
 	info, err := fs.Filesystem.Lstat(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Lstat", name, info, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Lstat", name, info, err)
 	return info, err
 }
 
 func (fs *logFilesystem) Mkdir(name string, perm FileMode) error {
 	err := fs.Filesystem.Mkdir(name, perm)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Mkdir", name, perm, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Mkdir", name, perm, err)
 	return err
 }
 
 func (fs *logFilesystem) MkdirAll(name string, perm FileMode) error {
 	err := fs.Filesystem.MkdirAll(name, perm)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "MkdirAll", name, perm, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "MkdirAll", name, perm, err)
 	return err
 }
 
 func (fs *logFilesystem) Open(name string) (File, error) {
 	file, err := fs.Filesystem.Open(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Open", name, file, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Open", name, file, err)
 	return file, err
 }
 
 func (fs *logFilesystem) OpenFile(name string, flags int, mode FileMode) (File, error) {
 	file, err := fs.Filesystem.OpenFile(name, flags, mode)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "OpenFile", name, flags, mode, file, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "OpenFile", name, flags, mode, file, err)
 	return file, err
 }
 
 func (fs *logFilesystem) ReadSymlink(name string) (string, error) {
 	target, err := fs.Filesystem.ReadSymlink(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "ReadSymlink", name, target, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "ReadSymlink", name, target, err)
 	return target, err
 }
 
 func (fs *logFilesystem) Remove(name string) error {
 	err := fs.Filesystem.Remove(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Remove", name, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Remove", name, err)
 	return err
 }
 
 func (fs *logFilesystem) RemoveAll(name string) error {
 	err := fs.Filesystem.RemoveAll(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "RemoveAll", name, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "RemoveAll", name, err)
 	return err
 }
 
 func (fs *logFilesystem) Rename(oldname, newname string) error {
 	err := fs.Filesystem.Rename(oldname, newname)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Rename", oldname, newname, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Rename", oldname, newname, err)
 	return err
 }
 
 func (fs *logFilesystem) Stat(name string) (FileInfo, error) {
 	info, err := fs.Filesystem.Stat(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Stat", name, info, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Stat", name, info, err)
 	return info, err
 }
 
 func (fs *logFilesystem) SymlinksSupported() bool {
 	supported := fs.Filesystem.SymlinksSupported()
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "SymlinksSupported", supported)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "SymlinksSupported", supported)
 	return supported
 }
 
 func (fs *logFilesystem) Walk(root string, walkFn WalkFunc) error {
 	err := fs.Filesystem.Walk(root, walkFn)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Walk", root, walkFn, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Walk", root, walkFn, err)
 	return err
 }
 
 func (fs *logFilesystem) Watch(path string, ignore Matcher, ctx context.Context, ignorePerms bool) (<-chan Event, <-chan error, error) {
 	evChan, errChan, err := fs.Filesystem.Watch(path, ignore, ctx, ignorePerms)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Watch", path, ignore, ignorePerms, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Watch", path, ignore, ignorePerms, err)
 	return evChan, errChan, err
 }
 
 func (fs *logFilesystem) Unhide(name string) error {
 	err := fs.Filesystem.Unhide(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Unhide", name, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Unhide", name, err)
 	return err
 }
 
 func (fs *logFilesystem) Hide(name string) error {
 	err := fs.Filesystem.Hide(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Hide", name, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Hide", name, err)
 	return err
 }
 
 func (fs *logFilesystem) Glob(name string) ([]string, error) {
 	names, err := fs.Filesystem.Glob(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Glob", name, names, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Glob", name, names, err)
 	return names, err
 }
 
 func (fs *logFilesystem) Roots() ([]string, error) {
 	roots, err := fs.Filesystem.Roots()
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Roots", roots, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Roots", roots, err)
 	return roots, err
 }
 
 func (fs *logFilesystem) Usage(name string) (Usage, error) {
 	usage, err := fs.Filesystem.Usage(name)
-	l.Debugln(getCaller(), fs.Type(), fs.URI(), "Usage", name, usage, err)
+	l.Debugln(fs.getCaller(), fs.Type(), fs.URI(), "Usage", name, usage, err)
 	return usage, err
 }
 


### PR DESCRIPTION
@calmh found the issue/reproducer here: https://github.com/syncthing/syncthing/pull/9685#issue-2509531571
I created a unit test that repros the issue with the changed caseFS wrapping (otherwise there is no issue). And I added a commit with one option to fix it: Only caching the cache, not the entire FS. Still to be decided if we want to cache at all.