### PR TITLE
fix(config): remove discontinued primary STUN server (fixes #10008)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -71,7 +71,8 @@ var (
 
 	// DefaultPrimaryStunServers are servers provided by us (to avoid causing the public servers burden)
 	DefaultPrimaryStunServers = []string{
-		"stun.syncthing.net:3478",
+		// Discontinued because of misuse. See https://forum.syncthing.net/t/stun-server-misuse/23319?u=marbens
+		//"stun.syncthing.net:3478",
 	}
 	DefaultSecondaryStunServers = []string{
 		"stun.callwithus.com:3478",

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -71,7 +71,7 @@ var (
 
 	// DefaultPrimaryStunServers are servers provided by us (to avoid causing the public servers burden)
 	DefaultPrimaryStunServers = []string{
-		// Discontinued because of misuse. See https://forum.syncthing.net/t/stun-server-misuse/23319?u=marbens
+		// Discontinued because of misuse. See https://forum.syncthing.net/t/stun-server-misuse/23319
 		//"stun.syncthing.net:3478",
 	}
 	DefaultSecondaryStunServers = []string{


### PR DESCRIPTION
The mechanism for primary STUN servers, is still intact, in case this gets retried with a different domain.

### Purpose

As seen in [stun.syncthing.net doesn’t resolve anymore](https://forum.syncthing.net/t/stun-syncthing-net-doesnt-resolve-anymore/24075/2?u=marbens) on the forums, stun.syncthing.net has been shut down, so I think it's probably a good idea to remove it.

### Testing

1. Have two or more devices
2. Disable Relaying
3. Have no Internet ports open on either end for incoming connections trigger STUN)
4. Enable the `stun` debugging facility in the Actions -> Logs -> Debugging Facilities
5. Verify that it doesn't output something like this within a few seconds:
```
2025-03-30 05:51:32 Enabled debug data for "stun"
2025-03-30 05:51:47 Starting stun for Stun@udp://[::]:22000
2025-03-30 05:51:47 Running stun for Stun@udp://[::]:22000 via stun.syncthing.net:3478
2025-03-30 05:51:47 Stun@udp://[::]:22000 stun addr resolution on stun.syncthing.net:3478: lookup stun.syncthing.net: no such host
```

