### PR TITLE
refactor(scanner): use recommended pattern for slice pool

### DIFF
--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -23,9 +23,11 @@ type Counter interface {
 	Update(bytes int64)
 }
 
+const bufSize = 32 << 10 // 32k
+
 var bufPool = sync.Pool{
 	New: func() any {
-		return new([32 << 10]byte) // 32k buffer
+		return new([bufSize]byte) // 32k buffer
 	},
 }
 
@@ -61,7 +63,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 	}
 
 	// A 32k buffer is used for copying into the hash function.
-	buf := bufPool.Get().(*[32 << 10]byte)[:] //nolint:forcetypeassert
+	buf := bufPool.Get().(*[bufSize]byte)[:] //nolint:forcetypeassert
 
 	var offset int64
 	lr := io.LimitReader(r, int64(blocksize)).(*io.LimitedReader)
@@ -100,7 +102,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 
 		hf.Reset()
 	}
-	bufPool.Put((*[32 << 10]byte)(buf))
+	bufPool.Put((*[bufSize]byte)(buf))
 	hf.Reset()
 	hashPool.Put(hf)
 

--- a/lib/scanner/blocks.go
+++ b/lib/scanner/blocks.go
@@ -25,7 +25,7 @@ type Counter interface {
 
 var bufPool = sync.Pool{
 	New: func() any {
-		return make([]byte, 32<<10) // 32k buffer
+		return new([32 << 10]byte) // 32k buffer
 	},
 }
 
@@ -61,7 +61,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 	}
 
 	// A 32k buffer is used for copying into the hash function.
-	buf := bufPool.Get().([]byte) //nolint:forcetypeassert
+	buf := bufPool.Get().(*[32 << 10]byte)[:] //nolint:forcetypeassert
 
 	var offset int64
 	lr := io.LimitReader(r, int64(blocksize)).(*io.LimitedReader)
@@ -100,7 +100,7 @@ func Blocks(ctx context.Context, r io.Reader, blocksize int, sizehint int64, cou
 
 		hf.Reset()
 	}
-	bufPool.Put(buf)
+	bufPool.Put((*[32 << 10]byte)(buf))
 	hf.Reset()
 	hashPool.Put(hf)
 


### PR DESCRIPTION
### Purpose

Uses recommended pattern for slice pools to avoid copying the slice struct, suggested by the linter and actually used in the go stdlib, for example in `net/http/h2_bundle.go`.