### PR TITLE
fix(fs): check for unsupported error on modern Windows (fixes #10164)

### DIFF
--- a/lib/fs/filesystem_copy_range_test.go
+++ b/lib/fs/filesystem_copy_range_test.go
@@ -8,6 +8,7 @@ package fs
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"math/rand"
 	"os"
@@ -329,7 +330,7 @@ func TestCopyRange(tttt *testing.T) {
 								t.Fatal("dst file is not a basic file")
 							}
 							if err := impl(srcBasic, dstBasic, testCase.srcOffset, testCase.dstOffset, testCase.copySize); err != nil {
-								if err == syscall.ENOTSUP {
+								if errors.Is(err, errors.ErrUnsupported) {
 									// Test runner can adjust directory in which to run the tests, that allow broader tests.
 									t.Skip("Not supported on the current filesystem, set STFSTESTPATH env var.")
 								}


### PR DESCRIPTION
### Purpose

Locally, on Windows 11, and on the windows-2025 GitHub runner (go 1.23 and 1.24), the `TestCopyRange` test is failing with `The request is not supported.`

On windows-2022 and windows-2019:
```go
err == syscall.ENOTSUP
```
worked, but on Windows 11 and windows-2025, we need:
```go
errors.Is(err, errors.ErrUnsupported)
```

### Testing

Tested on Windows 11, windows-2019, windows-2022, and [windows-2025](https://github.com/rasa/syncthing/actions/runs/15525123437/job/43703630634#step:7:2811).
