### PR TITLE
chore(gui): fix "Shut Down" spelling in Actions

### DIFF
--- a/gui/default/assets/lang/lang-ar.json
+++ b/gui/default/assets/lang/lang-ar.json
@@ -370,7 +370,7 @@
     "Show diff with previous version": "أظهر الفرق مقارنةً بالنسخة السابقة",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "يُعرَض بدلا من المُعرِّف ضمن العناقيد. سيُروَّج للأجهزة الأخرى على أنه اسم أساسي محتمل.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "يُعرَض بدلا من المُعرِّف ضمن العناقيد. إذا تُرك فارغا، سيُحدَّث إلى الاسم المختار من قِبَل الجهاز.",
-    "Shutdown": "إغلاق",
+    "Shut Down": "إغلاق",
     "Shutdown Complete": "أُغلِق",
     "Simple": "بسيط",
     "Simple File Versioning": "التقسيم البسيط لإصدارات الملفات",

--- a/gui/default/assets/lang/lang-be.json
+++ b/gui/default/assets/lang/lang-be.json
@@ -152,7 +152,7 @@
     "Show ID": "Паказаць ID",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.",
-    "Shutdown": "Выключыць",
+    "Shut Down": "Выключыць",
     "Shutdown Complete": "Выключэньне завершанае",
     "Simple File Versioning": "Простае захоўваньне вэрсій",
     "Single level wildcard (matches within a directory only)": "Single level wildcard (matches within a directory only)",

--- a/gui/default/assets/lang/lang-bg.json
+++ b/gui/default/assets/lang/lang-bg.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Показване на разликите с предходната версия",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "В списъка на устройствата се показва вместо идентификатор. Ще бъде предложено на другите устройства като име по подразбиране.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "В списъка на устройствата се показва вместо идентификатор. Ако бъде оставено празно ще бъде променено на името, което носи устройството.",
-    "Shutdown": "Изключване",
+    "Shut Down": "Изключване",
     "Shutdown Complete": "Спирането завършено",
     "Simple": "Обикновени",
     "Simple File Versioning": "Обикновени версии",

--- a/gui/default/assets/lang/lang-ca.json
+++ b/gui/default/assets/lang/lang-ca.json
@@ -370,7 +370,7 @@
     "Show diff with previous version": "Mostra la diferència amb la versió anterior",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Mostrat en comptes del ID del Node en l'estat del cluster. Serà advertit als altres dispositius com un nom opcional per defecte.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Mostrat en comptes del ID del Node en l'estat del cluster. S'actualitzarà al nom del dispositiu si es deixa buit.",
-    "Shutdown": "Apaga",
+    "Shut Down": "Apaga",
     "Shutdown Complete": "Apagat complet",
     "Simple": "Simple",
     "Simple File Versioning": "Versionat de Fitxers Senzill",

--- a/gui/default/assets/lang/lang-ca@valencia.json
+++ b/gui/default/assets/lang/lang-ca@valencia.json
@@ -353,7 +353,7 @@
     "Show diff with previous version": "Mostrar les diferències amb la versió prèvia",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Mostrat en lloc de l'ID del dispositiu en l'estat del grup (cluster). S'anunciarà als altres dispositius com el nom opcional per defecte.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Mostrat en lloc de l'ID del dispositiu en l'estat del grup (cluster). S'actualitzarà al nom que el dispositiu anuncia si es deixa buit.",
-    "Shutdown": "Apagar",
+    "Shut Down": "Apagar",
     "Shutdown Complete": "Apagar completament",
     "Simple": "Senzill",
     "Simple File Versioning": "Versionat de fitxers senzill",

--- a/gui/default/assets/lang/lang-cs.json
+++ b/gui/default/assets/lang/lang-cs.json
@@ -360,7 +360,7 @@
     "Show diff with previous version": "Ukázat rozdíl oproti předchozí verzi",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Zobrazeno místo identifikátoru zařízení na náhledu stavu clusteru. Bude odesíláno ostatním zařízením jako výchozí název zařízení.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Zobrazeno místo identifikátoru zařízení na náhledu stavu clusteru. Pokud nebude vyplněno, bude nastaveno na název, který zařízení odesílá.",
-    "Shutdown": "Vypnout",
+    "Shut Down": "Vypnout",
     "Shutdown Complete": "Vypnutí dokončeno",
     "Simple": "Jednoduché",
     "Simple File Versioning": "Jednoduchá správa verzí souborů",

--- a/gui/default/assets/lang/lang-da.json
+++ b/gui/default/assets/lang/lang-da.json
@@ -368,7 +368,7 @@
     "Show diff with previous version": "Vis forskelle fra tidligere version",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Vises i stedet for enheds-ID i klyngestatus. Vil blive sendt til andre enheder som valgfrit standardnavn.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Vises i stedet for enheds-ID i klyngestatus. Vil blive opdateret til det navn, som enheden sender, hvis det ikke er udfyldt.",
