### PR TITLE
fix(model): use same folder first in copier

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1346,7 +1346,10 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 			copied := false
 
 		folders:
-			for folderID, ffs := range folderFilesystems {
+			// Intentionally not iterating over `folderFilesystems` directly,
+			// to preserve order (same folder first).
+			for _, folderID := range folders {
+				ffs := folderFilesystems[folderID]
 				for e, err := range itererr.Zip(f.model.sdb.AllLocalBlocksWithHash(folderID, block.Hash)) {
 					if err != nil {
 						// We just ignore this and continue pulling instead (though
@@ -1393,7 +1396,7 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 	}
 }
 
-// Returns true, if the block was successfully copied to buf. The returned
+// Returns true, if the block was successfully copied. The returned
 // errors is *only* non-nil for errors that are fatal for pulling this entire
 // file (i.e. writing to dstFd fails). For other errors that mean the block
 // wasn't copied, but we can continue trying, the error is nil and the bool


### PR DESCRIPTION
Where `folderFilesystems` and `folders` is built, there's a comment spelling out the purpose: To have the same folder first, as that's the most likely to get hits. Plus a copy is possibly more efficient than from another folder, e.g. if that's on a different filesystem. We lost that behaviour during some unrelated change.

(Also sneaking in a comment fix on yesterdays change.)