### PR TITLE
chore(db): use shorter read transactions and periodic checkpoint for smaller WAL

### DIFF
--- a/internal/db/sqlite/db.go
+++ b/internal/db/sqlite/db.go
@@ -20,6 +20,7 @@ type DB struct {
 	sql            *sqlx.DB
 	localDeviceIdx int64
 	updateLock     sync.Mutex
+	updatePoints   int
 
 	statementsMut sync.RWMutex
 	statements    map[string]*sqlx.Stmt

--- a/internal/db/sqlite/db_open.go
+++ b/internal/db/sqlite/db_open.go
@@ -36,10 +36,6 @@ func Open(path string) (*DB, error) {
 		// https://www.sqlite.org/pragma.html#pragma_optimize
 		return nil, wrap(err, "PRAGMA optimize")
 	}
-	if _, err := sqlDB.Exec(`PRAGMA journal_size_limit = 67108864`); err != nil {
-		// https://www.powersync.com/blog/sqlite-optimizations-for-ultra-high-performance
-		return nil, wrap(err, "PRAGMA journal_size_limit")
-	}
 	return openCommon(sqlDB)
 }
 

--- a/internal/db/sqlite/db_service.go
+++ b/internal/db/sqlite/db_service.go
@@ -86,10 +86,16 @@ func (s *Service) periodic(ctx context.Context) error {
 		return wrap(err)
 	}
 
-	_, _ = s.sdb.sql.ExecContext(ctx, `ANALYZE`)
-	_, _ = s.sdb.sql.ExecContext(ctx, `PRAGMA optimize`)
-	_, _ = s.sdb.sql.ExecContext(ctx, `PRAGMA incremental_vacuum`)
-	_, _ = s.sdb.sql.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
+	conn, err := s.sdb.sql.Conn(ctx)
+	if err != nil {
+		return wrap(err)
+	}
+	defer conn.Close()
+	_, _ = conn.ExecContext(ctx, `ANALYZE`)
+	_, _ = conn.ExecContext(ctx, `PRAGMA optimize`)
+	_, _ = conn.ExecContext(ctx, `PRAGMA incremental_vacuum`)
+	_, _ = conn.ExecContext(ctx, `PRAGMA journal_size_limit = 67108864`)
+	_, _ = conn.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE)`)
 
 	return nil
 }

--- a/internal/db/sqlite/db_update.go
+++ b/internal/db/sqlite/db_update.go
@@ -578,7 +578,15 @@ func (s *DB) periodicCheckpoint(fs []protocol.FileInfo) {
 	}
 	if s.updatePoints > updatePointsThreshold {
 		l.Debugln("checkpoint at", s.updatePoints)
-		if _, err := s.sql.Exec(`PRAGMA wal_checkpoint(RESTART)`); err != nil {
+		conn, err := s.sql.Conn(context.Background())
+		if err != nil {
+			l.Debugln("conn:", err)
+		}
+		defer conn.Close()
+		if _, err := conn.ExecContext(context.Background(), `PRAGMA journal_size_limit = 67108864`); err != nil {
+			l.Debugln("PRAGMA journal_size_limit(RESTART):", err)
+		}
+		if _, err := conn.ExecContext(context.Background(), `PRAGMA wal_checkpoint(RESTART)`); err != nil {
 			l.Debugln("PRAGMA wal_checkpoint(RESTART):", err)
 		}
 		s.updatePoints = 0

--- a/internal/db/sqlite/db_update.go
+++ b/internal/db/sqlite/db_update.go
@@ -154,7 +154,7 @@ func (s *DB) Update(folder string, device protocol.DeviceID, fs []protocol.FileI
 		return wrap(err)
 	}
 
-	s.periodicCheckpoint(fs)
+	s.periodicCheckpointLocked(fs)
 	return nil
 }
 
@@ -567,7 +567,7 @@ func (e fileRow) Compare(other fileRow) int {
 	}
 }
 
-func (s *DB) periodicCheckpoint(fs []protocol.FileInfo) {
+func (s *DB) periodicCheckpointLocked(fs []protocol.FileInfo) {
 	// Induce periodic checkpoints. We add points for each file and block,
 	// and checkpoint when we've written more than a threshold of points.
 	// This ensures we do not go too long without a checkpoint, while also

--- a/internal/db/sqlite/db_update.go
+++ b/internal/db/sqlite/db_update.go
@@ -23,6 +23,13 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const (
+	// Arbitrarily chosen values for checkpoint frequency....
+	updatePointsPerFile   = 100
+	updatePointsPerBlock  = 1
+	updatePointsThreshold = 250_000
+)
+
 func (s *DB) Update(folder string, device protocol.DeviceID, fs []protocol.FileInfo) error {
 	s.updateLock.Lock()
 	defer s.updateLock.Unlock()
@@ -143,7 +150,12 @@ func (s *DB) Update(folder string, device protocol.DeviceID, fs []protocol.FileI
 		}
 	}
 
-	return wrap(tx.Commit())
+	if err := tx.Commit(); err != nil {
+		return wrap(err)
+	}
+
+	s.periodicCheckpoint(fs)
+	return nil
 }
 
 func (s *DB) DropFolder(folder string) error {
@@ -552,5 +564,23 @@ func (e fileRow) Compare(other fileRow) int {
 		return 1 // they win
 	default:
 		return 0
+	}
+}
+
+func (s *DB) periodicCheckpoint(fs []protocol.FileInfo) {
+	// Induce periodic checkpoints. We add points for each file and block,
+	// and checkpoint when we've written more than a threshold of points.
+	// This ensures we do not go too long without a checkpoint, while also
+	// not doing it incessantly for every update.
+	s.updatePoints += updatePointsPerFile * len(fs)
+	for _, f := range fs {
+		s.updatePoints += len(f.Blocks) * updatePointsPerBlock
+	}
+	if s.updatePoints > updatePointsThreshold {
+		l.Debugln("checkpoint at", s.updatePoints)
+		if _, err := s.sql.Exec(`PRAGMA wal_checkpoint(RESTART)`); err != nil {
+			l.Debugln("PRAGMA wal_checkpoint(RESTART):", err)
+		}
+		s.updatePoints = 0
 	}
 }

--- a/internal/db/sqlite/db_update.go
+++ b/internal/db/sqlite/db_update.go
@@ -581,6 +581,7 @@ func (s *DB) periodicCheckpoint(fs []protocol.FileInfo) {
 		conn, err := s.sql.Conn(context.Background())
 		if err != nil {
 			l.Debugln("conn:", err)
+			return
 		}
 		defer conn.Close()
 		if _, err := conn.ExecContext(context.Background(), `PRAGMA journal_size_limit = 67108864`); err != nil {


### PR DESCRIPTION
Also make sure our journal size limit is in effect when checkpointing.