### PR TITLE
feat(ignore): add .stignore escaping on Windows

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -30,7 +30,7 @@ import (
 
 const escapePrefix = "#escape="
 
-var defaultEscapeChar = `\`
+var defaultEscapeChar = '\\'
 
 func init() {
 	if os.PathSeparator == defaultEscapeChar {

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -30,7 +30,7 @@ import (
 
 const escapePrefix = "#escape="
 
-var defaultEscapeChar = '\\'
+var defaultEscapeChar = `\`
 
 func init() {
 	if os.PathSeparator == defaultEscapeChar {

--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -28,7 +28,7 @@ import (
 	"github.com/syncthing/syncthing/lib/sync"
 )
 
-const escapePrefix = "#escape="
+const escapePrefix = "#escape"
 
 var defaultEscapeChar = '\\'
 
@@ -538,10 +538,11 @@ func parseIgnoreFile(fs fs.Filesystem, fd io.Reader, currentFile string, cd Chan
 			// Silently ignore multiple #escape='s in a file.
 			if escaping {
 				trimmed = strings.TrimPrefix(trimmed, escapePrefix)
-				if len(trimmed) == 0 {
+				runes := []rune(trimmed)
+				if len(runes) != 2 || runes[0] != '=' {
 					return nil, nil, fmt.Errorf("failed to parse #escape= line in ignore file: %q", line)
 				}
-				escapeChar = []rune(trimmed)[0]
+				escapeChar = runes[1]
 				escaping = false
 			}
 			continue

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1353,7 +1353,7 @@ type escapeTest struct {
 	want    bool
 }
 
-// pathSepIsBackslash could also be set to !build.IsWindows, but this will work
+// pathSepIsBackslash could also be set to build.IsWindows, but this will work
 // on any platform where the os.PathSeparator is a backslash (which is
 // currently only Windows).
 const pathSepIsBackslash = os.PathSeparator == '\\'
@@ -1416,9 +1416,6 @@ var backslashTests = []escapeTest{
 	{`a\*\*b\*\*c`, `a**b**c`, !pathSepIsBackslash},
 	{`\*\*/c/\*\*`, `**/c/**`, !pathSepIsBackslash},
 
-	{`a]b`, `a]b`, true},
-	{`a}b`, `a}b`, true},
-
 	{`\a`, `a`, true}, // backslash is first character
 
 	{`\a\b`, `ab`, !pathSepIsBackslash},
@@ -1432,7 +1429,7 @@ var backslashTests = []escapeTest{
 	{`\a\r\n`, `/a/r/n`, false}, // leading backslash is stripped off
 }
 
-// TestEscapeBackslash tests backslash (\) as the escape character
+// TestEscapeBackslash tests backslash (\) as the escape character.
 func TestEscapeBackslash(t *testing.T) {
 	testEscape(t, backslashTests)
 }
@@ -1483,7 +1480,7 @@ var pipeTests = []escapeTest{
 	{`|a|r|n`, `/a/r/n`, false}, // leading backslash is stripped off
 }
 
-// TestEscapeBackslash tests pipe (|) as the escape character
+// TestEscapeBackslash tests pipe (|) as the escape character.
 func TestEscapePipe(t *testing.T) {
 	if defaultEscapeChar == '\\' {
 		t.Skip("Skipping test as defaultEscapeChar=\\ (as we're not on Windows)")
@@ -1538,7 +1535,7 @@ var overrideBackslashTests = []escapeTest{
 	{`\a\r\n`, `/a/r/n`, false}, // leading backslash is stripped off
 }
 
-// TestEscapeOverrideBackslash tests when #escape=\ is in the .stignore file
+// TestEscapeOverrideBackslash tests when #escape=\ is in the .stignore file.
 func TestEscapeOverrideBackslash(t *testing.T) {
 	for i, test := range overrideBackslashTests {
 		overrideBackslashTests[i].pattern = escapePrefix + "\\\n" + test.pattern
@@ -1548,7 +1545,7 @@ func TestEscapeOverrideBackslash(t *testing.T) {
 }
 
 // TestEscapeOverridePipe tests when #escape=| (or another character) is in the
-// .stignore file
+// .stignore file.
 func TestEscapeOverridePipe(t *testing.T) {
 	escapeChars := []string{
 		"|",
@@ -1579,7 +1576,7 @@ func TestEscapeOverridePipe(t *testing.T) {
 	testEscape(t, tests)
 }
 
-// TestEscapeOverrideEmpty tests when #escape= (no char) is in the .stignore file
+// TestEscapeOverrideEmpty tests when #escape= (no char) is in the .stignore file.
 func TestEscapeOverrideEmpty(t *testing.T) {
 	suffixes := []string{"", " "}
 

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1492,7 +1492,7 @@ func TestEscapePipe(t *testing.T) {
 	testEscape(t, pipeTests)
 }
 
-// overrideBackslashTests same wants as the pipeTests tests.
+// overrideBackslashTests has the same wants as the pipeTests tests.
 // The only difference in the tests is the pipe symbol in the pattern has been
 // changed to a backslash. This could be done programatically, if desired.
 var overrideBackslashTests = []escapeTest{

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1704,7 +1704,7 @@ var testEscapeFiles = map[string]string{
 func testEscape(t *testing.T, tests []escapeTest, noErrors bool) {
 	t.Helper()
 
-	for _, test := range tests {
+	for i, test := range tests {
 		testFS := fs.NewFilesystem(fs.FilesystemTypeFake, rand.String(32)+"?content=true&nostfolder=true")
 
 		for name, content := range testEscapeFiles {
@@ -1715,18 +1715,18 @@ func testEscape(t *testing.T, tests []escapeTest, noErrors bool) {
 		err := pats.Parse(bytes.NewBufferString(test.pattern), ".stignore")
 		if noErrors {
 			if err != nil {
-				t.Fatalf("%q: err=%v", test.pattern, err)
+				t.Fatalf("%q: err=%v (test %d)", test.pattern, err, i+1)
 			}
 		} else {
 			if err == nil {
-				t.Fatalf("%q: got nil, want error", test.pattern)
+				t.Fatalf("%q: got nil, want error (test %d)", test.pattern, i+1)
 			}
 			continue
 		}
 
 		got := pats.Match(test.match).IsIgnored()
 		if got != test.want {
-			t.Errorf("%-20q: %-20q: got %v, want %v", test.pattern, test.match, got, test.want)
+			t.Errorf("%-20q: %-20q: got %v, want %v (test %d)", test.pattern, test.match, got, test.want, i+1)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #10057: Support escaping in .stignore files on Windows
Fixes #7547: Ignore pattern with \\[ and \\] does not work

### Purpose

Based on the discussion in
https://forum.syncthing.net/t/towards-syncthing-2-0/24072/35
this PR adds the ability for Windows users to use the pipe character (`|`) to escape the metacharacters `*`, `?`, `[`, and `{` in .stignore files.

Additionally, this PR adds the ability for the user to set the escape character to backslash, or any character they want, by adding a line in the form:

 `#escape=X`

(where X is any single rune), to the top of the .stginore file.

This would allow users to use the same .stignore files across platforms, by simply adding

 `#escape=\`

to their files.

**edit**: Of course, when a Windows user does this, they will need replace any backslashes with forward slashes, so
```
\path\to\file-with-braces?1?.txt
``` 
would become:
```
#escape=\
/path/to/file-with-braces\[1\].txt
```

### Testing

Tested on Ubuntu and Windows 11.

### Documentation

I'll submit a PR to update the docs if this is accepted.
