### PR TITLE
added LAN-only mode

### DIFF
--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -190,23 +190,6 @@
             <label translate for="ListenAddressesStr">Sync Protocol Listen Addresses</label>&emsp;<a href="{{docsURL('users/config#listen-addresses')}}" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
             <input id="ListenAddressesStr" class="form-control" type="text" ng-model="tmpOptions._listenAddressesStr" />
           </div>
-          
-          <!-- Perhaps it would be helpfull to grey out the global/NAT/discovery options when LAN only is enabled -->
-          <div class="row">
-            <div class="col-md-12">
-              <div class="form-group">
-                <div class="checkbox">
-                  <label>
-                    <input id="LANOnly" type="checkbox" ng-model="tmpOptions.lanOnly" /> <span translate>LAN Only</span>
-                  </label>
-                  <p class="help-block">
-                    <span translate>When enabled, disables global discovery, relaying, and NAT traversal to restrict connections to local network only.</span>
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          
           <div class="row">
             <div class="col-md-6">
               <div class="form-group" ng-class="{'has-error': settingsEditor.MaxRecvKbps.$invalid && settingsEditor.MaxRecvKbps.$dirty}">

--- a/gui/default/syncthing/settings/settingsModalView.html
+++ b/gui/default/syncthing/settings/settingsModalView.html
@@ -190,6 +190,23 @@
             <label translate for="ListenAddressesStr">Sync Protocol Listen Addresses</label>&emsp;<a href="{{docsURL('users/config#listen-addresses')}}" target="_blank"><span class="fas fa-question-circle"></span>&nbsp;<span translate>Help</span></a>
             <input id="ListenAddressesStr" class="form-control" type="text" ng-model="tmpOptions._listenAddressesStr" />
           </div>
+          
+          <!-- Perhaps it would be helpfull to grey out the global/NAT/discovery options when LAN only is enabled -->
+          <div class="row">
+            <div class="col-md-12">
+              <div class="form-group">
+                <div class="checkbox">
+                  <label>
+                    <input id="LANOnly" type="checkbox" ng-model="tmpOptions.lanOnly" /> <span translate>LAN Only</span>
+                  </label>
+                  <p class="help-block">
+                    <span translate>When enabled, disables global discovery, relaying, and NAT traversal to restrict connections to local network only.</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          
           <div class="row">
             <div class="col-md-6">
               <div class="form-group" ng-class="{'has-error': settingsEditor.MaxRecvKbps.$invalid && settingsEditor.MaxRecvKbps.$dirty}">

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -69,6 +69,7 @@ type OptionsConfiguration struct {
 	FeatureFlags                []string `json:"featureFlags" xml:"featureFlag"`
 	AuditEnabled                bool     `json:"auditEnabled" xml:"auditEnabled" default:"false" restart:"true"`
 	AuditFile                   string   `json:"auditFile" xml:"auditFile" restart:"true"`
+	LANOnly                     bool     `json:"lanOnly" xml:"lanOnly" default:"false"`
 	// The number of connections at which we stop trying to connect to more
 	// devices, zero meaning no limit. Does not affect incoming connections.
 	ConnectionLimitEnough int `json:"connectionLimitEnough" xml:"connectionLimitEnough"`
@@ -107,6 +108,27 @@ func (opts OptionsConfiguration) Copy() OptionsConfiguration {
 
 func (opts *OptionsConfiguration) prepare(guiPWIsSet bool) {
 	structutil.FillNilSlices(opts)
+
+	if opts.LANOnly {
+		if opts.GlobalAnnEnabled {
+			l.Infoln("LAN-only mode enabled, disabling global discovery")
+			opts.GlobalAnnEnabled = false
+		}
+
+		if opts.RelaysEnabled {
+			l.Infoln("LAN-only mode enabled, disabling relays")
+			opts.RelaysEnabled = false
+		}
+
+		if opts.NATEnabled {
+			l.Infoln("LAN-only mode enabled, disabling NAT traversal")
+			opts.NATEnabled = false
+		}
+
+		// may not be needed, but I'll need to test this.
+		opts.RawGlobalAnnServers = []string{}
+		opts.RawStunServers = []string{}
+	}
 
 	opts.RawListenAddresses = stringutil.UniqueTrimmedStrings(opts.RawListenAddresses)
 	opts.RawGlobalAnnServers = stringutil.UniqueTrimmedStrings(opts.RawGlobalAnnServers)

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -120,6 +120,16 @@ func (opts *OptionsConfiguration) prepare(guiPWIsSet bool) {
 			opts.RelaysEnabled = false
 		}
 
+		if opts.AutoUpgradeIntervalH != -1 {
+			l.Infoln("LAN-only mode enabled, disabling auto upgrade")
+			opts.AutoUpgradeIntervalH = -1
+		}
+
+		if opts.URAccepted != -1 {
+			l.Infoln("LAN-only mode enabled, disabling user reporting")
+			opts.URAccepted = -1
+		}
+
 		if opts.NATEnabled {
 			l.Infoln("LAN-only mode enabled, disabling NAT traversal")
 			opts.NATEnabled = false

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -126,7 +126,7 @@ func (opts *OptionsConfiguration) prepare(guiPWIsSet bool) {
 		}
 
 		if opts.URAccepted != -1 {
-			l.Infoln("LAN-only mode enabled, disabling user reporting")
+			l.Infoln("LAN-only mode enabled, disabling usage reporting")
 			opts.URAccepted = -1
 		}
 


### PR DESCRIPTION
implements #9377 

Added the LAN only option, and it's toggle in the webinterface.
I think it would be best UX if the LAN toggle and the global discovery/relaying/NAT traversal would be mutually exclusive, meaning, that when the LAN toggle is set to true, it atleast grays out those options and preferably toggles them off. For now, everything works as far as I see automatically, but the mutual exclusivity may require extra work.

First time contributor to the codebase, so still wrapping my head around how it all connects.

Extra documentation, translations and perhaps tests not yet included

Jakob Borg's suggestions can be added:
https://forum.syncthing.net/t/limit-syncthing-to-only-use-local-network-review-and-suggestions-appreciated/20117


usage reporting disabled (urAccepted = -1)
upgrade checks are disabled (autoUpgradeIntervalH = -1 
and set releasesURL = http://example.com or something to be sure


### Screenshots
<img width="1031" height="1494" alt="image" src="https://github.com/user-attachments/assets/6945fabc-0f44-4ed7-b50c-3374e4d59c48" />
