### PR TITLE
chore(syncthing): remove support for TLS 1.2 sync connections

### DIFF
--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -74,16 +74,13 @@ type OptionsConfiguration struct {
 	// The maximum number of connections which we will allow in total, zero
 	// meaning no limit. Affects incoming connections and prevents
 	// attempting outgoing connections.
-	ConnectionLimitMax int `json:"connectionLimitMax" xml:"connectionLimitMax"`
-	// When set, this allows TLS 1.2 on sync connections, where we otherwise
-	// default to TLS 1.3+ only.
-	InsecureAllowOldTLSVersions        bool `json:"insecureAllowOldTLSVersions" xml:"insecureAllowOldTLSVersions"`
-	ConnectionPriorityTCPLAN           int  `json:"connectionPriorityTcpLan" xml:"connectionPriorityTcpLan" default:"10"`
-	ConnectionPriorityQUICLAN          int  `json:"connectionPriorityQuicLan" xml:"connectionPriorityQuicLan" default:"20"`
-	ConnectionPriorityTCPWAN           int  `json:"connectionPriorityTcpWan" xml:"connectionPriorityTcpWan" default:"30"`
-	ConnectionPriorityQUICWAN          int  `json:"connectionPriorityQuicWan" xml:"connectionPriorityQuicWan" default:"40"`
-	ConnectionPriorityRelay            int  `json:"connectionPriorityRelay" xml:"connectionPriorityRelay" default:"50"`
-	ConnectionPriorityUpgradeThreshold int  `json:"connectionPriorityUpgradeThreshold" xml:"connectionPriorityUpgradeThreshold" default:"0"`
+	ConnectionLimitMax                 int `json:"connectionLimitMax" xml:"connectionLimitMax"`
+	ConnectionPriorityTCPLAN           int `json:"connectionPriorityTcpLan" xml:"connectionPriorityTcpLan" default:"10"`
+	ConnectionPriorityQUICLAN          int `json:"connectionPriorityQuicLan" xml:"connectionPriorityQuicLan" default:"20"`
+	ConnectionPriorityTCPWAN           int `json:"connectionPriorityTcpWan" xml:"connectionPriorityTcpWan" default:"30"`
+	ConnectionPriorityQUICWAN          int `json:"connectionPriorityQuicWan" xml:"connectionPriorityQuicWan" default:"40"`
+	ConnectionPriorityRelay            int `json:"connectionPriorityRelay" xml:"connectionPriorityRelay" default:"50"`
+	ConnectionPriorityUpgradeThreshold int `json:"connectionPriorityUpgradeThreshold" xml:"connectionPriorityUpgradeThreshold" default:"0"`
 	// Legacy deprecated
 	DeprecatedUPnPEnabled        bool     `json:"-" xml:"upnpEnabled,omitempty"`        // Deprecated: Do not use.
 	DeprecatedUPnPLeaseM         int      `json:"-" xml:"upnpLeaseMinutes,omitempty"`   // Deprecated: Do not use.

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -252,13 +252,7 @@ func (a *App) startup() error {
 	// The TLS configuration is used for both the listening socket and outgoing
 	// connections.
 
-	var tlsCfg *tls.Config
-	if a.cfg.Options().InsecureAllowOldTLSVersions {
-		l.Infoln("TLS 1.2 is allowed on sync connections. This is less than optimally secure.")
-		tlsCfg = tlsutil.SecureDefaultWithTLS12()
-	} else {
-		tlsCfg = tlsutil.SecureDefaultTLS13()
-	}
+	tlsCfg := tlsutil.SecureDefaultTLS13()
 	tlsCfg.Certificates = []tls.Certificate{a.cert}
 	tlsCfg.NextProtos = []string{bepProtocolName}
 	tlsCfg.ClientAuth = tls.RequestClientCert


### PR DESCRIPTION
This cleans up the option to allow old TLS 1.2 sync connections. The flag existed for compatibility with old Syncthing versions that don't support TLS 1.3, which is approximately Syncthing 1.2.2 (September 2019) and older. ("Approximately" because it depends on the Go version it's built with and that's when we switched to building with Go 1.13.)

Ref #10062 because it reminded me this exists.