### PR TITLE
refactor: replace interface{} with any

### DIFF
--- a/build.go
+++ b/build.go
@@ -701,7 +701,7 @@ func createPostInstScript(target target) (string, error) {
 }
 
 func shouldBuildSyso(dir string) (string, error) {
-	type M map[string]interface{}
+	type M map[string]any
 	version := getVersion()
 	version = strings.TrimPrefix(version, "v")
 	major, minor, patch := semanticVersion()

--- a/cmd/dev/stevents/main.go
+++ b/cmd/dev/stevents/main.go
@@ -19,10 +19,10 @@ import (
 )
 
 type event struct {
-	ID   int                    `json:"id"`
-	Type string                 `json:"type"`
-	Time time.Time              `json:"time"`
-	Data map[string]interface{} `json:"data"`
+	ID   int            `json:"id"`
+	Type string         `json:"type"`
+	Time time.Time      `json:"time"`
+	Data map[string]any `json:"data"`
 }
 
 func main() {

--- a/cmd/dev/stvanity/main.go
+++ b/cmd/dev/stvanity/main.go
@@ -141,7 +141,7 @@ func printProgress(prefix string, count *atomic.Int64) {
 	}
 }
 
-func saveCert(priv interface{}, derBytes []byte) {
+func saveCert(priv any, derBytes []byte) {
 	certOut, err := os.Create("cert.pem")
 	if err != nil {
 		fmt.Println(err)
@@ -182,7 +182,7 @@ func saveCert(priv interface{}, derBytes []byte) {
 	}
 }
 
-func pemBlockForKey(priv interface{}) (*pem.Block, error) {
+func pemBlockForKey(priv any) (*pem.Block, error) {
 	switch k := priv.(type) {
 	case *rsa.PrivateKey:
 		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}, nil

--- a/cmd/infra/stupgrades/main.go
+++ b/cmd/infra/stupgrades/main.go
@@ -185,7 +185,7 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.WriteHeader(resp.StatusCode)
 	if strings.HasPrefix(ct, "application/json") {
 		// Special JSON handling; clean it up a bit.
-		var v interface{}
+		var v any
 		if err := json.NewDecoder(resp.Body).Decode(&v); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/cmd/strelaysrv/listener.go
+++ b/cmd/strelaysrv/listener.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	outboxesMut    = sync.RWMutex{}
-	outboxes       = make(map[syncthingprotocol.DeviceID]chan interface{})
+	outboxes       = make(map[syncthingprotocol.DeviceID]chan any)
 	numConnections atomic.Int64
 )
 
@@ -97,9 +97,9 @@ func protocolConnectionHandler(tcpConn net.Conn, config *tls.Config, token strin
 
 	id := syncthingprotocol.NewDeviceID(certs[0].Raw)
 
-	messages := make(chan interface{})
+	messages := make(chan any)
 	errors := make(chan error, 1)
-	outbox := make(chan interface{})
+	outbox := make(chan any)
 
 	// Read messages from the connection and send them on the messages
 	// channel. When there is an error, send it on the error channel and
@@ -364,7 +364,7 @@ func sessionConnectionHandler(conn net.Conn) {
 	}
 }
 
-func messageReader(conn net.Conn, messages chan<- interface{}, errors chan<- error) {
+func messageReader(conn net.Conn, messages chan<- any, errors chan<- error) {
 	numConnections.Add(1)
 	defer numConnections.Add(-1)
 

--- a/cmd/strelaysrv/status.go
+++ b/cmd/strelaysrv/status.go
@@ -38,7 +38,7 @@ func statusService(addr string) {
 
 func getStatus(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
-	status := make(map[string]interface{})
+	status := make(map[string]any)
 
 	sessionMut.Lock()
 	// This can potentially be double the number of pending sessions, as each session has two keys, one for each side.
@@ -67,7 +67,7 @@ func getStatus(w http.ResponseWriter, _ *http.Request) {
 		rc.rate(30*60/10) * 8 / 1000,
 		rc.rate(60*60/10) * 8 / 1000,
 	}
-	status["options"] = map[string]interface{}{
+	status["options"] = map[string]any{
 		"network-timeout":  networkTimeout / time.Second,
 		"ping-interval":    pingInterval / time.Second,
 		"message-timeout":  messageTimeout / time.Second,

--- a/cmd/syncthing/cli/client.go
+++ b/cmd/syncthing/cli/client.go
@@ -27,7 +27,7 @@ import (
 type APIClient interface {
 	Get(url string) (*http.Response, error)
 	Post(url, body string) (*http.Response, error)
-	PutJSON(url string, o interface{}) (*http.Response, error)
+	PutJSON(url string, o any) (*http.Response, error)
 }
 
 type apiClient struct {
@@ -133,7 +133,7 @@ func (c *apiClient) RequestString(url, method, data string) (*http.Response, err
 	return c.Request(url, method, bytes.NewBufferString(data))
 }
 
-func (c *apiClient) RequestJSON(url, method string, o interface{}) (*http.Response, error) {
+func (c *apiClient) RequestJSON(url, method string, o any) (*http.Response, error) {
 	data, err := json.Marshal(o)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (c *apiClient) Post(url, body string) (*http.Response, error) {
 	return c.RequestString(url, "POST", body)
 }
 
-func (c *apiClient) PutJSON(url string, o interface{}) (*http.Response, error) {
+func (c *apiClient) PutJSON(url string, o any) (*http.Response, error) {
 	return c.RequestJSON(url, "PUT", o)
 }
 

--- a/cmd/syncthing/cli/config.go
+++ b/cmd/syncthing/cli/config.go
@@ -32,7 +32,7 @@ func (c *configCommand) Run(ctx Context, _ *kong.Context) error {
 	app := cli.NewApp()
 	app.Name = "syncthing"
 	app.Author = "The Syncthing Authors"
-	app.Metadata = map[string]interface{}{
+	app.Metadata = map[string]any{
 		"clientFactory": ctx.clientFactory,
 	}
 

--- a/cmd/syncthing/cli/utils.go
+++ b/cmd/syncthing/cli/utils.go
@@ -114,7 +114,7 @@ func getConfig(c APIClient) (config.Configuration, error) {
 	return cfg, nil
 }
 
-func prettyPrintJSON(data interface{}) error {
+func prettyPrintJSON(data any) error {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	return enc.Encode(data)
@@ -125,7 +125,7 @@ func prettyPrintResponse(response *http.Response) error {
 	if err != nil {
 		return err
 	}
-	var data interface{}
+	var data any
 	if err := json.Unmarshal(bytes, &data); err != nil {
 		return err
 	}

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -1803,7 +1803,7 @@ func TestConfigChanges(t *testing.T) {
 		return resp
 	}
 
-	mod := func(method, path string, data interface{}) {
+	mod := func(method, path string, data any) {
 		t.Helper()
 		bs, err := json.Marshal(data)
 		if err != nil {

--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -438,7 +438,7 @@ func (c *configMuxBuilder) adjustLDAP(w http.ResponseWriter, r *http.Request, ld
 }
 
 // Unmarshals the content of the given body and stores it in to (i.e. to must be a pointer).
-func unmarshalTo(body io.ReadCloser, to interface{}) error {
+func unmarshalTo(body io.ReadCloser, to any) error {
 	bs, err := io.ReadAll(body)
 	body.Close()
 	if err != nil {

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -665,7 +665,7 @@ func (defaults *Defaults) prepare(myID protocol.DeviceID, existingDevices map[pr
 	defaults.Device.prepare(nil)
 }
 
-func ensureZeroForNodefault(empty interface{}, target interface{}) {
+func ensureZeroForNodefault(empty any, target any) {
 	copyMatchingTag(empty, target, "nodefault", func(v string) bool {
 		if len(v) > 0 && v != "true" {
 			panic(fmt.Sprintf(`unexpected tag value: %s. expected untagged or "true"`, v))
@@ -675,7 +675,7 @@ func ensureZeroForNodefault(empty interface{}, target interface{}) {
 }
 
 // copyMatchingTag copies fields tagged tag:"value" from "from" struct onto "to" struct.
-func copyMatchingTag(from interface{}, to interface{}, tag string, shouldCopy func(value string) bool) {
+func copyMatchingTag(from any, to any, tag string, shouldCopy func(value string) bool) {
 	fromStruct := reflect.ValueOf(from).Elem()
 	fromType := fromStruct.Type()
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -1132,8 +1132,8 @@ func TestInvalidDeviceIDRejected(t *testing.T) {
 
 		// Change the device ID of the first device to "invalid". Fast and loose
 		// with the type assertions as we know what the JSON decoder returns.
-		devs := cfg["devices"].([]interface{})
-		dev0 := devs[0].(map[string]interface{})
+		devs := cfg["devices"].([]any)
+		dev0 := devs[0].(map[string]any)
 		dev0["deviceID"] = tc.id
 		devs[0] = dev0
 
@@ -1171,8 +1171,8 @@ func TestInvalidFolderIDRejected(t *testing.T) {
 		// Change the folder ID of the first folder to the empty string.
 		// Fast and loose with the type assertions as we know what the JSON
 		// decoder returns.
-		devs := cfg["folders"].([]interface{})
-		dev0 := devs[0].(map[string]interface{})
+		devs := cfg["folders"].([]any)
+		dev0 := devs[0].(map[string]any)
 		dev0["id"] = tc.id
 		devs[0] = dev0
 
@@ -1296,9 +1296,9 @@ func adjustFolderConfiguration(cfg *FolderConfiguration, id, label string, fsTyp
 }
 
 // defaultConfigAsMap returns a valid default config as a JSON-decoded
-// map[string]interface{}. This is useful to override random elements and
+// map[string]any. This is useful to override random elements and
 // re-encode into JSON.
-func defaultConfigAsMap() map[string]interface{} {
+func defaultConfigAsMap() map[string]any {
 	cfg := New(device1)
 	dev := cfg.Defaults.Device.Copy()
 	adjustDeviceConfiguration(&dev, device2, "name")
@@ -1311,7 +1311,7 @@ func defaultConfigAsMap() map[string]interface{} {
 		// can't happen
 		panic(err)
 	}
-	var tmp map[string]interface{}
+	var tmp map[string]any
 	if err := json.Unmarshal(bs, &tmp); err != nil {
 		// can't happen
 		panic(err)

--- a/lib/config/mocks/mocked_wrapper.go
+++ b/lib/config/mocks/mocked_wrapper.go
@@ -296,7 +296,7 @@ type Wrapper struct {
 	unsubscribeArgsForCall []struct {
 		arg1 config.Committer
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -307,7 +307,7 @@ func (fake *Wrapper) ConfigPath() string {
 	}{})
 	stub := fake.ConfigPathStub
 	fakeReturns := fake.configPathReturns
-	fake.recordInvocation("ConfigPath", []interface{}{})
+	fake.recordInvocation("ConfigPath", []any{})
 	fake.configPathMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -360,7 +360,7 @@ func (fake *Wrapper) DefaultDevice() config.DeviceConfiguration {
 	}{})
 	stub := fake.DefaultDeviceStub
 	fakeReturns := fake.defaultDeviceReturns
-	fake.recordInvocation("DefaultDevice", []interface{}{})
+	fake.recordInvocation("DefaultDevice", []any{})
 	fake.defaultDeviceMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -413,7 +413,7 @@ func (fake *Wrapper) DefaultFolder() config.FolderConfiguration {
 	}{})
 	stub := fake.DefaultFolderStub
 	fakeReturns := fake.defaultFolderReturns
-	fake.recordInvocation("DefaultFolder", []interface{}{})
+	fake.recordInvocation("DefaultFolder", []any{})
 	fake.defaultFolderMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -466,7 +466,7 @@ func (fake *Wrapper) DefaultIgnores() config.Ignores {
 	}{})
 	stub := fake.DefaultIgnoresStub
 	fakeReturns := fake.defaultIgnoresReturns
-	fake.recordInvocation("DefaultIgnores", []interface{}{})
+	fake.recordInvocation("DefaultIgnores", []any{})
 	fake.defaultIgnoresMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -520,7 +520,7 @@ func (fake *Wrapper) Device(arg1 protocol.DeviceID) (config.DeviceConfiguration,
 	}{arg1})
 	stub := fake.DeviceStub
 	fakeReturns := fake.deviceReturns
-	fake.recordInvocation("Device", []interface{}{arg1})
+	fake.recordInvocation("Device", []any{arg1})
 	fake.deviceMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -583,7 +583,7 @@ func (fake *Wrapper) DeviceList() []config.DeviceConfiguration {
 	}{})
 	stub := fake.DeviceListStub
 	fakeReturns := fake.deviceListReturns
-	fake.recordInvocation("DeviceList", []interface{}{})
+	fake.recordInvocation("DeviceList", []any{})
 	fake.deviceListMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -636,7 +636,7 @@ func (fake *Wrapper) Devices() map[protocol.DeviceID]config.DeviceConfiguration 
 	}{})
 	stub := fake.DevicesStub
 	fakeReturns := fake.devicesReturns
-	fake.recordInvocation("Devices", []interface{}{})
+	fake.recordInvocation("Devices", []any{})
 	fake.devicesMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -690,7 +690,7 @@ func (fake *Wrapper) Folder(arg1 string) (config.FolderConfiguration, bool) {
 	}{arg1})
 	stub := fake.FolderStub
 	fakeReturns := fake.folderReturns
-	fake.recordInvocation("Folder", []interface{}{arg1})
+	fake.recordInvocation("Folder", []any{arg1})
 	fake.folderMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -753,7 +753,7 @@ func (fake *Wrapper) FolderList() []config.FolderConfiguration {
 	}{})
 	stub := fake.FolderListStub
 	fakeReturns := fake.folderListReturns
-	fake.recordInvocation("FolderList", []interface{}{})
+	fake.recordInvocation("FolderList", []any{})
 	fake.folderListMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -807,7 +807,7 @@ func (fake *Wrapper) FolderPasswords(arg1 protocol.DeviceID) map[string]string {
 	}{arg1})
 	stub := fake.FolderPasswordsStub
 	fakeReturns := fake.folderPasswordsReturns
-	fake.recordInvocation("FolderPasswords", []interface{}{arg1})
+	fake.recordInvocation("FolderPasswords", []any{arg1})
 	fake.folderPasswordsMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -867,7 +867,7 @@ func (fake *Wrapper) Folders() map[string]config.FolderConfiguration {
 	}{})
 	stub := fake.FoldersStub
 	fakeReturns := fake.foldersReturns
-	fake.recordInvocation("Folders", []interface{}{})
+	fake.recordInvocation("Folders", []any{})
 	fake.foldersMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -920,7 +920,7 @@ func (fake *Wrapper) GUI() config.GUIConfiguration {
 	}{})
 	stub := fake.GUIStub
 	fakeReturns := fake.gUIReturns
-	fake.recordInvocation("GUI", []interface{}{})
+	fake.recordInvocation("GUI", []any{})
 	fake.gUIMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -974,7 +974,7 @@ func (fake *Wrapper) IgnoredDevice(arg1 protocol.DeviceID) bool {
 	}{arg1})
 	stub := fake.IgnoredDeviceStub
 	fakeReturns := fake.ignoredDeviceReturns
-	fake.recordInvocation("IgnoredDevice", []interface{}{arg1})
+	fake.recordInvocation("IgnoredDevice", []any{arg1})
 	fake.ignoredDeviceMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1034,7 +1034,7 @@ func (fake *Wrapper) IgnoredDevices() []config.ObservedDevice {
 	}{})
 	stub := fake.IgnoredDevicesStub
 	fakeReturns := fake.ignoredDevicesReturns
-	fake.recordInvocation("IgnoredDevices", []interface{}{})
+	fake.recordInvocation("IgnoredDevices", []any{})
 	fake.ignoredDevicesMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1089,7 +1089,7 @@ func (fake *Wrapper) IgnoredFolder(arg1 protocol.DeviceID, arg2 string) bool {
 	}{arg1, arg2})
 	stub := fake.IgnoredFolderStub
 	fakeReturns := fake.ignoredFolderReturns
-	fake.recordInvocation("IgnoredFolder", []interface{}{arg1, arg2})
+	fake.recordInvocation("IgnoredFolder", []any{arg1, arg2})
 	fake.ignoredFolderMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1149,7 +1149,7 @@ func (fake *Wrapper) LDAP() config.LDAPConfiguration {
 	}{})
 	stub := fake.LDAPStub
 	fakeReturns := fake.lDAPReturns
-	fake.recordInvocation("LDAP", []interface{}{})
+	fake.recordInvocation("LDAP", []any{})
 	fake.lDAPMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1203,7 +1203,7 @@ func (fake *Wrapper) Modify(arg1 config.ModifyFunction) (config.Waiter, error) {
 	}{arg1})
 	stub := fake.ModifyStub
 	fakeReturns := fake.modifyReturns
-	fake.recordInvocation("Modify", []interface{}{arg1})
+	fake.recordInvocation("Modify", []any{arg1})
 	fake.modifyMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1266,7 +1266,7 @@ func (fake *Wrapper) MyID() protocol.DeviceID {
 	}{})
 	stub := fake.MyIDStub
 	fakeReturns := fake.myIDReturns
-	fake.recordInvocation("MyID", []interface{}{})
+	fake.recordInvocation("MyID", []any{})
 	fake.myIDMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1319,7 +1319,7 @@ func (fake *Wrapper) Options() config.OptionsConfiguration {
 	}{})
 	stub := fake.OptionsStub
 	fakeReturns := fake.optionsReturns
-	fake.recordInvocation("Options", []interface{}{})
+	fake.recordInvocation("Options", []any{})
 	fake.optionsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1372,7 +1372,7 @@ func (fake *Wrapper) RawCopy() config.Configuration {
 	}{})
 	stub := fake.RawCopyStub
 	fakeReturns := fake.rawCopyReturns
-	fake.recordInvocation("RawCopy", []interface{}{})
+	fake.recordInvocation("RawCopy", []any{})
 	fake.rawCopyMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1426,7 +1426,7 @@ func (fake *Wrapper) RemoveDevice(arg1 protocol.DeviceID) (config.Waiter, error)
 	}{arg1})
 	stub := fake.RemoveDeviceStub
 	fakeReturns := fake.removeDeviceReturns
-	fake.recordInvocation("RemoveDevice", []interface{}{arg1})
+	fake.recordInvocation("RemoveDevice", []any{arg1})
 	fake.removeDeviceMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1490,7 +1490,7 @@ func (fake *Wrapper) RemoveFolder(arg1 string) (config.Waiter, error) {
 	}{arg1})
 	stub := fake.RemoveFolderStub
 	fakeReturns := fake.removeFolderReturns
-	fake.recordInvocation("RemoveFolder", []interface{}{arg1})
+	fake.recordInvocation("RemoveFolder", []any{arg1})
 	fake.removeFolderMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1553,7 +1553,7 @@ func (fake *Wrapper) RequiresRestart() bool {
 	}{})
 	stub := fake.RequiresRestartStub
 	fakeReturns := fake.requiresRestartReturns
-	fake.recordInvocation("RequiresRestart", []interface{}{})
+	fake.recordInvocation("RequiresRestart", []any{})
 	fake.requiresRestartMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1606,7 +1606,7 @@ func (fake *Wrapper) Save() error {
 	}{})
 	stub := fake.SaveStub
 	fakeReturns := fake.saveReturns
-	fake.recordInvocation("Save", []interface{}{})
+	fake.recordInvocation("Save", []any{})
 	fake.saveMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1660,7 +1660,7 @@ func (fake *Wrapper) Serve(arg1 context.Context) error {
 	}{arg1})
 	stub := fake.ServeStub
 	fakeReturns := fake.serveReturns
-	fake.recordInvocation("Serve", []interface{}{arg1})
+	fake.recordInvocation("Serve", []any{arg1})
 	fake.serveMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1721,7 +1721,7 @@ func (fake *Wrapper) Subscribe(arg1 config.Committer) config.Configuration {
 	}{arg1})
 	stub := fake.SubscribeStub
 	fakeReturns := fake.subscribeReturns
-	fake.recordInvocation("Subscribe", []interface{}{arg1})
+	fake.recordInvocation("Subscribe", []any{arg1})
 	fake.subscribeMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1780,7 +1780,7 @@ func (fake *Wrapper) Unsubscribe(arg1 config.Committer) {
 		arg1 config.Committer
 	}{arg1})
 	stub := fake.UnsubscribeStub
-	fake.recordInvocation("Unsubscribe", []interface{}{arg1})
+	fake.recordInvocation("Unsubscribe", []any{arg1})
 	fake.unsubscribeMutex.Unlock()
 	if stub != nil {
 		fake.UnsubscribeStub(arg1)
@@ -1806,7 +1806,7 @@ func (fake *Wrapper) UnsubscribeArgsForCall(i int) config.Committer {
 	return argsForCall.arg1
 }
 
-func (fake *Wrapper) Invocations() map[string][][]interface{} {
+func (fake *Wrapper) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.configPathMutex.RLock()
@@ -1863,21 +1863,21 @@ func (fake *Wrapper) Invocations() map[string][][]interface{} {
 	defer fake.subscribeMutex.RUnlock()
 	fake.unsubscribeMutex.RLock()
 	defer fake.unsubscribeMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *Wrapper) recordInvocation(key string, args []interface{}) {
+func (fake *Wrapper) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/connections/connections_test.go
+++ b/lib/connections/connections_test.go
@@ -404,7 +404,7 @@ func TestConnectionEstablishment(t *testing.T) {
 	}
 }
 
-func withConnectionPair(b interface{ Fatal(...interface{}) }, connUri string, h func(client, server internalConn)) {
+func withConnectionPair(b interface{ Fatal(...any) }, connUri string, h func(client, server internalConn)) {
 	// Root of the service tree.
 	supervisor := suture.New("main", suture.Spec{
 		PassThroughPanics: true,
@@ -497,7 +497,7 @@ func withConnectionPair(b interface{ Fatal(...interface{}) }, connUri string, h 
 	_ = serverConn.Close()
 }
 
-func mustGetCert(b interface{ Fatal(...interface{}) }) tls.Certificate {
+func mustGetCert(b interface{ Fatal(...any) }) tls.Certificate {
 	cert, err := tlsutil.NewCertificateInMemory("bench", 10)
 	if err != nil {
 		b.Fatal(err)

--- a/lib/connections/mocks/service.go
+++ b/lib/connections/mocks/service.go
@@ -70,7 +70,7 @@ type Service struct {
 	serveReturnsOnCall map[int]struct {
 		result1 error
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -81,7 +81,7 @@ func (fake *Service) AllAddresses() []string {
 	}{})
 	stub := fake.AllAddressesStub
 	fakeReturns := fake.allAddressesReturns
-	fake.recordInvocation("AllAddresses", []interface{}{})
+	fake.recordInvocation("AllAddresses", []any{})
 	fake.allAddressesMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -134,7 +134,7 @@ func (fake *Service) ConnectionStatus() map[string]connections.ConnectionStatusE
 	}{})
 	stub := fake.ConnectionStatusStub
 	fakeReturns := fake.connectionStatusReturns
-	fake.recordInvocation("ConnectionStatus", []interface{}{})
+	fake.recordInvocation("ConnectionStatus", []any{})
 	fake.connectionStatusMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -187,7 +187,7 @@ func (fake *Service) ExternalAddresses() []string {
 	}{})
 	stub := fake.ExternalAddressesStub
 	fakeReturns := fake.externalAddressesReturns
-	fake.recordInvocation("ExternalAddresses", []interface{}{})
+	fake.recordInvocation("ExternalAddresses", []any{})
 	fake.externalAddressesMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -240,7 +240,7 @@ func (fake *Service) ListenerStatus() map[string]connections.ListenerStatusEntry
 	}{})
 	stub := fake.ListenerStatusStub
 	fakeReturns := fake.listenerStatusReturns
-	fake.recordInvocation("ListenerStatus", []interface{}{})
+	fake.recordInvocation("ListenerStatus", []any{})
 	fake.listenerStatusMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -293,7 +293,7 @@ func (fake *Service) NATType() string {
 	}{})
 	stub := fake.NATTypeStub
 	fakeReturns := fake.nATTypeReturns
-	fake.recordInvocation("NATType", []interface{}{})
+	fake.recordInvocation("NATType", []any{})
 	fake.nATTypeMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -347,7 +347,7 @@ func (fake *Service) Serve(arg1 context.Context) error {
 	}{arg1})
 	stub := fake.ServeStub
 	fakeReturns := fake.serveReturns
-	fake.recordInvocation("Serve", []interface{}{arg1})
+	fake.recordInvocation("Serve", []any{arg1})
 	fake.serveMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -400,7 +400,7 @@ func (fake *Service) ServeReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Service) Invocations() map[string][][]interface{} {
+func (fake *Service) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.allAddressesMutex.RLock()
@@ -415,21 +415,21 @@ func (fake *Service) Invocations() map[string][][]interface{} {
 	defer fake.nATTypeMutex.RUnlock()
 	fake.serveMutex.RLock()
 	defer fake.serveMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *Service) recordInvocation(key string, args []interface{}) {
+func (fake *Service) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/connections/registry/registry.go
+++ b/lib/connections/registry/registry.go
@@ -18,24 +18,24 @@ import (
 
 type Registry struct {
 	mut       sync.Mutex
-	available map[string][]interface{}
+	available map[string][]any
 }
 
 func New() *Registry {
 	return &Registry{
 		mut:       sync.NewMutex(),
-		available: make(map[string][]interface{}),
+		available: make(map[string][]any),
 	}
 }
 
-func (r *Registry) Register(scheme string, item interface{}) {
+func (r *Registry) Register(scheme string, item any) {
 	r.mut.Lock()
 	defer r.mut.Unlock()
 
 	r.available[scheme] = append(r.available[scheme], item)
 }
 
-func (r *Registry) Unregister(scheme string, item interface{}) {
+func (r *Registry) Unregister(scheme string, item any) {
 	r.mut.Lock()
 	defer r.mut.Unlock()
 
@@ -50,12 +50,12 @@ func (r *Registry) Unregister(scheme string, item interface{}) {
 
 // Get returns an item for a schema compatible with the given scheme.
 // If any item satisfies preferred, that has precedence over other items.
-func (r *Registry) Get(scheme string, preferred func(interface{}) bool) interface{} {
+func (r *Registry) Get(scheme string, preferred func(any) bool) any {
 	r.mut.Lock()
 	defer r.mut.Unlock()
 
 	var (
-		best       interface{}
+		best       any
 		bestPref   bool
 		bestScheme string
 	)

--- a/lib/connections/registry/registry_test.go
+++ b/lib/connections/registry/registry_test.go
@@ -14,8 +14,8 @@ import (
 func TestRegistry(t *testing.T) {
 	r := New()
 
-	want := func(i int) func(interface{}) bool {
-		return func(x interface{}) bool { return x.(int) == i }
+	want := func(i int) func(any) bool {
+		return func(x any) bool { return x.(int) == i }
 	}
 
 	if res := r.Get("int", want(1)); res != nil {
@@ -73,7 +73,7 @@ func TestShortSchemeFirst(t *testing.T) {
 	r.Register("foobar", 1)
 
 	// If we don't care about the value, we should get the one with "foo".
-	res := r.Get("foo", func(interface{}) bool { return false })
+	res := r.Get("foo", func(any) bool { return false })
 	if res != 0 {
 		t.Error("unexpected", res)
 	}
@@ -89,7 +89,7 @@ func BenchmarkGet(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		r.Get("tcp", func(x interface{}) bool {
+		r.Get("tcp", func(x any) bool {
 			return x.(*net.TCPAddr).IP.IsUnspecified()
 		})
 	}

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -838,7 +838,7 @@ func (s *service) createListener(factory listenerFactory, uri *url.URL) bool {
 }
 
 func (s *service) logListenAddressesChangedEvent(l ListenerAddresses) {
-	s.evLogger.Log(events.ListenAddressesChanged, map[string]interface{}{
+	s.evLogger.Log(events.ListenAddressesChanged, map[string]any{
 		"address": l.URI,
 		"lan":     l.LANAddresses,
 		"wan":     l.WANAddresses,

--- a/lib/dialer/public.go
+++ b/lib/dialer/public.go
@@ -111,7 +111,7 @@ func DialContextReusePortFunc(registry *registry.Registry) func(ctx context.Cont
 			return DialContext(ctx, network, addr)
 		}
 
-		localAddrInterface := registry.Get(network, func(addr interface{}) bool {
+		localAddrInterface := registry.Get(network, func(addr any) bool {
 			return addr.(*net.TCPAddr).IP.IsUnspecified()
 		})
 		if localAddrInterface == nil {

--- a/lib/discover/local.go
+++ b/lib/discover/local.go
@@ -292,7 +292,7 @@ func (c *localClient) registerDevice(src net.Addr, device *discoproto.Announce) 
 	})
 
 	if isNewDevice {
-		c.evLogger.Log(events.DeviceDiscovered, map[string]interface{}{
+		c.evLogger.Log(events.DeviceDiscovered, map[string]any{
 			"device": id.String(),
 			"addrs":  validAddresses,
 		})

--- a/lib/discover/mocks/manager.go
+++ b/lib/discover/mocks/manager.go
@@ -75,7 +75,7 @@ type Manager struct {
 	stringReturnsOnCall map[int]struct {
 		result1 string
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -86,7 +86,7 @@ func (fake *Manager) Cache() map[protocol.DeviceID]discover.CacheEntry {
 	}{})
 	stub := fake.CacheStub
 	fakeReturns := fake.cacheReturns
-	fake.recordInvocation("Cache", []interface{}{})
+	fake.recordInvocation("Cache", []any{})
 	fake.cacheMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -139,7 +139,7 @@ func (fake *Manager) ChildErrors() map[string]error {
 	}{})
 	stub := fake.ChildErrorsStub
 	fakeReturns := fake.childErrorsReturns
-	fake.recordInvocation("ChildErrors", []interface{}{})
+	fake.recordInvocation("ChildErrors", []any{})
 	fake.childErrorsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -192,7 +192,7 @@ func (fake *Manager) Error() error {
 	}{})
 	stub := fake.ErrorStub
 	fakeReturns := fake.errorReturns
-	fake.recordInvocation("Error", []interface{}{})
+	fake.recordInvocation("Error", []any{})
 	fake.errorMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -247,7 +247,7 @@ func (fake *Manager) Lookup(arg1 context.Context, arg2 protocol.DeviceID) ([]str
 	}{arg1, arg2})
 	stub := fake.LookupStub
 	fakeReturns := fake.lookupReturns
-	fake.recordInvocation("Lookup", []interface{}{arg1, arg2})
+	fake.recordInvocation("Lookup", []any{arg1, arg2})
 	fake.lookupMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -311,7 +311,7 @@ func (fake *Manager) Serve(arg1 context.Context) error {
 	}{arg1})
 	stub := fake.ServeStub
 	fakeReturns := fake.serveReturns
-	fake.recordInvocation("Serve", []interface{}{arg1})
+	fake.recordInvocation("Serve", []any{arg1})
 	fake.serveMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -371,7 +371,7 @@ func (fake *Manager) String() string {
 	}{})
 	stub := fake.StringStub
 	fakeReturns := fake.stringReturns
-	fake.recordInvocation("String", []interface{}{})
+	fake.recordInvocation("String", []any{})
 	fake.stringMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -417,7 +417,7 @@ func (fake *Manager) StringReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *Manager) Invocations() map[string][][]interface{} {
+func (fake *Manager) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.cacheMutex.RLock()
@@ -432,21 +432,21 @@ func (fake *Manager) Invocations() map[string][][]interface{} {
 	defer fake.serveMutex.RUnlock()
 	fake.stringMutex.RLock()
 	defer fake.stringMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *Manager) recordInvocation(key string, args []interface{}) {
+func (fake *Manager) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -231,7 +231,7 @@ const BufferSize = 64
 
 type Logger interface {
 	suture.Service
-	Log(t EventType, data interface{})
+	Log(t EventType, data any)
 	Subscribe(mask EventType) Subscription
 }
 
@@ -249,10 +249,10 @@ type Event struct {
 	// Per-subscription sequential event ID. Named "id" for backwards compatibility with the REST API
 	SubscriptionID int `json:"id"`
 	// Global ID of the event across all subscriptions
-	GlobalID int         `json:"globalID"`
-	Time     time.Time   `json:"time"`
-	Type     EventType   `json:"type"`
-	Data     interface{} `json:"data"`
+	GlobalID int       `json:"globalID"`
+	Time     time.Time `json:"time"`
+	Type     EventType `json:"type"`
+	Data     any       `json:"data"`
 }
 
 type Subscription interface {
@@ -321,7 +321,7 @@ loop:
 	return nil
 }
 
-func (l *logger) Log(t EventType, data interface{}) {
+func (l *logger) Log(t EventType, data any) {
 	l.events <- Event{
 		Time: time.Now(), // intentionally high precision
 		Type: t,
@@ -556,7 +556,7 @@ var NoopLogger Logger = &noopLogger{}
 
 func (*noopLogger) Serve(_ context.Context) error { return nil }
 
-func (*noopLogger) Log(_ EventType, _ interface{}) {}
+func (*noopLogger) Log(_ EventType, _ any) {}
 
 func (*noopLogger) Subscribe(_ EventType) Subscription {
 	return &noopSubscription{}

--- a/lib/events/mocks/buffered_subscription.go
+++ b/lib/events/mocks/buffered_subscription.go
@@ -32,7 +32,7 @@ type BufferedSubscription struct {
 	sinceReturnsOnCall map[int]struct {
 		result1 []events.Event
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -43,7 +43,7 @@ func (fake *BufferedSubscription) Mask() events.EventType {
 	}{})
 	stub := fake.MaskStub
 	fakeReturns := fake.maskReturns
-	fake.recordInvocation("Mask", []interface{}{})
+	fake.recordInvocation("Mask", []any{})
 	fake.maskMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -104,7 +104,7 @@ func (fake *BufferedSubscription) Since(arg1 int, arg2 []events.Event, arg3 time
 	}{arg1, arg2Copy, arg3})
 	stub := fake.SinceStub
 	fakeReturns := fake.sinceReturns
-	fake.recordInvocation("Since", []interface{}{arg1, arg2Copy, arg3})
+	fake.recordInvocation("Since", []any{arg1, arg2Copy, arg3})
 	fake.sinceMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -157,28 +157,28 @@ func (fake *BufferedSubscription) SinceReturnsOnCall(i int, result1 []events.Eve
 	}{result1}
 }
 
-func (fake *BufferedSubscription) Invocations() map[string][][]interface{} {
+func (fake *BufferedSubscription) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.maskMutex.RLock()
 	defer fake.maskMutex.RUnlock()
 	fake.sinceMutex.RLock()
 	defer fake.sinceMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *BufferedSubscription) recordInvocation(key string, args []interface{}) {
+func (fake *BufferedSubscription) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -635,6 +635,6 @@ func (fakeEventInfo) Event() notify.Event {
 	return notify.Write
 }
 
-func (fakeEventInfo) Sys() interface{} {
+func (fakeEventInfo) Sys() any {
 	return nil
 }

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -1016,7 +1016,7 @@ func (f *fakeFileInfo) Group() int {
 	return f.gid
 }
 
-func (*fakeFileInfo) Sys() interface{} {
+func (*fakeFileInfo) Sys() any {
 	return nil
 }
 

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -95,7 +95,7 @@ type FileInfo interface {
 	Size() int64
 	ModTime() time.Time
 	IsDir() bool
-	Sys() interface{}
+	Sys() any
 	// Extensions
 	IsRegular() bool
 	IsSymlink() bool

--- a/lib/fs/types.go
+++ b/lib/fs/types.go
@@ -26,8 +26,10 @@ type Option interface {
 type FilesystemFactory func(string, ...Option) (Filesystem, error)
 
 // For each registered file system type, a function to construct a file system.
-var filesystemFactories map[FilesystemType]FilesystemFactory = make(map[FilesystemType]FilesystemFactory)
-var filesystemFactoriesMutex sync.Mutex = sync.Mutex{}
+var (
+	filesystemFactories      map[FilesystemType]FilesystemFactory = make(map[FilesystemType]FilesystemFactory)
+	filesystemFactoriesMutex sync.Mutex                           = sync.Mutex{}
+)
 
 // Register a function to be called when a filesystem is to be constructed with
 // the specified fsType. The function will receive the URI for the file system as well

--- a/lib/logger/logger.go
+++ b/lib/logger/logger.go
@@ -43,14 +43,14 @@ type Logger interface {
 	AddHandler(level LogLevel, h MessageHandler)
 	SetFlags(flag int)
 	SetPrefix(prefix string)
-	Debugln(vals ...interface{})
-	Debugf(format string, vals ...interface{})
-	Verboseln(vals ...interface{})
-	Verbosef(format string, vals ...interface{})
-	Infoln(vals ...interface{})
-	Infof(format string, vals ...interface{})
-	Warnln(vals ...interface{})
-	Warnf(format string, vals ...interface{})
+	Debugln(vals ...any)
+	Debugf(format string, vals ...any)
+	Verboseln(vals ...any)
+	Verbosef(format string, vals ...any)
+	Infoln(vals ...any)
+	Infof(format string, vals ...any)
+	Warnln(vals ...any)
+	Warnf(format string, vals ...any)
 	ShouldDebug(facility string) bool
 	SetDebug(facility string, enabled bool)
 	Facilities() map[string]string
@@ -127,11 +127,11 @@ func (l *logger) callHandlers(level LogLevel, s string) {
 }
 
 // Debugln logs a line with a DEBUG prefix.
-func (l *logger) Debugln(vals ...interface{}) {
+func (l *logger) Debugln(vals ...any) {
 	l.debugln(3, vals...)
 }
 
-func (l *logger) debugln(level int, vals ...interface{}) {
+func (l *logger) debugln(level int, vals ...any) {
 	s := fmt.Sprintln(vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -140,11 +140,11 @@ func (l *logger) debugln(level int, vals ...interface{}) {
 }
 
 // Debugf logs a formatted line with a DEBUG prefix.
-func (l *logger) Debugf(format string, vals ...interface{}) {
+func (l *logger) Debugf(format string, vals ...any) {
 	l.debugf(3, format, vals...)
 }
 
-func (l *logger) debugf(level int, format string, vals ...interface{}) {
+func (l *logger) debugf(level int, format string, vals ...any) {
 	s := fmt.Sprintf(format, vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -153,7 +153,7 @@ func (l *logger) debugf(level int, format string, vals ...interface{}) {
 }
 
 // Infoln logs a line with a VERBOSE prefix.
-func (l *logger) Verboseln(vals ...interface{}) {
+func (l *logger) Verboseln(vals ...any) {
 	s := fmt.Sprintln(vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -162,7 +162,7 @@ func (l *logger) Verboseln(vals ...interface{}) {
 }
 
 // Infof logs a formatted line with a VERBOSE prefix.
-func (l *logger) Verbosef(format string, vals ...interface{}) {
+func (l *logger) Verbosef(format string, vals ...any) {
 	s := fmt.Sprintf(format, vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -171,7 +171,7 @@ func (l *logger) Verbosef(format string, vals ...interface{}) {
 }
 
 // Infoln logs a line with an INFO prefix.
-func (l *logger) Infoln(vals ...interface{}) {
+func (l *logger) Infoln(vals ...any) {
 	s := fmt.Sprintln(vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -180,7 +180,7 @@ func (l *logger) Infoln(vals ...interface{}) {
 }
 
 // Infof logs a formatted line with an INFO prefix.
-func (l *logger) Infof(format string, vals ...interface{}) {
+func (l *logger) Infof(format string, vals ...any) {
 	s := fmt.Sprintf(format, vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -189,7 +189,7 @@ func (l *logger) Infof(format string, vals ...interface{}) {
 }
 
 // Warnln logs a formatted line with a WARNING prefix.
-func (l *logger) Warnln(vals ...interface{}) {
+func (l *logger) Warnln(vals ...any) {
 	s := fmt.Sprintln(vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -198,7 +198,7 @@ func (l *logger) Warnln(vals ...interface{}) {
 }
 
 // Warnf logs a formatted line with a WARNING prefix.
-func (l *logger) Warnf(format string, vals ...interface{}) {
+func (l *logger) Warnf(format string, vals ...any) {
 	s := fmt.Sprintf(format, vals...)
 	l.mut.Lock()
 	defer l.mut.Unlock()
@@ -290,7 +290,7 @@ type facilityLogger struct {
 }
 
 // Debugln logs a line with a DEBUG prefix.
-func (l *facilityLogger) Debugln(vals ...interface{}) {
+func (l *facilityLogger) Debugln(vals ...any) {
 	if !l.ShouldDebug(l.facility) {
 		return
 	}
@@ -298,7 +298,7 @@ func (l *facilityLogger) Debugln(vals ...interface{}) {
 }
 
 // Debugf logs a formatted line with a DEBUG prefix.
-func (l *facilityLogger) Debugf(format string, vals ...interface{}) {
+func (l *facilityLogger) Debugf(format string, vals ...any) {
 	if !l.ShouldDebug(l.facility) {
 		return
 	}

--- a/lib/logger/mocks/logger.go
+++ b/lib/logger/mocks/logger.go
@@ -24,7 +24,7 @@ type Recorder struct {
 	sinceReturnsOnCall map[int]struct {
 		result1 []logger.Line
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -33,7 +33,7 @@ func (fake *Recorder) Clear() {
 	fake.clearArgsForCall = append(fake.clearArgsForCall, struct {
 	}{})
 	stub := fake.ClearStub
-	fake.recordInvocation("Clear", []interface{}{})
+	fake.recordInvocation("Clear", []any{})
 	fake.clearMutex.Unlock()
 	if stub != nil {
 		fake.ClearStub()
@@ -60,7 +60,7 @@ func (fake *Recorder) Since(arg1 time.Time) []logger.Line {
 	}{arg1})
 	stub := fake.SinceStub
 	fakeReturns := fake.sinceReturns
-	fake.recordInvocation("Since", []interface{}{arg1})
+	fake.recordInvocation("Since", []any{arg1})
 	fake.sinceMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -113,28 +113,28 @@ func (fake *Recorder) SinceReturnsOnCall(i int, result1 []logger.Line) {
 	}{result1}
 }
 
-func (fake *Recorder) Invocations() map[string][][]interface{} {
+func (fake *Recorder) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.clearMutex.RLock()
 	defer fake.clearMutex.RUnlock()
 	fake.sinceMutex.RLock()
 	defer fake.sinceMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *Recorder) recordInvocation(key string, args []interface{}) {
+func (fake *Recorder) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/model/blockpullreorderer.go
+++ b/lib/model/blockpullreorderer.go
@@ -47,7 +47,7 @@ func (randomOrderBlockPullReorderer) Reorder(blocks []protocol.BlockInfo) []prot
 type standardBlockPullReorderer struct {
 	myIndex int
 	count   int
-	shuffle func(interface{}) // Used for test
+	shuffle func(any) // Used for test
 }
 
 func newStandardBlockPullReorderer(id protocol.DeviceID, otherDevices []protocol.DeviceID) *standardBlockPullReorderer {

--- a/lib/model/blockpullreorderer_test.go
+++ b/lib/model/blockpullreorderer_test.go
@@ -92,7 +92,7 @@ func Test_standardBlockPullReorderer_Reorder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := newStandardBlockPullReorderer(tt.myId, tt.devices)
-			p.shuffle = func(i interface{}) {} // Noop shuffle
+			p.shuffle = func(i any) {} // Noop shuffle
 			if got := p.Reorder(tt.blocks); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("reorderBlocksForDevices() = %v, want %v (my idx: %d, count %d)", got, tt.want, p.myIndex, p.count)
 			}

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -1087,7 +1087,7 @@ func (f *folder) setWatchError(err error, nextTryIn time.Duration) {
 	f.watchErr = err
 	f.watchMut.Unlock()
 	if err != prevErr {
-		data := map[string]interface{}{
+		data := map[string]any{
 			"folder": f.ID,
 		}
 		if prevErr != nil {
@@ -1244,7 +1244,7 @@ func (f *folder) updateLocals(fs []protocol.FileInfo) {
 	f.forcedRescanPathsMut.Unlock()
 
 	seq := f.fset.Sequence(protocol.LocalDeviceID)
-	f.evLogger.Log(events.LocalIndexUpdated, map[string]interface{}{
+	f.evLogger.Log(events.LocalIndexUpdated, map[string]any{
 		"folder":    f.ID,
 		"items":     len(fs),
 		"filenames": filenames,

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -223,7 +223,7 @@ func (f *sendReceiveFolder) pull() (bool, error) {
 
 	if pullErrNum > 0 {
 		l.Infof("%v: Failed to sync %v items", f.Description(), pullErrNum)
-		f.evLogger.Log(events.FolderErrors, map[string]interface{}{
+		f.evLogger.Log(events.FolderErrors, map[string]any{
 			"folder": f.folderID,
 			"errors": f.Errors(),
 		})
@@ -564,7 +564,7 @@ func (f *sendReceiveFolder) handleDir(file protocol.FileInfo, snap *db.Snapshot,
 	})
 
 	defer func() {
-		f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+		f.evLogger.Log(events.ItemFinished, map[string]any{
 			"folder": f.folderID,
 			"item":   file.Name,
 			"error":  events.Error(err),
@@ -729,7 +729,7 @@ func (f *sendReceiveFolder) handleSymlink(file protocol.FileInfo, snap *db.Snaps
 	})
 
 	defer func() {
-		f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+		f.evLogger.Log(events.ItemFinished, map[string]any{
 			"folder": f.folderID,
 			"item":   file.Name,
 			"error":  events.Error(err),
@@ -818,7 +818,7 @@ func (f *sendReceiveFolder) deleteDir(file protocol.FileInfo, snap *db.Snapshot,
 		if err != nil {
 			f.newPullError(file.Name, fmt.Errorf("delete dir: %w", err))
 		}
-		f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+		f.evLogger.Log(events.ItemFinished, map[string]any{
 			"folder": f.folderID,
 			"item":   file.Name,
 			"error":  events.Error(err),
@@ -868,7 +868,7 @@ func (f *sendReceiveFolder) deleteFileWithCurrent(file, cur protocol.FileInfo, h
 		if err != nil {
 			f.newPullError(file.Name, fmt.Errorf("delete file: %w", err))
 		}
-		f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+		f.evLogger.Log(events.ItemFinished, map[string]any{
 			"folder": f.folderID,
 			"item":   file.Name,
 			"error":  events.Error(err),
@@ -944,14 +944,14 @@ func (f *sendReceiveFolder) renameFile(cur, source, target protocol.FileInfo, sn
 	})
 
 	defer func() {
-		f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+		f.evLogger.Log(events.ItemFinished, map[string]any{
 			"folder": f.folderID,
 			"item":   source.Name,
 			"error":  events.Error(err),
 			"type":   "file",
 			"action": "delete",
 		})
-		f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+		f.evLogger.Log(events.ItemFinished, map[string]any{
 			"folder": f.folderID,
 			"item":   target.Name,
 			"error":  events.Error(err),
@@ -1224,7 +1224,7 @@ func (f *sendReceiveFolder) shortcutFile(file protocol.FileInfo, dbUpdateChan ch
 	})
 
 	var err error
-	defer f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+	defer f.evLogger.Log(events.ItemFinished, map[string]any{
 		"folder": f.folderID,
 		"item":   file.Name,
 		"error":  events.Error(err),
@@ -1692,7 +1692,7 @@ func (f *sendReceiveFolder) finisherRoutine(snap *db.Snapshot, in <-chan *shared
 				f.model.progressEmitter.Deregister(state)
 			}
 
-			f.evLogger.Log(events.ItemFinished, map[string]interface{}{
+			f.evLogger.Log(events.ItemFinished, map[string]any{
 				"folder": f.folderID,
 				"item":   state.file.Name,
 				"error":  events.Error(err),

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -541,7 +541,7 @@ func TestDeregisterOnFailInCopy(t *testing.T) {
 		t0 := time.Now()
 		if ev, err := s.Poll(time.Minute); err != nil {
 			t.Fatal("Got error waiting for ItemFinished event:", err)
-		} else if n := ev.Data.(map[string]interface{})["item"]; n != state.file.Name {
+		} else if n := ev.Data.(map[string]any)["item"]; n != state.file.Name {
 			t.Fatal("Got ItemFinished event for wrong file:", n)
 		}
 		t.Log("event took", time.Since(t0))
@@ -650,7 +650,7 @@ func TestDeregisterOnFailInPull(t *testing.T) {
 	t0 := time.Now()
 	if ev, err := s.Poll(time.Minute); err != nil {
 		t.Fatal("Got error waiting for ItemFinished event:", err)
-	} else if n := ev.Data.(map[string]interface{})["item"]; n != state.file.Name {
+	} else if n := ev.Data.(map[string]any)["item"]; n != state.file.Name {
 		t.Fatal("Got ItemFinished event for wrong file:", n)
 	}
 	t.Log("event took", time.Since(t0))

--- a/lib/model/folder_summary.go
+++ b/lib/model/folder_summary.go
@@ -68,7 +68,7 @@ func (c *folderSummaryService) String() string {
 	return fmt.Sprintf("FolderSummaryService@%p", c)
 }
 
-// FolderSummary replaces the previously used map[string]interface{}, and needs
+// FolderSummary replaces the previously used map[string]any, and needs
 // to keep the structure/naming for api backwards compatibility
 type FolderSummary struct {
 	Errors     int `json:"errors"`
@@ -270,7 +270,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 		return
 
 	case events.StateChanged:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		if data["to"].(string) != "idle" {
 			return
 		}
@@ -301,7 +301,7 @@ func (c *folderSummaryService) processUpdate(ev events.Event) {
 		// This folder needs to be refreshed whenever we do the next
 		// refresh.
 
-		folder = ev.Data.(map[string]interface{})["folder"].(string)
+		folder = ev.Data.(map[string]any)["folder"].(string)
 	}
 
 	c.foldersMut.Lock()

--- a/lib/model/folderstate.go
+++ b/lib/model/folderstate.go
@@ -121,7 +121,7 @@ func (s *stateTracker) setState(newState folderState) {
 	}
 	*/
 
-	eventData := map[string]interface{}{
+	eventData := map[string]any{
 		"folder": s.folderID,
 		"to":     newState.String(),
 		"from":   s.current.String(),
@@ -156,7 +156,7 @@ func (s *stateTracker) setError(err error) {
 		metricFolderState.WithLabelValues(s.folderID).Set(float64(s.current))
 	}()
 
-	eventData := map[string]interface{}{
+	eventData := map[string]any{
 		"folder": s.folderID,
 		"from":   s.current.String(),
 	}

--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -458,7 +458,7 @@ func (s *indexHandler) receive(fs []protocol.FileInfo, update bool, op string, p
 		})
 	}
 
-	s.evLogger.Log(events.RemoteIndexUpdated, map[string]interface{}{
+	s.evLogger.Log(events.RemoteIndexUpdated, map[string]any{
 		"device":   deviceID.String(),
 		"folder":   s.folder,
 		"items":    len(fs),

--- a/lib/model/mocks/folderSummaryService.go
+++ b/lib/model/mocks/folderSummaryService.go
@@ -33,7 +33,7 @@ type FolderSummaryService struct {
 		result1 *model.FolderSummary
 		result2 error
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -45,7 +45,7 @@ func (fake *FolderSummaryService) Serve(arg1 context.Context) error {
 	}{arg1})
 	stub := fake.ServeStub
 	fakeReturns := fake.serveReturns
-	fake.recordInvocation("Serve", []interface{}{arg1})
+	fake.recordInvocation("Serve", []any{arg1})
 	fake.serveMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -106,7 +106,7 @@ func (fake *FolderSummaryService) Summary(arg1 string) (*model.FolderSummary, er
 	}{arg1})
 	stub := fake.SummaryStub
 	fakeReturns := fake.summaryReturns
-	fake.recordInvocation("Summary", []interface{}{arg1})
+	fake.recordInvocation("Summary", []any{arg1})
 	fake.summaryMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -162,28 +162,28 @@ func (fake *FolderSummaryService) SummaryReturnsOnCall(i int, result1 *model.Fol
 	}{result1, result2}
 }
 
-func (fake *FolderSummaryService) Invocations() map[string][][]interface{} {
+func (fake *FolderSummaryService) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.serveMutex.RLock()
 	defer fake.serveMutex.RUnlock()
 	fake.summaryMutex.RLock()
 	defer fake.summaryMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *FolderSummaryService) recordInvocation(key string, args []interface{}) {
+func (fake *FolderSummaryService) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/model/mocks/model.go
+++ b/lib/model/mocks/model.go
@@ -87,15 +87,15 @@ type Model struct {
 	connectedToReturnsOnCall map[int]struct {
 		result1 bool
 	}
-	ConnectionStatsStub        func() map[string]interface{}
+	ConnectionStatsStub        func() map[string]any
 	connectionStatsMutex       sync.RWMutex
 	connectionStatsArgsForCall []struct {
 	}
 	connectionStatsReturns struct {
-		result1 map[string]interface{}
+		result1 map[string]any
 	}
 	connectionStatsReturnsOnCall map[int]struct {
-		result1 map[string]interface{}
+		result1 map[string]any
 	}
 	CurrentFolderFileStub        func(string, string) (protocol.FileInfo, bool, error)
 	currentFolderFileMutex       sync.RWMutex
@@ -576,7 +576,7 @@ type Model struct {
 	watchErrorReturnsOnCall map[int]struct {
 		result1 error
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -587,7 +587,7 @@ func (fake *Model) AddConnection(arg1 protocol.Connection, arg2 protocol.Hello) 
 		arg2 protocol.Hello
 	}{arg1, arg2})
 	stub := fake.AddConnectionStub
-	fake.recordInvocation("AddConnection", []interface{}{arg1, arg2})
+	fake.recordInvocation("AddConnection", []any{arg1, arg2})
 	fake.addConnectionMutex.Unlock()
 	if stub != nil {
 		fake.AddConnectionStub(arg1, arg2)
@@ -623,7 +623,7 @@ func (fake *Model) Availability(arg1 string, arg2 protocol.FileInfo, arg3 protoc
 	}{arg1, arg2, arg3})
 	stub := fake.AvailabilityStub
 	fakeReturns := fake.availabilityReturns
-	fake.recordInvocation("Availability", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("Availability", []any{arg1, arg2, arg3})
 	fake.availabilityMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -686,7 +686,7 @@ func (fake *Model) BringToFront(arg1 string, arg2 string) {
 		arg2 string
 	}{arg1, arg2})
 	stub := fake.BringToFrontStub
-	fake.recordInvocation("BringToFront", []interface{}{arg1, arg2})
+	fake.recordInvocation("BringToFront", []any{arg1, arg2})
 	fake.bringToFrontMutex.Unlock()
 	if stub != nil {
 		fake.BringToFrontStub(arg1, arg2)
@@ -719,7 +719,7 @@ func (fake *Model) Closed(arg1 protocol.Connection, arg2 error) {
 		arg2 error
 	}{arg1, arg2})
 	stub := fake.ClosedStub
-	fake.recordInvocation("Closed", []interface{}{arg1, arg2})
+	fake.recordInvocation("Closed", []any{arg1, arg2})
 	fake.closedMutex.Unlock()
 	if stub != nil {
 		fake.ClosedStub(arg1, arg2)
@@ -754,7 +754,7 @@ func (fake *Model) ClusterConfig(arg1 protocol.Connection, arg2 *protocol.Cluste
 	}{arg1, arg2})
 	stub := fake.ClusterConfigStub
 	fakeReturns := fake.clusterConfigReturns
-	fake.recordInvocation("ClusterConfig", []interface{}{arg1, arg2})
+	fake.recordInvocation("ClusterConfig", []any{arg1, arg2})
 	fake.clusterConfigMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -816,7 +816,7 @@ func (fake *Model) Completion(arg1 protocol.DeviceID, arg2 string) (model.Folder
 	}{arg1, arg2})
 	stub := fake.CompletionStub
 	fakeReturns := fake.completionReturns
-	fake.recordInvocation("Completion", []interface{}{arg1, arg2})
+	fake.recordInvocation("Completion", []any{arg1, arg2})
 	fake.completionMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -880,7 +880,7 @@ func (fake *Model) ConnectedTo(arg1 protocol.DeviceID) bool {
 	}{arg1})
 	stub := fake.ConnectedToStub
 	fakeReturns := fake.connectedToReturns
-	fake.recordInvocation("ConnectedTo", []interface{}{arg1})
+	fake.recordInvocation("ConnectedTo", []any{arg1})
 	fake.connectedToMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -933,14 +933,14 @@ func (fake *Model) ConnectedToReturnsOnCall(i int, result1 bool) {
 	}{result1}
 }
 
-func (fake *Model) ConnectionStats() map[string]interface{} {
+func (fake *Model) ConnectionStats() map[string]any {
 	fake.connectionStatsMutex.Lock()
 	ret, specificReturn := fake.connectionStatsReturnsOnCall[len(fake.connectionStatsArgsForCall)]
 	fake.connectionStatsArgsForCall = append(fake.connectionStatsArgsForCall, struct {
 	}{})
 	stub := fake.ConnectionStatsStub
 	fakeReturns := fake.connectionStatsReturns
-	fake.recordInvocation("ConnectionStats", []interface{}{})
+	fake.recordInvocation("ConnectionStats", []any{})
 	fake.connectionStatsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -957,32 +957,32 @@ func (fake *Model) ConnectionStatsCallCount() int {
 	return len(fake.connectionStatsArgsForCall)
 }
 
-func (fake *Model) ConnectionStatsCalls(stub func() map[string]interface{}) {
+func (fake *Model) ConnectionStatsCalls(stub func() map[string]any) {
 	fake.connectionStatsMutex.Lock()
 	defer fake.connectionStatsMutex.Unlock()
 	fake.ConnectionStatsStub = stub
 }
 
-func (fake *Model) ConnectionStatsReturns(result1 map[string]interface{}) {
+func (fake *Model) ConnectionStatsReturns(result1 map[string]any) {
 	fake.connectionStatsMutex.Lock()
 	defer fake.connectionStatsMutex.Unlock()
 	fake.ConnectionStatsStub = nil
 	fake.connectionStatsReturns = struct {
-		result1 map[string]interface{}
+		result1 map[string]any
 	}{result1}
 }
 
-func (fake *Model) ConnectionStatsReturnsOnCall(i int, result1 map[string]interface{}) {
+func (fake *Model) ConnectionStatsReturnsOnCall(i int, result1 map[string]any) {
 	fake.connectionStatsMutex.Lock()
 	defer fake.connectionStatsMutex.Unlock()
 	fake.ConnectionStatsStub = nil
 	if fake.connectionStatsReturnsOnCall == nil {
 		fake.connectionStatsReturnsOnCall = make(map[int]struct {
-			result1 map[string]interface{}
+			result1 map[string]any
 		})
 	}
 	fake.connectionStatsReturnsOnCall[i] = struct {
-		result1 map[string]interface{}
+		result1 map[string]any
 	}{result1}
 }
 
@@ -995,7 +995,7 @@ func (fake *Model) CurrentFolderFile(arg1 string, arg2 string) (protocol.FileInf
 	}{arg1, arg2})
 	stub := fake.CurrentFolderFileStub
 	fakeReturns := fake.currentFolderFileReturns
-	fake.recordInvocation("CurrentFolderFile", []interface{}{arg1, arg2})
+	fake.recordInvocation("CurrentFolderFile", []any{arg1, arg2})
 	fake.currentFolderFileMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1063,7 +1063,7 @@ func (fake *Model) CurrentGlobalFile(arg1 string, arg2 string) (protocol.FileInf
 	}{arg1, arg2})
 	stub := fake.CurrentGlobalFileStub
 	fakeReturns := fake.currentGlobalFileReturns
-	fake.recordInvocation("CurrentGlobalFile", []interface{}{arg1, arg2})
+	fake.recordInvocation("CurrentGlobalFile", []any{arg1, arg2})
 	fake.currentGlobalFileMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1130,7 +1130,7 @@ func (fake *Model) CurrentIgnores(arg1 string) ([]string, []string, error) {
 	}{arg1})
 	stub := fake.CurrentIgnoresStub
 	fakeReturns := fake.currentIgnoresReturns
-	fake.recordInvocation("CurrentIgnores", []interface{}{arg1})
+	fake.recordInvocation("CurrentIgnores", []any{arg1})
 	fake.currentIgnoresMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1197,7 +1197,7 @@ func (fake *Model) DBSnapshot(arg1 string) (*db.Snapshot, error) {
 	}{arg1})
 	stub := fake.DBSnapshotStub
 	fakeReturns := fake.dBSnapshotReturns
-	fake.recordInvocation("DBSnapshot", []interface{}{arg1})
+	fake.recordInvocation("DBSnapshot", []any{arg1})
 	fake.dBSnapshotMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1260,7 +1260,7 @@ func (fake *Model) DelayScan(arg1 string, arg2 time.Duration) {
 		arg2 time.Duration
 	}{arg1, arg2})
 	stub := fake.DelayScanStub
-	fake.recordInvocation("DelayScan", []interface{}{arg1, arg2})
+	fake.recordInvocation("DelayScan", []any{arg1, arg2})
 	fake.delayScanMutex.Unlock()
 	if stub != nil {
 		fake.DelayScanStub(arg1, arg2)
@@ -1293,7 +1293,7 @@ func (fake *Model) DeviceStatistics() (map[protocol.DeviceID]stats.DeviceStatist
 	}{})
 	stub := fake.DeviceStatisticsStub
 	fakeReturns := fake.deviceStatisticsReturns
-	fake.recordInvocation("DeviceStatistics", []interface{}{})
+	fake.recordInvocation("DeviceStatistics", []any{})
 	fake.deviceStatisticsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1350,7 +1350,7 @@ func (fake *Model) DismissPendingDevice(arg1 protocol.DeviceID) error {
 	}{arg1})
 	stub := fake.DismissPendingDeviceStub
 	fakeReturns := fake.dismissPendingDeviceReturns
-	fake.recordInvocation("DismissPendingDevice", []interface{}{arg1})
+	fake.recordInvocation("DismissPendingDevice", []any{arg1})
 	fake.dismissPendingDeviceMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1412,7 +1412,7 @@ func (fake *Model) DismissPendingFolder(arg1 protocol.DeviceID, arg2 string) err
 	}{arg1, arg2})
 	stub := fake.DismissPendingFolderStub
 	fakeReturns := fake.dismissPendingFolderReturns
-	fake.recordInvocation("DismissPendingFolder", []interface{}{arg1, arg2})
+	fake.recordInvocation("DismissPendingFolder", []any{arg1, arg2})
 	fake.dismissPendingFolderMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1474,7 +1474,7 @@ func (fake *Model) DownloadProgress(arg1 protocol.Connection, arg2 *protocol.Dow
 	}{arg1, arg2})
 	stub := fake.DownloadProgressStub
 	fakeReturns := fake.downloadProgressReturns
-	fake.recordInvocation("DownloadProgress", []interface{}{arg1, arg2})
+	fake.recordInvocation("DownloadProgress", []any{arg1, arg2})
 	fake.downloadProgressMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1535,7 +1535,7 @@ func (fake *Model) FolderErrors(arg1 string) ([]model.FileError, error) {
 	}{arg1})
 	stub := fake.FolderErrorsStub
 	fakeReturns := fake.folderErrorsReturns
-	fake.recordInvocation("FolderErrors", []interface{}{arg1})
+	fake.recordInvocation("FolderErrors", []any{arg1})
 	fake.folderErrorsMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1599,7 +1599,7 @@ func (fake *Model) FolderProgressBytesCompleted(arg1 string) int64 {
 	}{arg1})
 	stub := fake.FolderProgressBytesCompletedStub
 	fakeReturns := fake.folderProgressBytesCompletedReturns
-	fake.recordInvocation("FolderProgressBytesCompleted", []interface{}{arg1})
+	fake.recordInvocation("FolderProgressBytesCompleted", []any{arg1})
 	fake.folderProgressBytesCompletedMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1659,7 +1659,7 @@ func (fake *Model) FolderStatistics() (map[string]stats.FolderStatistics, error)
 	}{})
 	stub := fake.FolderStatisticsStub
 	fakeReturns := fake.folderStatisticsReturns
-	fake.recordInvocation("FolderStatistics", []interface{}{})
+	fake.recordInvocation("FolderStatistics", []any{})
 	fake.folderStatisticsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1716,7 +1716,7 @@ func (fake *Model) GetFolderVersions(arg1 string) (map[string][]versioner.FileVe
 	}{arg1})
 	stub := fake.GetFolderVersionsStub
 	fakeReturns := fake.getFolderVersionsReturns
-	fake.recordInvocation("GetFolderVersions", []interface{}{arg1})
+	fake.recordInvocation("GetFolderVersions", []any{arg1})
 	fake.getFolderVersionsMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -1781,7 +1781,7 @@ func (fake *Model) GetMtimeMapping(arg1 string, arg2 string) (fs.MtimeMapping, e
 	}{arg1, arg2})
 	stub := fake.GetMtimeMappingStub
 	fakeReturns := fake.getMtimeMappingReturns
-	fake.recordInvocation("GetMtimeMapping", []interface{}{arg1, arg2})
+	fake.recordInvocation("GetMtimeMapping", []any{arg1, arg2})
 	fake.getMtimeMappingMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1848,7 +1848,7 @@ func (fake *Model) GlobalDirectoryTree(arg1 string, arg2 string, arg3 int, arg4 
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.GlobalDirectoryTreeStub
 	fakeReturns := fake.globalDirectoryTreeReturns
-	fake.recordInvocation("GlobalDirectoryTree", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("GlobalDirectoryTree", []any{arg1, arg2, arg3, arg4})
 	fake.globalDirectoryTreeMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4)
@@ -1913,7 +1913,7 @@ func (fake *Model) Index(arg1 protocol.Connection, arg2 *protocol.Index) error {
 	}{arg1, arg2})
 	stub := fake.IndexStub
 	fakeReturns := fake.indexReturns
-	fake.recordInvocation("Index", []interface{}{arg1, arg2})
+	fake.recordInvocation("Index", []any{arg1, arg2})
 	fake.indexMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -1975,7 +1975,7 @@ func (fake *Model) IndexUpdate(arg1 protocol.Connection, arg2 *protocol.IndexUpd
 	}{arg1, arg2})
 	stub := fake.IndexUpdateStub
 	fakeReturns := fake.indexUpdateReturns
-	fake.recordInvocation("IndexUpdate", []interface{}{arg1, arg2})
+	fake.recordInvocation("IndexUpdate", []any{arg1, arg2})
 	fake.indexUpdateMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -2036,7 +2036,7 @@ func (fake *Model) LoadIgnores(arg1 string) ([]string, []string, error) {
 	}{arg1})
 	stub := fake.LoadIgnoresStub
 	fakeReturns := fake.loadIgnoresReturns
-	fake.recordInvocation("LoadIgnores", []interface{}{arg1})
+	fake.recordInvocation("LoadIgnores", []any{arg1})
 	fake.loadIgnoresMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -2105,7 +2105,7 @@ func (fake *Model) LocalChangedFolderFiles(arg1 string, arg2 int, arg3 int) ([]p
 	}{arg1, arg2, arg3})
 	stub := fake.LocalChangedFolderFilesStub
 	fakeReturns := fake.localChangedFolderFilesReturns
-	fake.recordInvocation("LocalChangedFolderFiles", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("LocalChangedFolderFiles", []any{arg1, arg2, arg3})
 	fake.localChangedFolderFilesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -2171,7 +2171,7 @@ func (fake *Model) NeedFolderFiles(arg1 string, arg2 int, arg3 int) ([]protocol.
 	}{arg1, arg2, arg3})
 	stub := fake.NeedFolderFilesStub
 	fakeReturns := fake.needFolderFilesReturns
-	fake.recordInvocation("NeedFolderFiles", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("NeedFolderFiles", []any{arg1, arg2, arg3})
 	fake.needFolderFilesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -2243,7 +2243,7 @@ func (fake *Model) OnHello(arg1 protocol.DeviceID, arg2 net.Addr, arg3 protocol.
 	}{arg1, arg2, arg3})
 	stub := fake.OnHelloStub
 	fakeReturns := fake.onHelloReturns
-	fake.recordInvocation("OnHello", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("OnHello", []any{arg1, arg2, arg3})
 	fake.onHelloMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3)
@@ -2302,7 +2302,7 @@ func (fake *Model) Override(arg1 string) {
 		arg1 string
 	}{arg1})
 	stub := fake.OverrideStub
-	fake.recordInvocation("Override", []interface{}{arg1})
+	fake.recordInvocation("Override", []any{arg1})
 	fake.overrideMutex.Unlock()
 	if stub != nil {
 		fake.OverrideStub(arg1)
@@ -2335,7 +2335,7 @@ func (fake *Model) PendingDevices() (map[protocol.DeviceID]db.ObservedDevice, er
 	}{})
 	stub := fake.PendingDevicesStub
 	fakeReturns := fake.pendingDevicesReturns
-	fake.recordInvocation("PendingDevices", []interface{}{})
+	fake.recordInvocation("PendingDevices", []any{})
 	fake.pendingDevicesMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -2392,7 +2392,7 @@ func (fake *Model) PendingFolders(arg1 protocol.DeviceID) (map[string]db.Pending
 	}{arg1})
 	stub := fake.PendingFoldersStub
 	fakeReturns := fake.pendingFoldersReturns
-	fake.recordInvocation("PendingFolders", []interface{}{arg1})
+	fake.recordInvocation("PendingFolders", []any{arg1})
 	fake.pendingFoldersMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -2459,7 +2459,7 @@ func (fake *Model) RemoteNeedFolderFiles(arg1 string, arg2 protocol.DeviceID, ar
 	}{arg1, arg2, arg3, arg4})
 	stub := fake.RemoteNeedFolderFilesStub
 	fakeReturns := fake.remoteNeedFolderFilesReturns
-	fake.recordInvocation("RemoteNeedFolderFiles", []interface{}{arg1, arg2, arg3, arg4})
+	fake.recordInvocation("RemoteNeedFolderFiles", []any{arg1, arg2, arg3, arg4})
 	fake.remoteNeedFolderFilesMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4)
@@ -2524,7 +2524,7 @@ func (fake *Model) Request(arg1 protocol.Connection, arg2 *protocol.Request) (pr
 	}{arg1, arg2})
 	stub := fake.RequestStub
 	fakeReturns := fake.requestReturns
-	fake.recordInvocation("Request", []interface{}{arg1, arg2})
+	fake.recordInvocation("Request", []any{arg1, arg2})
 	fake.requestMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -2602,7 +2602,7 @@ func (fake *Model) RequestGlobal(arg1 context.Context, arg2 protocol.DeviceID, a
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8Copy, arg9, arg10})
 	stub := fake.RequestGlobalStub
 	fakeReturns := fake.requestGlobalReturns
-	fake.recordInvocation("RequestGlobal", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8Copy, arg9, arg10})
+	fake.recordInvocation("RequestGlobal", []any{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8Copy, arg9, arg10})
 	fake.requestGlobalMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
@@ -2666,7 +2666,7 @@ func (fake *Model) ResetFolder(arg1 string) error {
 	}{arg1})
 	stub := fake.ResetFolderStub
 	fakeReturns := fake.resetFolderReturns
-	fake.recordInvocation("ResetFolder", []interface{}{arg1})
+	fake.recordInvocation("ResetFolder", []any{arg1})
 	fake.resetFolderMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -2728,7 +2728,7 @@ func (fake *Model) RestoreFolderVersions(arg1 string, arg2 map[string]time.Time)
 	}{arg1, arg2})
 	stub := fake.RestoreFolderVersionsStub
 	fakeReturns := fake.restoreFolderVersionsReturns
-	fake.recordInvocation("RestoreFolderVersions", []interface{}{arg1, arg2})
+	fake.recordInvocation("RestoreFolderVersions", []any{arg1, arg2})
 	fake.restoreFolderVersionsMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -2790,7 +2790,7 @@ func (fake *Model) Revert(arg1 string) {
 		arg1 string
 	}{arg1})
 	stub := fake.RevertStub
-	fake.recordInvocation("Revert", []interface{}{arg1})
+	fake.recordInvocation("Revert", []any{arg1})
 	fake.revertMutex.Unlock()
 	if stub != nil {
 		fake.RevertStub(arg1)
@@ -2824,7 +2824,7 @@ func (fake *Model) ScanFolder(arg1 string) error {
 	}{arg1})
 	stub := fake.ScanFolderStub
 	fakeReturns := fake.scanFolderReturns
-	fake.recordInvocation("ScanFolder", []interface{}{arg1})
+	fake.recordInvocation("ScanFolder", []any{arg1})
 	fake.scanFolderMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -2891,7 +2891,7 @@ func (fake *Model) ScanFolderSubdirs(arg1 string, arg2 []string) error {
 	}{arg1, arg2Copy})
 	stub := fake.ScanFolderSubdirsStub
 	fakeReturns := fake.scanFolderSubdirsReturns
-	fake.recordInvocation("ScanFolderSubdirs", []interface{}{arg1, arg2Copy})
+	fake.recordInvocation("ScanFolderSubdirs", []any{arg1, arg2Copy})
 	fake.scanFolderSubdirsMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -2951,7 +2951,7 @@ func (fake *Model) ScanFolders() map[string]error {
 	}{})
 	stub := fake.ScanFoldersStub
 	fakeReturns := fake.scanFoldersReturns
-	fake.recordInvocation("ScanFolders", []interface{}{})
+	fake.recordInvocation("ScanFolders", []any{})
 	fake.scanFoldersMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -3005,7 +3005,7 @@ func (fake *Model) Serve(arg1 context.Context) error {
 	}{arg1})
 	stub := fake.ServeStub
 	fakeReturns := fake.serveReturns
-	fake.recordInvocation("Serve", []interface{}{arg1})
+	fake.recordInvocation("Serve", []any{arg1})
 	fake.serveMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -3072,7 +3072,7 @@ func (fake *Model) SetIgnores(arg1 string, arg2 []string) error {
 	}{arg1, arg2Copy})
 	stub := fake.SetIgnoresStub
 	fakeReturns := fake.setIgnoresReturns
-	fake.recordInvocation("SetIgnores", []interface{}{arg1, arg2Copy})
+	fake.recordInvocation("SetIgnores", []any{arg1, arg2Copy})
 	fake.setIgnoresMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -3133,7 +3133,7 @@ func (fake *Model) State(arg1 string) (string, time.Time, error) {
 	}{arg1})
 	stub := fake.StateStub
 	fakeReturns := fake.stateReturns
-	fake.recordInvocation("State", []interface{}{arg1})
+	fake.recordInvocation("State", []any{arg1})
 	fake.stateMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -3200,7 +3200,7 @@ func (fake *Model) UsageReportingStats(arg1 *contract.Report, arg2 int, arg3 boo
 		arg3 bool
 	}{arg1, arg2, arg3})
 	stub := fake.UsageReportingStatsStub
-	fake.recordInvocation("UsageReportingStats", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("UsageReportingStats", []any{arg1, arg2, arg3})
 	fake.usageReportingStatsMutex.Unlock()
 	if stub != nil {
 		fake.UsageReportingStatsStub(arg1, arg2, arg3)
@@ -3234,7 +3234,7 @@ func (fake *Model) WatchError(arg1 string) error {
 	}{arg1})
 	stub := fake.WatchErrorStub
 	fakeReturns := fake.watchErrorReturns
-	fake.recordInvocation("WatchError", []interface{}{arg1})
+	fake.recordInvocation("WatchError", []any{arg1})
 	fake.watchErrorMutex.Unlock()
 	if stub != nil {
 		return stub(arg1)
@@ -3287,7 +3287,7 @@ func (fake *Model) WatchErrorReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *Model) Invocations() map[string][][]interface{} {
+func (fake *Model) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.addConnectionMutex.RLock()
@@ -3382,21 +3382,21 @@ func (fake *Model) Invocations() map[string][][]interface{} {
 	defer fake.usageReportingStatsMutex.RUnlock()
 	fake.watchErrorMutex.RLock()
 	defer fake.watchErrorMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *Model) recordInvocation(key string, args []interface{}) {
+func (fake *Model) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -106,7 +106,7 @@ type Model interface {
 	Availability(folder string, file protocol.FileInfo, block protocol.BlockInfo) ([]Availability, error)
 
 	Completion(device protocol.DeviceID, folder string) (FolderCompletion, error)
-	ConnectionStats() map[string]interface{}
+	ConnectionStats() map[string]any
 	DeviceStatistics() (map[protocol.DeviceID]stats.DeviceStatistics, error)
 	FolderStatistics() (map[string]stats.FolderStatistics, error)
 	UsageReportingStats(report *contract.Report, version int, preview bool)
@@ -710,11 +710,11 @@ type ConnectionInfo struct {
 }
 
 // ConnectionStats returns a map with connection statistics for each device.
-func (m *model) ConnectionStats() map[string]interface{} {
+func (m *model) ConnectionStats() map[string]any {
 	m.mut.RLock()
 	defer m.mut.RUnlock()
 
-	res := make(map[string]interface{})
+	res := make(map[string]any)
 	devs := m.cfg.Devices()
 	conns := make(map[string]ConnectionStats, len(devs))
 	for device, deviceCfg := range devs {
@@ -774,7 +774,7 @@ func (m *model) ConnectionStats() map[string]interface{} {
 	res["connections"] = conns
 
 	in, out := protocol.TotalInOut()
-	res["total"] = map[string]interface{}{
+	res["total"] = map[string]any{
 		"at":            time.Now().Truncate(time.Second),
 		"inBytesTotal":  in,
 		"outBytesTotal": out,
@@ -874,8 +874,8 @@ func (comp *FolderCompletion) setCompletionPct() {
 }
 
 // Map returns the members as a map, e.g. used in api to serialize as JSON.
-func (comp *FolderCompletion) Map() map[string]interface{} {
-	return map[string]interface{}{
+func (comp *FolderCompletion) Map() map[string]any {
+	return map[string]any{
 		"completion":  comp.CompletionPct,
 		"globalBytes": comp.GlobalBytes,
 		"needBytes":   comp.NeedBytes,
@@ -1500,7 +1500,7 @@ func (m *model) ccHandleFolders(folders []protocol.Folder, deviceCfg config.Devi
 		})
 	}
 	if len(updatedPending) > 0 || len(expiredPendingList) > 0 {
-		m.evLogger.Log(events.PendingFoldersChanged, map[string]interface{}{
+		m.evLogger.Log(events.PendingFoldersChanged, map[string]any{
 			"added":   updatedPending,
 			"removed": expiredPendingList,
 		})
@@ -2290,7 +2290,7 @@ func (m *model) OnHello(remoteID protocol.DeviceID, addr net.Addr, hello protoco
 		if err := m.db.AddOrUpdatePendingDevice(remoteID, hello.DeviceName, addr.String()); err != nil {
 			l.Warnf("Failed to persist pending device entry to database: %v", err)
 		}
-		m.evLogger.Log(events.PendingDevicesChanged, map[string][]interface{}{
+		m.evLogger.Log(events.PendingDevicesChanged, map[string][]any{
 			"added": {map[string]string{
 				"deviceID": remoteID.String(),
 				"name":     hello.DeviceName,
@@ -2436,7 +2436,7 @@ func (m *model) DownloadProgress(conn protocol.Connection, p *protocol.DownloadP
 	downloads.Update(p.Folder, p.Updates)
 	state := downloads.GetBlockCounts(p.Folder)
 
-	m.evLogger.Log(events.RemoteDownloadProgress, map[string]interface{}{
+	m.evLogger.Log(events.RemoteDownloadProgress, map[string]any{
 		"device": deviceID.String(),
 		"folder": p.Folder,
 		"state":  state,
@@ -3209,7 +3209,7 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 		}
 	}
 	if len(removedPendingFolders) > 0 {
-		m.evLogger.Log(events.PendingFoldersChanged, map[string]interface{}{
+		m.evLogger.Log(events.PendingFoldersChanged, map[string]any{
 			"removed": removedPendingFolders,
 		})
 	}
@@ -3244,7 +3244,7 @@ func (m *model) cleanPending(existingDevices map[protocol.DeviceID]config.Device
 		})
 	}
 	if len(removedPendingDevices) > 0 {
-		m.evLogger.Log(events.PendingDevicesChanged, map[string]interface{}{
+		m.evLogger.Log(events.PendingDevicesChanged, map[string]any{
 			"removed": removedPendingDevices,
 		})
 	}
@@ -3290,7 +3290,7 @@ func (m *model) DismissPendingDevice(device protocol.DeviceID) error {
 	removedPendingDevices := []map[string]string{
 		{"deviceID": device.String()},
 	}
-	m.evLogger.Log(events.PendingDevicesChanged, map[string]interface{}{
+	m.evLogger.Log(events.PendingDevicesChanged, map[string]any{
 		"removed": removedPendingDevices,
 	})
 	return nil
@@ -3324,7 +3324,7 @@ func (m *model) DismissPendingFolder(device protocol.DeviceID, folder string) er
 		}
 	}
 	if len(removedPendingFolders) > 0 {
-		m.evLogger.Log(events.PendingFoldersChanged, map[string]interface{}{
+		m.evLogger.Log(events.PendingFoldersChanged, map[string]any{
 			"removed": removedPendingFolders,
 		})
 	}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1584,7 +1584,7 @@ func waitForState(t *testing.T, sub events.Subscription, folder, expected string
 	for {
 		select {
 		case ev := <-sub.C():
-			data := ev.Data.(map[string]interface{})
+			data := ev.Data.(map[string]any)
 			if data["folder"].(string) == folder {
 				if data["error"] == nil {
 					err = ""
@@ -1796,7 +1796,7 @@ func TestGlobalDirectoryTree(t *testing.T) {
 		f("zzrootfile"),
 	}
 
-	mm := func(data interface{}) string {
+	mm := func(data any) string {
 		bytes, err := json.MarshalIndent(data, "", "  ")
 		if err != nil {
 			panic(err)

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -594,7 +594,7 @@ func TestRequestSymlinkWindows(t *testing.T) {
 	for {
 		select {
 		case ev := <-sub.C():
-			switch data := ev.Data.(map[string]interface{}); {
+			switch data := ev.Data.(map[string]any); {
 			case ev.Type == events.LocalIndexUpdated:
 				t.Fatalf("Local index was updated unexpectedly: %v", data)
 			case ev.Type == events.StateChanged:

--- a/lib/model/testos_test.go
+++ b/lib/model/testos_test.go
@@ -12,7 +12,7 @@ import (
 
 // fatal is the required common interface between *testing.B and *testing.T
 type fatal interface {
-	Fatal(...interface{})
+	Fatal(...any)
 	Helper()
 }
 

--- a/lib/model/testutils_test.go
+++ b/lib/model/testutils_test.go
@@ -329,7 +329,7 @@ func localIndexUpdate(m *testModel, folder string, fs []protocol.FileInfo) {
 	for i, file := range fs {
 		filenames[i] = file.Name
 	}
-	m.evLogger.Log(events.LocalIndexUpdated, map[string]interface{}{
+	m.evLogger.Log(events.LocalIndexUpdated, map[string]any{
 		"folder":    folder,
 		"items":     len(fs),
 		"filenames": filenames,

--- a/lib/protocol/mocked_connection_info_test.go
+++ b/lib/protocol/mocked_connection_info_test.go
@@ -98,7 +98,7 @@ type mockedConnectionInfo struct {
 	typeReturnsOnCall map[int]struct {
 		result1 string
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -109,7 +109,7 @@ func (fake *mockedConnectionInfo) ConnectionID() string {
 	}{})
 	stub := fake.ConnectionIDStub
 	fakeReturns := fake.connectionIDReturns
-	fake.recordInvocation("ConnectionID", []interface{}{})
+	fake.recordInvocation("ConnectionID", []any{})
 	fake.connectionIDMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -162,7 +162,7 @@ func (fake *mockedConnectionInfo) Crypto() string {
 	}{})
 	stub := fake.CryptoStub
 	fakeReturns := fake.cryptoReturns
-	fake.recordInvocation("Crypto", []interface{}{})
+	fake.recordInvocation("Crypto", []any{})
 	fake.cryptoMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -215,7 +215,7 @@ func (fake *mockedConnectionInfo) EstablishedAt() time.Time {
 	}{})
 	stub := fake.EstablishedAtStub
 	fakeReturns := fake.establishedAtReturns
-	fake.recordInvocation("EstablishedAt", []interface{}{})
+	fake.recordInvocation("EstablishedAt", []any{})
 	fake.establishedAtMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -268,7 +268,7 @@ func (fake *mockedConnectionInfo) IsLocal() bool {
 	}{})
 	stub := fake.IsLocalStub
 	fakeReturns := fake.isLocalReturns
-	fake.recordInvocation("IsLocal", []interface{}{})
+	fake.recordInvocation("IsLocal", []any{})
 	fake.isLocalMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -321,7 +321,7 @@ func (fake *mockedConnectionInfo) Priority() int {
 	}{})
 	stub := fake.PriorityStub
 	fakeReturns := fake.priorityReturns
-	fake.recordInvocation("Priority", []interface{}{})
+	fake.recordInvocation("Priority", []any{})
 	fake.priorityMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -374,7 +374,7 @@ func (fake *mockedConnectionInfo) RemoteAddr() net.Addr {
 	}{})
 	stub := fake.RemoteAddrStub
 	fakeReturns := fake.remoteAddrReturns
-	fake.recordInvocation("RemoteAddr", []interface{}{})
+	fake.recordInvocation("RemoteAddr", []any{})
 	fake.remoteAddrMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -427,7 +427,7 @@ func (fake *mockedConnectionInfo) String() string {
 	}{})
 	stub := fake.StringStub
 	fakeReturns := fake.stringReturns
-	fake.recordInvocation("String", []interface{}{})
+	fake.recordInvocation("String", []any{})
 	fake.stringMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -480,7 +480,7 @@ func (fake *mockedConnectionInfo) Transport() string {
 	}{})
 	stub := fake.TransportStub
 	fakeReturns := fake.transportReturns
-	fake.recordInvocation("Transport", []interface{}{})
+	fake.recordInvocation("Transport", []any{})
 	fake.transportMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -533,7 +533,7 @@ func (fake *mockedConnectionInfo) Type() string {
 	}{})
 	stub := fake.TypeStub
 	fakeReturns := fake.typeReturns
-	fake.recordInvocation("Type", []interface{}{})
+	fake.recordInvocation("Type", []any{})
 	fake.typeMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -579,7 +579,7 @@ func (fake *mockedConnectionInfo) TypeReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *mockedConnectionInfo) Invocations() map[string][][]interface{} {
+func (fake *mockedConnectionInfo) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.connectionIDMutex.RLock()
@@ -600,21 +600,21 @@ func (fake *mockedConnectionInfo) Invocations() map[string][][]interface{} {
 	defer fake.transportMutex.RUnlock()
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *mockedConnectionInfo) recordInvocation(key string, args []interface{}) {
+func (fake *mockedConnectionInfo) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/protocol/mocks/connection.go
+++ b/lib/protocol/mocks/connection.go
@@ -194,7 +194,7 @@ type Connection struct {
 	typeReturnsOnCall map[int]struct {
 		result1 string
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -204,7 +204,7 @@ func (fake *Connection) Close(arg1 error) {
 		arg1 error
 	}{arg1})
 	stub := fake.CloseStub
-	fake.recordInvocation("Close", []interface{}{arg1})
+	fake.recordInvocation("Close", []any{arg1})
 	fake.closeMutex.Unlock()
 	if stub != nil {
 		fake.CloseStub(arg1)
@@ -237,7 +237,7 @@ func (fake *Connection) Closed() <-chan struct{} {
 	}{})
 	stub := fake.ClosedStub
 	fakeReturns := fake.closedReturns
-	fake.recordInvocation("Closed", []interface{}{})
+	fake.recordInvocation("Closed", []any{})
 	fake.closedMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -289,7 +289,7 @@ func (fake *Connection) ClusterConfig(arg1 *protocol.ClusterConfig) {
 		arg1 *protocol.ClusterConfig
 	}{arg1})
 	stub := fake.ClusterConfigStub
-	fake.recordInvocation("ClusterConfig", []interface{}{arg1})
+	fake.recordInvocation("ClusterConfig", []any{arg1})
 	fake.clusterConfigMutex.Unlock()
 	if stub != nil {
 		fake.ClusterConfigStub(arg1)
@@ -322,7 +322,7 @@ func (fake *Connection) ConnectionID() string {
 	}{})
 	stub := fake.ConnectionIDStub
 	fakeReturns := fake.connectionIDReturns
-	fake.recordInvocation("ConnectionID", []interface{}{})
+	fake.recordInvocation("ConnectionID", []any{})
 	fake.connectionIDMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -375,7 +375,7 @@ func (fake *Connection) Crypto() string {
 	}{})
 	stub := fake.CryptoStub
 	fakeReturns := fake.cryptoReturns
-	fake.recordInvocation("Crypto", []interface{}{})
+	fake.recordInvocation("Crypto", []any{})
 	fake.cryptoMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -428,7 +428,7 @@ func (fake *Connection) DeviceID() protocol.DeviceID {
 	}{})
 	stub := fake.DeviceIDStub
 	fakeReturns := fake.deviceIDReturns
-	fake.recordInvocation("DeviceID", []interface{}{})
+	fake.recordInvocation("DeviceID", []any{})
 	fake.deviceIDMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -481,7 +481,7 @@ func (fake *Connection) DownloadProgress(arg1 context.Context, arg2 *protocol.Do
 		arg2 *protocol.DownloadProgress
 	}{arg1, arg2})
 	stub := fake.DownloadProgressStub
-	fake.recordInvocation("DownloadProgress", []interface{}{arg1, arg2})
+	fake.recordInvocation("DownloadProgress", []any{arg1, arg2})
 	fake.downloadProgressMutex.Unlock()
 	if stub != nil {
 		fake.DownloadProgressStub(arg1, arg2)
@@ -514,7 +514,7 @@ func (fake *Connection) EstablishedAt() time.Time {
 	}{})
 	stub := fake.EstablishedAtStub
 	fakeReturns := fake.establishedAtReturns
-	fake.recordInvocation("EstablishedAt", []interface{}{})
+	fake.recordInvocation("EstablishedAt", []any{})
 	fake.establishedAtMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -569,7 +569,7 @@ func (fake *Connection) Index(arg1 context.Context, arg2 *protocol.Index) error 
 	}{arg1, arg2})
 	stub := fake.IndexStub
 	fakeReturns := fake.indexReturns
-	fake.recordInvocation("Index", []interface{}{arg1, arg2})
+	fake.recordInvocation("Index", []any{arg1, arg2})
 	fake.indexMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -631,7 +631,7 @@ func (fake *Connection) IndexUpdate(arg1 context.Context, arg2 *protocol.IndexUp
 	}{arg1, arg2})
 	stub := fake.IndexUpdateStub
 	fakeReturns := fake.indexUpdateReturns
-	fake.recordInvocation("IndexUpdate", []interface{}{arg1, arg2})
+	fake.recordInvocation("IndexUpdate", []any{arg1, arg2})
 	fake.indexUpdateMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -691,7 +691,7 @@ func (fake *Connection) IsLocal() bool {
 	}{})
 	stub := fake.IsLocalStub
 	fakeReturns := fake.isLocalReturns
-	fake.recordInvocation("IsLocal", []interface{}{})
+	fake.recordInvocation("IsLocal", []any{})
 	fake.isLocalMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -744,7 +744,7 @@ func (fake *Connection) Priority() int {
 	}{})
 	stub := fake.PriorityStub
 	fakeReturns := fake.priorityReturns
-	fake.recordInvocation("Priority", []interface{}{})
+	fake.recordInvocation("Priority", []any{})
 	fake.priorityMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -797,7 +797,7 @@ func (fake *Connection) RemoteAddr() net.Addr {
 	}{})
 	stub := fake.RemoteAddrStub
 	fakeReturns := fake.remoteAddrReturns
-	fake.recordInvocation("RemoteAddr", []interface{}{})
+	fake.recordInvocation("RemoteAddr", []any{})
 	fake.remoteAddrMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -852,7 +852,7 @@ func (fake *Connection) Request(arg1 context.Context, arg2 *protocol.Request) ([
 	}{arg1, arg2})
 	stub := fake.RequestStub
 	fakeReturns := fake.requestReturns
-	fake.recordInvocation("Request", []interface{}{arg1, arg2})
+	fake.recordInvocation("Request", []any{arg1, arg2})
 	fake.requestMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
@@ -914,7 +914,7 @@ func (fake *Connection) SetFolderPasswords(arg1 map[string]string) {
 		arg1 map[string]string
 	}{arg1})
 	stub := fake.SetFolderPasswordsStub
-	fake.recordInvocation("SetFolderPasswords", []interface{}{arg1})
+	fake.recordInvocation("SetFolderPasswords", []any{arg1})
 	fake.setFolderPasswordsMutex.Unlock()
 	if stub != nil {
 		fake.SetFolderPasswordsStub(arg1)
@@ -945,7 +945,7 @@ func (fake *Connection) Start() {
 	fake.startArgsForCall = append(fake.startArgsForCall, struct {
 	}{})
 	stub := fake.StartStub
-	fake.recordInvocation("Start", []interface{}{})
+	fake.recordInvocation("Start", []any{})
 	fake.startMutex.Unlock()
 	if stub != nil {
 		fake.StartStub()
@@ -971,7 +971,7 @@ func (fake *Connection) Statistics() protocol.Statistics {
 	}{})
 	stub := fake.StatisticsStub
 	fakeReturns := fake.statisticsReturns
-	fake.recordInvocation("Statistics", []interface{}{})
+	fake.recordInvocation("Statistics", []any{})
 	fake.statisticsMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1024,7 +1024,7 @@ func (fake *Connection) String() string {
 	}{})
 	stub := fake.StringStub
 	fakeReturns := fake.stringReturns
-	fake.recordInvocation("String", []interface{}{})
+	fake.recordInvocation("String", []any{})
 	fake.stringMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1077,7 +1077,7 @@ func (fake *Connection) Transport() string {
 	}{})
 	stub := fake.TransportStub
 	fakeReturns := fake.transportReturns
-	fake.recordInvocation("Transport", []interface{}{})
+	fake.recordInvocation("Transport", []any{})
 	fake.transportMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1130,7 +1130,7 @@ func (fake *Connection) Type() string {
 	}{})
 	stub := fake.TypeStub
 	fakeReturns := fake.typeReturns
-	fake.recordInvocation("Type", []interface{}{})
+	fake.recordInvocation("Type", []any{})
 	fake.typeMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -1176,7 +1176,7 @@ func (fake *Connection) TypeReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *Connection) Invocations() map[string][][]interface{} {
+func (fake *Connection) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.closeMutex.RLock()
@@ -1219,21 +1219,21 @@ func (fake *Connection) Invocations() map[string][][]interface{} {
 	defer fake.transportMutex.RUnlock()
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *Connection) recordInvocation(key string, args []interface{}) {
+func (fake *Connection) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/protocol/mocks/connection_info.go
+++ b/lib/protocol/mocks/connection_info.go
@@ -100,7 +100,7 @@ type ConnectionInfo struct {
 	typeReturnsOnCall map[int]struct {
 		result1 string
 	}
-	invocations      map[string][][]interface{}
+	invocations      map[string][][]any
 	invocationsMutex sync.RWMutex
 }
 
@@ -111,7 +111,7 @@ func (fake *ConnectionInfo) ConnectionID() string {
 	}{})
 	stub := fake.ConnectionIDStub
 	fakeReturns := fake.connectionIDReturns
-	fake.recordInvocation("ConnectionID", []interface{}{})
+	fake.recordInvocation("ConnectionID", []any{})
 	fake.connectionIDMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -164,7 +164,7 @@ func (fake *ConnectionInfo) Crypto() string {
 	}{})
 	stub := fake.CryptoStub
 	fakeReturns := fake.cryptoReturns
-	fake.recordInvocation("Crypto", []interface{}{})
+	fake.recordInvocation("Crypto", []any{})
 	fake.cryptoMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -217,7 +217,7 @@ func (fake *ConnectionInfo) EstablishedAt() time.Time {
 	}{})
 	stub := fake.EstablishedAtStub
 	fakeReturns := fake.establishedAtReturns
-	fake.recordInvocation("EstablishedAt", []interface{}{})
+	fake.recordInvocation("EstablishedAt", []any{})
 	fake.establishedAtMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -270,7 +270,7 @@ func (fake *ConnectionInfo) IsLocal() bool {
 	}{})
 	stub := fake.IsLocalStub
 	fakeReturns := fake.isLocalReturns
-	fake.recordInvocation("IsLocal", []interface{}{})
+	fake.recordInvocation("IsLocal", []any{})
 	fake.isLocalMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -323,7 +323,7 @@ func (fake *ConnectionInfo) Priority() int {
 	}{})
 	stub := fake.PriorityStub
 	fakeReturns := fake.priorityReturns
-	fake.recordInvocation("Priority", []interface{}{})
+	fake.recordInvocation("Priority", []any{})
 	fake.priorityMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -376,7 +376,7 @@ func (fake *ConnectionInfo) RemoteAddr() net.Addr {
 	}{})
 	stub := fake.RemoteAddrStub
 	fakeReturns := fake.remoteAddrReturns
-	fake.recordInvocation("RemoteAddr", []interface{}{})
+	fake.recordInvocation("RemoteAddr", []any{})
 	fake.remoteAddrMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -429,7 +429,7 @@ func (fake *ConnectionInfo) String() string {
 	}{})
 	stub := fake.StringStub
 	fakeReturns := fake.stringReturns
-	fake.recordInvocation("String", []interface{}{})
+	fake.recordInvocation("String", []any{})
 	fake.stringMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -482,7 +482,7 @@ func (fake *ConnectionInfo) Transport() string {
 	}{})
 	stub := fake.TransportStub
 	fakeReturns := fake.transportReturns
-	fake.recordInvocation("Transport", []interface{}{})
+	fake.recordInvocation("Transport", []any{})
 	fake.transportMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -535,7 +535,7 @@ func (fake *ConnectionInfo) Type() string {
 	}{})
 	stub := fake.TypeStub
 	fakeReturns := fake.typeReturns
-	fake.recordInvocation("Type", []interface{}{})
+	fake.recordInvocation("Type", []any{})
 	fake.typeMutex.Unlock()
 	if stub != nil {
 		return stub()
@@ -581,7 +581,7 @@ func (fake *ConnectionInfo) TypeReturnsOnCall(i int, result1 string) {
 	}{result1}
 }
 
-func (fake *ConnectionInfo) Invocations() map[string][][]interface{} {
+func (fake *ConnectionInfo) Invocations() map[string][][]any {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.connectionIDMutex.RLock()
@@ -602,21 +602,21 @@ func (fake *ConnectionInfo) Invocations() map[string][][]interface{} {
 	defer fake.transportMutex.RUnlock()
 	fake.typeMutex.RLock()
 	defer fake.typeMutex.RUnlock()
-	copiedInvocations := map[string][][]interface{}{}
+	copiedInvocations := map[string][][]any{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value
 	}
 	return copiedInvocations
 }
 
-func (fake *ConnectionInfo) recordInvocation(key string, args []interface{}) {
+func (fake *ConnectionInfo) recordInvocation(key string, args []any) {
 	fake.invocationsMutex.Lock()
 	defer fake.invocationsMutex.Unlock()
 	if fake.invocations == nil {
-		fake.invocations = map[string][][]interface{}{}
+		fake.invocations = map[string][][]any{}
 	}
 	if fake.invocations[key] == nil {
-		fake.invocations[key] = [][]interface{}{}
+		fake.invocations[key] = [][]any{}
 	}
 	fake.invocations[key] = append(fake.invocations[key], args)
 }

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -579,7 +579,7 @@ func TestIndexIDString(t *testing.T) {
 	}
 }
 
-func closeAndWait(c interface{}, closers ...io.Closer) {
+func closeAndWait(c any, closers ...io.Closer) {
 	for _, closer := range closers {
 		closer.Close()
 	}

--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -64,7 +64,7 @@ func Intn(n int) int {
 }
 
 // Shuffle the order of elements in slice.
-func Shuffle(slice interface{}) {
+func Shuffle(slice any) {
 	rv := reflect.ValueOf(slice)
 	swap := reflect.Swapper(slice)
 	length := rv.Len()

--- a/lib/rc/rc.go
+++ b/lib/rc/rc.go
@@ -218,7 +218,7 @@ type Event struct {
 	ID   int
 	Time time.Time
 	Type string
-	Data interface{}
+	Data any
 }
 
 func (p *Process) Events(since int) ([]Event, error) {
@@ -490,7 +490,7 @@ func (p *Process) eventLoop() {
 				// The Starting event tells us where the configuration is. Load
 				// it and populate our list of folders.
 
-				data := ev.Data.(map[string]interface{})
+				data := ev.Data.(map[string]any)
 				id, err := protocol.DeviceIDFromString(data["myID"].(string))
 				if err != nil {
 					log.Println("eventLoop: DeviceIdFromString:", err)
@@ -525,7 +525,7 @@ func (p *Process) eventLoop() {
 				select {
 				case <-p.startComplete:
 				default:
-					data := ev.Data.(map[string]interface{})
+					data := ev.Data.(map[string]any)
 					to := data["to"].(string)
 					if to == "idle" {
 						folder := data["folder"].(string)
@@ -537,7 +537,7 @@ func (p *Process) eventLoop() {
 				}
 
 			case "LocalIndexUpdated":
-				data := ev.Data.(map[string]interface{})
+				data := ev.Data.(map[string]any)
 				folder := data["folder"].(string)
 				p.eventMut.Lock()
 				m := p.updateSequenceLocked(folder, p.id.String(), data["sequence"])
@@ -546,7 +546,7 @@ func (p *Process) eventLoop() {
 				p.eventMut.Unlock()
 
 			case "RemoteIndexUpdated":
-				data := ev.Data.(map[string]interface{})
+				data := ev.Data.(map[string]any)
 				device := data["device"].(string)
 				folder := data["folder"].(string)
 				p.eventMut.Lock()
@@ -556,9 +556,9 @@ func (p *Process) eventLoop() {
 				p.eventMut.Unlock()
 
 			case "FolderSummary":
-				data := ev.Data.(map[string]interface{})
+				data := ev.Data.(map[string]any)
 				folder := data["folder"].(string)
-				summary := data["summary"].(map[string]interface{})
+				summary := data["summary"].(map[string]any)
 				need, _ := summary["needTotalItems"].(json.Number).Int64()
 				done := need == 0
 				p.eventMut.Lock()
@@ -568,7 +568,7 @@ func (p *Process) eventLoop() {
 				p.eventMut.Unlock()
 
 			case "FolderCompletion":
-				data := ev.Data.(map[string]interface{})
+				data := ev.Data.(map[string]any)
 				device := data["device"].(string)
 				folder := data["folder"].(string)
 				p.eventMut.Lock()
@@ -580,7 +580,7 @@ func (p *Process) eventLoop() {
 	}
 }
 
-func (p *Process) updateSequenceLocked(folder, device string, sequenceIntf interface{}) map[string]int64 {
+func (p *Process) updateSequenceLocked(folder, device string, sequenceIntf any) map[string]int64 {
 	sequence, _ := sequenceIntf.(json.Number).Int64()
 	m := p.sequence[folder]
 	if m == nil {

--- a/lib/relay/client/static.go
+++ b/lib/relay/client/static.go
@@ -67,7 +67,7 @@ func (c *staticClient) serve(ctx context.Context) error {
 
 	l.Infof("Joined relay %s://%s", c.uri.Scheme, c.uri.Host)
 
-	messages := make(chan interface{})
+	messages := make(chan any)
 	errorsc := make(chan error, 1)
 
 	go messageReader(ctx, c.conn, messages, errorsc)
@@ -233,7 +233,7 @@ func performHandshakeAndValidation(conn *tls.Conn, uri *url.URL) error {
 	return nil
 }
 
-func messageReader(ctx context.Context, conn net.Conn, messages chan<- interface{}, errors chan<- error) {
+func messageReader(ctx context.Context, conn net.Conn, messages chan<- any, errors chan<- error) {
 	for {
 		msg, err := protocol.ReadMessage(conn)
 		if err != nil {

--- a/lib/relay/protocol/protocol.go
+++ b/lib/relay/protocol/protocol.go
@@ -21,7 +21,7 @@ var (
 	ResponseUnexpectedMessage = Response{100, "unexpected message"}
 )
 
-func WriteMessage(w io.Writer, message interface{}) error {
+func WriteMessage(w io.Writer, message any) error {
 	header := header{
 		magic: magic,
 	}
@@ -73,7 +73,7 @@ func WriteMessage(w io.Writer, message interface{}) error {
 	return err
 }
 
-func ReadMessage(r io.Reader) (interface{}, error) {
+func ReadMessage(r io.Reader) (any, error) {
 	var header header
 
 	buf := make([]byte, header.XDRSize())

--- a/lib/scanner/virtualfs_test.go
+++ b/lib/scanner/virtualfs_test.go
@@ -125,7 +125,7 @@ func (f fakeInfo) IsRegular() bool          { return !f.IsDir() }
 func (fakeInfo) IsSymlink() bool            { return false }
 func (fakeInfo) Owner() int                 { return 0 }
 func (fakeInfo) Group() int                 { return 0 }
-func (fakeInfo) Sys() interface{}           { return nil }
+func (fakeInfo) Sys() any                   { return nil }
 func (fakeInfo) InodeChangeTime() time.Time { return time.Time{} }
 
 type fakeFile struct {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -179,7 +179,7 @@ func (w *walker) walk(ctx context.Context) chan ScanResult {
 				current := progress.Total()
 				rate := progress.Rate()
 				l.Debugf("%v: Walk %s %s current progress %d/%d at %.01f MiB/s (%d%%)", w, w.Folder, w.Subs, current, total, rate/1024/1024, current*100/total)
-				w.EventLogger.Log(events.FolderScanProgress, map[string]interface{}{
+				w.EventLogger.Log(events.FolderScanProgress, map[string]any{
 					"folder":  w.Folder,
 					"current": current,
 					"total":   total,

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -450,7 +450,7 @@ func printServiceTree(w io.Writer, sup supervisor, level int) {
 	}
 }
 
-func printService(w io.Writer, svc interface{}, level int) {
+func printService(w io.Writer, svc any, level int) {
 	type errorer interface{ Error() error }
 
 	t := "-"

--- a/lib/syncthing/verboseservice.go
+++ b/lib/syncthing/verboseservice.go
@@ -63,7 +63,7 @@ func (*verboseService) formatEvent(ev events.Event) string {
 		return "Startup complete"
 
 	case events.DeviceDiscovered:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		return fmt.Sprintf("Discovered device %v at %v", data["device"], data["addrs"])
 
 	case events.DeviceConnected:
@@ -75,7 +75,7 @@ func (*verboseService) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Disconnected from device %v", data["id"])
 
 	case events.StateChanged:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		return fmt.Sprintf("Folder %q is now %v", data["folder"], data["to"])
 
 	case events.LocalChangeDetected:
@@ -87,11 +87,11 @@ func (*verboseService) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Remote change detected in folder %q: %s %s %s", data["folder"], data["action"], data["type"], data["path"])
 
 	case events.LocalIndexUpdated:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		return fmt.Sprintf("Local index update for %q with %d items (seq: %d)", data["folder"], data["items"], data["sequence"])
 
 	case events.RemoteIndexUpdated:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		return fmt.Sprintf("Device %v sent an index update for %q with %d items (seq: %d)", data["device"], data["folder"], data["items"], data["sequence"])
 
 	case events.DeviceRejected:
@@ -107,9 +107,9 @@ func (*verboseService) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Started syncing %q / %q (%v %v)", data["folder"], data["item"], data["action"], data["type"])
 
 	case events.ItemFinished:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		if err, ok := data["error"].(*string); ok && err != nil {
-			// If the err interface{} is not nil, it is a string pointer.
+			// If the err any is not nil, it is a string pointer.
 			// Dereference it to get the actual error or Sprintf will print
 			// the pointer value....
 			return fmt.Sprintf("Finished syncing %q / %q (%v %v): %v", data["folder"], data["item"], data["action"], data["type"], *err)
@@ -120,7 +120,7 @@ func (*verboseService) formatEvent(ev events.Event) string {
 		return "Configuration was saved"
 
 	case events.FolderCompletion:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		return fmt.Sprintf("Completion for folder %q on device %v is %v%% (state: %s, seq: %d)", data["folder"], data["device"], data["completion"], data["remoteState"], data["sequence"])
 
 	case events.FolderSummary:
@@ -128,7 +128,7 @@ func (*verboseService) formatEvent(ev events.Event) string {
 		return folderSummaryRemoveDeprecatedRe.ReplaceAllString(fmt.Sprintf("Summary for folder %q is %+v", data.Folder, data.Summary), "")
 
 	case events.FolderScanProgress:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		folder := data["folder"].(string)
 		current := data["current"].(int64)
 		total := data["total"].(int64)
@@ -166,14 +166,14 @@ func (*verboseService) formatEvent(ev events.Event) string {
 		return fmt.Sprintf("Folder %v (%v) was resumed", id, label)
 
 	case events.ListenAddressesChanged:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		address := data["address"]
 		lan := data["lan"]
 		wan := data["wan"]
 		return fmt.Sprintf("Listen address %s resolution has changed: lan addresses: %s wan addresses: %s", address, lan, wan)
 
 	case events.LoginAttempt:
-		data := ev.Data.(map[string]interface{})
+		data := ev.Data.(map[string]any)
 		username := data["username"].(string)
 		var success string
 		if data["success"].(bool) {

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -236,7 +236,7 @@ func (c *UnionedConnection) Read(b []byte) (n int, err error) {
 	return c.Conn.Read(b)
 }
 
-func pemBlockForKey(priv interface{}) (*pem.Block, error) {
+func pemBlockForKey(priv any) (*pem.Block, error) {
 	switch k := priv.(type) {
 	case *rsa.PrivateKey:
 		return &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}, nil

--- a/lib/upgrade/upgrade_common.go
+++ b/lib/upgrade/upgrade_common.go
@@ -210,8 +210,8 @@ func CompareVersions(a, b string) Relation {
 }
 
 // Split a version into parts.
-// "1.2.3-beta.2" -> []int{1, 2, 3}, []interface{}{"beta", 2}
-func versionParts(v string) ([]int, []interface{}) {
+// "1.2.3-beta.2" -> []int{1, 2, 3}, []any{"beta", 2}
+func versionParts(v string) ([]int, []any) {
 	if strings.HasPrefix(v, "v") || strings.HasPrefix(v, "V") {
 		// Strip initial 'v' or 'V' prefix if present.
 		v = v[1:]
@@ -226,10 +226,10 @@ func versionParts(v string) ([]int, []interface{}) {
 		release[i] = v
 	}
 
-	var prerelease []interface{}
+	var prerelease []any
 	if len(parts) > 1 {
 		fields = strings.Split(parts[1], ".")
-		prerelease = make([]interface{}, len(fields))
+		prerelease = make([]any, len(fields))
 		for i, s := range fields {
 			v, err := strconv.Atoi(s)
 			if err == nil {

--- a/lib/ur/contract/contract.go
+++ b/lib/ur/contract/contract.go
@@ -232,7 +232,7 @@ func (r Report) Value() (driver.Value, error) {
 	return string(bs), err
 }
 
-func (r *Report) Scan(value interface{}) error {
+func (r *Report) Scan(value any) error {
 	// Zero out the previous value
 	// JSON un-marshaller does not touch fields that are not in the payload, so we carry over values from a previous
 	// scan.
@@ -245,7 +245,7 @@ func (r *Report) Scan(value interface{}) error {
 	return json.Unmarshal(b, &r)
 }
 
-func clear(v interface{}, since int) error {
+func clear(v any, since int) error {
 	s := reflect.ValueOf(v).Elem()
 	t := s.Type()
 

--- a/lib/ur/contract/contract_test.go
+++ b/lib/ur/contract/contract_test.go
@@ -118,7 +118,7 @@ func TestClean(t *testing.T) {
 	expect(t, 6, x)
 }
 
-func expect(t *testing.T, since int, b interface{}) {
+func expect(t *testing.T, since int, b any) {
 	t.Helper()
 	x := testValue()
 	if err := clear(&x, since); err != nil {

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -453,7 +453,7 @@ func updateInProgressSet(event events.Event, inProgress map[string]struct{}) {
 		path := event.Data.(map[string]string)["item"]
 		inProgress[path] = struct{}{}
 	} else if event.Type == events.ItemFinished {
-		path := event.Data.(map[string]interface{})["item"].(string)
+		path := event.Data.(map[string]any)["item"].(string)
 		delete(inProgress, path)
 	}
 }

--- a/lib/watchaggregator/aggregator_test.go
+++ b/lib/watchaggregator/aggregator_test.go
@@ -163,7 +163,7 @@ func TestInProgress(t *testing.T) {
 		sleepMs(100)
 		c <- fs.Event{Name: "inprogress", Type: fs.NonRemove}
 		sleepMs(1000)
-		evLogger.Log(events.ItemFinished, map[string]interface{}{
+		evLogger.Log(events.ItemFinished, map[string]any{
 			"item": "inprogress",
 		})
 		sleepMs(100)

--- a/script/translate.go
+++ b/script/translate.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	trans      = make(map[string]interface{})
+	trans      = make(map[string]any)
 	attrRe     = regexp.MustCompile(`\{\{\s*'([^']+)'\s+\|\s+translate\s*\}\}`)
 	attrReCond = regexp.MustCompile(`\{\{.+\s+\?\s+'([^']+)'\s+:\s+'([^']+)'\s+\|\s+translate\s*\}\}`)
 )
@@ -114,7 +114,7 @@ func isTranslated(id string) bool {
 		if _, ok := namespace[subNamespace]; !ok {
 			return false
 		}
-		namespace = namespace[subNamespace].(map[string]interface{})
+		namespace = namespace[subNamespace].(map[string]any)
 	}
 
 	_, ok := namespace[id]
@@ -127,9 +127,9 @@ func translation(id string, v string) {
 	id = idParts[len(idParts)-1]
 	for _, subNamespace := range idParts[0 : len(idParts)-1] {
 		if _, ok := namespace[subNamespace]; !ok {
-			namespace[subNamespace] = make(map[string]interface{})
+			namespace[subNamespace] = make(map[string]any)
 		}
-		namespace = namespace[subNamespace].(map[string]interface{})
+		namespace = namespace[subNamespace].(map[string]any)
 	}
 
 	v = strings.TrimSpace(v)


### PR DESCRIPTION
### Purpose

The goal is to have a up-to-date syntax. Running the Go modernizer (https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) is (not yet) possible because the modernizer upgrades all found constructs and the commit will be difficult to review. So first make some simple reproducable changes:

```
find . -type f -name "*.go" -print0 | xargs -0 sed -i -e 's/interface{}/any/g' && golangci-lint fmt
```

```
find --version
find (GNU findutils) 4.10.0
sed --version
sed (GNU sed) 4.9
golangci-lint --version
golangci-lint has version 2.1.6
```