### PR TITLE
chore(scanner): avoid scan failures and report if they happen

### DIFF
--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -239,8 +239,12 @@ func TestNormalization(t *testing.T) {
 			if fd, err := testFs.OpenFile(filepath.Join("normalization", s1, s2), os.O_CREATE|os.O_EXCL, 0o644); err != nil {
 				t.Fatal(err)
 			} else {
-				fd.Write([]byte("test"))
-				fd.Close()
+				if _, err := fd.Write([]byte("test")); err != nil {
+					t.Fatal(err)
+				}
+				if err := fd.Close(); err != nil {
+					t.Fatal(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Currently we simply ignore those errors. And these are errors that don't just affect one file, but they caused the entire scan to abort and thus leaving potential a large amount of files unchecked. This shouldn't ever happen, so log at warning level and add failure reporting.

When the above came up, Jakob mentioned there are a bunch of error conditions where we probably shouldn't actually abort. I agree, we should probably never abort, even if the error is entirely unexpected - no harm trying to continue to find more files that we may be able to scan. As such streamline the handleItem resp. it's child `walk...` functions to simply return an error, not doing anything special to categorize them. And in the top-level walk function handle those errors without returning them.
