### PR TITLE
fix(meta): return read error in forbidden_words_test

### DIFF
--- a/meta/forbidden_words_test.go
+++ b/meta/forbidden_words_test.go
@@ -35,7 +35,7 @@ func TestForbiddenWords(t *testing.T) {
 
 			bs, err := os.ReadFile(path)
 			if err != nil {
-				return nil
+				return err
 			}
 
 			for _, word := range forbiddenWords {


### PR DESCRIPTION
When reading a file fails, the error is currently swallowed / hidden.  Probably just a typo.