-    "Shutdown": "Luk ned",
+    "Shut Down": "Luk ned",
     "Shutdown Complete": "Nedlukning fuldført",
     "Simple": "Enkel",
     "Simple File Versioning": "Simpel filversionering",

--- a/gui/default/assets/lang/lang-de.json
+++ b/gui/default/assets/lang/lang-de.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Unterschied zur vorherigen Version anzeigen",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Wird anstelle der Gerätekennung im Verbundstatus angezeigt. Wird anderen Geräten als optionaler Standardname bekannt gegeben.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Wird anstelle der Gerätekennung im Verbundstatus angezeigt. Wird auf den Namen aktualisiert, den das Gerät anzeigt, wenn er leer bleibt.",
-    "Shutdown": "Herunterfahren",
+    "Shut Down": "Herunterfahren",
     "Shutdown Complete": "Vollständig heruntergefahren",
     "Simple": "Einfach",
     "Simple File Versioning": "Einfache Dateiversionierung",

--- a/gui/default/assets/lang/lang-el.json
+++ b/gui/default/assets/lang/lang-el.json
@@ -368,7 +368,7 @@
     "Show diff with previous version": "Εμφάνιση διαφορών με προηγούμενη έκδοση",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Θα φαίνεται αντί για την ταυτότητα της συσκευής στην προβολή της κατάστασης ολόκληρης της συστάδας. Θα γνωστοποιείται σαν το προαιρετικό όνομα της συσκευής.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Θα φαίνεται αντί για την ταυτότητα της συσκευής στην προβολή της κατάστασης ολόκληρης της συστάδας. Θα ενημερώνεται αυτόματα αν αλλάξει το όνομα της συσκευής.",
-    "Shutdown": "Απενεργοποίηση",
+    "Shut Down": "Απενεργοποίηση",
     "Shutdown Complete": "Πλήρης απενεργοποίηση",
     "Simple": "Απλό",
     "Simple File Versioning": "Απλή τήρηση εκδόσεων",

--- a/gui/default/assets/lang/lang-en-AU.json
+++ b/gui/default/assets/lang/lang-en-AU.json
@@ -353,7 +353,7 @@
     "Show diff with previous version": "Show diff with previous version",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.",
-    "Shutdown": "Shutdown",
+    "Shut Down": "Shut Down",
     "Shutdown Complete": "Shutdown Complete",
     "Simple": "Simple",
     "Simple File Versioning": "Simple File Versioning",

--- a/gui/default/assets/lang/lang-en-GB.json
+++ b/gui/default/assets/lang/lang-en-GB.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Show diff with previous version",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.",
-    "Shutdown": "Shutdown",
+    "Shut Down": "Shut Down",
     "Shutdown Complete": "Shutdown Complete",
     "Simple": "Simple",
     "Simple File Versioning": "Simple File Versioning",

--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Show diff with previous version",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.",
-    "Shutdown": "Shutdown",
+    "Shut Down": "Shut Down",
     "Shutdown Complete": "Shutdown Complete",
     "Simple": "Simple",
     "Simple File Versioning": "Simple File Versioning",

--- a/gui/default/assets/lang/lang-eo.json
+++ b/gui/default/assets/lang/lang-eo.json
@@ -258,7 +258,7 @@
     "Show diff with previous version": "Montri diferenco kun antaŭa versio",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Montrita anstataŭ ID de Aparato en la statuso de la grupo. Estos anoncita al aliaj aparatoj kiel laŭvola defaŭlta nomo.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Montri anstataŭ ID de Aparato en la statuso de la grupo. Estos ĝisdatigita al la nomo de la aparato sciigante se ĝi estas lasita malplena.",
-    "Shutdown": "Sistemfermo",
+    "Shut Down": "Sistemfermo",
     "Shutdown Complete": "Sistemfermo Tuta",
     "Simple File Versioning": "Simpla Versionado de Dosieroj",
     "Single level wildcard (matches within a directory only)": "Ununivela ĵokero (egalas nur ene de dosierujo)",

--- a/gui/default/assets/lang/lang-es.json
+++ b/gui/default/assets/lang/lang-es.json
@@ -368,7 +368,7 @@
     "Show diff with previous version": "Mostrar la diferencia con la versión anterior",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Se muestra en lugar del ID del dispositivo en el estado del grupo (cluster). Se notificará a los otros dispositivos como nombre opcional por defecto.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Se muestra en lugar del ID del dispositivo en el estado del grupo (cluster). Se actualizará al nombre que el dispositivo anuncia si se deja vacío.",
