### PR TITLE
build: Upgrade Go version to 1.24.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/syncthing/syncthing
 
-go 1.23.0
+go 1.24.6
 
 require (
 	github.com/AudriusButkevicius/recli v0.0.7


### PR DESCRIPTION
Updates the Go version in go.mod to 1.24.6. This addresses four vulnerabilities in the Go standard library that were detected by govulncheck:

- GO-2025-3849 (database/sql)
- GO-2025-3751 (net/http)
- GO-2025-3750 (syscall)
- GO-2025-3749 (crypto/x509)

The dependency list has been updated accordingly by running `go mod tidy`.



