### PR TITLE
fix(syncthing): use separate lock file instead of locking the certificate (fixes #10053)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -376,7 +376,7 @@ func (options serveOptions) Run() error {
 	if options.Upgrade {
 		release, err := checkUpgrade()
 		if err == nil {
-			lf := flock.New(locations.Get(locations.CertFile))
+			lf := flock.New(locations.Get(locations.LockFile))
 			locked, err := lf.TryLock()
 			if err != nil {
 				l.Warnln("Upgrade:", err)
@@ -546,7 +546,7 @@ func syncthingMain(options serveOptions) {
 	}
 
 	// Ensure we are the only running instance
-	lf := flock.New(locations.Get(locations.CertFile))
+	lf := flock.New(locations.Get(locations.LockFile))
 	locked, err := lf.TryLock()
 	if err != nil {
 		l.Warnln("Failed to acquire lock:", err)
@@ -691,6 +691,10 @@ func syncthingMain(options serveOptions) {
 	if options.DebugProfileCPU {
 		pprof.StopCPUProfile()
 	}
+
+	// Best effort remove lockfile, doesn't matter if it succeeds
+	_ = lf.Unlock()
+	_ = os.Remove(locations.Get(locations.LockFile))
 
 	os.Exit(int(status))
 }

--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -386,6 +386,8 @@ func (options serveOptions) Run() error {
 			} else {
 				err = upgrade.To(release)
 			}
+			_ = lf.Unlock()
+			_ = os.Remove(locations.Get(locations.LockFile))
 		}
 		if err != nil {
 			l.Warnln("Upgrade:", err)

--- a/lib/locations/locations.go
+++ b/lib/locations/locations.go
@@ -33,6 +33,7 @@ const (
 	AuditLog      LocationEnum = "auditLog"
 	GUIAssets     LocationEnum = "guiAssets"
 	DefFolder     LocationEnum = "defFolder"
+	LockFile      LocationEnum = "lockFile"
 )
 
 type BaseDirEnum string
@@ -124,6 +125,7 @@ var locationTemplates = map[LocationEnum]string{
 	AuditLog:      "${data}/audit-%{timestamp}.log",
 	GUIAssets:     "${config}/gui",
 	DefFolder:     "${userHome}/Sync",
+	LockFile:      "${data}/syncthing.lock",
 }
 
 var locations = make(map[LocationEnum]string)


### PR DESCRIPTION
Apparently that nukes the cert under some circumstances on some Windows 🤷 