### PR TITLE
chore(db): process "unchanged" files anyway

### DIFF
--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -212,12 +212,8 @@ func (db *Lowlevel) updateLocalFiles(folder []byte, fs []protocol.FileInfo, meta
 		if err != nil {
 			return err
 		}
-		if ok && unchanged(f, ef) {
-			l.Debugf("not inserting unchanged (local); folder=%q %v", folder, f)
-			continue
-		}
-		blocksHashSame := ok && bytes.Equal(ef.BlocksHash, f.BlocksHash)
 
+		blocksHashSame := ok && bytes.Equal(ef.BlocksHash, f.BlocksHash)
 		if ok {
 			keyBuf, err = db.removeLocalBlockAndSequenceInfo(keyBuf, folder, name, ef, !blocksHashSame, &t)
 			if err != nil {
@@ -1437,13 +1433,6 @@ func (db *Lowlevel) checkErrorForRepair(err error) {
 			}
 		}
 	}
-}
-
-// unchanged checks if two files are the same and thus don't need to be updated.
-// Local flags or the invalid bit might change without the version
-// being bumped.
-func unchanged(nf, ef protocol.FileIntf) bool {
-	return ef.FileVersion().Equal(nf.FileVersion()) && ef.IsInvalid() == nf.IsInvalid() && ef.FileLocalFlags() == nf.FileLocalFlags()
 }
 
 func (db *Lowlevel) handleFailure(err error) {

--- a/lib/db/lowlevel.go
+++ b/lib/db/lowlevel.go
@@ -159,10 +159,6 @@ func (db *Lowlevel) updateRemoteFiles(folder, device []byte, fs []protocol.FileI
 		if err != nil {
 			return err
 		}
-		if ok && unchanged(f, ef) {
-			l.Debugf("not inserting unchanged (remote); folder=%q device=%v %v", folder, devID, f)
-			continue
-		}
 
 		if ok {
 			meta.removeFile(devID, ef)


### PR DESCRIPTION
Skipping these makes the sequence numbering inconcistent; we've received a file and suppsedly added it to the database, but if you check the sequence number afterwards it didn't increase, i.e., we trigger [this failure condition](https://github.com/syncthing/syncthing/blob/47f48faed7331b7ba4ad3d6775d5cffacf8931b5/lib/model/indexhandler.go#L447-L459) and, similarly, a future update will look like there was a hole in the numbering.

I propose to at least temporarily remove this optimisation in order for things to make more sense. Is there a reason to keep this beyond saving some database operations?
