### PR TITLE
fix(gui): hide non-functional log-out button when using basic authentication

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -129,8 +129,8 @@
               <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
               <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
 
-              <li ng-if="authenticated && isAuthEnabled()" class="divider" aria-hidden="true"></li>
-              <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>
+              <li ng-if="authenticated && isAuthEnabled() && !config.gui.sendBasicAuthPrompt" class="divider" aria-hidden="true"></li>
+              <li ng-if="authenticated && isAuthEnabled() && !config.gui.sendBasicAuthPrompt"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
fix(gui): hide non-functional log-out button when using basic authentication

Currently, the log-out button does nothing when basic authentication is
enabled. Thus, hide it from the GUI completely to avoid confusion when
the user presses it expecting to be logged out, which does not happen.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>