### PR TITLE
fix(ur): actually send usage report directly when enabled

### DIFF
--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -305,6 +305,11 @@ func TestOverriddenValues(t *testing.T) {
 		t.Error(err)
 	}
 
+	if cfg.Options().URUniqueID == "" {
+		t.Error("expected usage reporting unique ID to be set since usage reporting is enabled")
+	}
+	expected.URUniqueID = cfg.Options().URUniqueID // it's random
+
 	if diff, equal := messagediff.PrettyDiff(expected, cfg.Options()); !equal {
 		t.Errorf("Overridden config differs. Diff:\n%s", diff)
 	}

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -65,6 +65,11 @@ func (opts *OptionsConfiguration) prepare(guiPWIsSet bool) {
 		l.Warnln("Connection priority number for TCP over WAN must be worse (higher) than TCP over LAN. Correcting.")
 		opts.ConnectionPriorityTCPWAN = opts.ConnectionPriorityTCPLAN + 1
 	}
+
+	// If usage reporting is enabled we must have a unique ID.
+	if opts.URAccepted > 0 && opts.URUniqueID == "" {
+		opts.URUniqueID = rand.String(8)
+	}
 }
 
 // RequiresRestartOnly returns a copy with only the attributes that require

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -36,7 +36,6 @@ import (
 	"github.com/syncthing/syncthing/lib/model"
 	"github.com/syncthing/syncthing/lib/osutil"
 	"github.com/syncthing/syncthing/lib/protocol"
-	"github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/svcutil"
 	"github.com/syncthing/syncthing/lib/tlsutil"
 	"github.com/syncthing/syncthing/lib/upgrade"
@@ -290,11 +289,6 @@ func (a *App) startup() error {
 				cfg.Options.URAccepted = ur.Version
 				// Unique ID will be set and config saved below if necessary.
 			}
-		}
-
-		// If we are going to do usage reporting, ensure we have a valid unique ID.
-		if cfg.Options.URAccepted > 0 && cfg.Options.URUniqueID == "" {
-			cfg.Options.URUniqueID = rand.String(8)
 		}
 	})
 

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -396,7 +396,7 @@ func (s *Service) Serve(ctx context.Context) error {
 }
 
 func (s *Service) CommitConfiguration(from, to config.Configuration) bool {
-	if from.Options.URAccepted != to.Options.URAccepted || from.Options.URURL != to.Options.URURL {
+	if from.Options.URAccepted != to.Options.URAccepted || from.Options.URUniqueID != to.Options.URUniqueID || from.Options.URURL != to.Options.URURL {
 		select {
 		case s.forceRun <- struct{}{}:
 		default:

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -26,6 +26,7 @@ import (
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/protocol"
+	srand "github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/scanner"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur/contract"
@@ -383,6 +384,20 @@ func (s *Service) Serve(ctx context.Context) error {
 			t.Reset(0)
 		case <-t.C:
 			if s.cfg.Options().URAccepted >= 2 {
+				if s.cfg.Options().URUniqueID == "" {
+					// Set a unique ID if this is the first time we're
+					// sending a report
+					w, err := s.cfg.Modify(func(cfg *config.Configuration) {
+						cfg.Options.URUniqueID = srand.String(8)
+					})
+					if err != nil {
+						// Hope for better luck next time, no need to try to
+						// send a report without a unique ID
+						continue
+					}
+					w.Wait()
+				}
+
 				err := s.sendUsageReport(ctx)
 				if err != nil {
 					l.Infoln("Usage report:", err)
@@ -396,7 +411,7 @@ func (s *Service) Serve(ctx context.Context) error {
 }
 
 func (s *Service) CommitConfiguration(from, to config.Configuration) bool {
-	if from.Options.URAccepted != to.Options.URAccepted || from.Options.URUniqueID != to.Options.URUniqueID || from.Options.URURL != to.Options.URURL {
+	if from.Options.URAccepted != to.Options.URAccepted || from.Options.URURL != to.Options.URURL {
 		select {
 		case s.forceRun <- struct{}{}:
 		default:

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -26,7 +26,6 @@ import (
 	"github.com/syncthing/syncthing/lib/db"
 	"github.com/syncthing/syncthing/lib/dialer"
 	"github.com/syncthing/syncthing/lib/protocol"
-	srand "github.com/syncthing/syncthing/lib/rand"
 	"github.com/syncthing/syncthing/lib/scanner"
 	"github.com/syncthing/syncthing/lib/upgrade"
 	"github.com/syncthing/syncthing/lib/ur/contract"
@@ -384,20 +383,6 @@ func (s *Service) Serve(ctx context.Context) error {
 			t.Reset(0)
 		case <-t.C:
 			if s.cfg.Options().URAccepted >= 2 {
-				if s.cfg.Options().URUniqueID == "" {
-					// Set a unique ID if this is the first time we're
-					// sending a report
-					w, err := s.cfg.Modify(func(cfg *config.Configuration) {
-						cfg.Options.URUniqueID = srand.String(8)
-					})
-					if err != nil {
-						// Hope for better luck next time, no need to try to
-						// send a report without a unique ID
-						continue
-					}
-					w.Wait()
-				}
-
 				err := s.sendUsageReport(ctx)
 				if err != nil {
 					l.Infoln("Usage report:", err)


### PR DESCRIPTION
There was a bug that the unique ID was not set when reporting was enabled, and thus the reports where rejected by the server. The unique ID got set only on startup, so next time Syncthing restarted.

This makes sure to set the unique ID when blank. The check to send a new report when the ID changes is removed, because it would result in double reports being sent, and is in general not required for anything.
