### PR TITLE
chore(config): remove fallback STUN servers that are CNAMEs to stun.counterpath.com

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -72,8 +72,6 @@ var (
 	// The fallback stun servers are used if the primary ones can't be resolved or are down.
 	DefaultFallbackStunServers = []string{
 		"stun.counterpath.com:3478",
-		"stun.counterpath.net:3478",
-		"stun.ekiga.net:3478",
 		"stun.hitv.com:3478",
 		"stun.internetcalls.com:3478",
 		"stun.miwifi.com:3478",
@@ -82,7 +80,6 @@ var (
 		"stun.voip.aebc.com:3478",
 		"stun.voipbuster.com:3478",
 		"stun.voipstunt.com:3478",
-		"stun.xten.com:3478",
 	}
 )
 


### PR DESCRIPTION
ref https://forum.syncthing.net/t/my-local-dns-server-technitium-is-getting-spammed-with-stun-lookups-that-are-failing/24627/2?u=marbens

### Purpose

Reduces unnecessary load on CounterPath's server(s).

### Testing

STUN is still functional, and appears to get the correct external ports, if enabled.


