### PR TITLE
chore(model): remove redundant removal of internal fields in indexsender

### DIFF
--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -489,14 +489,8 @@ func prepareFileInfoForIndex(f protocol.FileInfo) protocol.FileInfo {
 	if f.IsReceiveOnlyChanged() {
 		f.Version = protocol.Vector{}
 	}
-	// The trailer with the encrypted fileinfo is device local, don't send info
-	// about that to remotes
+	// The trailer with the encrypted fileinfo is device local, announce the size without it to remotes.
 	f.Size -= int64(f.EncryptionTrailerSize)
-	f.EncryptionTrailerSize = 0
-	// never sent externally
-	f.LocalFlags = 0
-	f.VersionHash = nil
-	f.InodeChangeNs = 0
 	return f
 }
 


### PR DESCRIPTION
While it doesn't hurt, it's unnecessary since the big protobuf modernisation, that also introduced types separate from the generated ones for internal use. Those fields are already dropped when converting to the wire in protocol.
