### PR TITLE
fix(sqlite): apply options

### DIFF
--- a/internal/db/sqlite/db_open.go
+++ b/internal/db/sqlite/db_open.go
@@ -65,6 +65,10 @@ func Open(path string, opts ...Option) (*DB, error) {
 		folderDBOpener: openFolderDB,
 	}
 
+	for _, opt := range opts {
+		opt(db)
+	}
+
 	return db, nil
 }
 


### PR DESCRIPTION
@calmh it seems `sqlite.Open` forgets to apply options supplied to it (currently only the delete retention interval).