### PR TITLE
fix(model): shut down index sender faster

### DIFF
--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -233,6 +233,12 @@ func (s *indexHandler) sendIndexTo(ctx context.Context, fset *db.FileSet) error 
 	batch := db.NewFileInfoBatch(nil)
 	var batchError error
 	batch.SetFlushFunc(func(fs []protocol.FileInfo) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		if len(fs) == 0 {
 			// can't happen, flush is not called with an empty batch
 			panic("bug: flush called with empty batch (race condition?)")

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -354,6 +354,8 @@ func (c *rawConnection) Index(ctx context.Context, idx *Index) error {
 	select {
 	case <-c.closed:
 		return ErrClosed
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 	}
 	c.idxMut.Lock()
@@ -367,6 +369,8 @@ func (c *rawConnection) IndexUpdate(ctx context.Context, idxUp *IndexUpdate) err
 	select {
 	case <-c.closed:
 		return ErrClosed
+	case <-ctx.Done():
+		return ctx.Err()
 	default:
 	}
 	c.idxMut.Lock()
@@ -377,6 +381,14 @@ func (c *rawConnection) IndexUpdate(ctx context.Context, idxUp *IndexUpdate) err
 
 // Request returns the bytes for the specified block after fetching them from the connected peer.
 func (c *rawConnection) Request(ctx context.Context, req *Request) ([]byte, error) {
+	select {
+	case <-c.closed:
+		return nil, ErrClosed
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	rc := make(chan asyncResult, 1)
 
 	c.awaitingMut.Lock()


### PR DESCRIPTION
The index sender didn't check the context in the sending loop, so could potentially continue sending index messages for quite a while after it was supposed to stop. The actual Index/IndexUpdate methods on the connection did check the context, but only concurrently with the outbox so, again, no guarantee that they'd take that path. Now check it on the way in, so that if the context is already cancelled it will be an early return.