### PR TITLE
chore: forget deleted files older than six months (fixes #6284)

### DIFF
--- a/internal/db/sqlite/db_service.go
+++ b/internal/db/sqlite/db_service.go
@@ -96,7 +96,7 @@ func (s *Service) periodic(ctx context.Context) error {
 
 func (s *Service) garbageCollectOldDeletedLocked() error {
 	// Remove deleted files that are marked as not needed (we have processed
-	// them) and they were deleted more than deletedAgeCutoff ago.
+	// them) and they were deleted more than MaxDeletedFileAge ago.
 	res, err := s.sdb.stmt(`
 		DELETE FROM files
 		WHERE deleted AND modified < ? AND local_flags & {{.FlagLocalNeeded}} == 0

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -251,6 +251,11 @@ func TryMigrateDatabase() error {
 			return err
 		}
 		_ = snap.WithHaveSequence(0, func(fi protocol.FileInfo) bool {
+			if fi.Deleted && time.Since(fi.ModTime()) > sqlite.MaxDeletedFileAge {
+				// Skip deleted files that match the garbage collection
+				// criteria in the database
+				return true
+			}
 			fis <- fi
 			return true
 		})


### PR DESCRIPTION
This reduces the number of file entries we carry in the database, sometimes significantly. The downside is that if a file is deleted while a device is offline, and that device comes back more than the cutoff interval (six months) later, those files will get resurrected at some point.

(v2)