### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/lib/model/folder_test.go
+++ b/lib/model/folder_test.go
@@ -8,6 +8,7 @@ package model
 
 import (
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/d4l3k/messagediff"
@@ -117,20 +118,11 @@ func unifySubsCases() []unifySubsCase {
 	return cases
 }
 
-func unifyExists(f string, tc unifySubsCase) bool {
-	for _, e := range tc.exists {
-		if f == e {
-			return true
-		}
-	}
-	return false
-}
-
 func TestUnifySubs(t *testing.T) {
 	cases := unifySubsCases()
 	for i, tc := range cases {
 		exists := func(f string) bool {
-			return unifyExists(f, tc)
+			return slices.Contains(tc.exists, f)
 		}
 		out := unifySubs(tc.in, exists)
 		if diff, equal := messagediff.PrettyDiff(tc.out, out); !equal {
@@ -146,7 +138,7 @@ func BenchmarkUnifySubs(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		for _, tc := range cases {
 			exists := func(f string) bool {
-				return unifyExists(f, tc)
+				return slices.Contains(tc.exists, f)
 			}
 			unifySubs(tc.in, exists)
 		}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	stdsync "sync"
 	"sync/atomic"
@@ -1804,11 +1805,9 @@ func (m *model) handleAutoAccepts(deviceID protocol.DeviceID, folder protocol.Fo
 		l.Infof("Failed to auto-accept folder %s from %s due to path conflict", folder.Description(), deviceID)
 		return config.FolderConfiguration{}, false
 	} else {
-		for _, device := range cfg.DeviceIDs() {
-			if device == deviceID {
-				// Already shared nothing todo.
-				return config.FolderConfiguration{}, false
-			}
+		if slices.Contains(cfg.DeviceIDs(), deviceID) {
+			// Already shared nothing todo.
+			return config.FolderConfiguration{}, false
 		}
 		if cfg.Type == config.FolderTypeReceiveEncrypted {
 			if len(ccDeviceInfos.remote.EncryptionPasswordToken) == 0 && len(ccDeviceInfos.local.EncryptionPasswordToken) == 0 {

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/pprof"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1253,10 +1254,8 @@ func TestAutoAcceptPausedWhenFolderConfigChanged(t *testing.T) {
 	} else if fcfg.Path != idOther {
 		t.Error("folder path changed")
 	} else {
-		for _, dev := range fcfg.DeviceIDs() {
-			if dev == device1 {
-				return
-			}
+		if slices.Contains(fcfg.DeviceIDs(), device1) {
+			return
 		}
 		t.Error("device missing")
 	}
@@ -1302,10 +1301,8 @@ func TestAutoAcceptPausedWhenFolderConfigNotChanged(t *testing.T) {
 	} else if fcfg.Path != idOther {
 		t.Error("folder path changed")
 	} else {
-		for _, dev := range fcfg.DeviceIDs() {
-			if dev == device1 {
-				return
-			}
+		if slices.Contains(fcfg.DeviceIDs(), device1) {
+			return
 		}
 		t.Error("device missing")
 	}


### PR DESCRIPTION
### Purpose

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

### Testing

Describe what testing has been done, and how the reviewer can test the change
if new tests are not included.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

