### PR TITLE
chore(connections): lower log level from INFO to DEBUG for "already connected to this device" messages (fixes #9715)

### DIFF
--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -283,7 +283,11 @@ func (s *service) handleConns(ctx context.Context) error {
 		}
 
 		if err := s.connectionCheckEarly(remoteID, c); err != nil {
-			l.Infof("Connection from %s at %s (%s) rejected: %v", remoteID, c.RemoteAddr(), c.Type(), err)
+			if err == errDeviceAlreadyConnected {
+				l.Debugf("Connection from %s at %s (%s) rejected: %v", remoteID, c.RemoteAddr(), c.Type(), err)
+			} else {
+				l.Infof("Connection from %s at %s (%s) rejected: %v", remoteID, c.RemoteAddr(), c.Type(), err)
+			}
 			c.Close()
 			continue
 		}

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -283,7 +283,7 @@ func (s *service) handleConns(ctx context.Context) error {
 		}
 
 		if err := s.connectionCheckEarly(remoteID, c); err != nil {
-			if err == errDeviceAlreadyConnected {
+			if errors.Is(err, errDeviceAlreadyConnected) {
 				l.Debugf("Connection from %s at %s (%s) rejected: %v", remoteID, c.RemoteAddr(), c.Type(), err)
 			} else {
 				l.Infof("Connection from %s at %s (%s) rejected: %v", remoteID, c.RemoteAddr(), c.Type(), err)


### PR DESCRIPTION
### Purpose

The primary aim of this change is to minimize log clutter in production environments. There are many lines in the logs coming from an expected race condition when two devices connect `already connected to this device`. These messages do not indicate errors and can overwhelm the log files with unnecessary noise.

By lowering the logging level, we enhance the usability of the logs, making it easier for users and developers to identify actual issues without being distracted

### Testing
1. Build syncthing locally
2. Start two Syncthing instances
```bash
./syncthing -no-browser -home=~/.config/syncthing1
./syncthing -no-browser -home=~/.config/syncthing2
```
3. Enable the DEBUG logs from UI for `connections` package
4. Connect the synching instances by adding remote devices from the UI
5. Observe the logs for the message `XXXX already connected to this device`

### Screenshots

![image](https://github.com/user-attachments/assets/882ccb4c-d39d-463a-8f66-2aad97010700)

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

