### PR TITLE
chore: update policy to allow approvals by contributors

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -48,6 +48,9 @@ approval_rules:
       count: 1
       teams:
         - syncthing/maintainers
+    options:
+      ignore_update_merges: true
+      allow_contributor: true
 
   # Regular pull requests require approval by an active contributor
   - name: is approved by a syncthing contributor
@@ -55,6 +58,9 @@ approval_rules:
       count: 1
       teams:
         - syncthing/contributors
+    options:
+      ignore_update_merges: true
+      allow_contributor: true
 
   # Changes to some files (translations, dependencies, compatibility) do not
   # require approval if they were proposed by a contributor and have a


### PR DESCRIPTION
This adds `allow_contributor: true` which allows approvals by contributors to the PR (but still not the author themself, which is a different thing). This allows things like pushing minor fixups while also approving.

The `ignore_update_merges: true` option makes it so that someone is not considered a "contributor" just because they push the merge button to update the branch. In principle this is not needed given the above, but I like it for clarity.
