### PR TITLE
chore(db, model): simplify per hash DB lookup in copier

### DIFF
--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -41,7 +41,7 @@ type DB interface {
 	AllLocalFilesWithPrefix(folder string, device protocol.DeviceID, prefix string) (iter.Seq[protocol.FileInfo], func() error)
 	AllLocalFilesWithBlocksHash(folder string, h []byte) (iter.Seq[FileMetadata], func() error)
 	AllNeededGlobalFiles(folder string, device protocol.DeviceID, order config.PullOrder, limit, offset int) (iter.Seq[protocol.FileInfo], func() error)
-	AllLocalBlocksWithHashAnyFolder(hash []byte) (iter.Seq[BlockMapEntry], func() error)
+	AllLocalBlocksWithHash(folder string, hash []byte) (iter.Seq[BlockMapEntry], func() error)
 
 	// Cleanup
 	DropAllFiles(folder string, device protocol.DeviceID) error
@@ -87,7 +87,6 @@ type BlockMapEntry struct {
 	Offset        int64
 	BlockIndex    int
 	Size          int
-	FolderID      string
 	FileName      string
 }
 

--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -41,7 +41,7 @@ type DB interface {
 	AllLocalFilesWithPrefix(folder string, device protocol.DeviceID, prefix string) (iter.Seq[protocol.FileInfo], func() error)
 	AllLocalFilesWithBlocksHash(folder string, h []byte) (iter.Seq[FileMetadata], func() error)
 	AllNeededGlobalFiles(folder string, device protocol.DeviceID, order config.PullOrder, limit, offset int) (iter.Seq[protocol.FileInfo], func() error)
-	AllLocalBlocksWithHash(hash []byte) (map[string][]BlockMapEntry, error)
+	AllLocalBlocksWithHashAnyFolder(hash []byte) (iter.Seq[BlockMapEntry], func() error)
 
 	// Cleanup
 	DropAllFiles(folder string, device protocol.DeviceID) error
@@ -87,6 +87,7 @@ type BlockMapEntry struct {
 	Offset        int64
 	BlockIndex    int
 	Size          int
+	FolderID      string
 	FileName      string
 }
 

--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -41,8 +41,7 @@ type DB interface {
 	AllLocalFilesWithPrefix(folder string, device protocol.DeviceID, prefix string) (iter.Seq[protocol.FileInfo], func() error)
 	AllLocalFilesWithBlocksHash(folder string, h []byte) (iter.Seq[FileMetadata], func() error)
 	AllNeededGlobalFiles(folder string, device protocol.DeviceID, order config.PullOrder, limit, offset int) (iter.Seq[protocol.FileInfo], func() error)
-	AllLocalBlocksWithHash(hash []byte) ([]BlockMapEntry, error)
-	AllLocalFilesWithBlocksHashAnyFolder(hash []byte) (map[string][]FileMetadata, error)
+	AllLocalBlocksWithHash(hash []byte) (map[string][]BlockMapEntry, error)
 
 	// Cleanup
 	DropAllFiles(folder string, device protocol.DeviceID) error
@@ -88,6 +87,7 @@ type BlockMapEntry struct {
 	Offset        int64
 	BlockIndex    int
 	Size          int
+	FileName      string
 }
 
 type KeyValue struct {

--- a/internal/db/metrics.go
+++ b/internal/db/metrics.go
@@ -67,11 +67,6 @@ func (m metricsDB) AllLocalFilesWithBlocksHash(folder string, h []byte) (iter.Se
 	return m.DB.AllLocalFilesWithBlocksHash(folder, h)
 }
 
-func (m metricsDB) AllLocalFilesWithBlocksHashAnyFolder(hash []byte) (map[string][]FileMetadata, error) {
-	defer m.account("-", "AllLocalFilesWithBlocksHashAnyFolder")()
-	return m.DB.AllLocalFilesWithBlocksHashAnyFolder(hash)
-}
-
 func (m metricsDB) AllGlobalFiles(folder string) (iter.Seq[FileMetadata], func() error) {
 	defer m.account(folder, "AllGlobalFiles")()
 	return m.DB.AllGlobalFiles(folder)
@@ -107,7 +102,7 @@ func (m metricsDB) GetGlobalAvailability(folder, file string) ([]protocol.Device
 	return m.DB.GetGlobalAvailability(folder, file)
 }
 
-func (m metricsDB) AllLocalBlocksWithHash(hash []byte) ([]BlockMapEntry, error) {
+func (m metricsDB) AllLocalBlocksWithHash(hash []byte) (map[string][]BlockMapEntry, error) {
 	defer m.account("-", "AllLocalBlocksWithHash")()
 	return m.DB.AllLocalBlocksWithHash(hash)
 }

--- a/internal/db/metrics.go
+++ b/internal/db/metrics.go
@@ -102,9 +102,9 @@ func (m metricsDB) GetGlobalAvailability(folder, file string) ([]protocol.Device
 	return m.DB.GetGlobalAvailability(folder, file)
 }
 
-func (m metricsDB) AllLocalBlocksWithHashAnyFolder(hash []byte) (iter.Seq[BlockMapEntry], func() error) {
+func (m metricsDB) AllLocalBlocksWithHash(folder string, hash []byte) (iter.Seq[BlockMapEntry], func() error) {
 	defer m.account("-", "AllLocalBlocksWithHash")()
-	return m.DB.AllLocalBlocksWithHashAnyFolder(hash)
+	return m.DB.AllLocalBlocksWithHash(folder, hash)
 }
 
 func (m metricsDB) Close() error {

--- a/internal/db/metrics.go
+++ b/internal/db/metrics.go
@@ -102,9 +102,9 @@ func (m metricsDB) GetGlobalAvailability(folder, file string) ([]protocol.Device
 	return m.DB.GetGlobalAvailability(folder, file)
 }
 
-func (m metricsDB) AllLocalBlocksWithHash(hash []byte) (map[string][]BlockMapEntry, error) {
+func (m metricsDB) AllLocalBlocksWithHashAnyFolder(hash []byte) (iter.Seq[BlockMapEntry], func() error) {
 	defer m.account("-", "AllLocalBlocksWithHash")()
-	return m.DB.AllLocalBlocksWithHash(hash)
+	return m.DB.AllLocalBlocksWithHashAnyFolder(hash)
 }
 
 func (m metricsDB) Close() error {

--- a/internal/db/sqlite/db_folderdb.go
+++ b/internal/db/sqlite/db_folderdb.go
@@ -154,21 +154,11 @@ func (s *DB) AllGlobalFilesPrefix(folder string, prefix string) (iter.Seq[db.Fil
 	return fdb.AllGlobalFilesPrefix(prefix)
 }
 
-func (s *DB) AllLocalBlocksWithHash(hash []byte) ([]db.BlockMapEntry, error) {
-	var entries []db.BlockMapEntry
+func (s *DB) AllLocalBlocksWithHash(hash []byte) (map[string][]db.BlockMapEntry, error) {
+	res := make(map[string][]db.BlockMapEntry)
 	err := s.forEachFolder(func(fdb *folderDB) error {
-		es, err := itererr.Collect(fdb.AllLocalBlocksWithHash(hash))
-		entries = append(entries, es...)
-		return err
-	})
-	return entries, err
-}
-
-func (s *DB) AllLocalFilesWithBlocksHashAnyFolder(hash []byte) (map[string][]db.FileMetadata, error) {
-	res := make(map[string][]db.FileMetadata)
-	err := s.forEachFolder(func(fdb *folderDB) error {
-		files, err := itererr.Collect(fdb.AllLocalFilesWithBlocksHash(hash))
-		res[fdb.folderID] = files
+		blocks, err := itererr.Collect(fdb.AllLocalBlocksWithHash(hash))
+		res[fdb.folderID] = blocks
 		return err
 	})
 	return res, err

--- a/internal/db/sqlite/db_folderdb.go
+++ b/internal/db/sqlite/db_folderdb.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/syncthing/syncthing/internal/db"
-	"github.com/syncthing/syncthing/internal/itererr"
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/protocol"
 	"github.com/syncthing/syncthing/lib/rand"
@@ -154,22 +153,15 @@ func (s *DB) AllGlobalFilesPrefix(folder string, prefix string) (iter.Seq[db.Fil
 	return fdb.AllGlobalFilesPrefix(prefix)
 }
 
-func (s *DB) AllLocalBlocksWithHashAnyFolder(hash []byte) (iter.Seq[db.BlockMapEntry], func() error) {
-	var retErr error
-	return func(yield func(db.BlockMapEntry) bool) {
-		retErr = s.forEachFolder(func(fdb *folderDB) error {
-			for e, err := range itererr.Zip(fdb.AllLocalBlocksWithHash(hash)) {
-				if err != nil {
-					return err
-				}
-				e.FolderID = fdb.folderID
-				if !yield(e) {
-					return nil
-				}
-			}
-			return nil
-		})
-	}, func() error { return retErr }
+func (s *DB) AllLocalBlocksWithHash(folder string, hash []byte) (iter.Seq[db.BlockMapEntry], func() error) {
+	fdb, err := s.getFolderDB(folder, false)
+	if errors.Is(err, errNoSuchFolder) {
+		return func(yield func(db.BlockMapEntry) bool) {}, func() error { return nil }
+	}
+	if err != nil {
+		return func(yield func(db.BlockMapEntry) bool) {}, func() error { return err }
+	}
+	return fdb.AllLocalBlocksWithHash(hash)
 }
 
 func (s *DB) AllLocalFiles(folder string, device protocol.DeviceID) (iter.Seq[protocol.FileInfo], func() error) {

--- a/internal/db/sqlite/db_folderdb.go
+++ b/internal/db/sqlite/db_folderdb.go
@@ -162,6 +162,7 @@ func (s *DB) AllLocalBlocksWithHashAnyFolder(hash []byte) (iter.Seq[db.BlockMapE
 				if err != nil {
 					return err
 				}
+				e.FolderID = fdb.folderID
 				if !yield(e) {
 					return nil
 				}

--- a/internal/db/sqlite/db_local_test.go
+++ b/internal/db/sqlite/db_local_test.go
@@ -51,7 +51,7 @@ func TestBlocks(t *testing.T) {
 
 	// Search for blocks
 
-	vals, err := itererr.Collect(db.AllLocalBlocksWithHashAnyFolder([]byte{1, 2, 3}))
+	vals, err := itererr.Collect(db.AllLocalBlocksWithHash(folderID, []byte{1, 2, 3}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -68,7 +68,7 @@ func TestBlocks(t *testing.T) {
 
 	// Get the other blocks
 
-	vals, err = itererr.Collect(db.AllLocalBlocksWithHashAnyFolder([]byte{3, 4, 5}))
+	vals, err = itererr.Collect(db.AllLocalBlocksWithHash(folderID, []byte{3, 4, 5}))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestBlocksDeleted(t *testing.T) {
 
 	// We should find one entry for the block hash
 	search := file.Blocks[0].Hash
-	es, err := itererr.Collect(sdb.AllLocalBlocksWithHashAnyFolder(search))
+	es, err := itererr.Collect(sdb.AllLocalBlocksWithHash(folderID, search))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestBlocksDeleted(t *testing.T) {
 	}
 
 	// Searching for the old hash should yield no hits
-	if hits, err := itererr.Collect(sdb.AllLocalBlocksWithHashAnyFolder(search)); err != nil {
+	if hits, err := itererr.Collect(sdb.AllLocalBlocksWithHash(folderID, search)); err != nil {
 		t.Fatal(err)
 	} else if len(hits) != 0 {
 		t.Log(hits)
@@ -130,7 +130,7 @@ func TestBlocksDeleted(t *testing.T) {
 	}
 
 	// Searching for the new hash should yield one hits
-	if hits, err := itererr.Collect(sdb.AllLocalBlocksWithHashAnyFolder(file.Blocks[0].Hash)); err != nil {
+	if hits, err := itererr.Collect(sdb.AllLocalBlocksWithHash(folderID, file.Blocks[0].Hash)); err != nil {
 		t.Fatal(err)
 	} else if len(hits) != 1 {
 		t.Log(hits)

--- a/internal/db/sqlite/db_local_test.go
+++ b/internal/db/sqlite/db_local_test.go
@@ -49,41 +49,22 @@ func TestBlocks(t *testing.T) {
 	}
 
 	// Search for blocks
-
-	vals, err := db.AllLocalBlocksWithHash([]byte{1, 2, 3})
-	if err != nil {
-		t.Fatal(err)
-	}
+	vals := allLocalBlocksForSingleTestFolder(t, db, []byte{1, 2, 3})
 	if len(vals) != 1 {
 		t.Log(vals)
 		t.Fatal("expected one hit")
-	} else if vals[0].BlockIndex != 0 || vals[0].Offset != 0 || vals[0].Size != 42 {
+	}
+	if vals[0].BlockIndex != 0 || vals[0].Offset != 0 || vals[0].Size != 42 {
 		t.Log(vals[0])
 		t.Fatal("bad entry")
 	}
-
-	// Get FileInfos for those blocks
-
-	res, err := db.AllLocalFilesWithBlocksHashAnyFolder(vals[0].BlocklistHash)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(res) != 1 {
-		t.Fatal("should return one folder")
-	}
-	if len(res[folderID]) != 1 {
-		t.Fatal("should find one file")
-	}
-	if res[folderID][0].Name != "file1" {
+	if vals[0].Filename != "file1" {
 		t.Fatal("should be file1")
 	}
 
 	// Get the other blocks
 
-	vals, err = db.AllLocalBlocksWithHash([]byte{3, 4, 5})
-	if err != nil {
-		t.Fatal(err)
-	}
+	vals = allLocalBlocksForSingleTestFolder(t, db, []byte{3, 4, 5})
 	if len(vals) != 2 {
 		t.Log(vals)
 		t.Fatal("expected two hits")
@@ -200,4 +181,17 @@ func TestRemoteSequence(t *testing.T) {
 		t.Log(seqs)
 		t.Error("bad seqs")
 	}
+}
+
+func allLocalBlocksForSingleTestFolder(t testing.TB, db *DB, hash []byte) []BlockMapEntry {
+	t.Helper()
+
+	valsPerFolder, err := db.AllLocalBlocksWithHash(hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(valsPerFolder) != 1 {
+		t.Fatal("should return one folder")
+	}
+	return valsPerFolder[folderID]
 }

--- a/internal/db/sqlite/db_test.go
+++ b/internal/db/sqlite/db_test.go
@@ -1084,7 +1084,7 @@ func TestInsertLargeFile(t *testing.T) {
 	// Verify all the blocks are here
 
 	for i, block := range files[0].Blocks {
-		bs, err := sdb.AllLocalBlocksWithHash(block.Hash)
+		bs, err := itererr.Collect(sdb.AllLocalBlocksWithHashAnyFolder(block.Hash))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/db/sqlite/db_test.go
+++ b/internal/db/sqlite/db_test.go
@@ -1084,7 +1084,7 @@ func TestInsertLargeFile(t *testing.T) {
 	// Verify all the blocks are here
 
 	for i, block := range files[0].Blocks {
-		bs, err := itererr.Collect(sdb.AllLocalBlocksWithHashAnyFolder(block.Hash))
+		bs, err := itererr.Collect(sdb.AllLocalBlocksWithHash(folderID, block.Hash))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/db/sqlite/folderdb_local.go
+++ b/internal/db/sqlite/folderdb_local.go
@@ -99,7 +99,7 @@ func (s *folderDB) AllLocalBlocksWithHash(hash []byte) (iter.Seq[db.BlockMapEntr
 	// & blocklists is deferred (garbage collected) while the files list is
 	// not. This filters out blocks that are in fact deleted.
 	return iterStructs[db.BlockMapEntry](s.stmt(`
-		SELECT f.blocklist_hash as blocklisthash, b.idx as blockindex, b.offset, b.size FROM files f
+		SELECT f.blocklist_hash as blocklisthash, b.idx as blockindex, b.offset, b.size, f.name as filename FROM files f
 		LEFT JOIN blocks b ON f.blocklist_hash = b.blocklist_hash
 		WHERE f.device_idx = {{.LocalDeviceIdx}} AND b.hash = ?
 	`).Queryx(hash))

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/syncthing/syncthing/internal/itererr"
 	"github.com/syncthing/syncthing/lib/build"
 	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/events"
@@ -325,11 +326,11 @@ func TestCopierCleanup(t *testing.T) {
 	// Update index (removing old blocks)
 	f.updateLocalsFromScanning([]protocol.FileInfo{file})
 
-	if vals, err := m.sdb.AllLocalBlocksWithHash(blocks[0].Hash); err != nil || len(vals) > 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[0].Hash)); err != nil || len(vals) > 0 {
 		t.Error("Unexpected block found")
 	}
 
-	if vals, err := m.sdb.AllLocalBlocksWithHash(blocks[1].Hash); err != nil || len(vals) == 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[1].Hash)); err != nil || len(vals) == 0 {
 		t.Error("Expected block not found")
 	}
 
@@ -338,11 +339,11 @@ func TestCopierCleanup(t *testing.T) {
 	// Update index (removing old blocks)
 	f.updateLocalsFromScanning([]protocol.FileInfo{file})
 
-	if vals, err := m.sdb.AllLocalBlocksWithHash(blocks[0].Hash); err != nil || len(vals) == 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[0].Hash)); err != nil || len(vals) == 0 {
 		t.Error("Unexpected block found")
 	}
 
-	if vals, err := m.sdb.AllLocalBlocksWithHash(blocks[1].Hash); err != nil || len(vals) > 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[1].Hash)); err != nil || len(vals) > 0 {
 		t.Error("Expected block not found")
 	}
 }

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -326,11 +326,11 @@ func TestCopierCleanup(t *testing.T) {
 	// Update index (removing old blocks)
 	f.updateLocalsFromScanning([]protocol.FileInfo{file})
 
-	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[0].Hash)); err != nil || len(vals) > 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHash(f.ID, blocks[0].Hash)); err != nil || len(vals) > 0 {
 		t.Error("Unexpected block found")
 	}
 
-	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[1].Hash)); err != nil || len(vals) == 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHash(f.ID, blocks[1].Hash)); err != nil || len(vals) == 0 {
 		t.Error("Expected block not found")
 	}
 
@@ -339,11 +339,11 @@ func TestCopierCleanup(t *testing.T) {
 	// Update index (removing old blocks)
 	f.updateLocalsFromScanning([]protocol.FileInfo{file})
 
-	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[0].Hash)); err != nil || len(vals) == 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHash(f.ID, blocks[0].Hash)); err != nil || len(vals) == 0 {
 		t.Error("Unexpected block found")
 	}
 
-	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHashAnyFolder(blocks[1].Hash)); err != nil || len(vals) > 0 {
+	if vals, err := itererr.Collect(m.sdb.AllLocalBlocksWithHash(f.ID, blocks[1].Hash)); err != nil || len(vals) > 0 {
 		t.Error("Expected block not found")
 	}
 }


### PR DESCRIPTION
This is a draft because I haven't adjusted all the tests yet, I'd like to get feedback on the change overall first, before spending time on that.

In my opinion the main win of this change is in it's lower complexity
resp. fewer moving parts. It should also be faster as it only does one
query instead of two, but I have no idea if that's practically
relevant.

This also mirrors the v1 DB, where a block map key had the name
appended. Not that this is an argument for the change, it was mostly
reassuring me that I might not be missing something key here
conceptually (I might still be of course, please tell me :) ).

And the change isn't mainly intrinsically motivated, instead it came
up while fixing a bug in the copier. And the nested nature of that code
makes the fix harder, and "un-nesting" it required me to understand
what's happening. This change fell out of that.