### PR TITLE
fix(syncthing): ensure both config and data dirs exist at startup (fixes #10126)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -349,10 +349,12 @@ func (options serveOptions) Run() error {
 		return nil
 	}
 
-	// Ensure that our home directory exists.
-	if err := syncthing.EnsureDir(locations.GetBaseDir(locations.ConfigBaseDir), 0o700); err != nil {
-		l.Warnln("Failure on home directory:", err)
-		os.Exit(svcutil.ExitError.AsInt())
+	// Ensure that our config and data directories exist.
+	for _, loc := range []locations.BaseDirEnum{locations.ConfigBaseDir, locations.DataBaseDir} {
+		if err := syncthing.EnsureDir(locations.GetBaseDir(loc), 0o700); err != nil {
+			l.Warnln("Failed to ensure directory exists:", err)
+			os.Exit(svcutil.ExitError.AsInt())
+		}
 	}
 
 	if options.UpgradeTo != "" {


### PR DESCRIPTION
Previously we'd only ensure the config dir, which is often but not always the same as the data dir.

Fixes #10126