### PR TITLE
fix(model): correct type of fileInfoType in API browse response (fixes #9904)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2732,11 +2732,11 @@ func (m *model) Revert(folder string) {
 }
 
 type TreeEntry struct {
-	Name     string                `json:"name"`
-	ModTime  time.Time             `json:"modTime"`
-	Size     int64                 `json:"size"`
-	Type     protocol.FileInfoType `json:"type"`
-	Children []*TreeEntry          `json:"children,omitempty"`
+	Name     string       `json:"name"`
+	ModTime  time.Time    `json:"modTime"`
+	Size     int64        `json:"size"`
+	Type     string       `json:"type"`
+	Children []*TreeEntry `json:"children,omitempty"`
 }
 
 func findByName(slice []*TreeEntry, name string) *TreeEntry {
@@ -2804,7 +2804,7 @@ func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly 
 
 		parent.Children = append(parent.Children, &TreeEntry{
 			Name:    base,
-			Type:    f.Type,
+			Type:    f.Type.String(),
 			ModTime: f.ModTime(),
 			Size:    f.FileSize(),
 		})

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1729,7 +1729,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 			Name:    name,
 			ModTime: time.Unix(0x666, 0),
 			Size:    0xa,
-			Type:    protocol.FileInfoTypeFile,
+			Type:    protocol.FileInfoTypeFile.String(),
 		}
 	}
 	d := func(name string, entries ...*TreeEntry) *TreeEntry {
@@ -1737,7 +1737,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 			Name:     name,
 			ModTime:  time.Unix(0x666, 0),
 			Size:     128,
-			Type:     protocol.FileInfoTypeDirectory,
+			Type:     protocol.FileInfoTypeDirectory.String(),
 			Children: entries,
 		}
 	}


### PR DESCRIPTION
This was broken in the Protobuf refactor. The reason is that with the previous library, generated types would have a JSON marshalling method that would automatically return strings for enums. In the current library you need to use the jsonpb marshaller for that, but these are hand crafted structs so we can't do that. The easy solution is to just use strings directly, since this is an API-only type anyway.
