### PR TITLE
chore(build): use conventional commit title in update script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ case "${1:-default}" in
 		build weblate
 		pushd man ; ./refresh.sh ; popd
 		git add -A gui man AUTHORS
-		git commit -m 'gui, man, authors: Update docs, translations, and contributors'
+		git commit -m 'chore(gui, man, authors): update docs, translations, and contributors'
 		;;
 
 	*)


### PR DESCRIPTION
chore(build): use conventional commit title in update script

Update the commit title to match the conventional style, which is
currently used for all other commits in the repository.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>