### PR TITLE
fix(model): check if remote folder state before pulling files (fixes #9686)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -505,13 +505,13 @@ nextFile:
 			continue nextFile
 		}
 
-		devices := f.model.availabilityInSnapshot(f.FolderConfiguration, snap, fi)
+		devices := f.model.fileAvailability(f.FolderConfiguration, snap, fi)
 		if len(devices) > 0 {
 			f.handleFile(fi, snap, copyChan)
-		} else {
-			f.newPullError(fileName, errNotAvailable)
-			f.queue.Done(fileName)
+			continue
 		}
+		f.newPullError(fileName, errNotAvailable)
+		f.queue.Done(fileName)
 	}
 
 	return changed, fileDeletions, dirDeletions, nil
@@ -1544,7 +1544,7 @@ func (f *sendReceiveFolder) pullBlock(state pullBlockState, snap *db.Snapshot, o
 	}
 
 	var lastError error
-	candidates := f.model.availabilityInSnapshot(f.FolderConfiguration, snap, state.file)
+	candidates := f.model.blockAvailability(f.FolderConfiguration, snap, state.file, state.block)
 loop:
 	for {
 		select {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2882,25 +2882,31 @@ func (m *model) Availability(folder string, file protocol.FileInfo, block protoc
 	}
 	defer snap.Release()
 
-	return m.availability(cfg, snap, file, block), nil
+	return m.blockAvailabilityRLocked(cfg, snap, file, block), nil
 }
 
-func (m *model) availability(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
+func (m *model) blockAvailability(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
+	m.mut.RLock()
+	defer m.mut.RUnlock()
+	return m.blockAvailabilityRLocked(cfg, snap, file, block)
+}
+
+func (m *model) blockAvailabilityRLocked(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
 	var candidates []Availability
 
-	candidates = append(candidates, m.availabilityInSnapshotRLocked(cfg, snap, file)...)
-	candidates = append(candidates, m.availabilityFromTemporaryRLocked(cfg, file, block)...)
+	candidates = append(candidates, m.fileAvailabilityRLocked(cfg, snap, file)...)
+	candidates = append(candidates, m.blockAvailabilityFromTemporaryRLocked(cfg, file, block)...)
 
 	return candidates
 }
 
-func (m *model) availabilityInSnapshot(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo) []Availability {
+func (m *model) fileAvailability(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo) []Availability {
 	m.mut.RLock()
 	defer m.mut.RUnlock()
-	return m.availabilityInSnapshotRLocked(cfg, snap, file)
-
+	return m.fileAvailabilityRLocked(cfg, snap, file)
 }
-func (m *model) availabilityInSnapshotRLocked(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo) []Availability {
+
+func (m *model) fileAvailabilityRLocked(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo) []Availability {
 	var availabilities []Availability
 	for _, device := range snap.Availability(file.Name) {
 		if _, ok := m.remoteFolderStates[device]; !ok {
@@ -2917,7 +2923,7 @@ func (m *model) availabilityInSnapshotRLocked(cfg config.FolderConfiguration, sn
 	return availabilities
 }
 
-func (m *model) availabilityFromTemporaryRLocked(cfg config.FolderConfiguration, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
+func (m *model) blockAvailabilityFromTemporaryRLocked(cfg config.FolderConfiguration, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
 	var availabilities []Availability
 	for _, device := range cfg.Devices {
 		if m.deviceDownloads[device.DeviceID].Has(cfg.ID, file.Name, file.Version, int(block.Offset/int64(file.BlockSize()))) {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2882,16 +2882,30 @@ func (m *model) Availability(folder string, file protocol.FileInfo, block protoc
 	}
 	defer snap.Release()
 
-	return m.availabilityInSnapshotRLocked(cfg, snap, file, block), nil
+	if devices := m.availabilityInSnapshot(cfg, snap, file); len(devices) > 0 {
+		return devices, nil
+	}
+
+	return m.availabilityFromTemporaryRLocked(cfg, file, block), nil
 }
 
-func (m *model) availabilityInSnapshot(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
+func (m *model) availabilityInSnapshot(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo) []Availability {
 	m.mut.RLock()
 	defer m.mut.RUnlock()
-	return m.availabilityInSnapshotRLocked(cfg, snap, file, block)
+	return m.availabilityInSnapshotRLocked(cfg, snap, file)
 }
 
-func (m *model) availabilityInSnapshotRLocked(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
+func (m *model) availabilityFromTemporaryRLocked(cfg config.FolderConfiguration, file protocol.FileInfo, block protocol.BlockInfo) []Availability {
+	var availabilities []Availability
+	for _, device := range cfg.Devices {
+		if m.deviceDownloads[device.DeviceID].Has(cfg.ID, file.Name, file.Version, int(block.Offset/int64(file.BlockSize()))) {
+			availabilities = append(availabilities, Availability{ID: device.DeviceID, FromTemporary: true})
+		}
+	}
+	return availabilities
+}
+
+func (m *model) availabilityInSnapshotRLocked(cfg config.FolderConfiguration, snap *db.Snapshot, file protocol.FileInfo) []Availability {
 	var availabilities []Availability
 	for _, device := range snap.Availability(file.Name) {
 		if _, ok := m.remoteFolderStates[device]; !ok {
@@ -2903,12 +2917,7 @@ func (m *model) availabilityInSnapshotRLocked(cfg config.FolderConfiguration, sn
 		_, ok := m.deviceConnIDs[device]
 		if ok {
 			availabilities = append(availabilities, Availability{ID: device, FromTemporary: false})
-		}
-	}
 
-	for _, device := range cfg.Devices {
-		if m.deviceDownloads[device.DeviceID].Has(cfg.ID, file.Name, file.Version, int(block.Offset/int64(file.BlockSize()))) {
-			availabilities = append(availabilities, Availability{ID: device.DeviceID, FromTemporary: true})
 		}
 	}
 


### PR DESCRIPTION
### Purpose

As discussed in #9686 
Syncthing currently does not check folderstate on remote device before pulling. If no devices have a valid folderstate (i.e all devices have the folder paused) it will still attempt to pull. On large folders this will cause a hanging "Syncing" status.

This checks whether at least one connected device has the file available and has a valid folderstate.

### Testing
Tested locally on multiple devices.
We're new to Go (all our stuff is Python) so please bear with!
Interested if there may be a better place to slot this in.

Thanks,
Jon

