### PR TITLE
fix(model): correct bufferpool handling; simplify

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1286,11 +1286,6 @@ func (f *sendReceiveFolder) shortcutFile(file protocol.FileInfo, dbUpdateChan ch
 // copierRoutine reads copierStates until the in channel closes and performs
 // the relevant copies when possible, or passes it to the puller routine.
 func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan chan<- pullBlockState, out chan<- *sharedPullerState) {
-	buf := protocol.BufferPool.Get(protocol.MinBlockSize)
-	defer func() {
-		protocol.BufferPool.Put(buf)
-	}()
-
 	otherFolderFilesystems := make(map[string]fs.Filesystem)
 	for folder, cfg := range f.model.cfg.Folders() {
 		if folder == f.ID {
@@ -1333,7 +1328,7 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 				continue
 			}
 
-			if f.copyBlock(block, state, otherFolderFilesystems, buf) {
+			if f.copyBlock(block, state, otherFolderFilesystems) {
 				state.copyDone(block)
 				continue
 			}
@@ -1362,8 +1357,9 @@ func (f *sendReceiveFolder) copierRoutine(in <-chan copyBlocksState, pullChan ch
 }
 
 // Returns true when the block was successfully copied.
-func (f *sendReceiveFolder) copyBlock(block protocol.BlockInfo, state copyBlocksState, otherFolderFilesystems map[string]fs.Filesystem, buf []byte) bool {
-	buf = protocol.BufferPool.Upgrade(buf, int(block.Size))
+func (f *sendReceiveFolder) copyBlock(block protocol.BlockInfo, state copyBlocksState, otherFolderFilesystems map[string]fs.Filesystem) bool {
+	buf := protocol.BufferPool.Get(int(block.Size))
+	defer protocol.BufferPool.Put(buf)
 
 	// Hope that it's usually in the same folder, so start with that
 	// one. Also possibly more efficient copy (same filesystem).

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1974,6 +1974,9 @@ func (f *sendReceiveFolder) deleteDirOnDiskHandleChildren(dir string, scanChan c
 			return nil
 		}
 		cf, ok, err := f.model.sdb.GetDeviceFile(f.folderID, protocol.LocalDeviceID, path)
+		if err != nil {
+			return err
+		}
 		switch {
 		case !ok || cf.IsDeleted():
 			// Something appeared in the dir that we either are not

--- a/lib/protocol/bufferpool.go
+++ b/lib/protocol/bufferpool.go
@@ -59,7 +59,7 @@ func (p *bufferPool) Get(size int) []byte {
 }
 
 // Put makes the given byte slice available again in the global pool.
-// You must only Put() slices that were returned by Get() or Upgrade().
+// You must only Put() slices that were returned by Get().
 func (p *bufferPool) Put(bs []byte) {
 	// Don't buffer slices outside of our pool range
 	if cap(bs) > MaxBlockSize || cap(bs) < MinBlockSize {
@@ -70,20 +70,6 @@ func (p *bufferPool) Put(bs []byte) {
 	p.puts.Add(1)
 	bkt := putBucketForCap(cap(bs))
 	p.pools[bkt].Put(&bs)
-}
-
-// Upgrade grows the buffer to the requested size, while attempting to reuse
-// it if possible.
-func (p *bufferPool) Upgrade(bs []byte, size int) []byte {
-	if cap(bs) >= size {
-		// Reslicing is enough, lets go!
-		return bs[:size]
-	}
-
-	// It was too small. But it pack into the pool and try to get another
-	// buffer.
-	p.Put(bs)
-	return p.Get(size)
 }
 
 // getBucketForLen returns the bucket where we should get a slice of a


### PR DESCRIPTION
The copier routine refactor resulted in bad buffer pool handling, putting a buffer back into the pool twice. This simplifies and removes the danger prone Upgrade() method.