### PR TITLE
chore: remove GUI "debugging" toggle, debug HTTP metrics

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -116,13 +116,12 @@
             </a>
             <ul class="dropdown-menu">
               <li ng-if="authenticated"><a href="" ng-click="showSettings()"><span class="fa fa-fw fa-cog"></span>&nbsp;<span translate>Settings</span></a></li>
-              <li ng-if="authenticated"><a href="" ng-click="showDeviceIdentification(thisDevice())"><span class="fa fa-fw fa-qrcode"></span>&nbsp;<span translate>Show ID</span></a></li>
-
-              <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
-              <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
 
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
+
+              <li ng-if="authenticated"><a href="" ng-click="showDeviceIdentification(thisDevice())"><span class="fa fa-fw fa-qrcode"></span>&nbsp;<span translate>Show ID</span></a></li>
+              <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
               <li ng-if="authenticated"><a href="/rest/debug/support" target="_blank"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
 
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -108,7 +108,7 @@
               <li><a href="" ng-click="about.show()"><span class="fa fa-fw fa-heart"></span>&nbsp;<span translate>About</span></a></li>
             </ul>
           </li>
-          <li ng-if="authenticated || config.gui.debugging" class="dropdown action-menu">
+          <li ng-if="authenticated" class="dropdown action-menu">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
               <span class="fa fa-cog"></span>
               <span class="hidden-xs" translate>Actions</span>
@@ -122,8 +122,8 @@
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
 
-              <li class="divider" aria-hidden="true" ng-if="config.gui.debugging"></li>
-              <li><a href="/rest/debug/support" target="_blank" ng-if="config.gui.debugging"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
+              <li class="divider" aria-hidden="true"></li>
+              <li><a href="/rest/debug/support" target="_blank"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
 
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -122,8 +122,8 @@
               <li ng-if="authenticated"><a href="" ng-click="advanced()"><span class="fa fa-fw fa-cogs"></span>&nbsp;<span translate>Advanced</span></a></li>
               <li ng-if="authenticated"><a href="" ng-click="logging.show()"><span class="fa fa-fw fa-wrench"></span>&nbsp;<span translate>Logs</span></a></li>
 
-              <li class="divider" aria-hidden="true"></li>
-              <li><a href="/rest/debug/support" target="_blank"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
+              <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
+              <li ng-if="authenticated"><a href="/rest/debug/support" target="_blank"><span class="fa fa-fw fa-user-md"></span>&nbsp;<span translate>Support Bundle</span></a></li>
 
               <li ng-if="authenticated" class="divider" aria-hidden="true"></li>
               <li ng-if="authenticated && isAuthEnabled()"><a href="" ng-click="logout()"><span class="far fa-fw fa-sign-out"></span>&nbsp;<span translate>Log Out</span></a></li>

--- a/lib/config/guiconfiguration.go
+++ b/lib/config/guiconfiguration.go
@@ -30,7 +30,6 @@ type GUIConfiguration struct {
 	APIKey                    string   `json:"apiKey" xml:"apikey,omitempty"`
 	InsecureAdminAccess       bool     `json:"insecureAdminAccess" xml:"insecureAdminAccess,omitempty"`
 	Theme                     string   `json:"theme" xml:"theme" default:"default"`
-	Debugging                 bool     `json:"debugging" xml:"debugging,attr"`
 	InsecureSkipHostCheck     bool     `json:"insecureSkipHostcheck" xml:"insecureSkipHostcheck,omitempty"`
 	InsecureAllowFrameLoading bool     `json:"insecureAllowFrameLoading" xml:"insecureAllowFrameLoading,omitempty"`
 	SendBasicAuthPrompt       bool     `json:"sendBasicAuthPrompt" xml:"sendBasicAuthPrompt,attr"`

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -308,9 +308,6 @@ func (s *Service) reportData(ctx context.Context, urVersion int, preview bool) (
 			if guiCfg.InsecureAdminAccess {
 				report.GUIStats.InsecureAdminAccess++
 			}
-			if guiCfg.Debugging {
-				report.GUIStats.Debugging++
-			}
 			if guiCfg.InsecureSkipHostCheck {
 				report.GUIStats.InsecureSkipHostCheck++
 			}

--- a/test/h1/config.xml
+++ b/test/h1/config.xml
@@ -65,7 +65,7 @@
         <remoteGUIPort>0</remoteGUIPort>
         <numConnections>3</numConnections>
     </device>
-    <gui enabled="true" tls="false" debugging="true" sendBasicAuthPrompt="false">
+    <gui enabled="true" tls="false" sendBasicAuthPrompt="false">
         <address>127.0.0.1:8081</address>
         <user>testuser</user>
         <password>$2a$10$7tKL5uvLDGn5s2VLPM2yWOK/II45az0mTel8hxAUJDRQN1Tk2QYwu</password>

--- a/test/h2/config.xml
+++ b/test/h2/config.xml
@@ -65,7 +65,7 @@
         <remoteGUIPort>0</remoteGUIPort>
         <numConnections>3</numConnections>
     </device>
-    <gui enabled="true" tls="false" debugging="true" sendBasicAuthPrompt="false">
+    <gui enabled="true" tls="false" sendBasicAuthPrompt="false">
         <address>127.0.0.1:8082</address>
         <metricsWithoutAuth>false</metricsWithoutAuth>
         <apikey>abc123</apikey>


### PR DESCRIPTION
This removes the `debugging` bool under GUI configuration, and two no longer relevant development endpoints: `httpmetrics` (which I can't imagine anyone using for anything -- if we need such metrics today, the right place is the Prometheus exported metrics) and the `peerCompletion` endpoint (previously used by integration tests).

The debugging bool initially enabled just those two endpoints, which are not for end users. Then we added profiling and support bundles, which are very useful indeed for end users to access, and they were hidden behind the same debug flag. I don't see any reason for keeping that flag now that these methods are more generally useful.

https://github.com/syncthing/docs/pull/949