### PR TITLE
fix(db): handle large numbers of blocks in update

### DIFF
--- a/internal/db/sqlite/db_test.go
+++ b/internal/db/sqlite/db_test.go
@@ -1068,7 +1068,7 @@ func TestInsertLargeFile(t *testing.T) {
 		}
 	})
 
-	// Add a large files (many blocks)
+	// Add a large file (many blocks)
 
 	files := []protocol.FileInfo{genFile("test1", 16000, 1)}
 	if err := sdb.Update(folderID, protocol.LocalDeviceID, files); err != nil {

--- a/internal/db/sqlite/db_update.go
+++ b/internal/db/sqlite/db_update.go
@@ -315,9 +315,9 @@ func (*DB) insertBlocksLocked(tx *txPreparedStmts, blocklistHash []byte, blocks 
 	// error. Chunk it to a reasonable size.
 	for chunk := range slices.Chunk(bs, 1000) {
 		if _, err := tx.NamedExec(`
-		INSERT OR IGNORE INTO blocks (hash, blocklist_hash, idx, offset, size)
-		VALUES (:hash, :blocklist_hash, :idx, :offset, :size)
-	`, chunk); err != nil {
+			INSERT OR IGNORE INTO blocks (hash, blocklist_hash, idx, offset, size)
+			VALUES (:hash, :blocklist_hash, :idx, :offset, :size)
+		`, chunk); err != nil {
 			return wrap(err)
 		}
 	}


### PR DESCRIPTION
Avoid failure when inserting file with very large block list