### PR TITLE
chore(fs): only cache the cache for case FS, not the entire FS

### DIFF
--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -175,7 +175,10 @@ func BenchmarkWalkCaseFakeFS100k(b *testing.B) {
 		// Construct the casefs manually or it will get cached and the benchmark is invalid.
 		casefs := &caseFilesystem{
 			Filesystem: fsys,
-			realCaser:  newDefaultRealCaser(fsys),
+			realCaser: &defaultRealCaser{
+				fs:    fsys,
+				cache: newCaseCache(),
+			},
 		}
 		var fakefs *fakeFS
 		if ffs, ok := unwrapFilesystem(fsys, filesystemWrapperTypeNone); ok {
@@ -201,7 +204,10 @@ func BenchmarkWalkCaseFakeFS100k(b *testing.B) {
 		// Construct the casefs manually or it will get cached and the benchmark is invalid.
 		casefs := &caseFilesystem{
 			Filesystem: fsys,
-			realCaser:  newDefaultRealCaser(fsys),
+			realCaser: &defaultRealCaser{
+				fs:    fsys,
+				cache: newCaseCache(),
+			},
 		}
 		var fakefs *fakeFS
 		if ffs, ok := unwrapFilesystem(fsys, filesystemWrapperTypeNone); ok {

--- a/lib/fs/filesystem_test.go
+++ b/lib/fs/filesystem_test.go
@@ -221,7 +221,7 @@ func TestRepro9677MissingMtimeFS(t *testing.T) {
 
 	// Now syncthing gets upgraded (or even just restarted), which resets the
 	// case FS registry as it lives in memory.
-	globalCaseFilesystemRegistry = caseFilesystemRegistry{fss: make(map[fskey]*caseFilesystem)}
+	globalCaseFilesystemRegistry = caseFilesystemRegistry{caseCaches: make(map[fskey]*caseCache)}
 
 	// This time we first create some filesystem without a database and thus no
 	// mtime-FS, which is used in various places outside of the folder code. We


### PR DESCRIPTION
This would have addressed a recent issue that arose when re-ordering our "filesystem layers". Specifically moving the caseFilesystem to the outermost layer. The previous cache included the filesystem, and as such all the layers below. This isn't desirable (to put it mildly), as you can create different variants of filesystems with different layers for the same path and options. Concretely this did happen with the mtime layer, which isn't always present. A test for the mtime related breakage was added in #9687, and I intend to redo the caseFilesystem reordering after this.

Ref: #9677
Followup to: #9687