### PR TITLE
chore(gui): update fancytree from 2.38.0 to 2.38.5 (ref #10051, ref #10155)

### DIFF
--- a/gui/default/vendor/fancytree/LICENSE.txt
+++ b/gui/default/vendor/fancytree/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2008-2021 Martin Wendt,
+Copyright 2008-2023 Martin Wendt,
 https://wwWendt.de/
 
 Permission is hereby granted, free of charge, to any person obtaining


### PR DESCRIPTION
chore(gui): update fancytree from 2.38.0 to 2.38.5 (ref #10051, ref #10155)

Update the jQuery Fancytree Plugin to the newest version. Apart from
keeping it up-to-date out of principle, this may also help with further
investigation of issue #10155, which is related to the plugin.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>