### PR TITLE
fix(slogutil): quote values with parentheses in them

### DIFF
--- a/internal/slogutil/formatting.go
+++ b/internal/slogutil/formatting.go
@@ -127,7 +127,7 @@ func appendAttr(sb *strings.Builder, prefix string, a slog.Attr, attrCount *int)
 	sb.WriteString(a.Key)
 	sb.WriteRune('=')
 	v := a.Value.Resolve().String()
-	if strings.ContainsAny(v, ` "`) {
+	if strings.ContainsAny(v, ` "()`) {
 		v = strconv.Quote(v)
 	}
 	sb.WriteString(v)

--- a/internal/slogutil/formatting_test.go
+++ b/internal/slogutil/formatting_test.go
@@ -23,6 +23,7 @@ func TestFormattingHandler(t *testing.T) {
 
 	l := slog.New(h).With("a", "a")
 	l.Info("A basic info line", "attr1", "val with spaces", "attr2", 2, "attr3", `val"quote`)
+	l.Info("A basic info line", "attr1", "paren)thesis")
 	l.Info("An info line with grouped values", "attr1", "val1", slog.Group("foo", "attr2", 2, slog.Group("bar", "attr3", "3")))
 
 	l2 := l.WithGroup("foo")
@@ -37,6 +38,7 @@ func TestFormattingHandler(t *testing.T) {
 
 	exp := `
 2009-02-13 23:31:30 INF A basic info line (attr1="val with spaces" attr2=2 attr3="val\"quote" a=a log.pkg=slogutil)
+2009-02-13 23:31:30 INF A basic info line (attr1="paren)thesis" a=a log.pkg=slogutil)
 2009-02-13 23:31:30 INF An info line with grouped values (attr1=val1 foo.attr2=2 foo.bar.attr3=3 a=a log.pkg=slogutil)
 2009-02-13 23:31:30 INF An info line with grouped values via logger (foo.attr1=val1 foo.attr2=2 a=a log.pkg=slogutil)
 2009-02-13 23:31:30 INF An info line with nested grouped values via logger (bar.foo.attr1=val1 bar.foo.attr2=2 a=a log.pkg=slogutil)


### PR DESCRIPTION
Avoids an obvious parsing ambiguity in log lines.