### PR TITLE
fix(watchaggregator): properly handle sub-second watch durations (fixes #9927)

### DIFF
--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -440,7 +440,7 @@ func (a *aggregator) updateConfig(folderCfg config.FolderConfiguration) {
 	if maxDelay := folderCfg.FSWatcherTimeoutS; maxDelay > 0 {
 		// FSWatcherTimeoutS is set explicitly so use that, but it also
 		// can't be lower than FSWatcherDelayS
-		a.notifyTimeout = time.Duration(max(maxDelay, folderCfg.FSWatcherDelayS)) * time.Second
+		a.notifyTimeout = time.Duration(max(maxDelay, folderCfg.FSWatcherDelayS) * float64(time.Second))
 	} else {
 		// Use the default FSWatcherTimeoutS calculation
 		a.notifyTimeout = notifyTimeout(folderCfg.FSWatcherDelayS)
@@ -471,10 +471,10 @@ func notifyTimeout(eventDelayS float64) time.Duration {
 		longDelayTimeout        = time.Minute
 	)
 	if eventDelayS < shortDelayS {
-		return time.Duration(eventDelayS*shortDelayMultiplicator) * time.Second
+		return time.Duration(eventDelayS*shortDelayMultiplicator * float64(time.Second))
 	}
 	if eventDelayS < longDelayS {
 		return longDelayTimeout
 	}
-	return time.Duration(eventDelayS) * time.Second
+	return time.Duration(eventDelayS * float64(time.Second))
 }

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -471,7 +471,7 @@ func notifyTimeout(eventDelayS float64) time.Duration {
 		longDelayTimeout        = time.Minute
 	)
 	if eventDelayS < shortDelayS {
-		return time.Duration(eventDelayS*shortDelayMultiplicator * float64(time.Second))
+		return time.Duration(eventDelayS * shortDelayMultiplicator * float64(time.Second))
 	}
 	if eventDelayS < longDelayS {
 		return longDelayTimeout


### PR DESCRIPTION
I'll let Audrius words from the ticket explain this :)

> I'm a bit lost, time.Duration is an int64, yet watcher delay is float,
> anything sub 1s gets rounded down to 0, so you just end up going into an
> infinite loop.

https://github.com/syncthing/syncthing/issues/9927#issuecomment-2967736106