### PR TITLE
fix(gui): reflect folder password visibility by changing button icon

### DIFF
--- a/gui/default/syncthing/core/editShareTemplate.html
+++ b/gui/default/syncthing/core/editShareTemplate.html
@@ -36,7 +36,7 @@
     </span>
     <span ng-switch="selected[id] && folderType !== 'receiveencrypted'" class="input-group-addon">
       <span ng-switch-when='true'>
-        <span class="button fas fa-fw fa-eye" ng-click="togglePasswordVisibility()"></span>
+        <span class="button fas fa-fw {{plain ? 'fa-eye-slash' : 'fa-eye'}}" ng-click="togglePasswordVisibility()"></span>
       </span>
       <span ng-switch-default>
         <span class="button fas fa-fw fa-eye" disabled></span>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -3703,7 +3703,6 @@ angular.module('syncthing.core')
                 untrusted: '=',
             },
             link: function (scope, elem, attrs) {
-                var plain = false;
                 scope.togglePasswordVisibility = function() {
                     scope.plain = !scope.plain;
                 };


### PR DESCRIPTION
### Purpose

This PR makes the "toggle password visibility" button on encrypted folders change its icon from `fa-eye` to `fa-eye-slash` while the password is visible.

### Testing

Manually tested the GUI change on my machine.

### Screenshots

Icon while password is not visible:

![icon-fa-eye](https://github.com/user-attachments/assets/a0ea65f6-4a68-4e5e-a1d5-f53ea32baf6c)

Icon while password is visible:

![icon-fa-eye-slash](https://github.com/user-attachments/assets/9b718fa8-2f7d-43cf-8f2e-23562a07070a)