-    "Shutdown": "Apagar",
+    "Shut Down": "Apagar",
     "Shutdown Complete": "Apagar completamente",
     "Simple": "Sencillo",
     "Simple File Versioning": "Versionado simple de fichero",

--- a/gui/default/assets/lang/lang-eu.json
+++ b/gui/default/assets/lang/lang-eu.json
@@ -309,7 +309,7 @@
     "Show diff with previous version": "Erakutsi aurreko bertsioarekiko aldeak",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Tresnaren ID-aren ordez erakutsia, taldearen egoeran. Beste tresneri erakutsia izanen da, izen erabilgarri bat bezala",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Tresnaren ID-aren ordez erakutsia, taldearen egoeran. Hutsa utzia balin bada, urrun den tresnak proposatu izenarekin aktualizatua izanen da",
-    "Shutdown": "Geldi",
+    "Shut Down": "Geldi",
     "Shutdown Complete": "Gelditua!",
     "Simple File Versioning": "Bertsioen segitze sinplifikatua",
     "Single level wildcard (matches within a directory only)": "Hein bakar bateko jokerra (karpetaren barnean bakarrik dagokiona)",

--- a/gui/default/assets/lang/lang-fi.json
+++ b/gui/default/assets/lang/lang-fi.json
@@ -288,7 +288,7 @@
     "Show diff with previous version": "Näytä muutokset edelliseen versioon",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Näytetään ryhmän tiedoissa laitteen ID:n sijaan. Ilmoitetaan muille laitteille vaihtoehtoisena oletusnimenä.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Näytetään ryhmän tiedoissa laitteen ID:n sijaan. Tyhjä nimi päivitetään laitteen ilmoittamaksi nimeksi.",
-    "Shutdown": "Sammuta",
+    "Shut Down": "Sammuta",
     "Shutdown Complete": "Sammutus valmis",
     "Simple File Versioning": "Yksinkertainen tiedostoversiointi",
     "Single level wildcard (matches within a directory only)": "Yksitasoinen jokerimerkki (vaikuttaa vain kyseisen kansion sisällä)",

--- a/gui/default/assets/lang/lang-fil.json
+++ b/gui/default/assets/lang/lang-fil.json
@@ -370,7 +370,7 @@
     "Show diff with previous version": "Ipakita ang diff sa nakaraang bersyon",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Ipinapakita sa halip na Device ID sa status ng cluster. Ia-advertise sa iba pang mga device bilang opsyonal na default na pangalan.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Ipinapakita sa halip na Device ID sa status ng cluster. Ia-update sa pangalan na ina-advertise ng device kung iiwanang walang laman.",
-    "Shutdown": "I-shutdown",
+    "Shut Down": "I-shutdown",
     "Shutdown Complete": "Tapos na ang Shutdown",
     "Simple": "Simple",
     "Simple File Versioning": "Simpleng File Versioning",

--- a/gui/default/assets/lang/lang-fr-CA.json
+++ b/gui/default/assets/lang/lang-fr-CA.json
@@ -160,7 +160,7 @@
     "Show QR": "Afficher l'image QR",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Affiché à la place de l'ID de l'appareil dans l'état du groupe. Sera diffusé aux autres appareils comme nom convivial optionnel par défaut.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Affiché à la place de l'ID de l'appareil dans l'état du groupe. Si laissé vide, il sera renseigné par le nom convivial proposé par l'appareil distant.",
-    "Shutdown": "Arrêter",
+    "Shut Down": "Arrêter",
     "Shutdown Complete": "Arrêté !",
     "Simple File Versioning": "Suivi simplifié des versions",
     "Single level wildcard (matches within a directory only)": "Joker à un seul niveau (correspond uniquement à l’intérieur du répertoire)",

--- a/gui/default/assets/lang/lang-fr.json
+++ b/gui/default/assets/lang/lang-fr.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Afficher les différences avec la version précédente",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Affiché à la place de l'ID de l'appareil dans l'état du groupe. Sera diffusé aux autres appareils comme nom convivial optionnel par défaut.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Nom convivial local affiché à la place de l'ID de l'appareil dans la plupart des écrans. Si laissé vide, c'est le nom convivial local de l'appareil distant qui sera utilisé. (Modifiable ultérieurement).",
-    "Shutdown": "Arrêter",
+    "Shut Down": "Arrêter",
     "Shutdown Complete": "Arrêt complet",
     "Simple": "Suivi simplifié",
     "Simple File Versioning": "Suivi simplifié des versions",

