### PR TITLE
fix(model): create fileset under lock

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -565,15 +565,15 @@ func (m *model) restartFolder(from, to config.FolderConfiguration, cacheIgnoredF
 }
 
 func (m *model) newFolder(cfg config.FolderConfiguration, cacheIgnoredFiles bool) error {
-	// Creating the fileset can take a long time (metadata calculation) so
-	// we do it outside of the lock.
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	// Creating the fileset can take a long time (metadata calculation), but
+	// nevertheless should happen inside the lock.
 	fset, err := db.NewFileSet(cfg.ID, m.db)
 	if err != nil {
 		return fmt.Errorf("adding %v: %w", cfg.Description(), err)
 	}
-
-	m.mut.Lock()
-	defer m.mut.Unlock()
 
 	m.addAndStartFolderLocked(cfg, fset, cacheIgnoredFiles)
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -569,7 +569,8 @@ func (m *model) newFolder(cfg config.FolderConfiguration, cacheIgnoredFiles bool
 	defer m.mut.Unlock()
 
 	// Creating the fileset can take a long time (metadata calculation), but
-	// nevertheless should happen inside the lock.
+	// nevertheless should happen inside the lock (same as when restarting
+	// a folder).
 	fset, err := db.NewFileSet(cfg.ID, m.db)
 	if err != nil {
 		return fmt.Errorf("adding %v: %w", cfg.Description(), err)


### PR DESCRIPTION
I came accross this in another context and didn't investigate fully, but literally ten lines above this code, in another method, we say that filesets _must_ be created under the lock. It's either one or the other and I'm taking the safer route here.
