### PR TITLE
fix(model): don't panic in index consistency print (fixes #9821)

### DIFF
--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -448,7 +448,7 @@ func (s *indexHandler) receive(fs []protocol.FileInfo, update bool, op string, p
 	seq := fset.Sequence(deviceID)
 
 	// Check that the sequence we get back is what we put in...
-	if lastSequence > 0 && seq != lastSequence {
+	if lastSequence > 0 && len(fs) > 0 && seq != lastSequence {
 		s.logSequenceAnomaly("unexpected sequence after update", map[string]any{
 			"prevSeq":     prevSequence,
 			"lastSeq":     lastSequence,


### PR DESCRIPTION
We try to compare to the last fileinfo, but apparently we can end up here with an empty file list and crash on out of index.