--- a/gui/default/assets/lang/lang-fy.json
+++ b/gui/default/assets/lang/lang-fy.json
@@ -312,7 +312,7 @@
     "Show diff with previous version": "Ferskil (diff) mei de foarige ferzje sjen litte",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Wurd ynstee fan apparaat-ID sjen litten by de bondeltastân. Wurd nei oare apparaten advertearre as in mooglike standertnamme.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Wurd yn de bondeltastân sjen litten ynstee fan apparaat-ID. Wannear't leech litten wurd, wurd it fernijt nei de namme die it apparaat útstjoert.",
-    "Shutdown": "Ofslute",
+    "Shut Down": "Ofslute",
     "Shutdown Complete": "Ofsluten klear",
     "Simple File Versioning": "Ienfâldich triemferzjebehear",
     "Single level wildcard (matches within a directory only)": "Inkel-nivo jokerteken (wildcard) (fergeliket allinnich binnen in map)",

--- a/gui/default/assets/lang/lang-ga.json
+++ b/gui/default/assets/lang/lang-ga.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Taispeáin diff leis an leagan roimhe seo",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Taispeántar é in ionad ID gléis i stádas na braisle. Fógrófar é do ghléasanna eile mar ainm réamhshocraithe roghnach.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Taispeántar é in ionad ID gléis i stádas na braisle. Déanfar é a nuashonrú go dtí an t-ainm a fhógraíonn an gléas má fhágtar folamh é.",
-    "Shutdown": "Múchadh",
+    "Shut Down": "Múchadh",
     "Shutdown Complete": "Múchadh Críochnaithe",
     "Simple": "Simplí",
     "Simple File Versioning": "Leagan Simplí Comhad",

--- a/gui/default/assets/lang/lang-gl.json
+++ b/gui/default/assets/lang/lang-gl.json
@@ -323,7 +323,7 @@
     "Show diff with previous version": "Mostrar a diferencia coa versión anterior",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Mostrado en lugar do ID de Dispositivo no estado do clúster. Anunciarase a outros dispositivos como nome por defecto opcional.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Mostrado en lugar do ID de Dispositivo no estado do clúster. Actualizarase ao nome que anuncia o dispositivo de se deixar baleiro.",
-    "Shutdown": "Apagar",
+    "Shut Down": "Apagar",
     "Shutdown Complete": "Apagado Completado",
     "Simple": "Simple",
     "Simple File Versioning": "Versionado de Ficheiros Sinxelo",

--- a/gui/default/assets/lang/lang-he-IL.json
+++ b/gui/default/assets/lang/lang-he-IL.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "הצג הבדל עם הגרסה הקודמת",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "מוצג במקום מזהה ההתקן במצב האשכול. יפורסם להתקנים אחרים כשם ברירת מחדל אופציונלי.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "מוצג במקום מזהה ההתקן במצב האשכול. יעודכן לשם שההתקן מפרסם אם נותר ריק.",
-    "Shutdown": "כיבוי",
+    "Shut Down": "כיבוי",
     "Shutdown Complete": "הכיבוי הושלם",
     "Simple": "פשוט",
     "Simple File Versioning": "ניהול גרסאות קבצים פשוט",

--- a/gui/default/assets/lang/lang-hi.json
+++ b/gui/default/assets/lang/lang-hi.json
@@ -368,7 +368,7 @@
     "Show diff with previous version": "पिछले संस्करण के साथ अंतर दिखाएं",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "समूह स्थिति में उपकरण ID के बजाय दिखाया गया। वैकल्पिक तयशुदा नाम के रूप में अन्य उपकरणों पर विज्ञापित किया जाएगा।",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "समूह स्थिति में उपकरण ID के बजाय दिखाया गया। खाली छोड़े जाने पर उपकरण द्वारा विज्ञापित नाम में अद्यतित कर दिया जाएगा।",
-    "Shutdown": "शटडाउन",
+    "Shut Down": "शटडाउन",
     "Shutdown Complete": "शटडाउन पूर्ण",
     "Simple": "सरल",
     "Simple File Versioning": "सरल फाइल संस्करण",

--- a/gui/default/assets/lang/lang-hu.json
+++ b/gui/default/assets/lang/lang-hu.json
@@ -345,7 +345,7 @@
     "Show diff with previous version": "Előző verzió eltérésének megjelenítése",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Az eszközazonosító helyett jelenik meg. A többi eszközön alapértelmezett névként használható.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Az eszközazonosító helyett jelenik meg. Üresen hagyva az eszköz saját neve lesz alkalmazva.",
-    "Shutdown": "Leállítás",
+    "Shut Down": "Leállítás",
     "Shutdown Complete": "Leállítás kész",
     "Simple": "Egyszerű",
     "Simple File Versioning": "Egyszerű fájlverzió-követés",

