### PR TITLE
build: switch to cloud code signing for Windows

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -127,6 +127,7 @@ jobs:
       - package-cross
       - package-source
       - package-debian
+      - package-windows
       - govulncheck
     steps:
       - uses: actions/checkout@v4
@@ -137,8 +138,6 @@ jobs:
 
   package-windows:
     name: Package for Windows
-    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
-    environment: release
     runs-on: windows-latest
     steps:
       - name: Set git to use LF

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -200,6 +200,8 @@ jobs:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
     environment: release
     runs-on: windows-latest
+    needs:
+      - package-windows
     steps:
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -207,15 +207,33 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: unsigned-packages-windows
+          path: packages
 
       - name: Extract packages
+        working-directory: packages
         run: |
           $files = Get-ChildItem "." -Filter *.zip
           foreach ($file in $files) {
             7z x $file.Name
           }
 
+      - name: Sign files with Trusted Signing
+        uses: azure/trusted-signing-action@v0.5.1
+        with:
+          azure-tenant-id: ${{ secrets.AZURE_TRUSTED_SIGNING_TENANT_ID }}
+          azure-client-id: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_ID }}
+          azure-client-secret: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_SECRET }}
+          endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
+          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_PROFILE }}
+          files-folder: ${{ github.workspace }}/packages
+          files-folder-filter: exe
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
       - name: Repackage packages
+        working-directory: packages
         run: |
           $files = Get-ChildItem "." -Filter *.zip
           foreach ($file in $files) {
@@ -227,7 +245,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: packages-windows
-          path: "*.zip"
+          path: "packages/*.zip"
 
   #
   # Linux

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -226,7 +226,7 @@ jobs:
           endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
           trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT }}
           certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_PROFILE }}
-          files-folder: ${{ github.workspace }}/packages
+          files-folder: ${{ github.workspace }}\packages
           files-folder-filter: exe
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -188,15 +188,44 @@ jobs:
           }
         env:
           CGO_ENABLED: "0"
-          CODESIGN_SIGNTOOL: ${{ secrets.CODESIGN_SIGNTOOL }}
-          CODESIGN_CERTIFICATE_BASE64: ${{ secrets.CODESIGN_CERTIFICATE_BASE64 }}
-          CODESIGN_CERTIFICATE_PASSWORD: ${{ secrets.CODESIGN_CERTIFICATE_PASSWORD }}
-          CODESIGN_TIMESTAMP_SERVER: ${{ secrets.CODESIGN_TIMESTAMP_SERVER }}
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:
           name: packages-windows
+          path: "*.zip"
+
+  codesign-windows:
+    name: Codesign for Windows
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/v'))
+    environment: release
+    runs-on: windows-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: packages-windows
+
+      - name: Extract packages
+        run: |
+          $files = Get-ChildItem "." -Filter *.zip
+          foreach ($file in $files) {
+            7z x $file.BaseName
+          }
+
+      - name: Repackage packages
+        run: |
+          $files = Get-ChildItem "." -Filter *.zip
+          foreach ($file in $files) {
+            $dir = $file.BaseName.replace('.zip', '')
+            Remove-Item $file.BaseName
+            7z a -tzip $file.BaseName $dir
+          }
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-windows-codesigned
           path: "*.zip"
 
   #

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -192,7 +192,7 @@ jobs:
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: packages-windows
+          name: unsigned-packages-windows
           path: "*.zip"
 
   codesign-windows:
@@ -206,28 +206,27 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: packages-windows
+          name: unsigned-packages-windows
 
       - name: Extract packages
         run: |
           $files = Get-ChildItem "." -Filter *.zip
           foreach ($file in $files) {
-            7z x $file.BaseName
+            7z x $file.Name
           }
 
       - name: Repackage packages
         run: |
           $files = Get-ChildItem "." -Filter *.zip
           foreach ($file in $files) {
-            $dir = $file.BaseName.replace('.zip', '')
-            Remove-Item $file.BaseName
-            7z a -tzip $file.BaseName $dir
+            Remove-Item $file.Name
+            7z a -tzip $file.Name $file.BaseName
           }
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: packages-windows-codesigned
+          name: packages-windows
           path: "*.zip"
 
   #
@@ -533,7 +532,7 @@ jobs:
     if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/release' || startsWith(github.ref, 'refs/heads/release-')  || startsWith(github.ref, 'refs/tags/v'))
     environment: release
     needs:
-      - package-windows
+      - codesign-windows
       - package-linux
       - package-macos
       - package-cross

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -228,6 +228,7 @@ jobs:
           certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_PROFILE }}
           files-folder: ${{ github.workspace }}\packages
           files-folder-filter: exe
+          files-folder-recurse: true
           file-digest: SHA256
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256


### PR DESCRIPTION
The requirements for Windows code signing changed in 2023, so that newly generated certificates can only be stored in hardware modules. Luckily, I managed to snag a three year certificate before that so it hasn't affected us so much. Now though, it does, because our cert is expiring in March.

This changes the code signing process for Windows to use a cloud service, Azure Trusted Signing. This appears to work equally well and outsources the problem entirely, while also being cheaper than the actual certificate was to begin with. 🤷 

The signing entity will be Kastelo AB and not the Syncthing Foundation, because the latter is almost impossible to get a certificate for as it's not a normal corporate entity whose existence can be verified, etc. This is also how it was prior to the latest certificate; it's not ideal, but I think it's acceptable under the circumstances.