### PR TITLE
fix(scanner): don't warn when legitimately skipping a directory

### DIFF
--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -243,7 +243,7 @@ const walkFailureEventDesc = "Unexpected error while walking the filesystem duri
 func (w *walker) scan(ctx context.Context, toHashChan chan<- protocol.FileInfo, finishedChan chan<- ScanResult) {
 	hashFiles := w.walkAndHashFiles(ctx, toHashChan, finishedChan)
 	if len(w.Subs) == 0 {
-		if err := w.Filesystem.Walk(".", hashFiles); err != nil {
+		if err := w.Filesystem.Walk(".", hashFiles); err != nil && !errors.Is(err, fs.SkipDir) {
 			w.EventLogger.Log(events.Failure, walkFailureEventDesc)
 			l.Warnf("Aborted scan due to an unexpected error: %v", err)
 		}
@@ -253,7 +253,7 @@ func (w *walker) scan(ctx context.Context, toHashChan chan<- protocol.FileInfo, 
 				l.Debugf("%v: Skip walking %v as it is below a symlink", w, sub)
 				continue
 			}
-			if err := w.Filesystem.Walk(sub, hashFiles); err != nil {
+			if err := w.Filesystem.Walk(sub, hashFiles); err != nil && !errors.Is(err, fs.SkipDir) {
 				w.EventLogger.Log(events.Failure, walkFailureEventDesc)
 				l.Warnf("Aborted scan of path '%v' due to an unexpected error: %v", sub, err)
 			}


### PR DESCRIPTION
Such as ignored directories etc.