--- a/gui/default/assets/lang/lang-id.json
+++ b/gui/default/assets/lang/lang-id.json
@@ -322,7 +322,7 @@
     "Show diff with previous version": "Tampilkan perbedaan dengan versi sebelumnya",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Ditampilkan sebagai ganti ID Perangkat dalam status gugus. Akan diumumkan ke perangkat lain sebagai nama bawaan opsional.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Ditampilkan sebagai ganti ID Perangkat dalam status gugus. Akan diubah menjadi nama yang perangkat umumkan jika tidak diisi.",
-    "Shutdown": "Matikan",
+    "Shut Down": "Matikan",
     "Shutdown Complete": "Pematian Selesai",
     "Simple File Versioning": "Pemversian Berkas Sederhana",
     "Single level wildcard (matches within a directory only)": "Wildcard tingkat tunggal (cocok hanya dalam satu direktori saja)",

--- a/gui/default/assets/lang/lang-it.json
+++ b/gui/default/assets/lang/lang-it.json
@@ -370,7 +370,7 @@
     "Show diff with previous version": "Mostra le differenze con la versione precedente",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Visibile al posto dell'ID Dispositivo nello stato del cluster. Negli altri dispositivi verrà presentato come nome predefinito opzionale.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Visibile al posto dell'ID Dispositivo nello stato del cluster. Se viene lasciato vuoto, verrà utilizzato il nome proposto dal dispositivo.",
-    "Shutdown": "Arresta",
+    "Shut Down": "Arresta",
     "Shutdown Complete": "Arresto Eseguito",
     "Simple": "Semplice",
     "Simple File Versioning": "Controllo Versione Semplice",

--- a/gui/default/assets/lang/lang-ja.json
+++ b/gui/default/assets/lang/lang-ja.json
@@ -311,7 +311,7 @@
     "Show diff with previous version": "前バージョンとの差分を表示",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "ステータス画面でデバイスIDの代わりに表示されます。他のデバイスに対してもデフォルトの名前として通知されます。",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "ステータス画面でデバイスIDの代わりに表示されます。空欄にすると相手側デバイスが通知してきた名前で更新されます。",
-    "Shutdown": "シャットダウン",
+    "Shut Down": "シャットダウン",
     "Shutdown Complete": "シャットダウン完了",
     "Simple File Versioning": "単純バージョン管理",
     "Single level wildcard (matches within a directory only)": "ワイルドカード (単一のディレクトリ内だけでマッチします)",

--- a/gui/default/assets/lang/lang-ko-KR.json
+++ b/gui/default/assets/lang/lang-ko-KR.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "이전 버전과의 diff 보기",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "기기 아이디를 대신해 기기 목록에서 나타납니다. 다른 기기에 선택적 기본값 이름으로 통보됩니다.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "기기 아이디를 대신해 기기 목록에서 나타납니다. 비워 둘 경우 다른 기기에서 통보받은 이름으로 갱신됩니다.",
-    "Shutdown": "종료",
+    "Shut Down": "종료",
     "Shutdown Complete": "종료 완료",
     "Simple": "간단",
     "Simple File Versioning": "간단한 파일 버전 관리",

--- a/gui/default/assets/lang/lang-lt.json
+++ b/gui/default/assets/lang/lang-lt.json
@@ -337,7 +337,7 @@
     "Show diff with previous version": "Rodyti skirtumus su ankstesne versija",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Grupės būsenoje rodomas vietoje įrenginio vardo. Kiti įrenginiai matys kaip pasirinktinį vardą.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Grupės būsenoje rodomas vietoje įrenginio vardo. Bus atnaujintas į įrenginio vardą jei nieko neįrašysite.",
-    "Shutdown": "Išjungti",
+    "Shut Down": "Išjungti",
     "Shutdown Complete": "Sėkmingai išjungta",
     "Simple File Versioning": "Supaprastintas versijų valdymas",
     "Single level wildcard (matches within a directory only)": "Vieno lygio pakaitos simbolis (atitinka tik vieną katalogo lygį)",

--- a/gui/default/assets/lang/lang-nb.json
+++ b/gui/default/assets/lang/lang-nb.json
@@ -339,7 +339,7 @@
     "Show diff with previous version": "Vis diff med forrige version",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Vis i stedet for enhets-ID i gruppestatus. Vil bli kringkastet til andre enheter som et valgfritt forvalgsnavn.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Vist i stedet for mappe-ID i gruppestatus. Vil bli oppdatert til navnet enheten kringkaster dersom tomt.",
-    "Shutdown": "Avslutt",
+    "Shut Down": "Avslutt",
     "Shutdown Complete": "Avslutning fullført",
     "Simple": "Enkel",
     "Simple File Versioning": "Enkel versjonskontroll",

