### PR TITLE
fix(config): deep copy configuration defaults (fixes #9916)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -235,6 +235,10 @@ func ReadJSON(r io.Reader, myID protocol.DeviceID) (Configuration, error) {
 func (cfg Configuration) Copy() Configuration {
 	newCfg := cfg
 
+	// Deep copy Defaults
+	newCfg.Defaults.Folder = cfg.Defaults.Folder.Copy()
+	newCfg.Defaults.Device = cfg.Defaults.Device.Copy()
+
 	// Deep copy FolderConfigurations
 	newCfg.Folders = make([]FolderConfiguration, len(cfg.Folders))
 	for i := range newCfg.Folders {


### PR DESCRIPTION
### Purpose

Setting default configuration was not working properly since the defaults struct is not deeply copied.

### Testing

Try running commands to change default configuration and either inspect `config.xml` or `/rest/config` result to see the applied changed. Example:
```
./syncthing cli config defaults folder versioning params set keep 5
```

