### PR TITLE
feat(config): enable multiple connections by default

### DIFF
--- a/lib/config/deviceconfiguration.go
+++ b/lib/config/deviceconfiguration.go
@@ -13,7 +13,7 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
-const defaultNumConnections = 1 // number of connections to use by default; may change in the future.
+const defaultNumConnections = 3 // number of connections to use by default
 
 type DeviceConfiguration struct {
 	DeviceID                 protocol.DeviceID `json:"deviceID" xml:"id,attr" nodefault:"true"`

--- a/relnotes/v2.0.md
+++ b/relnotes/v2.0.md
@@ -21,3 +21,7 @@
   efficient without it.
 
 - A "default folder" is no longer created on first startup.
+
+- Multiple connections are now used by default between v2 devices. The new
+  default value is to use three connections: one for index metadata and two
+  for data exchange.


### PR DESCRIPTION
This changes the default number of connections from one to three (one metadata + two data connections). This should give some advantages of multiple connections, while also not being an overwhelming change for larger installations. (Though those may need to tweak their settings anyway, as always.)
