### PR TITLE
chore(next-gen-gui): update README and fix build target location

### DIFF
--- a/build.go
+++ b/build.go
@@ -856,7 +856,7 @@ func buildNextGenGUI() bool {
 	// time by the build process. This assumes the new GUI ends up in
 	// next-gen-gui/dist/next-gen-gui.
 
-	if !shouldRebuildAssets("gui/next-gen-gui/index.html", "next-gen-gui") {
+	if !shouldRebuildAssets("gui/default/next-gen-gui/index.html", "next-gen-gui") {
 		// The GUI is up to date.
 		return false
 	}
@@ -868,7 +868,7 @@ func buildNextGenGUI() bool {
 
 	for _, src := range listFiles("next-gen-gui/dist") {
 		rel, _ := filepath.Rel("next-gen-gui/dist", src)
-		dst := filepath.Join("gui", rel)
+		dst := filepath.Join("gui", "default", rel)
 		if err := copyFile(src, dst, 0644); err != nil {
 			fmt.Println("copy:", err)
 			os.Exit(1)

--- a/next-gen-gui/README.md
+++ b/next-gen-gui/README.md
@@ -8,13 +8,13 @@ zip](https://github.com/kastelo/syncthing-tech-ui/releases) and unpack it
 into the GUI override directory (assuming default Linux setup):
 
 ```
-$ cd ~/.config/syncthing
+$ cd ~/.local/state/syncthing
 $ mkdir -p gui/default
 $ cd gui/default
-$ unzip ~/tech-ui-v1.0.0.zip
+$ unzip ~/next-gen-gui-v1.0.0.zip
 ```
 
-Then load the GUI via http://localhost:8384/tech-ui/ or similar. You should see something like this:
+Then load the GUI via http://localhost:8384/next-gen-gui/ or similar. You should see something like this:
 
 ![Screenshot](screenshot.png)
 
@@ -31,11 +31,11 @@ Syncthing's config directory.
 
 ```
 $ npm run build -- --prod
-$ rsync -va --delete dist/tech-ui/ ~/.config/syncthing/gui/default/tech-ui/
+$ rsync -va --delete dist/next-gen-gui/ ~/.local/state/syncthing/gui/default/next-gen-gui/
 ```
 
 Adjust for your actual Syncthing config dir if different. Navigate to
-`http://localhost:8384/tech-ui/`.
+`http://localhost:8384/next-gen-gui/`.
 
 Another option is to start Syncthing with the STGUIASSETS environment
 variable pointing to the distribution directory.
@@ -48,7 +48,7 @@ $ syncthing
 ```
 
 The magic is symlink is because Syncthing will look for the GUI in the
-`default` subdirectory. Navigate to `http://localhost:8384/tech-ui/`.
+`default` subdirectory. Navigate to `http://localhost:8384/next-gen-gui/`.
 
 ## Code scaffolding
 

--- a/next-gen-gui/README.md
+++ b/next-gen-gui/README.md
@@ -4,7 +4,7 @@
 
 This is a very bare bones read-only GUI for viewing the status of large
 setups. Download a [release
-zip](https://github.com/kastelo/syncthing-tech-ui/releases) and unpack it
+zip](https://github.com/syncthing/tech-ui/releases) and unpack it
 into the GUI override directory (assuming default Linux setup):
 
 ```

--- a/next-gen-gui/README.md
+++ b/next-gen-gui/README.md
@@ -50,6 +50,13 @@ $ syncthing
 The magic is symlink is because Syncthing will look for the GUI in the
 `default` subdirectory. Navigate to `http://localhost:8384/next-gen-gui/`.
 
+**NOTE**: You will need to enable the `sendBasicAuthPrompt` setting in the
+backend if authentication is configured, as this GUI doesn’t have an HTML
+login form yet. To do that, go to *Actions > Advanced > GUI* in the standard
+variant, and enable the *Send Basic Auth Prompt* checkbox, then
+save. Otherwise, you’ll always need to log into the standard GUI first before
+using this one.
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You


### PR DESCRIPTION
The README file was imported verbatim from the former tech-ui repository.  Although the Node.js project was renamed to next-gen-gui in the process of importing to the syncthing main repo, its documentation still refers to the old name and an even older download location.  Fix that by pointing at the main repo releases (where actual builds are still to be published) and change the name references to next-gen-gui all over.

As the README advises to place the `next-gen-gui` folder under the `gui/default/` theme directory, adjust the build script to do exactly that.  Previously, `build.go` ended up placing it in `gui/next-gen-gui/`, making it a pseudo "theme" which one could switch to from the standard GUI.  This caused the documented query path-based GUI switching to actually fail.  Having it inside the `default` theme subdirectory fixes that and thereby allows using both
GUIs in parallel under different URL paths.