### PR TITLE
fix(api): don't crash requests after failing to unmarshal tokens (fixes #9909)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -402,6 +402,9 @@ func (s *service) Serve(ctx context.Context) error {
 		// care about we log ourselves from the handlers.
 		ErrorLog: log.New(io.Discard, "", 0),
 	}
+	if shouldDebugHTTP() {
+		srv.ErrorLog = log.Default()
+	}
 
 	l.Infoln("GUI and API listening on", listener.Addr())
 	l.Infoln("Access the GUI via the following URL:", guiCfg.URL())

--- a/lib/api/tokenmanager.go
+++ b/lib/api/tokenmanager.go
@@ -36,11 +36,12 @@ type tokenManager struct {
 }
 
 func newTokenManager(key string, miscDB *db.NamespacedKV, lifetime time.Duration, maxItems int) *tokenManager {
-	tokens := &apiproto.TokenSet{
-		Tokens: make(map[string]int64),
-	}
+	var tokens apiproto.TokenSet
 	if bs, ok, _ := miscDB.Bytes(key); ok {
-		_ = proto.Unmarshal(bs, tokens) // best effort
+		_ = proto.Unmarshal(bs, &tokens) // best effort
+	}
+	if tokens.Tokens == nil {
+		tokens.Tokens = make(map[string]int64)
 	}
 	return &tokenManager{
 		key:      key,
@@ -49,7 +50,7 @@ func newTokenManager(key string, miscDB *db.NamespacedKV, lifetime time.Duration
 		maxItems: maxItems,
 		timeNow:  time.Now,
 		mut:      sync.NewMutex(),
-		tokens:   tokens,
+		tokens:   &tokens,
 	}
 }
 


### PR DESCRIPTION
Unclear why this would happen, but apparently it does?
