### PR TITLE
feat(api, gui): allow authentication bypass for metrics

### DIFF
--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -60,7 +60,7 @@ func isNoAuthPath(path string, promMetricsNoAuth bool) bool {
 		"/rest/svc/lang", // Required to load language settings on login page
 	}
 
-	if promMetricsNoAuth {  // 'Prom Metrics No Auth' GUI option
+	if promMetricsNoAuth { // 'Prom Metrics No Auth' GUI option
 		noAuthPaths = append(noAuthPaths, "/metrics")
 	}
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -51,7 +51,7 @@ func forbidden(w http.ResponseWriter) {
 	http.Error(w, "Forbidden", http.StatusForbidden)
 }
 
-func isNoAuthPath(path string, promMetricsNoAuth bool) bool {
+func isNoAuthPath(path string, metricsWithoutAuth bool) bool {
 	// Local variable instead of module var to prevent accidental mutation
 	noAuthPaths := []string{
 		"/",
@@ -60,7 +60,7 @@ func isNoAuthPath(path string, promMetricsNoAuth bool) bool {
 		"/rest/svc/lang", // Required to load language settings on login page
 	}
 
-	if promMetricsNoAuth { // 'Prom Metrics No Auth' GUI option
+	if metricsWithoutAuth {
 		noAuthPaths = append(noAuthPaths, "/metrics")
 	}
 

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -119,7 +119,7 @@ func (m *basicAuthAndSessionMiddleware) ServeHTTP(w http.ResponseWriter, r *http
 	}
 
 	// Exception for static assets and REST calls that don't require authentication.
-	if isNoAuthPath(r.URL.Path, m.guiCfg.MetricsNoAuth()) {
+	if isNoAuthPath(r.URL.Path, m.guiCfg.MetricsWithoutAuth) {
 		m.next.ServeHTTP(w, r)
 		return
 	}

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -51,13 +51,17 @@ func forbidden(w http.ResponseWriter) {
 	http.Error(w, "Forbidden", http.StatusForbidden)
 }
 
-func isNoAuthPath(path string) bool {
+func isNoAuthPath(path string, promMetricsNoAuth bool) bool {
 	// Local variable instead of module var to prevent accidental mutation
 	noAuthPaths := []string{
 		"/",
 		"/index.html",
 		"/modal.html",
 		"/rest/svc/lang", // Required to load language settings on login page
+	}
+
+	if promMetricsNoAuth {  // 'Prom Metrics No Auth' GUI option
+		noAuthPaths = append(noAuthPaths, "/metrics")
 	}
 
 	// Local variable instead of module var to prevent accidental mutation
@@ -115,7 +119,7 @@ func (m *basicAuthAndSessionMiddleware) ServeHTTP(w http.ResponseWriter, r *http
 	}
 
 	// Exception for static assets and REST calls that don't require authentication.
-	if isNoAuthPath(r.URL.Path) {
+	if isNoAuthPath(r.URL.Path, m.guiCfg.MetricsNoAuth()) {
 		m.next.ServeHTTP(w, r)
 		return
 	}

--- a/lib/api/api_csrf.go
+++ b/lib/api/api_csrf.go
@@ -78,7 +78,7 @@ func (m *csrfManager) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if isNoAuthPath(r.URL.Path) {
+	if isNoAuthPath(r.URL.Path, false) {
 		// REST calls that don't require authentication also do not
 		// need a CSRF token.
 		m.next.ServeHTTP(w, r)

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -25,6 +25,7 @@ type GUIConfiguration struct {
 	User                      string   `json:"user" xml:"user,omitempty"`
 	Password                  string   `json:"password" xml:"password,omitempty"`
 	AuthMode                  AuthMode `json:"authMode" xml:"authMode,omitempty"`
+	PromMetricsNoAuth         bool     `json:"promMetricsNoAuth" xml:"promMetricsNoAuth" default:"false"`
 	RawUseTLS                 bool     `json:"useTLS" xml:"tls,attr"`
 	APIKey                    string   `json:"apiKey" xml:"apikey,omitempty"`
 	InsecureAdminAccess       bool     `json:"insecureAdminAccess" xml:"insecureAdminAccess,omitempty"`
@@ -180,4 +181,8 @@ func (c *GUIConfiguration) prepare() {
 
 func (c GUIConfiguration) Copy() GUIConfiguration {
 	return c
+}
+
+func (c GUIConfiguration) MetricsNoAuth() bool {
+	return c.PromMetricsNoAuth
 }

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -25,7 +25,7 @@ type GUIConfiguration struct {
 	User                      string   `json:"user" xml:"user,omitempty"`
 	Password                  string   `json:"password" xml:"password,omitempty"`
 	AuthMode                  AuthMode `json:"authMode" xml:"authMode,omitempty"`
-	PromMetricsNoAuth         bool     `json:"promMetricsNoAuth" xml:"promMetricsNoAuth" default:"false"`
+	MetricsWithoutAuth        bool     `json:"metricsWithoutAuth" xml:"metricsWithoutAuth" default:"false"`
 	RawUseTLS                 bool     `json:"useTLS" xml:"tls,attr"`
 	APIKey                    string   `json:"apiKey" xml:"apikey,omitempty"`
 	InsecureAdminAccess       bool     `json:"insecureAdminAccess" xml:"insecureAdminAccess,omitempty"`
@@ -181,8 +181,4 @@ func (c *GUIConfiguration) prepare() {
 
 func (c GUIConfiguration) Copy() GUIConfiguration {
 	return c
-}
-
-func (c GUIConfiguration) MetricsNoAuth() bool {
-	return c.PromMetricsNoAuth
 }


### PR DESCRIPTION
### Purpose

Give the ability to skip authentication for prometheus metrics ("/metrics").

### Testing

When authentication is enabled and "Metrics Without Auth" is checked (not the default), the "/metrics" path remains accessible even when disconnected.

### Screenshots

![image](https://github.com/user-attachments/assets/144b696b-dd72-46f4-94d5-cd21848e4a4c)

### Documentation

https://github.com/syncthing/docs/pull/906

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

