### PR TITLE
chore(scanner): reduce memory pressure by using pools inside hasher

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -28,6 +28,7 @@ var bufPool = sync.Pool{
 		return make([]byte, 32<<10) // 32k buffer
 	},
 }
+
 var hashPool = sync.Pool{
 	New: func() any {
 		return sha256.New()
@@ -40,7 +41,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 		counter = &noopCounter{}
 	}
 
-	hf := hashPool.Get().(hash.Hash)
+	hf := hashPool.Get().(hash.Hash) //nolint:forcetypeassert
 	const hashLength = sha256.Size
 
 	var blocks []protocol.BlockInfo
@@ -60,7 +61,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 	}
 
 	// A 32k buffer is used for copying into the hash function.
-	buf := bufPool.Get().([]byte)
+	buf := bufPool.Get().([]byte) //nolint:forcetypeassert
 
 	var offset int64
 	lr := io.LimitReader(r, int64(blocksize)).(*io.LimitedReader)

--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -10,7 +10,9 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"hash"
 	"io"
+	"sync"
 
 	"github.com/syncthing/syncthing/lib/protocol"
 )
@@ -21,13 +23,24 @@ type Counter interface {
 	Update(bytes int64)
 }
 
+var bufPool = sync.Pool{
+	New: func() any {
+		return make([]byte, 32<<10) // 32k buffer
+	},
+}
+var hashPool = sync.Pool{
+	New: func() any {
+		return sha256.New()
+	},
+}
+
 // Blocks returns the blockwise hash of the reader.
 func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, counter Counter) ([]protocol.BlockInfo, error) {
 	if counter == nil {
 		counter = &noopCounter{}
 	}
 
-	hf := sha256.New()
+	hf := hashPool.Get().(hash.Hash)
 	const hashLength = sha256.Size
 
 	var blocks []protocol.BlockInfo
@@ -47,7 +60,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 	}
 
 	// A 32k buffer is used for copying into the hash function.
-	buf := make([]byte, 32<<10)
+	buf := bufPool.Get().([]byte)
 
 	var offset int64
 	lr := io.LimitReader(r, int64(blocksize)).(*io.LimitedReader)
@@ -86,6 +99,9 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 
 		hf.Reset()
 	}
+	bufPool.Put(buf)
+	hf.Reset()
+	hashPool.Put(hf)
 
 	if len(blocks) == 0 {
 		// Empty file


### PR DESCRIPTION
### Purpose

While profiling syncthing, noticed this easily amortizable allocation source.

This PR reuses the buffer and sha256 instance in the hasher function using a sync.Pool, greatly reducing memory pressure and speeding up the function.

### Testing

Benchmark results, before (using benchmarks from https://github.com/syncthing/syncthing/pull/10221):

```
[daniil@arch-lenovo syncthing]$ go test -benchtime=100000x -bench -run=^$ -bench '^BenchmarkWalkHugeWithBuffer$' github.com/syncthing/syncthing/lib/scanner
goos: linux
goarch: amd64
pkg: github.com/syncthing/syncthing/lib/scanner
cpu: 12th Gen Intel(R) Core(TM) i5-12450H
BenchmarkWalkHugeWithBuffer-12    	  100000	      6820 ns/op
PASS
ok  	github.com/syncthing/syncthing/lib/scanner	2.010s
```

After:

```
[daniil@arch-lenovo syncthing]$ go test -benchtime=100000x -bench -run=^$ -bench '^BenchmarkWalkHugeWithBuffer$' github.com/syncthing/syncthing/lib/scanner
goos: linux
goarch: amd64
pkg: github.com/syncthing/syncthing/lib/scanner
cpu: 12th Gen Intel(R) Core(TM) i5-12450H
BenchmarkWalkHugeWithBuffer-12    	  100000	      3926 ns/op
PASS
ok  	github.com/syncthing/syncthing/lib/scanner	1.714s
```

(the benchmarks use 4 hasher workers)

