### PR TITLE
chore(model): remove GUI/log warning on sequence anomaly

### DIFF
--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -448,13 +448,7 @@ func (s *indexHandler) receive(fs []protocol.FileInfo, update bool, op string, p
 	return nil
 }
 
-var warnSequenceAnomalyOnce sync.Once
-
 func (s *indexHandler) logSequenceAnomaly(msg string, extra map[string]any) {
-	warnSequenceAnomalyOnce.Do(func() {
-		l.Warnf("Index sequence anomaly detected (please report at https://forum.syncthing.net/t/22660): %s (%v)", msg, extra)
-	})
-
 	extraStrs := make(map[string]string, len(extra))
 	for k, v := range extra {
 		extraStrs[k] = fmt.Sprint(v)


### PR DESCRIPTION
I can see already in our Sentry data that there are a fair amount of these warnings, and mostly the shape of it. Asking users to report them will likely cause a lot of reporting effort to fairly little additional value. We can do that when/if we have something more targeted to ask for.
