### PR TITLE
chore(ursrv): add Nix detection

### DIFF
--- a/cmd/infra/ursrv/serve/serve.go
+++ b/cmd/infra/ursrv/serve/serve.go
@@ -81,6 +81,7 @@ var (
 		{regexp.MustCompile(`\sbrew@`), "Homebrew (3rd party)"},
 		{regexp.MustCompile(`\sroot@buildkitsandbox`), "LinuxServer.io (3rd party)"},
 		{regexp.MustCompile(`\sports@freebsd`), "FreeBSD (3rd party)"},
+		{regexp.MustCompile(`\snix@nix`), "NixOS (3rd party)"},
 		{regexp.MustCompile(`.`), "Others"},
 	}
 )

--- a/cmd/infra/ursrv/serve/serve.go
+++ b/cmd/infra/ursrv/serve/serve.go
@@ -81,7 +81,7 @@ var (
 		{regexp.MustCompile(`\sbrew@`), "Homebrew (3rd party)"},
 		{regexp.MustCompile(`\sroot@buildkitsandbox`), "LinuxServer.io (3rd party)"},
 		{regexp.MustCompile(`\sports@freebsd`), "FreeBSD (3rd party)"},
-		{regexp.MustCompile(`\snix@nix`), "NixOS (3rd party)"},
+		{regexp.MustCompile(`\snix@nix`), "Nix (3rd party)"},
 		{regexp.MustCompile(`.`), "Others"},
 	}
 )


### PR DESCRIPTION
### Purpose

Classify the builder `nix@nix` as [Nix](https://nixos.org/)

![369684243-172cab09-df6f-449a-a638-1f0a0c080ab3](https://github.com/user-attachments/assets/37a6e0a5-bdcb-4b31-8b36-eaaa42423382)

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

