### PR TITLE
fix(gui): improve device ID readability in black and dark themes (fixes #9757)

### DIFF
--- a/gui/black/assets/css/theme.css
+++ b/gui/black/assets/css/theme.css
@@ -224,7 +224,6 @@ code.ng-binding{
 }
 
 .well, .form-control[readonly="readonly"], .popover { /* read-only fields*/
-    color: #666 !important;
     border-color: #444 !important;
     background-color: #111 !important;
 }

--- a/gui/dark/assets/css/theme.css
+++ b/gui/dark/assets/css/theme.css
@@ -228,7 +228,6 @@ code.ng-binding{
 }
 
 .well, .form-control[readonly="readonly"], .popover { /* read-only fields*/
-    color: #666 !important;
     border-color: #424242 !important;
     background-color: #3B3B3B !important;
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -58,6 +58,7 @@ ul+h5 {
 
 .text-monospace {
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
+    font-weight: bold;
 }
 
 .table-condensed>thead>tr>th, .table-condensed>tbody>tr>th, .table-condensed>tfoot>tr>th, .table-condensed>thead>tr>td, .table-condensed>tbody>tr>td, .table-condensed>tfoot>tr>td {

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -58,7 +58,6 @@ ul+h5 {
 
 .text-monospace {
     font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-    font-weight: bold;
 }
 
 .table-condensed>thead>tr>th, .table-condensed>tbody>tr>th, .table-condensed>tfoot>tr>th, .table-condensed>thead>tr>td, .table-condensed>tbody>tr>td, .table-condensed>tfoot>tr>td {

--- a/gui/default/syncthing/device/idqrModalView.html
+++ b/gui/default/syncthing/device/idqrModalView.html
@@ -1,6 +1,6 @@
 <modal id="idqr" status="info" icon="fas fa-qrcode" heading="{{'Device Identification' | translate}} - {{deviceName(currentDevice)}}" large="yes" closeable="yes">
   <div class="modal-body text-center">
-    <div class="well well-sm text-monospace select-on-click">{{currentDevice.deviceID}}</div>
+    <div class="well well-sm text-monospace select-on-click"><strong>{{currentDevice.deviceID}}</strong></div>
     <div ng-if="currentDevice.deviceID">
       <img class="img-thumbnail" ng-src="qr/?text={{currentDevice.deviceID}}" height="328" width="328" alt="{{'QR code' | translate}}" />
       <div class="btn-group-vertical" style="vertical-align: top;">


### PR DESCRIPTION
Remove the foreground color override from the "well" class, to make it inherit the base text color, which is brighter and better matches the grey background.

Switch to a bold font for even better readability.  This also affects the GUI API key in the settings dialog.

![image](https://github.com/user-attachments/assets/59a8de2d-e28b-4e16-a54a-ee0a7f5ec153)
![image](https://github.com/user-attachments/assets/0896ad02-5fd9-447b-aa6d-c509d4d58647)
![image](https://github.com/user-attachments/assets/120502ff-9ee5-481a-a370-6f17d851e097)
