### PR TITLE
feat(lib/connections): add `name` label to `syncthing_connections_active` metric

### DIFF
--- a/lib/connections/metrics.go
+++ b/lib/connections/metrics.go
@@ -16,10 +16,10 @@ var metricDeviceActiveConnections = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Subsystem: "connections",
 	Name:      "active",
 	Help:      "Number of currently active connections, per device. If value is 0, the device is disconnected.",
-}, []string{"device"})
+}, []string{"device", "name"})
 
-func registerDeviceMetrics(deviceID string) {
+func registerDeviceMetrics(deviceID, name string) {
 	// Register metrics for this device, so that counters & gauges are present even
 	// when zero.
-	metricDeviceActiveConnections.WithLabelValues(deviceID)
+	metricDeviceActiveConnections.WithLabelValues(deviceID, name)
 }


### PR DESCRIPTION
### Purpose

Adds a `name` label with the device name to the `syncthing_connections_active` metric.

### Testing

Tested locally:

```
# HELP syncthing_connections_active Number of currently active connections, per device. If value is 0, the device is disconnected.
# TYPE syncthing_connections_active gauge
syncthing_connections_active{device="XXXXX",name="host-a"} 0
syncthing_connections_active{device="XXXXX",name="host-b"} 1
syncthing_connections_active{device="XXXXX",name="host-c"} 1
```

### Documentation

Metrics docs need to be regenerated.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

