### PR TITLE
docs: general notes about v2 coming

### DIFF
--- a/relnotes/v1.md
+++ b/relnotes/v1.md
@@ -1,0 +1,8 @@
+## Syncthing 2 is coming
+
+Syncthing version 1.x will soon be replaced by Syncthing version 2.x.
+Version 2 brings a new database format and various cleanups, but remains
+protocol compatible with Syncthing 1.
+
+More detailed information about Syncthing 2 can be found in the release
+notes at https://github.com/syncthing/syncthing/releases.


### PR DESCRIPTION
This adds a file that will be prepended to release notes (tag messages, GitHub releases, forum posts) for v1 releases. I'd like there to be something there to flag that things are going to change.