### PR TITLE
chore(db): increase journal limit to 64MiB

### DIFF
--- a/internal/db/sqlite/db_open.go
+++ b/internal/db/sqlite/db_open.go
@@ -36,7 +36,7 @@ func Open(path string) (*DB, error) {
 		// https://www.sqlite.org/pragma.html#pragma_optimize
 		return nil, wrap(err, "PRAGMA optimize")
 	}
-	if _, err := sqlDB.Exec(`PRAGMA journal_size_limit = 6144000`); err != nil {
+	if _, err := sqlDB.Exec(`PRAGMA journal_size_limit = 67108864`); err != nil {
 		// https://www.powersync.com/blog/sqlite-optimizations-for-ultra-high-performance
 		return nil, wrap(err, "PRAGMA journal_size_limit")
 	}


### PR DESCRIPTION
The current limit is far too low for our workloads. Perhaps we should aim even higher than the 64MiB this patch proposes?

Citing the sqlite docs:

> [...] after committing a transaction the rollback journal file may remain in the file-system. **This increases performance for subsequent transactions since overwriting an existing file is faster than append to a file**, but it also consumes file-system space.

tl;dr: if the limit is too low, we're shooting ourselves in the foot in terms of performance.