### PR TITLE
Update lang-cs.json

### DIFF
--- a/gui/default/assets/lang/lang-cs.json
+++ b/gui/default/assets/lang/lang-cs.json
@@ -227,7 +227,7 @@
     "Listeners": "Naslouchající",
     "Loading data...": "Načítání dat…",
     "Loading...": "Načítání…",
-    "Local Additions": "Místní příbytky",
+    "Local Additions": "Místní přebytky",
     "Local Discovery": "Místní objevování",
     "Local State": "Místní status",
     "Local State (Total)": "Místní status (Celkem)",


### PR DESCRIPTION
### Purpose

Fix Czech language translation

Old string "příbytky" means "dwellings".