### PR TITLE
chore(gui): added spacing between folder name and error message

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -333,7 +333,7 @@
               </p>
               <table>
                 <tr ng-repeat="(id, err) in fsWatcherErrorMap()">
-                  <td>{{folderLabel(id)}}</td><td>{{err}}</td>
+                  <td>{{folderLabel(id)}}: </td><td>{{err}}</td>
                 </tr>
               </table>
             </div>


### PR DESCRIPTION
### Purpose
Filesystem watcher errors didnt have any whitespace between the share name and the error message, making it hard to read. A simple colon and whitespace solves this issue
