### PR TITLE
build: remove netgo and osusergo build tags

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -26,7 +26,7 @@ env:
   BUILD_USER: builder
   BUILD_HOST: github.syncthing.net
 
-  TAGS: "netgo osusergo sqlite_omit_load_extension sqlite_dbstat"
+  TAGS: "sqlite_omit_load_extension sqlite_dbstat"
 
 # A note on actions and third party code... The actions under actions/ (like
 # `uses: actions/checkout`) are maintained by GitHub, and we need to trust


### PR DESCRIPTION
I added these tags as part of the big database PR, but I forget why. I think it came from an attempt at a static binary using the Go-based SQLite packages, but that's not the primary build anymore anyway. We can remove this and go back to the standard resolvers, which gives better support for primarily Windows and macOS special resolution methods...