### PR TITLE
chore(syncthing): ensure response body is closed in upgrade request

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -403,9 +403,11 @@ func upgradeViaRest() error {
 	if err != nil {
 		return err
 	}
+
+	defer resp.Body.Close()
+
 	if resp.StatusCode != 200 {
 		bs, err := io.ReadAll(resp.Body)
-		defer resp.Body.Close()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION


### Purpose

On a successful 200, resp.Body was never closed,
tying up the underlying TCP connection. This commit ensures the response body is always closed as its called right after the Do call.
