### PR TITLE
fix(model): use better file paths for encrypted files

### DIFF
--- a/lib/protocol/encryption_test.go
+++ b/lib/protocol/encryption_test.go
@@ -33,7 +33,7 @@ func TestEnDecryptName(t *testing.T) {
 
 	pattern := regexp.MustCompile(
 		fmt.Sprintf("^[0-9A-V]%s/[0-9A-V]{2}/([0-9A-V]{%d}/)*[0-9A-V]{1,%d}$",
-			regexp.QuoteMeta(encryptedDirExtension),
+			regexp.QuoteMeta(encryptedDirExtensionV1),
 			maxPathComponent, maxPathComponent-1))
 
 	makeName := func(n int) string {
@@ -236,17 +236,26 @@ func TestIsEncryptedParent(t *testing.T) {
 		{"", false},
 		{".", false},
 		{"/", false},
-		{"12" + encryptedDirExtension, false},
-		{"1" + encryptedDirExtension, true},
-		{"1" + encryptedDirExtension + "/b", false},
-		{"1" + encryptedDirExtension + "/bc", true},
-		{"1" + encryptedDirExtension + "/bcd", false},
-		{"1" + encryptedDirExtension + "/bc/foo", false},
+		{"12" + encryptedDirExtensionV1, false},
+		{"12" + encryptedDirExtensionV2, false},
+		{"1" + encryptedDirExtensionV1, true},
+		{"1" + encryptedDirExtensionV2, true},
+		{"1" + encryptedDirExtensionV1 + "/b", false},
+		{"1" + encryptedDirExtensionV1 + "/bc", true},
+		{"1" + encryptedDirExtensionV2 + "/bc", true},
+		{"1" + encryptedDirExtensionV1 + "/bcd", false},
+		{"1" + encryptedDirExtensionV2 + "/bcd", false},
+		{"1" + encryptedDirExtensionV1 + "/bc/foo", false},
+		{"1" + encryptedDirExtensionV2 + "/bc/foo", false},
 		{"1.12/22", false},
-		{"1" + encryptedDirExtension + "/bc/" + comp, true},
-		{"1" + encryptedDirExtension + "/bc/" + comp + "/" + comp, true},
-		{"1" + encryptedDirExtension + "/bc/" + comp + "a", false},
-		{"1" + encryptedDirExtension + "/bc/" + comp + "/a/" + comp, false},
+		{"1" + encryptedDirExtensionV1 + "/bc/" + comp, true},
+		{"1" + encryptedDirExtensionV2 + "/bc/" + comp, true},
+		{"1" + encryptedDirExtensionV1 + "/bc/" + comp + "/" + comp, true},
+		{"1" + encryptedDirExtensionV2 + "/bc/" + comp + "/" + comp, true},
+		{"1" + encryptedDirExtensionV1 + "/bc/" + comp + "a", false},
+		{"1" + encryptedDirExtensionV2 + "/bc/" + comp + "a", false},
+		{"1" + encryptedDirExtensionV1 + "/bc/" + comp + "/a/" + comp, false},
+		{"1" + encryptedDirExtensionV2 + "/bc/" + comp + "/a/" + comp, false},
 	}
 	for _, tc := range cases {
 		if res := IsEncryptedParent(strings.Split(tc.path, "/")); res != tc.is {


### PR DESCRIPTION
This slightly changes the file paths for encrypted files. The changes are:

- top level directories are called `0.syncthing-enc.v2` (adding `.v2`) to indicate that newer file names are in use
- max path component length is reduced from 200 to 64 characters (fixes #9441)
- a file ending `.enc` is added to the last path component, making it always unambiguous whether a directory is an intermediate or last path component (fixes #7987)
- short path components get an additional `x` prefix (fixes #7808)
- names are all lower case (doesn't fix anything, it's just less LOUD)

There are a couple of aspects and constraints to making this change...

- we can't change the filenames we send on the wire, or we'll break existing clients who wouldn't understand the new format
- however, normal/trusted nodes don't really care about or store the encrypted format anywhere, they just need to be able to decode it on receive -- this means we can send the v1 format, and still be able to handle requests and updates for files in the v2 format
- we need a given folder on disk to use either the new or the old format, not a mixture, as we need unambiguous names for any given file

This makes the new format the default, but detects if there are already old-style names on disk and in that case continues using that format. "Upgrading" an existing folder to the new format thus consists of removing it and letting it sync again, I don't plan on making a migration. Newly added folders will get the new format automatically.

⚠️ Currently it will break to sync an old-style untrusted device with a new-style untrusted device... We could potentially fix that by re-translating names to the old style on the way out from an untrusted device, I'm not sure it's worth it.