### PR TITLE
chore(etc): remove /usr/bin prefix from .desktop files

### DIFF
--- a/etc/linux-desktop/syncthing-start.desktop
+++ b/etc/linux-desktop/syncthing-start.desktop
@@ -2,7 +2,7 @@
 Name=Start Syncthing
 GenericName=File synchronization
 Comment=Starts the main syncthing process in the background.
-Exec=/usr/bin/syncthing serve --no-browser --logfile=default
+Exec=syncthing serve --no-browser --logfile=default
 Icon=syncthing
 Terminal=false
 Type=Application

--- a/etc/linux-desktop/syncthing-ui.desktop
+++ b/etc/linux-desktop/syncthing-ui.desktop
@@ -2,7 +2,7 @@
 Name=Syncthing Web UI
 GenericName=File synchronization UI
 Comment=Opens Syncthing's Web UI in the default browser (Syncthing must already be started).
-Exec=/usr/bin/syncthing --browser-only
+Exec=syncthing --browser-only
 Icon=syncthing
 Terminal=false
 Type=Application


### PR DESCRIPTION
Exec accepts just the program name and will look for it in $PATH. This makes these files work on NixOS which does not create a /usr/bin directory.
