### PR TITLE
fix(gui): get version from header when not authenticated

### DIFF
--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -21,6 +21,24 @@ var authUrlbase = urlbase + '/noauth/auth';
 // keep consistent with ShortIDStringLength in lib/protocol/deviceid.go
 var shortIDStringLength = 7;
 
+
+angular.module('syncthing.core')
+    .factory('versionService', function () {
+        'use strict';
+        return { version: null };
+    })
+    .factory('versionHeaderInterceptor', function (versionService) {
+        return {
+            response: function (response) {
+                var ver = response.headers('X-Syncthing-Version');
+                if (ver) {
+                    versionService.version = ver;
+                }
+                return response;
+            },
+        };
+    });
+
 syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvider) {
     // language and localisation
 
@@ -35,6 +53,7 @@ syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvi
     LocaleServiceProvider.setDefaultLocale('en');
 
     $httpProvider.useApplyAsync(true);
+    $httpProvider.interceptors.push('versionHeaderInterceptor');
 
     if (!window.metadata) {
         // Most likely we're not authenticated yet, in which case we can't proceed with the rest of the setup.

--- a/gui/default/syncthing/app.js
+++ b/gui/default/syncthing/app.js
@@ -21,24 +21,6 @@ var authUrlbase = urlbase + '/noauth/auth';
 // keep consistent with ShortIDStringLength in lib/protocol/deviceid.go
 var shortIDStringLength = 7;
 
-
-angular.module('syncthing.core')
-    .factory('versionService', function () {
-        'use strict';
-        return { version: null };
-    })
-    .factory('versionHeaderInterceptor', function (versionService) {
-        return {
-            response: function (response) {
-                var ver = response.headers('X-Syncthing-Version');
-                if (ver) {
-                    versionService.version = ver;
-                }
-                return response;
-            },
-        };
-    });
-
 syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvider) {
     // language and localisation
 
@@ -53,7 +35,6 @@ syncthing.config(function ($httpProvider, $translateProvider, LocaleServiceProvi
     LocaleServiceProvider.setDefaultLocale('en');
 
     $httpProvider.useApplyAsync(true);
-    $httpProvider.interceptors.push('versionHeaderInterceptor');
 
     if (!window.metadata) {
         // Most likely we're not authenticated yet, in which case we can't proceed with the rest of the setup.

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2,7 +2,7 @@ angular.module('syncthing.core')
     .config(function ($locationProvider) {
         $locationProvider.html5Mode({ enabled: true, requireBase: false }).hashPrefix('!');
     })
-    .controller('SyncthingController', function ($scope, $http, $location, LocaleService, Events, $filter, $q, $compile, $timeout, $rootScope, $translate, versionService) {
+    .controller('SyncthingController', function ($scope, $http, $location, LocaleService, Events, $filter, $q, $compile, $timeout, $rootScope, $translate) {
         'use strict';
 
         // private/helper definitions
@@ -3288,10 +3288,10 @@ angular.module('syncthing.core')
         };
 
         $scope.versionBase = function () {
-            var version = $scope.version.version || versionService.version;
-            if (!version) {
+            if (!$scope.version.version) {
                 return '';
             }
+            var version = $scope.version.version;
             var pos = version.indexOf('-');
             if (pos > 0) {
                 version = version.slice(0, pos);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -16,6 +16,15 @@ angular.module('syncthing.core')
             LocaleService.autoConfigLocale();
 
             if (!$scope.authenticated) {
+                function setVersionFromHeader(_data, _status, headers) {
+                    var version = headers('X-Syncthing-Version');
+                    if (version) {
+                        $scope.version = { version: version };
+                    }
+                }
+                // Get index.html again (likely cached) to retrieve the version header
+                $http.get('').success(setVersionFromHeader).error(setVersionFromHeader);
+
                 // Can't proceed yet - wait for the page reload after successful login.
                 return;
             }

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3308,12 +3308,14 @@ angular.module('syncthing.core')
                 // Undefined or null should become a valid string.
                 path = '';
             }
-            var hashIndex = path.indexOf('#');
-            url += '/' + (hashIndex === -1 ? path : path.slice(0, hashIndex));
-            url += '?version=' + $scope.versionBase();
-            var hash = hashIndex === -1 ? '' : path.slice(hashIndex);
-            if (hash) {
-                url += hash;
+            var hash = path.indexOf('#');
+            if (hash != -1) {
+                url += '/' + path.slice(0, hash);
+                url += '?version=' + $scope.versionBase();
+                url += path.slice(hash);
+            } else {
+                url += '/' + path;
+                url += '?version=' + $scope.versionBase();
             }
             return url;
         };

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -2,7 +2,7 @@ angular.module('syncthing.core')
     .config(function ($locationProvider) {
         $locationProvider.html5Mode({ enabled: true, requireBase: false }).hashPrefix('!');
     })
-    .controller('SyncthingController', function ($scope, $http, $location, LocaleService, Events, $filter, $q, $compile, $timeout, $rootScope, $translate) {
+    .controller('SyncthingController', function ($scope, $http, $location, LocaleService, Events, $filter, $q, $compile, $timeout, $rootScope, $translate, versionService) {
         'use strict';
 
         // private/helper definitions
@@ -3288,10 +3288,10 @@ angular.module('syncthing.core')
         };
 
         $scope.versionBase = function () {
-            if (!$scope.version.version) {
+            var version = $scope.version.version || versionService.version;
+            if (!version) {
                 return '';
             }
-            var version = $scope.version.version;
             var pos = version.indexOf('-');
             if (pos > 0) {
                 version = version.slice(0, pos);

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3308,14 +3308,12 @@ angular.module('syncthing.core')
                 // Undefined or null should become a valid string.
                 path = '';
             }
-            var hash = path.indexOf('#');
-            if (hash != -1) {
-                url += '/' + path.slice(0, hash);
-                url += '?version=' + $scope.versionBase();
-                url += path.slice(hash);
-            } else {
-                url += '/' + path;
-                url += '?version=' + $scope.versionBase();
+            var hashIndex = path.indexOf('#');
+            url += '/' + (hashIndex === -1 ? path : path.slice(0, hashIndex));
+            url += '?version=' + $scope.versionBase();
+            var hash = hashIndex === -1 ? '' : path.slice(hashIndex);
+            if (hash) {
+                url += hash;
             }
             return url;
         };

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3301,16 +3301,16 @@ angular.module('syncthing.core')
 
         $scope.docsURL = function (path) {
             var url = 'https://docs.syncthing.net';
+            if (!$scope.versionBase()) {
+                return url;
+            }
             if (!path) {
                 // Undefined or null should become a valid string.
                 path = '';
             }
             var hashIndex = path.indexOf('#');
             url += '/' + (hashIndex === -1 ? path : path.slice(0, hashIndex));
-            var ver = $scope.versionBase();
-            if (ver) {
-                url += '?version=' + ver;
-            }
+            url += '?version=' + $scope.versionBase();
             var hash = hashIndex === -1 ? '' : path.slice(hashIndex);
             if (hash) {
                 url += hash;

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3301,16 +3301,16 @@ angular.module('syncthing.core')
 
         $scope.docsURL = function (path) {
             var url = 'https://docs.syncthing.net';
-            if (!$scope.versionBase()) {
-                return url;
-            }
             if (!path) {
                 // Undefined or null should become a valid string.
                 path = '';
             }
             var hashIndex = path.indexOf('#');
             url += '/' + (hashIndex === -1 ? path : path.slice(0, hashIndex));
-            url += '?version=' + $scope.versionBase();
+            var ver = $scope.versionBase();
+            if (ver) {
+                url += '?version=' + ver;
+            }
             var hash = hashIndex === -1 ? '' : path.slice(hashIndex);
             if (hash) {
                 url += hash;


### PR DESCRIPTION
### Purpose

Since #8757, the Syncthing GUI now has an unauthenticated state. One consequence of this is that `$scope.versionBase()` is not initialized while unauthenticated, which causes the `docsURL` function to truncate links to just `https://docs.syncthing.net`/, discarding the section path. This currently affects at least the "Help > Introduction" link reachable both while logged in and not. The issue is exacerbated in https://github.com/syncthing/syncthing/pull/9175 where we sometimes want to show additional contextual help links from the login page to particular sections of the docs.

I don't think it's any worse to try to preserve the section path even without an explicit version tag, than to fall back to just the host and lose all context the link was attempting to provide.

### Testing

- On commit b1ed2802fb944bb5e3dea3b4a80c05db3a9df7c3 (before):
  - Open the GUI, set a username and log out.
  - Open the "Help" drop-down. The "Introduction" item links to: https://docs.syncthing.net/
  - Log in.
  - Open the "Help" drop-down. The "Introduction" item links to: https://docs.syncthing.net/v1.27.10/intro/gui
- On commit 44fef317800ce1d0795b4e2ebfbd5e9deda849ef (after):
  - Open the GUI, set a username and log out.
  - Open the "Help" drop-down. The "Introduction" item links to: https://docs.syncthing.net/intro/gui
  - Log in.
  - Open the "Help" drop-down. The "Introduction" item links to: https://docs.syncthing.net/v1.27.10/intro/gui

### Screenshots

This is a GUI change, but affecting only URLs in the markup with no visual changes.


### Drawbacks

If a `docsURL` call generates a versionless link to a docs page that doesn't exist on https://docs.syncthing.net - presumably because Syncthing is not the latest version and links to a deleted page? - then this will lead to GitHub's generic 404 page with no link to the Syncthing docs root. Before, any versionless link would also be a pathless link, leading to the Syncthing docs root instead of a 404 page.