### PR TITLE
feat(syncthing, fs): allow setting tmpdir on command line (fixes #2208)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -144,7 +144,6 @@ type serveOptions struct {
 	AuditFile        string `name:"auditfile" placeholder:"PATH" help:"Specify audit file (use \"-\" for stdout, \"--\" for stderr)"`
 	BrowserOnly      bool   `help:"Open GUI in browser"`
 	DataDir          string `name:"data" placeholder:"PATH" env:"STDATADIR" help:"Set data directory (database and logs)"`
-	TempDir          string `name:"temp" placeholder:"TEMPDIR" env:"STTEMPDIR" help:"Set single tempdir for storing incomplete files (optional)"`
 	DeviceID         bool   `help:"Show the device ID"`
 	GenerateDir      string `name:"generate" placeholder:"PATH" help:"Generate key and config in specified dir, then exit"` // DEPRECATED: replaced by subcommand!
 	GUIAddress       string `name:"gui-address" placeholder:"URL" help:"Override GUI address (e.g. \"http://192.0.2.42:8443\")"`
@@ -287,13 +286,6 @@ func (options serveOptions) Run() error {
 	if err != nil {
 		l.Warnln("Command line options:", err)
 		os.Exit(svcutil.ExitError.AsInt())
-	}
-
-	if options.TempDir != "" {
-		if err := fs.SetTempDir(options.TempDir); err != nil {
-			l.Warnln("Setting temp dir:", err)
-			os.Exit(svcutil.ExitError.AsInt())
-		}
 	}
 
 	// Treat an explicitly empty log file name as no log file

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -52,6 +52,7 @@ type FolderConfiguration struct {
 	Label                   string                      `json:"label" xml:"label,attr" restart:"false"`
 	FilesystemType          FilesystemType              `json:"filesystemType" xml:"filesystemType" default:"basic"`
 	Path                    string                      `json:"path" xml:"path,attr"`
+	TempDir                 string                      `json:"tempdir" xml:"tempdir"`
 	Type                    FolderType                  `json:"type" xml:"type,attr"`
 	Devices                 []FolderDeviceConfiguration `json:"devices" xml:"device"`
 	RescanIntervalS         int                         `json:"rescanIntervalS" xml:"rescanIntervalS,attr" default:"3600"`

--- a/lib/fs/tempname.go
+++ b/lib/fs/tempname.go
@@ -8,9 +8,7 @@ package fs
 
 import (
 	"crypto/sha256"
-	"errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
@@ -21,8 +19,6 @@ const (
 	WindowsTempPrefix = "~syncthing~"
 	UnixTempPrefix    = ".syncthing."
 )
-
-var tempdir string
 
 func tempPrefix() string {
 	if build.IsWindows {
@@ -46,7 +42,7 @@ func IsTemporary(name string) bool {
 		strings.HasPrefix(name, UnixTempPrefix)
 }
 
-func TempNameWithPrefix(name, prefix string) string {
+func TempNameWithPrefix(name, prefix, tempdir string) string {
 	var tdir, tname string
 	if tempdir != "" {
 		tdir = tempdir
@@ -64,22 +60,6 @@ func TempNameWithPrefix(name, prefix string) string {
 	return filepath.Join(tdir, tname)
 }
 
-func TempName(name string) string {
-	return TempNameWithPrefix(name, tempPrefix())
-}
-
-func SetTempDir(dir string) error {
-	fi, err := os.Stat(dir)
-	if err != nil {
-		return err
-	}
-	if !fi.IsDir() {
-		return errors.New("not a directory")
-	}
-	perm := fi.Mode().Perm()
-	if perm&(1<<(uint(7))) == 0 {
-		return errors.New("tempdir not writable")
-	}
-	tempdir = dir
-	return nil
+func TempName(name, tempdir string) string {
+	return TempNameWithPrefix(name, tempPrefix(), tempdir)
 }

--- a/lib/fs/tempname_test.go
+++ b/lib/fs/tempname_test.go
@@ -14,23 +14,39 @@ import (
 
 func TestLongTempFilename(t *testing.T) {
 	filename := strings.Repeat("l", 300)
-	tFile := TempName(filename)
+	tFile := TempName(filename, "")
 	if len(tFile) < 10 || len(tFile) > 160 {
 		t.Fatal("Invalid long filename")
 	}
-	if !strings.HasSuffix(TempName("short"), "short.tmp") {
-		t.Fatal("Invalid short filename", TempName("short"))
+	if !strings.HasSuffix(TempName("short", ""), "short.tmp") {
+		t.Fatal("Invalid short filename", TempName("short", ""))
 	}
 }
 
 func TestCustomTempDirHashesFileNames(t *testing.T) {
-	tempdir = "local-temp-dir"
+	tempdir := "local-temp-dir"
 	filename1 := "file/to/sync.txt"
-	tFile1 := TempName(filename1)
+	tFile1 := TempName(filename1, tempdir)
 	filename2 := "duplicate-file/to/sync.txt"
-	tFile2 := TempName(filename2)
+	tFile2 := TempName(filename2, tempdir)
 	if tFile1 == tFile2 {
 		t.Fatal("non-unique temp names", tFile1, tFile2)
+	}
+}
+
+func TestIsTemporary(t *testing.T) {
+	tempdir := "local-temp-dir"
+	filename := "file/to/sync.txt"
+	if IsTemporary(filename) {
+		t.Fatal("file should not be temporary", filename)
+	}
+	tFile := TempName(filename, tempdir)
+	if !IsTemporary(tFile) {
+		t.Fatal("file should be temporary", tFile)
+	}
+	tFile = TempName(filename, "")
+	if !IsTemporary(tFile) {
+		t.Fatal("file should be temporary", tFile)
 	}
 }
 
@@ -40,7 +56,7 @@ func benchmarkTempName(b *testing.B, filename string) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		TempName(filename)
+		TempName(filename, "")
 	}
 }
 

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1014,7 +1014,7 @@ func (f *sendReceiveFolder) renameFile(cur, source, target protocol.FileInfo, sn
 		return err
 	}
 
-	tempName := fs.TempName(target.Name)
+	tempName := fs.TempName(target.Name, f.FolderConfiguration.TempDir)
 
 	if f.versioner != nil {
 		err = f.CheckAvailableSpace(uint64(source.Size))
@@ -1091,7 +1091,7 @@ func (f *sendReceiveFolder) handleFile(file protocol.FileInfo, snap *db.Snapshot
 
 	have, _ := blockDiff(curFile.Blocks, file.Blocks)
 
-	tempName := fs.TempName(file.Name)
+	tempName := fs.TempName(file.Name, f.FolderConfiguration.TempDir)
 
 	populateOffsets(file.Blocks)
 

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -43,7 +43,7 @@ var blocks = []protocol.BlockInfo{
 }
 
 func prepareTmpFile(to fs.Filesystem) (string, error) {
-	tmpName := fs.TempName("file")
+	tmpName := fs.TempName("file", "")
 	in, err := os.Open("testdata/tmpfile")
 	if err != nil {
 		return "", err
@@ -228,10 +228,10 @@ func TestCopierFinder(t *testing.T) {
 	// After dropping out blocks found locally:
 	// Pull: 1, 5, 6, 8
 
-	tempFile := fs.TempName("file2")
+	tempFile := fs.TempName("file2", "")
 
 	existingBlocks := []int{0, 2, 3, 4, 0, 0, 7, 0}
-	existingFile := setupFile(fs.TempName("file"), existingBlocks)
+	existingFile := setupFile(fs.TempName("file", ""), existingBlocks)
 	existingFile.Size = 1
 	requiredFile := existingFile
 	requiredFile.Blocks = blocks[1:]
@@ -318,7 +318,7 @@ func TestWeakHash(t *testing.T) {
 	defer wcfgCancel()
 	ffs := fo.Filesystem(nil)
 
-	tempFile := fs.TempName("weakhash")
+	tempFile := fs.TempName("weakhash", "")
 	var shift int64 = 10
 	var size int64 = 1 << 20
 	expectBlocks := int(size / protocol.MinBlockSize)
@@ -1117,7 +1117,7 @@ func TestPullCaseOnlyPerformFinish(t *testing.T) {
 	remote.Version = protocol.Vector{}.Update(device1.Short())
 	remote.Name = strings.ToUpper(cur.Name)
 
-	temp := fs.TempName(remote.Name)
+	temp := fs.TempName(remote.Name, "")
 	writeFile(t, ffs, temp, contents)
 	scanChan := make(chan string, 1)
 	dbUpdateChan := make(chan dbUpdateJob, 1)
@@ -1213,7 +1213,7 @@ func TestPullTempFileCaseConflict(t *testing.T) {
 
 	file := protocol.FileInfo{Name: "foo"}
 	confl := "Foo"
-	tempNameConfl := fs.TempName(confl)
+	tempNameConfl := fs.TempName(confl, "")
 	if fd, err := f.mtimefs.Create(tempNameConfl); err != nil {
 		t.Fatal(err)
 	} else {

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2027,7 +2027,7 @@ func (m *model) Request(conn protocol.Connection, req *protocol.Request) (out pr
 	// Only check temp files if the flag is set, and if we are set to advertise
 	// the temp indexes.
 	if req.FromTemporary && !folderCfg.DisableTempIndexes {
-		tempFn := fs.TempName(req.Name)
+		tempFn := fs.TempName(req.Name, folderCfg.TempDir)
 
 		if info, err := folderFs.Lstat(tempFn); err != nil || !info.IsRegular() {
 			// Reject reads for anything that doesn't exist or is something

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -187,7 +187,7 @@ func TestRequestCreateTmpSymlink(t *testing.T) {
 	// We listen for incoming index updates and trigger when we see one for
 	// the expected test file.
 	goodIdx := make(chan struct{})
-	name := fs.TempName("testlink")
+	name := fs.TempName("testlink", "")
 	fc.setIndexFn(func(_ context.Context, folder string, fs []protocol.FileInfo) error {
 		for _, f := range fs {
 			if f.Name == name {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -624,7 +624,7 @@ func (w *walker) applyNormalization(path, normPath string, info fs.FileInfo) (st
 		// We don't want to use the standard syncthing prefix here, as that will result in the file being ignored
 		// and eventually deleted by Syncthing if the rename back fails.
 
-		tempPath := fs.TempNameWithPrefix(normPath, "")
+		tempPath := fs.TempNameWithPrefix(normPath, "", "")
 		if err = w.Filesystem.Rename(path, tempPath); err != nil {
 			return "", err
 		}

--- a/lib/versioner/trashcan.go
+++ b/lib/versioner/trashcan.go
@@ -126,7 +126,7 @@ func (t *trashcan) Restore(filepath string, versionTime time.Time) error {
 			return taggedName
 		}
 
-		taggedName = fs.TempName(name)
+		taggedName = fs.TempName(name, "")
 		return name
 	}
 


### PR DESCRIPTION
### Purpose

Allow users to specify a tempdir where they want to store all files as they're being downloaded.

Requested in https://github.com/syncthing/syncthing/issues/2208

### Testing

Looking for help with manual and automated testing. So far, I've only verified that the project compiles and print statements are being executed.

### Documentation

https://github.com/syncthing/docs/pull/923

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

