### PR TITLE
refactor(api): make shutdown timeout configurable for tests

### DIFF
--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -923,6 +923,10 @@ func TestApiCache(t *testing.T) {
 }
 
 func startHTTP(cfg config.Wrapper) (string, context.CancelFunc, error) {
+	return startHTTPWithShutdownTimeout(cfg, 0)
+}
+
+func startHTTPWithShutdownTimeout(cfg config.Wrapper, shutdownTimeout time.Duration) (string, context.CancelFunc, error) {
 	m := new(modelmocks.Model)
 	assetDir := "../../gui"
 	eventSub := new(eventmocks.BufferedSubscription)
@@ -949,6 +953,10 @@ func startHTTP(cfg config.Wrapper) (string, context.CancelFunc, error) {
 	kdb := db.NewMiscDataNamespace(mdb)
 	svc := New(protocol.LocalDeviceID, cfg, assetDir, "syncthing", m, eventSub, diskEventSub, events.NoopLogger, discoverer, connections, urService, mockedSummary, errorLog, systemLog, false, kdb).(*service)
 	svc.started = addrChan
+
+	if shutdownTimeout > 0*time.Millisecond {
+		svc.shutdownTimeout = shutdownTimeout
+	}
 
 	// Actually start the API service
 	supervisor := suture.New("API test", suture.Spec{


### PR DESCRIPTION
This is extracted from [PR #9175][1], which adds some tests that seem to need a longer shutdown timeout when running on GitHub Actions. The problem manifests in errors like this in `TestWebauthnConfigChanges`:

```
2024-05-05T17:00:45.0503602Z     api_test.go:2919: TestWebauthnConfigChanges/Can_edit_GUIConfiguration.WebauthnUserId Put "http://127.0.0.1:37585/rest/config/gui": EOF []
2024-05-05T17:00:45.0566336Z --- FAIL: TestWebauthnConfigChanges/Can_edit_GUIConfiguration.WebauthnUserId (0.52s)
```

indicating that the server was forcefully shut down (or panicked, but that was ruled out in these cases) before the response was fully written (and likely before the request was fully handled).

[1]: https://github.com/syncthing/syncthing/pull/9175

### Purpose

- Make #9175 easier to review by reducing its diff volume.
- Retroactively: This is now a prerequisite of: #9979.

### Testing

N/A (tests still pass)