### PR TITLE
fix(model): loop-break regression while block copying in puller

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1346,6 +1346,7 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 
 			found := false
 			blocks, _ := f.model.sdb.AllLocalBlocksWithHash(block.Hash)
+		innerBlocks:
 			for _, e := range blocks {
 				res, err := f.model.sdb.AllLocalFilesWithBlocksHashAnyFolder(e.BlocklistHash)
 				if err != nil {
@@ -1387,7 +1388,7 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 						}
 						if err != nil {
 							state.fail(fmt.Errorf("dst write: %w", err))
-							break
+							break innerBlocks
 						}
 						if fi.Name == state.file.Name {
 							state.copiedFromOrigin(block.Size)
@@ -1395,7 +1396,7 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 							state.copiedFromElsewhere(block.Size)
 						}
 						found = true
-						break
+						break innerBlocks
 					}
 				}
 			}


### PR DESCRIPTION
Possibly/likely the man cause for the issues tomasz is reporting in the forum:
First relevant reply: https://forum.syncthing.net/t/syncthing-on-sqlite-help-test/23981/204 Reply with profiles I used to troubleshoot: https://forum.syncthing.net/t/syncthing-on-sqlite-help-test/23981/208

I don't particularly like my fix - to me this asks for better names (too many "blocks") or probably refactors. I also found at least one more bug (fd not closed at end of loop, only end of entire function), but haven't yet had the time/energy to find a (nice) solution. Likely that's going to benefit from refactoring parts of this into a separate function too.

Regression introduced when splitting the DB (second nested loop added):

cf1cf85ce60c87c01abd7162eb9cb28f31a8446a

