### PR TITLE
chore(protocol): don't start connection routines a second time

### DIFF
--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -265,12 +265,15 @@ func newRawConnection(deviceID DeviceID, reader io.Reader, writer io.Writer, clo
 }
 
 // Start creates the goroutines for sending and receiving of messages. It must
-// be called exactly once after creating a connection.
+// be called once after creating a connection. It should only be called once,
+// subsequent calls will have no effect.
 func (c *rawConnection) Start() {
 	c.startStopMut.Lock()
 	defer c.startStopMut.Unlock()
 
 	select {
+	case <-c.started:
+		return
 	case <-c.closed:
 		// we have already closed the connection before starting processing
 		// on it.


### PR DESCRIPTION
While the comment states that it should be only started once, we do already have the channel to indicate if it was already started - might as well use that to avoid any issues if a connection is nevertheless started more than once.