### PR TITLE
fix(all): various typos

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -15,7 +15,7 @@ env:
   # expression.
   GO_VERSION: "~1.24.0"
 
-  # Optimize compatibility on the slow archictures.
+  # Optimize compatibility on the slow architectures.
   GOMIPS: softfloat
   GOARM: "6"
 
@@ -207,7 +207,7 @@ jobs:
             go run build.go -tags "${{env.TAGS}}" -goos windows -goarch amd64 -cc "zig cc -target x86_64-windows" zip $tgt
             go run build.go -tags "${{env.TAGS}}" -goos windows -goarch 386 -cc "zig cc -target x86-windows" zip $tgt
             go run build.go -tags "${{env.TAGS}}" -goos windows -goarch arm64 -cc "zig cc -target aarch64-windows" zip $tgt
-            # go run build.go -tags "${{env.TAGS}}" -goos windows -goarch arm -cc "zig cc -target thumb-windows" zip $tgt # failes with linker errors
+            # go run build.go -tags "${{env.TAGS}}" -goos windows -goarch arm -cc "zig cc -target thumb-windows" zip $tgt # fails with linker errors
           done
         env:
           CGO_ENABLED: "1"

--- a/cmd/infra/stcrashreceiver/main.go
+++ b/cmd/infra/stcrashreceiver/main.go
@@ -44,7 +44,7 @@ type cli struct {
 	SentryQueue    int    `help:"Maximum number of reports to queue for sending to Sentry" default:"64" env:"SENTRY_QUEUE"`
 	DiskQueue      int    `help:"Maximum number of reports to queue for writing to disk" default:"64" env:"DISK_QUEUE"`
 	MetricsListen  string `help:"HTTP listen address for metrics" default:":8081" env:"METRICS_LISTEN_ADDRESS"`
-	IngorePatterns string `help:"File containing ignore patterns (regexp)" env:"IGNORE_PATTERNS" type:"existingfile"`
+	IgnorePatterns string `help:"File containing ignore patterns (regexp)" env:"IGNORE_PATTERNS" type:"existingfile"`
 }
 
 func main() {
@@ -68,9 +68,9 @@ func main() {
 	go ss.Serve(context.Background())
 
 	var ip *ignorePatterns
-	if params.IngorePatterns != "" {
+	if params.IgnorePatterns != "" {
 		var err error
-		ip, err = loadIgnorePatterns(params.IngorePatterns)
+		ip, err = loadIgnorePatterns(params.IgnorePatterns)
 		if err != nil {
 			log.Fatalf("Failed to load ignore patterns: %v", err)
 		}

--- a/cmd/infra/stupgrades/main.go
+++ b/cmd/infra/stupgrades/main.go
@@ -138,7 +138,7 @@ func (p *githubReleases) serveReleases(w http.ResponseWriter, req *http.Request)
 	osv := req.Header.Get("Syncthing-Os-Version")
 	if ua != "" && osv != "" {
 		// We should determine the compatibility of the releases.
-		rels = filterForCompabitility(rels, ua, osv)
+		rels = filterForCompatibility(rels, ua, osv)
 	} else {
 		metricFilterCalls.WithLabelValues("no-ua-or-osversion").Inc()
 	}
@@ -224,7 +224,7 @@ func filterForLatest(rels []upgrade.Release) []upgrade.Release {
 
 var userAgentOSArchExp = regexp.MustCompile(`^syncthing.*\(.+ (\w+)-(\w+)\)$`)
 
-func filterForCompabitility(rels []upgrade.Release, ua, osv string) []upgrade.Release {
+func filterForCompatibility(rels []upgrade.Release, ua, osv string) []upgrade.Release {
 	osArch := userAgentOSArchExp.FindStringSubmatch(ua)
 	if len(osArch) != 3 {
 		metricFilterCalls.WithLabelValues("bad-os-arch").Inc()

--- a/gui/default/syncthing/core/modalDirective.js
+++ b/gui/default/syncthing/core/modalDirective.js
@@ -27,7 +27,7 @@ angular.module('syncthing.core')
                 // before modal show animation
                 $(element).on('show.bs.modal', function () {
 
-                    // cycle through open modals, acertain modal with highest z-index
+                    // cycle through open modals, ascertain modal with highest z-index
                     var largestZ = 1040;
                     $('.modal:visible').each(function (i) {
                         var thisZ = parseInt($(this).css('zIndex'));

--- a/internal/db/sqlite/sql/schema/folder/20-files.sql
+++ b/internal/db/sqlite/sql/schema/folder/20-files.sql
@@ -12,7 +12,7 @@
 -- version of each file is considered the "global" version - the latest one,
 -- that all other devices strive to replicate. This instance gets the Global
 -- flag bit set. There may be other identical instances of this file
--- announced by other devices, but only one onstance gets the Global flag;
+-- announced by other devices, but only one instance gets the Global flag;
 -- this simplifies accounting. If the current device has the Global version,
 -- the LocalDeviceID instance of the file is the one that has the Global
 -- bit.

--- a/lib/build/parse.go
+++ b/lib/build/parse.go
@@ -49,7 +49,7 @@ func (v VersionParts) Environment() string {
 func ParseVersion(line string) (VersionParts, error) {
 	m := longVersionRE.FindStringSubmatch(line)
 	if len(m) == 0 {
-		return VersionParts{}, errors.New("unintelligeble version string")
+		return VersionParts{}, errors.New("unintelligible version string")
 	}
 
 	v := VersionParts{

--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -333,7 +333,7 @@ func (cfg *Configuration) prepareDeviceList() map[protocol.DeviceID]*DeviceConfi
 	// - free from duplicates
 	// - no devices with empty ID
 	// - sorted by ID
-	// Happen before preparting folders as that needs a correct device list.
+	// Happen before preparing folders as that needs a correct device list.
 	cfg.Devices = ensureNoDuplicateOrEmptyIDDevices(cfg.Devices)
 	slices.SortFunc(cfg.Devices, func(a, b DeviceConfiguration) int {
 		return a.DeviceID.Compare(b.DeviceID)

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -235,7 +235,7 @@ func (opts OptionsConfiguration) MaxFolderConcurrency() int {
 		return 0
 	}
 	// Otherwise default to the number of CPU cores in the system as a rough
-	// approximation of system powerfullness.
+	// approximation of system powerfulness.
 	if n := runtime.GOMAXPROCS(-1); n > 0 {
 		return n
 	}

--- a/lib/fs/fakefs.go
+++ b/lib/fs/fakefs.go
@@ -657,7 +657,7 @@ func (*fakeFS) SetXattr(_ string, _ []protocol.Xattr, _ XattrFilter) error {
 	return nil
 }
 
-// A basic glob-impelementation that should be able to handle
+// A basic glob-implementation that should be able to handle
 // simple test cases.
 func (fs *fakeFS) Glob(pattern string) ([]string, error) {
 	dir := filepath.Dir(pattern)

--- a/lib/fs/filesystem.go
+++ b/lib/fs/filesystem.go
@@ -323,7 +323,7 @@ func Canonicalize(file string) (string, error) {
 	}
 
 	// The relative path should be clean from internal dotdots and similar
-	// funkyness.
+	// funkiness.
 	file = filepath.Clean(file)
 
 	// It is not acceptable to attempt to traverse upwards.

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1494,7 +1494,7 @@ func TestEscapePipe(t *testing.T) {
 
 // overrideBackslashTests has the same wants as the pipeTests tests.
 // The only difference in the tests is the pipe symbol in the pattern has been
-// changed to a backslash. This could be done programatically, if desired.
+// changed to a backslash. This could be done programmatically, if desired.
 var overrideBackslashTests = []escapeTest{
 	{`a\*`, `a*`, true},
 	{`a\*b`, `a*b`, true},

--- a/lib/model/devicedownloadstate.go
+++ b/lib/model/devicedownloadstate.go
@@ -14,7 +14,7 @@ import (
 )
 
 // deviceFolderFileDownloadState holds current download state of a file that
-// a remote device has advertised. blockIndexes represends indexes within
+// a remote device has advertised. blockIndexes represents indexes within
 // FileInfo.Blocks that the remote device already has, and version represents
 // the version of the file that the remote device is downloading.
 type deviceFolderFileDownloadState struct {

--- a/lib/model/devicedownloadstate_test.go
+++ b/lib/model/devicedownloadstate_test.go
@@ -66,7 +66,7 @@ func TestDeviceDownloadState(t *testing.T) {
 			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p2},
 		},
 		{ // 7
-			// v2 replacees v1, v2 gets deleted, and v2 part 2 gets added.
+			// v2 replaces v1, v2 gets deleted, and v2 part 2 gets added.
 			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p1, f1v2del, f1v2p2},
 			[]protocol.FileDownloadProgressUpdate{f1v2p2},
 			[]protocol.FileDownloadProgressUpdate{f1v1p1, f1v1p2, f1v2p1},

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -951,7 +951,7 @@ func (f *folder) scanTimerFired() error {
 		if err != nil {
 			f.sl.Error("Failed initial scan", slogutil.Error(err))
 		} else {
-			f.sl.Info("Competed initial scan")
+			f.sl.Info("Completed initial scan")
 		}
 		close(f.initialScanFinished)
 	}

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1541,7 +1541,7 @@ func (m *model) ccCheckEncryption(fcfg config.FolderConfiguration, folderDevice 
 	}
 
 	if isEncryptedRemote && isEncryptedLocal {
-		// Should never happen, but config racyness and be safe.
+		// Should never happen, but config raciness and be safe.
 		return errEncryptionInvConfigLocal
 	}
 
@@ -3105,7 +3105,7 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 
 	// Some options don't require restart as those components handle it fine
 	// by themselves. Compare the options structs containing only the
-	// attributes that require restart and act apprioriately.
+	// attributes that require restart and act appropriately.
 	if !reflect.DeepEqual(from.Options.RequiresRestartOnly(), to.Options.RequiresRestartOnly()) {
 		l.Debugln(m, "requires restart, options differ")
 		return false

--- a/lib/model/requests_test.go
+++ b/lib/model/requests_test.go
@@ -745,7 +745,7 @@ func TestRequestRemoteRenameChanged(t *testing.T) {
 			}
 		case strings.HasPrefix(path, b+".sync-conflict-"):
 			if err := equalContents(tfs, path, otherData); err != nil {
-				t.Error(`Sync conflict of "b" has unexptected content`)
+				t.Error(`Sync conflict of "b" has unexpected content`)
 			}
 		case path == "." || strings.HasPrefix(path, ".stfolder"):
 		default:

--- a/lib/osutil/net.go
+++ b/lib/osutil/net.go
@@ -14,7 +14,7 @@ import (
 )
 
 // GetInterfaceAddrs returns the IP networks of all interfaces that are up.
-// Point-to-point interfaces are exluded unless includePtP is true.
+// Point-to-point interfaces are excluded unless includePtP is true.
 func GetInterfaceAddrs(includePtP bool) ([]*net.IPNet, error) {
 	intfs, err := netutil.Interfaces()
 	if err != nil {

--- a/lib/protocol/protocol.go
+++ b/lib/protocol/protocol.go
@@ -933,7 +933,7 @@ func (c *rawConnection) shouldCompressMessage(msg proto.Message) bool {
 	}
 }
 
-// Close is called when the connection is regularely closed and thus the Close
+// Close is called when the connection is regularly closed and thus the Close
 // BEP message is sent before terminating the actual connection. The error
 // argument specifies the reason for closing the connection.
 func (c *rawConnection) Close(err error) {

--- a/lib/protocol/protocol_test.go
+++ b/lib/protocol/protocol_test.go
@@ -289,7 +289,7 @@ func TestWriteCompressed(t *testing.T) {
 
 		msg := (&Response{Data: make([]byte, 10240)}).toWire()
 		if random {
-			// This should make the message uncompressible.
+			// This should make the message incompressible.
 			rand.Read(msg.Data)
 		}
 

--- a/lib/relay/client/dynamic.go
+++ b/lib/relay/client/dynamic.go
@@ -139,7 +139,7 @@ type dynamicAnnouncement struct {
 // relayAddressesOrder checks the latency to each relay, rounds latency down to
 // the closest 50ms, and puts them in buckets of 50ms latency ranges. Then
 // shuffles each bucket, and returns all addresses starting with the ones from
-// the lowest latency bucket, ending with the highest latency buceket.
+// the lowest latency bucket, ending with the highest latency bucket.
 func relayAddressesOrder(ctx context.Context, input []string) []string {
 	buckets := make(map[int][]string)
 

--- a/script/codecov-upload.sh
+++ b/script/codecov-upload.sh
@@ -1133,7 +1133,7 @@ fi
 
 if [ "$ft_search" = "1" ];
 then
-  # detect bower comoponents location
+  # detect bower components location
   bower_components="bower_components"
   bower_rc=$(cd "$git_root" && cat .bowerrc 2>/dev/null || echo "")
   if [ "$bower_rc" != "" ];

--- a/test/transfer-bench_test.go
+++ b/test/transfer-bench_test.go
@@ -75,7 +75,7 @@ func setupAndBenchmarkTransfer(t *testing.T, files, sizeExp int) {
 }
 
 // TestBenchmarkTransferSameFiles doesn't actually transfer anything, but tests
-// how fast two devicees get in sync if they have the same data locally.
+// how fast two devices get in sync if they have the same data locally.
 func TestBenchmarkTransferSameFiles(t *testing.T) {
 	cleanBenchmarkTransfer(t)
 

--- a/test/util.go
+++ b/test/util.go
@@ -443,7 +443,7 @@ func startWalker(dir string, res chan<- fileInfo, abort <-chan struct{}) chan er
 				name: rn,
 				mode: info.Mode(),
 				// comparing timestamps with better precision than a second
-				// is problematic as there is rounding and truncatign going
+				// is problematic as there is rounding and truncation going
 				// on at every level
 				mod:  info.ModTime().Unix(),
 				size: info.Size(),


### PR DESCRIPTION
Here's the list:
```
acertain                                             #  2 hits in  1 file: gui/default/syncthing/core/modalDirective.js
apprioriately                                        #  2 hits in  1 file: lib/model/model.go
archictures                                          #  2 hits in  1 file: .github/workflows/build-syncthing.yaml
buceket                                              #  2 hits in  1 file: lib/relay/client/dynamic.go
comoponents                                          #  2 hits in  1 file: script/codecov-upload.sh
Compabitility                                        #  4 hits in  1 file: cmd/infra/stupgrades/main.go
devicees                                             #  2 hits in  1 file: test/transfer-bench_test.go
exluded                                              #  2 hits in  1 file: lib/osutil/net.go
failes                                               #  2 hits in  1 file: .github/workflows/build-syncthing.yaml
funkyness                                            #  2 hits in  1 file: lib/fs/filesystem.go
impelementation                                      #  2 hits in  1 file: lib/fs/fakefs.go
Ingore                                               #  6 hits in  1 file: cmd/infra/stcrashreceiver/main.go
onstance                                             #  2 hits in  1 file: internal/db/sqlite/sql/schema/folder/20-files.sql
powerfullness                                        #  2 hits in  1 file: lib/config/optionsconfiguration.go
preparting                                           #  2 hits in  1 file: lib/config/config.go
programatically                                      #  2 hits in  1 file: lib/ignore/ignore_test.go
racyness                                             #  2 hits in  1 file: lib/model/model.go
regularely                                           #  2 hits in  1 file: lib/protocol/protocol.go
replacees                                            #  2 hits in  1 file: lib/model/devicedownloadstate_test.go
represends                                           #  2 hits in  1 file: lib/model/devicedownloadstate.go
truncatign                                           #  2 hits in  1 file: test/util.go
uncompressible                                       #  2 hits in  1 file: lib/protocol/protocol_test.go
unexptected                                          #  2 hits in  1 file: lib/model/requests_test.go
unintelligeble                                       #  2 hits in  1 file: lib/build/parse.go
and
Competed => Completed
```