--- a/gui/default/assets/lang/lang-nl.json
+++ b/gui/default/assets/lang/lang-nl.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Verschil met vorige versie weergeven",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Weergegeven in plaats van de apparaat-ID in de cluster-status. Zal aan andere apparaten voorgesteld worden als een optionele standaardnaam.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Weergegeven in plaats van de apparaat-ID in de clusterstatus. Zal bijgewerkt worden met de naam die het apparaat voorstelt wanneer leeg gelaten.",
-    "Shutdown": "Afsluiten",
+    "Shut Down": "Afsluiten",
     "Shutdown Complete": "Afsluiten voltooid",
     "Simple": "Eenvoudig",
     "Simple File Versioning": "Eenvoudig versiebeheer",

--- a/gui/default/assets/lang/lang-nn.json
+++ b/gui/default/assets/lang/lang-nn.json
@@ -187,7 +187,7 @@
     "Show QR": "Vis QR",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Vist i staden for einings-ID-en i klyngjestatusen. Vil verta kringkasta til dei andre einingane som eit valfritt standardnamn.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Vist i staden for mappe-ID-en i klyngjestatuses. Vil verta oppdatert til namnet eininga kringkastar dersom tomt.",
-    "Shutdown": "Slå Av",
+    "Shut Down": "Slå Av",
     "Shutdown Complete": "Slått av",
     "Simple File Versioning": "Enkel filutgåvehandtering",
     "Single level wildcard (matches within a directory only)": "Enkeltnivå-jokerteikn (søkjer berre i éi mappe)",

--- a/gui/default/assets/lang/lang-pl.json
+++ b/gui/default/assets/lang/lang-pl.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Pokaż diff z poprzednią wersją",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Widoczna na liście urządzeń zamiast identyfikatora urządzenia. Będzie anonsowana do innych urządzeń jako opcjonalna nazwa domyślna.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Widoczna na liście urządzeń zamiast identyfikatora urządzenia. Zostanie zaktualizowana do nazwy anonsowanej przez urządzenie, jeżeli pozostanie pusta.",
-    "Shutdown": "Wyłącz",
+    "Shut Down": "Wyłącz",
     "Shutdown Complete": "Wyłączanie ukończone",
     "Simple": "Proste",
     "Simple File Versioning": "Proste wersjonowanie plików",

--- a/gui/default/assets/lang/lang-pt-BR.json
+++ b/gui/default/assets/lang/lang-pt-BR.json
@@ -370,7 +370,7 @@
     "Show diff with previous version": "Mostrar diferenças da versão anterior",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Mostrado no lugar do ID do dispositivo no indicador de estado do grupo. Será divulgado aos outros dispositivos como um nome opcional e pré-definido.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Mostrado no lugar do ID do dispositivo no indicador de estado do grupo. Será atualizado para o nome que o dispositivo divulga, caso seja deixado em branco.",
-    "Shutdown": "Desligar",
+    "Shut Down": "Desligar",
     "Shutdown Complete": "Desligamento completado",
     "Simple": "Simples",
     "Simple File Versioning": "Simples",

--- a/gui/default/assets/lang/lang-pt-PT.json
+++ b/gui/default/assets/lang/lang-pt-PT.json
@@ -370,7 +370,7 @@
     "Show diff with previous version": "Mostrar diferenças em relação à versão anterior",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Apresentado ao invés do ID do dispositivo no indicador de estado do grupo. Será divulgado aos outros dispositivos como um nome predefinido opcional.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Apresentado ao invés do ID do dispositivo no indicador de estado do grupo. Será actualizado para o nome que o dispositivo divulga, se for deixado em branco.",
-    "Shutdown": "Desligar",
+    "Shut Down": "Desligar",
     "Shutdown Complete": "Encerramento completado",
     "Simple": "Simples",
     "Simple File Versioning": "Simples",

--- a/gui/default/assets/lang/lang-ro-RO.json
+++ b/gui/default/assets/lang/lang-ro-RO.json
@@ -312,7 +312,7 @@
     "Show diff with previous version": "Show diff with previous version",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Vizibil în locul ID-ului dispozitivului într-un grup. Va fi sugerat celorlalte dispozitive ca nume opţional. ",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Vizibil în locul ID-ului dispozitivului într-un grup. Va fi înlocuit de numele sugerat de dispozitiv daca nu este completat. ",
-    "Shutdown": "Opreşte",
+    "Shut Down": "Opreşte",
     "Shutdown Complete": "Oprește Complet",
     "Simple File Versioning": "Versiuni simple ale documentelor",
     "Single level wildcard (matches within a directory only)": "Asterisc de nivel simplu (corespunde doar unui fişier)",

