### PR TITLE
chore(ursrv): extend F-Droid detection

### DIFF
--- a/cmd/infra/ursrv/serve/serve.go
+++ b/cmd/infra/ursrv/serve/serve.go
@@ -72,6 +72,7 @@ var (
 		{regexp.MustCompile(`\sandroid-builder@github\.syncthing\.net`), "Google Play"},
 		{regexp.MustCompile(`\sandroid-.*teamcity@build\.syncthing\.net`), "Google Play"},
 		{regexp.MustCompile(`\sandroid-.*vagrant@basebox-stretch64`), "F-Droid"},
+		{regexp.MustCompile(`\svagrant@bookworm`), "F-Droid"},
 		{regexp.MustCompile(`\svagrant@bullseye`), "F-Droid"},
 		{regexp.MustCompile(`\sbuilduser@(archlinux|svetlemodry)`), "Arch (3rd party)"},
 		{regexp.MustCompile(`\ssyncthing@archlinux`), "Arch (3rd party)"},


### PR DESCRIPTION
### Purpose

Our f-droid apps are currently built using `vagrant@bookworm`:

![grafik](https://github.com/user-attachments/assets/172cab09-df6f-449a-a638-1f0a0c080ab3)

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

