### PR TITLE
fix(scanner): continue walk after special files (fixes #9872)

### DIFF
--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -392,9 +392,13 @@ func (w *walker) handleItem(ctx context.Context, path string, info fs.FileInfo, 
 
 	case info.IsRegular():
 		return w.walkRegular(ctx, path, info, toHashChan)
-	}
 
-	return fmt.Errorf("bug: file info for %v is neither symlink, dir nor regular", path)
+	default:
+		// A special file, socket, fifo, etc. -- do nothing but return
+		// success so we continue the walk.
+		l.Debugf("Skipping non-regular file %s (%s)", path, info.Mode())
+		return nil
+	}
 }
 
 func (w *walker) walkRegular(ctx context.Context, relPath string, info fs.FileInfo, toHashChan chan<- protocol.FileInfo) error {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -341,7 +341,10 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 
 		if ignoredParent == "" {
 			// parent isn't ignored, nothing special
-			return w.handleItem(ctx, path, info, toHashChan, finishedChan)
+			if err := w.handleItem(ctx, path, info, toHashChan, finishedChan); err != nil {
+				handleError(ctx, "handle item", path, err, finishedChan)
+				return skip
+			}
 		}
 
 		// Part of current path below the ignored (potential) parent
@@ -350,7 +353,10 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 		// ignored path isn't actually a parent of the current path
 		if rel == path {
 			ignoredParent = ""
-			return w.handleItem(ctx, path, info, toHashChan, finishedChan)
+			if err := w.handleItem(ctx, path, info, toHashChan, finishedChan); err != nil {
+				handleError(ctx, "handle item", path, err, finishedChan)
+				return skip
+			}
 		}
 
 		// The previously ignored parent directories of the current, not
@@ -366,7 +372,8 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 				return skip
 			}
 			if err = w.handleItem(ctx, ignoredParent, info, toHashChan, finishedChan); err != nil {
-				return err
+				handleError(ctx, "handle item", path, err, finishedChan)
+				return skip
 			}
 		}
 		ignoredParent = ""

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -341,10 +341,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 
 		if ignoredParent == "" {
 			// parent isn't ignored, nothing special
-			if err := w.handleItem(ctx, path, info, toHashChan, finishedChan); err != nil {
-				handleError(ctx, "handle item", path, err, finishedChan)
-				return skip
-			}
+			return w.handleItem(ctx, path, info, toHashChan, finishedChan)
 		}
 
 		// Part of current path below the ignored (potential) parent
@@ -353,10 +350,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 		// ignored path isn't actually a parent of the current path
 		if rel == path {
 			ignoredParent = ""
-			if err := w.handleItem(ctx, path, info, toHashChan, finishedChan); err != nil {
-				handleError(ctx, "handle item", path, err, finishedChan)
-				return skip
-			}
+			return w.handleItem(ctx, path, info, toHashChan, finishedChan)
 		}
 
 		// The previously ignored parent directories of the current, not
@@ -372,8 +366,7 @@ func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protoco
 				return skip
 			}
 			if err = w.handleItem(ctx, ignoredParent, info, toHashChan, finishedChan); err != nil {
-				handleError(ctx, "handle item", path, err, finishedChan)
-				return skip
+				return err
 			}
 		}
 		ignoredParent = ""


### PR DESCRIPTION
We must skip unix sockets, fifos, etc when scanning as these are not filetypes we can handle. Currently we return a "bug" error, which results in the walk being aborted and the rest of the tree being essentially invisible to Syncthing. Instead, just ignore these files and continue onwards.

This might well be #9859 as well but I can't confirm.