--- a/gui/default/assets/lang/lang-ru.json
+++ b/gui/default/assets/lang/lang-ru.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Показать различия с предыдущей версией",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Отображается вместо ID устройства в статусе группы. Будет разослан другим устройствам в качестве имени по умолчанию.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Отображается вместо ID устройства в статусе группы. Если поле не заполнено, то будет установлено имя, передаваемое этим устройством.",
-    "Shutdown": "Выключить",
+    "Shut Down": "Выключить",
     "Shutdown Complete": "Выключение",
     "Simple": "Просто",
     "Simple File Versioning": "Простое управление версиями файлов",

--- a/gui/default/assets/lang/lang-si.json
+++ b/gui/default/assets/lang/lang-si.json
@@ -340,7 +340,7 @@
     "Show diff with previous version": "පෙර අනුවාදය සමඟ වෙනස පෙන්වන්න",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "පොකුරු තත්ත්‍වයේ උපාංග හැඳුනුම්පත වෙනුවට පෙන්වා ඇත. විකල්ප පෙරනිමි නාමයක් ලෙස වෙනත් උපාංග වෙත ප්‍රචාරණය කරනු ඇත.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "පොකුරු තත්ත්‍වයේ උපාංග හැඳුනුම්පත වෙනුවට පෙන්වා ඇත. හිස්ව තැබුවහොත් උපාංගය ප්‍රචාරණය කරන නමට යාවත්කාලීන වේ.",
-    "Shutdown": "වසා දමන්න",
+    "Shut Down": "වසා දමන්න",
     "Shutdown Complete": "වසා දැමීම සම්පූර්ණයි",
     "Simple": "සරල",
     "Simple File Versioning": "සරල ගොනු අනුවාදය",

--- a/gui/default/assets/lang/lang-sk.json
+++ b/gui/default/assets/lang/lang-sk.json
@@ -366,7 +366,7 @@
     "Show diff with previous version": "Ukázať rozdiely s predchádzajúcou verziou",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Zobrazované namiesto ID zariadenia v štatúte klastra. Toto pomenovanie bude oznamovať ostatným zariadeniam ako voliteľné predvolené pomenovanie.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Zobrazované namiesto ID zariadenia v klastri. Ak je ponechané prázdne, bude nahradené pomenovaním, ktoré oznamuje zariadenie.",
-    "Shutdown": "Vypnutie",
+    "Shut Down": "Vypnutie",
     "Shutdown Complete": "Vypnutie ukončené",
     "Simple": "Jednoduché",
     "Simple File Versioning": "Jednoduché verzie súborov",

--- a/gui/default/assets/lang/lang-sl.json
+++ b/gui/default/assets/lang/lang-sl.json
@@ -315,7 +315,7 @@
     "Show diff with previous version": "Pokaži razliko s prejšnjo različico",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Prikazano namesto ID-ja naprave v stanju gruče. Oglašuje se drugim napravam kot neobvezno privzeto ime.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Prikazano namesto ID-ja naprave v stanju gruče. Če ostane prazno, bo posodobljeno na ime, ki ga oglašuje naprava.",
-    "Shutdown": "Izklopi",
+    "Shut Down": "Izklopi",
     "Shutdown Complete": "Izklop končan",
     "Simple File Versioning": "Enostvno beleženje različic datotek",
     "Single level wildcard (matches within a directory only)": "Enostopenjski nadomestni znak (ujema se samo v imeniku)",

--- a/gui/default/assets/lang/lang-sv.json
+++ b/gui/default/assets/lang/lang-sv.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Visa skillnad med tidigare version",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Visas istället för enhets-ID i klusterstatus. Kommer att annonseras på andra enheter som ett valfritt standardnamn.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Visas istället för enhets-ID i klusterstatusen. Kommer att uppdateras till det namn som enheten annonserar om det lämnas tomt.",
-    "Shutdown": "Stäng av",
+    "Shut Down": "Stäng av",
     "Shutdown Complete": "Avstängning slutförd",
     "Simple": "Enkel",
     "Simple File Versioning": "Enkel filversionshantering",

--- a/gui/default/assets/lang/lang-tr.json
+++ b/gui/default/assets/lang/lang-tr.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "Önceki sürüm ile farklılıkları göster",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Küme durumunda Cihaz Kimliği yerine gösterilir. İsteğe bağlı varsayılan ad olarak diğer cihazlara duyurulacaktır.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Küme durumunda Cihaz Kimliği yerine gösterilir. Boş bırakılırsa duyurulan cihaz adına güncellenecektir.",
-    "Shutdown": "Kapat",
+    "Shut Down": "Kapat",
     "Shutdown Complete": "Kapatma İşlemi Tamamlandı",
     "Simple": "Basit",
     "Simple File Versioning": "Basit Dosya Sürümlendirme",

