### PR TITLE
fix(api): prevent tilde expansion in path suggestions (fixes #9990)

### DIFF
--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -1764,7 +1764,7 @@ func browse(fsType fs.FilesystemType, current string) []string {
 		return browseRoots(fsType)
 	}
 
-	parent, base := parentAndBase(current)
+	parent, base := filepath.Split(current)
 	ffs := fs.NewFilesystem(fsType, parent)
 	files := browseFiles(ffs, base)
 	for i := range files {
@@ -1798,27 +1798,6 @@ func browseRoots(fsType fs.FilesystemType) []string {
 	}
 
 	return nil
-}
-
-// parentAndBase returns the parent directory and the remaining base of the
-// path. The base may be empty if the path ends with a path separator.
-func parentAndBase(current string) (string, string) {
-	search, _ := fs.ExpandTilde(current)
-	pathSeparator := string(fs.PathSeparator)
-
-	if strings.HasSuffix(current, pathSeparator) && !strings.HasSuffix(search, pathSeparator) {
-		search = search + pathSeparator
-	}
-	searchDir := filepath.Dir(search)
-
-	// The searchFile should be the last component of search, or empty if it
-	// ends with a path separator
-	var searchFile string
-	if !strings.HasSuffix(search, pathSeparator) {
-		searchFile = filepath.Base(search)
-	}
-
-	return searchDir, searchFile
 }
 
 func browseFiles(ffs fs.Filesystem, search string) []string {


### PR DESCRIPTION
### Purpose

Path autocompletion wasn't working when using `~` as a shortcut for the home directory. The issue occurred because the tilde was expanded to /home/user, which caused the suggestion to no longer match the input (thus preventing the autocompletion from appearing in the suggestion list).

To fix this, I replaced the custom `parentAndBase` function, which handled path splitting in a more complex way, with `filepath.Split` from the standard `path/filepath` package. This prevents tilde expansion while keeping the expected behavior for path splitting.

### Testing

The issue has been tested manually on Linux.

### Screenshots

![screenshot](https://github.com/user-attachments/assets/49dd96e2-6d75-4476-946d-0dfb2ac474ef)

