### PR TITLE
fix(connections): add Prometheus labels for folders and devices (fixes #9519)

### DIFF
--- a/lib/connections/metrics.go
+++ b/lib/connections/metrics.go
@@ -30,7 +30,7 @@ func registerDeviceMetrics(dc config.DeviceConfiguration) {
 
 func registerDeviceInfoGauge(dc config.DeviceConfiguration) {
 	// Create a dynamic "info" gauge to help users
-	// map IDs to humane strings.
+	// map IDs to human-readable strings.
 	// It produces a constant `1`
 	did := dc.DeviceID.String()
 	info_gauge := prometheus.NewGaugeFunc(

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -850,7 +850,7 @@ func (s *service) CommitConfiguration(from, to config.Configuration) bool {
 	newDevices := make(map[protocol.DeviceID]bool, len(to.Devices))
 	for _, dev := range to.Devices {
 		newDevices[dev.DeviceID] = true
-		registerDeviceMetrics(dev.DeviceID.String())
+		registerDeviceMetrics(dev)
 	}
 
 	for _, dev := range from.Devices {

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -139,7 +139,7 @@ func newFolder(model *model, fset *db.FileSet, ignores *ignore.Matcher, cfg conf
 	f.pullFailTimer = time.NewTimer(0)
 	<-f.pullFailTimer.C
 
-	registerFolderMetrics(f.ID)
+	registerFolderMetrics(f.FolderConfiguration)
 
 	return f
 }

--- a/lib/model/metrics.go
+++ b/lib/model/metrics.go
@@ -87,7 +87,7 @@ const (
 )
 
 func registerFolderMetrics(fc config.FolderConfiguration) {
-	registerInfoGauge(fc)
+	registerFolderInfoGauge(fc)
 	// Register metrics for this folder, so that
 	// counters are present even when zero.
 	folderID := fc.ID
@@ -104,9 +104,9 @@ func registerFolderMetrics(fc config.FolderConfiguration) {
 	metricFolderConflictsTotal.WithLabelValues(folderID)
 }
 
-func registerInfoGauge(fc config.FolderConfiguration) {
+func registerFolderInfoGauge(fc config.FolderConfiguration) {
 	// Create a dynamic "info" gauge to help users
-	// map IDs to humane strings.
+	// map IDs to human-readable strings.
 	// It produces a constant `1`
 	info_gauge := prometheus.NewGaugeFunc(
 		prometheus.GaugeOpts{


### PR DESCRIPTION
### Purpose

This is intended to address concerns raised in #9519.  The intent is to add an info gauge (as suggested by @calmh) to ease human cross-referencing of stats as stored by IDs and meaningful strings. 

### Testing

I have run the automated tests.  I did not see where these tests exercise the metrics reporting in particular.
As such, I have not added any new tests.  An interested party could use their favorite metrics explorer to find the new gauges and correlate them with other labeled metrics.

### Documentation

This change will be visible to users in their metrics databases, but not within any interface of syncthing to my knowledge. I am happy to document the new metric gauges if there is a reasonable place to do so.

### Additional Info

This is my first attempt to contribute to `syncthing`.  Process errors or omissions are somewhat expected.  I am happy to iterate on this work and make such adjustments as help the project.