--- a/gui/default/assets/lang/lang-uk.json
+++ b/gui/default/assets/lang/lang-uk.json
@@ -370,7 +370,7 @@
     "Show diff with previous version": "Показати відмінності від попередньої версії",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Показується замість ID пристрою в статусі кластера. Буде розголошено іншим вузлам як опціональне типове ім’я.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Показується замість ID пристрою в статусі кластера. Буде оновлено ім’ям, яке розголошене пристроєм, якщо залишити порожнім.",
-    "Shutdown": "Вимкнути",
+    "Shut Down": "Вимкнути",
     "Shutdown Complete": "Вимикання завершене",
     "Simple": "Просте",
     "Simple File Versioning": "Просте версіювання",

--- a/gui/default/assets/lang/lang-vi.json
+++ b/gui/default/assets/lang/lang-vi.json
@@ -161,7 +161,7 @@
     "Show QR": "Hiển thị QR",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "Hiển thị thay cho ID th.bị trong trạng thái cụm. Sẽ được giới thiệu đến các th.bị khác như tên mặc định tuỳ chọn.",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "Hiển thị thay cho ID thiết bị trong trạng thái cụm. Nếu để trống sẽ được cập nhật thành tên mà thiết bị giới thiệu.",
-    "Shutdown": "Tắt",
+    "Shut Down": "Tắt",
     "Shutdown Complete": "Tắt hoàn tất",
     "Simple File Versioning": "Kiểu đơn giản",
     "Single level wildcard (matches within a directory only)": "Ký tự thay thế đơn cấp (phù hợp với chỉ một thư mục)",

--- a/gui/default/assets/lang/lang-zh-CN.json
+++ b/gui/default/assets/lang/lang-zh-CN.json
@@ -371,7 +371,7 @@
     "Show diff with previous version": "显示与以前版本的差异",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "在集群状态中显示该名称，而不是设备 ID。将作为可选的默认名称向其他设备通告。",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "在集群状态中显示该名称，而不是设备 ID。如果留空，将更新为设备通告的名称。",
-    "Shutdown": "关闭",
+    "Shut Down": "关闭",
     "Shutdown Complete": "关闭完成",
     "Simple": "简单",
     "Simple File Versioning": "简单文件版本控制",

--- a/gui/default/assets/lang/lang-zh-HK.json
+++ b/gui/default/assets/lang/lang-zh-HK.json
@@ -340,7 +340,7 @@
     "Show diff with previous version": "顯示與先前版本的差異",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "在集群狀態中顯示該名稱，而不是設備 ID。將會作為當前設備的可選的默認名稱，報告給所有其他設備。",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "在集群狀態中顯示該名稱，而不是設備 ID。如果設置為空，則會使用目標設備自報的默認名稱。",
-    "Shutdown": "關閉",
+    "Shut Down": "關閉",
     "Shutdown Complete": "關閉完成",
     "Simple": "簡易",
     "Simple File Versioning": "簡易版本控制",

--- a/gui/default/assets/lang/lang-zh-TW.json
+++ b/gui/default/assets/lang/lang-zh-TW.json
@@ -368,7 +368,7 @@
     "Show diff with previous version": "顯示與前一個版本的差異",
     "Shown instead of Device ID in the cluster status. Will be advertised to other devices as an optional default name.": "代替裝置識別碼顯示在叢集狀態中。這段文字將會廣播到其他的裝置作為一個可選的預設名稱。",
     "Shown instead of Device ID in the cluster status. Will be updated to the name the device advertises if left empty.": "代替裝置識別碼顯示在叢集狀態中。本欄若未填寫則將被更新為此裝置所廣播的名稱。",
-    "Shutdown": "關閉",
+    "Shut Down": "關閉",
     "Shutdown Complete": "關閉完成",
     "Simple": "簡單",
     "Simple File Versioning": "簡單檔案版本控制",

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -128,7 +128,7 @@
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="restart()"><span class="fa fa-fw fa-refresh"></span>&nbsp;<span translate>Restart</span></a></li>
-              <li ng-if="authenticated"><a href="" ng-click="shutdown()"><span class="fa fa-fw fa-power-off"></span>&nbsp;<span translate>Shutdown</span></a></li>
+              <li ng-if="authenticated"><a href="" ng-click="shutdown()"><span class="fa fa-fw fa-power-off"></span>&nbsp;<span translate>Shut Down</span></a></li>
             </ul>
           </li>
         </ul>


### PR DESCRIPTION
chore(gui): Fix "Shut Down" spelling in Actions

Currently, the word is written as "Shutdown". However, similarly to
"Log Out", it is used as a verb here, thus it should be written as two
separate words, i.e. "Shut Down".

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>