### PR TITLE
chore(config): increase max concurrent writes default

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -31,7 +31,7 @@ import (
 
 const (
 	OldestHandledVersion = 10
-	CurrentVersion       = 50
+	CurrentVersion       = 51
 	MaxRescanIntervalS   = 365 * 24 * 60 * 60
 )
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -120,7 +120,7 @@ func TestDefaultValues(t *testing.T) {
 				},
 				MaxConflicts:        10,
 				MarkerName:          ".stfolder",
-				MaxConcurrentWrites: 2,
+				MaxConcurrentWrites: maxConcurrentWritesDefault,
 				XattrFilter: XattrFilter{
 					Entries:            []XattrFilterEntry{},
 					MaxSingleEntrySize: 1024,

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -36,8 +36,8 @@ var (
 const (
 	DefaultMarkerName          = ".stfolder"
 	EncryptionTokenName        = "syncthing-encryption_password_token" //nolint: gosec
-	maxConcurrentWritesDefault = 2
-	maxConcurrentWritesLimit   = 64
+	maxConcurrentWritesDefault = 16
+	maxConcurrentWritesLimit   = 256
 )
 
 type FolderDeviceConfiguration struct {
@@ -76,7 +76,7 @@ type FolderConfiguration struct {
 	MarkerName              string                      `json:"markerName" xml:"markerName"`
 	CopyOwnershipFromParent bool                        `json:"copyOwnershipFromParent" xml:"copyOwnershipFromParent"`
 	RawModTimeWindowS       int                         `json:"modTimeWindowS" xml:"modTimeWindowS"`
-	MaxConcurrentWrites     int                         `json:"maxConcurrentWrites" xml:"maxConcurrentWrites" default:"2"`
+	MaxConcurrentWrites     int                         `json:"maxConcurrentWrites" xml:"maxConcurrentWrites" default:"0"`
 	DisableFsync            bool                        `json:"disableFsync" xml:"disableFsync"`
 	BlockPullOrder          BlockPullOrder              `json:"blockPullOrder" xml:"blockPullOrder"`
 	CopyRangeMethod         CopyRangeMethod             `json:"copyRangeMethod" xml:"copyRangeMethod" default:"standard"`

--- a/lib/config/migrations.go
+++ b/lib/config/migrations.go
@@ -28,6 +28,7 @@ import (
 // put the newest on top for readability.
 var (
 	migrations = migrationSet{
+		{51, migrateToConfigV51},
 		{50, migrateToConfigV50},
 		{37, migrateToConfigV37},
 		{36, migrateToConfigV36},
@@ -96,6 +97,18 @@ func (m migration) apply(cfg *Configuration) {
 		m.convert(cfg)
 	}
 	cfg.Version = m.targetVersion
+}
+
+func migrateToConfigV51(cfg *Configuration) {
+	oldDefault := 2
+	for i, fcfg := range cfg.Folders {
+		if fcfg.MaxConcurrentWrites == oldDefault {
+			cfg.Folders[i].MaxConcurrentWrites = maxConcurrentWritesDefault
+		}
+	}
+	if cfg.Defaults.Folder.MaxConcurrentWrites == oldDefault {
+		cfg.Defaults.Folder.MaxConcurrentWrites = maxConcurrentWritesDefault
+	}
 }
 
 func migrateToConfigV50(cfg *Configuration) {


### PR DESCRIPTION
I lately wanted some photos on my phone, and watched them sync
excrutiatingly slowly. I am used to android being slow, but not that
slow. This restriction caught my eye and I increased it beyond the
limit (didn't spot it at first), and I did see a clear improvement. Of
course as always with such a one-off test, I might also have
hallucinated it, but it seems plausible with the slow thing in android
being some layer between the actual filesystem and apps.

Also increase the max limit, mostly just because I don't see any reason
to restrict it that low - not that I have a particular reason to want
more.

I also changed the xml default to 0: The `prepare` code will change it
to the actual default - no need to change that anymore if we change the
default in the future.