### PR TITLE
fix(gui): validate device ID in canonical form (fixes #7291)

### DIFF
--- a/gui/default/syncthing/core/validDeviceidDirective.js
+++ b/gui/default/syncthing/core/validDeviceidDirective.js
@@ -5,18 +5,12 @@ angular.module('syncthing.core')
             link: function (scope, elm, attrs, ctrl) {
                 ctrl.$parsers.unshift(function (viewValue) {
                     $http.get(urlbase + '/svc/deviceid?id=' + viewValue).success(function (resp) {
-                        if (resp.error) {
-                            ctrl.$setValidity('validDeviceid', false);
-                        } else {
-                            ctrl.$setValidity('validDeviceid', true);
-                        }
+                        let isValid = !resp.error;
+                        let isUnique = !isValid || !scope.devices.hasOwnProperty(resp.id);
+
+                        ctrl.$setValidity('validDeviceid', isValid);
+                        ctrl.$setValidity('unique', isUnique);
                     });
-                    //Prevents user from adding a duplicate ID
-                    if (scope.devices.hasOwnProperty(viewValue)) {
-                        ctrl.$setValidity('unique', false);
-                    } else {
-                        ctrl.$setValidity('unique', true);
-                    }
                     return viewValue;
                 });
             }


### PR DESCRIPTION
### Purpose

In the GUI, the device ID validation was case-sensitive and didn’t account for dash variations, which allowed users to enter an existing device ID without receiving proper feedback.

This fix ensures the ID is validated in its canonical form, thus preventing the user from submitting the request if the device ID already exists.

### Testing

To test this change, try adding a new device with an ID that matches an existing device, but with a different case or dashes.