### PR TITLE
fix(db): remove invalid member from FileMetadata

### DIFF
--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -103,7 +103,6 @@ type FileMetadata struct {
 	LocalFlags protocol.FlagLocal
 	Type       protocol.FileInfoType
 	Deleted    bool
-	Invalid    bool
 }
 
 func (f *FileMetadata) ModTime() time.Time {
@@ -120,4 +119,8 @@ func (f *FileMetadata) IsDirectory() bool {
 
 func (f *FileMetadata) ShouldConflict() bool {
 	return f.LocalFlags&protocol.LocalConflictFlags != 0
+}
+
+func (f *FileMetadata) IsInvalid() bool {
+	return f.LocalFlags.IsInvalid()
 }

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2757,7 +2757,7 @@ func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly 
 		}
 
 		// Don't include the prefix itself.
-		if f.Invalid || f.Deleted || strings.HasPrefix(prefix, f.Name) {
+		if f.IsInvalid() || f.Deleted || strings.HasPrefix(prefix, f.Name) {
 			continue
 		}
 


### PR DESCRIPTION
Missed this one in the previous refactor to only use `LocalFlags` to indicate if a file is invalid:

7b319111d3c07f092760fd781bf16daa192d46b6
