### PR TITLE
lib/fs: Fix (remove) casefs caching

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -369,7 +369,13 @@ func (r *defaultRealCaser) realCase(name string) (string, error) {
 }
 
 func (r *defaultRealCaser) dropCache(paths ...string) {
-	r.cache.Purge(paths...)
+	if len(paths) == 0 {
+		r.cache.Purge()
+		return
+	}
+	for _, path := range paths {
+		r.cache.Remove(path)
+	}
 }
 
 type caseCache struct {

--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -32,15 +32,11 @@ func TestRealCase(t *testing.T) {
 	})
 }
 
-func newCaseFilesystem(fsys Filesystem) *caseFilesystem {
-	return globalCaseFilesystemRegistry.get(fsys).(*caseFilesystem)
-}
-
 func testRealCase(t *testing.T, fsys Filesystem) {
 	testFs := newCaseFilesystem(fsys)
 	comps := []string{"Foo", "bar", "BAZ", "bAs"}
 	path := filepath.Join(comps...)
-	testFs.MkdirAll(filepath.Join(comps[:len(comps)-1]...), 0777)
+	testFs.MkdirAll(filepath.Join(comps[:len(comps)-1]...), 0o777)
 	fd, err := testFs.Create(path)
 	if err != nil {
 		t.Fatal(err)
@@ -93,7 +89,7 @@ func testRealCaseSensitive(t *testing.T, fsys Filesystem) {
 	names[0] = "foo"
 	names[1] = strings.ToUpper(names[0])
 	for _, n := range names {
-		if err := testFs.MkdirAll(n, 0777); err != nil {
+		if err := testFs.MkdirAll(n, 0o777); err != nil {
 			if IsErrCaseConflict(err) {
 				t.Skip("Filesystem is case-insensitive")
 			}

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -297,6 +297,21 @@ func NewFilesystem(fsType FilesystemType, uri string, opts ...Option) Filesystem
 		fs = caseOpt.apply(fs)
 	}
 
+	if l.ShouldDebug("fs") {
+		l.Debugln(fs.URI(), fs.Options())
+		pfs := fs
+		indent := ""
+		for {
+			l.Debugf("%s %T(%p)", indent, pfs, pfs)
+			var ok bool
+			pfs, ok = pfs.underlying()
+			if !ok {
+				break
+			}
+			indent += "  "
+		}
+	}
+
 	return fs
 }
 


### PR DESCRIPTION
@imsodin 👋 

This is a somewhat unclean patch as I'm doing a couple of things at once, but we can sort that out in time. The main thing is that I want a discussion around the caching of caseFs instances. That's what causes the problem in #9677, because at the end of the chain in NewFilesystem we try to wrap it in a caseFs, but then the caseFs registry pulls a switcheroo on us and gives us a different wrapped filesystem that doesn't have an mtimeFs in the stack. This happens because we only sometimes create with an mtimeFs -- namely when we have a FileSet (database) available.

Now, I completely forget why we thought we needed to cache caseFs instances. As far as I can tell we create essentially two "kinds" of FS instances -- very short lives ones here and there when we want to check folder health and free space and such, and these don't include mtimeFs in the stack, or the long lived one that is set in the folder instance and shares the folder lifetime.

The current cache manager does one other thing though and that is it periodically clears the cache inside the cacheFs. We could potentially do that some other way, like the folder itself could explicitly do it when it completes a scan/pull cycle for example.