### PR TITLE
fix(model): don't clobber local flags when receiving index

### DIFF
--- a/internal/db/sqlite/basedb.go
+++ b/internal/db/sqlite/basedb.go
@@ -22,7 +22,7 @@ import (
 	"github.com/syncthing/syncthing/lib/protocol"
 )
 
-const currentSchemaVersion = 2
+const currentSchemaVersion = 3
 
 //go:embed sql/**
 var embedded embed.FS

--- a/internal/db/sqlite/sql/migrations/folder/03-drop-bad-invalid.sql
+++ b/internal/db/sqlite/sql/migrations/folder/03-drop-bad-invalid.sql
@@ -1,0 +1,17 @@
+-- Copyright (C) 2025 The Syncthing Authors.
+--
+-- This Source Code Form is subject to the terms of the Mozilla Public
+-- License, v. 2.0. If a copy of the MPL was not distributed with this file,
+-- You can obtain one at https://mozilla.org/MPL/2.0/.
+
+-- Remove broken file entries in the database.
+DELETE FROM files
+    WHERE type == 0 -- files
+        AND NOT deleted -- that are not deleted
+        AND blocklist_hash IS null -- with no blocks
+        AND local_flags & {{.LocalInvalidFlags}} == 0 -- and not invalid
+;
+
+-- Force a new index transmission.
+DELETE FROM indexids
+;

--- a/lib/model/indexhandler.go
+++ b/lib/model/indexhandler.go
@@ -421,11 +421,6 @@ func (s *indexHandler) receive(fs []protocol.FileInfo, update bool, op string, p
 				"precedingSeq": fs[i-1].Sequence,
 			})
 		}
-
-		// The local attributes should never be transmitted over the wire.
-		// Make sure they look like they weren't.
-		fs[i].LocalFlags = 0
-		fs[i].VersionHash = nil
 	}
 
 	// Verify the claimed last sequence number

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3498,6 +3498,7 @@ func TestScanDeletedROChangedOnSR(t *testing.T) {
 	}
 	// A remote must have the file, otherwise the deletion below is
 	// automatically resolved as not a ro-changed item.
+	file.LocalFlags = 0 // clear as we're shortcutting the index path where it would otherwise be cleared naturally
 	must(t, m.IndexUpdate(conn, &protocol.IndexUpdate{Folder: fcfg.ID, Files: []protocol.FileInfo{file}}))
 
 	must(t, ffs.Remove(name))

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3498,7 +3498,7 @@ func TestScanDeletedROChangedOnSR(t *testing.T) {
 	}
 	// A remote must have the file, otherwise the deletion below is
 	// automatically resolved as not a ro-changed item.
-	file.LocalFlags = 0 // clear as we're shortcutting the index path where it would otherwise be cleared naturally
+	file.LocalFlags = 0 // clear as we're skipping the code path where it would otherwise be cleared naturally
 	must(t, m.IndexUpdate(conn, &protocol.IndexUpdate{Folder: fcfg.ID, Files: []protocol.FileInfo{file}}))
 
 	must(t, ffs.Remove(name))


### PR DESCRIPTION
This was an extra safety operation in the before times, but now we've already run through the conversion from a bep.FileInfo to a protocol.FileInfo and will have potentially set the LocalFlags to a useful value. (And will not have set VersionHash.)
