### PR TITLE
build: set osusergo for linux build

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -289,6 +289,7 @@ jobs:
     env:
       VERSION: ${{ needs.facts.outputs.version }}
       RELEASE_KIND: ${{ needs.facts.outputs.release-kind }}
+      TAGS: "sqlite_omit_load_extension sqlite_dbstat osusergo"
     steps:
       - uses: actions/checkout@v4
 

--- a/lib/build/build.go
+++ b/lib/build/build.go
@@ -49,6 +49,7 @@ var (
 	replaceTags = map[string]string{
 		"sqlite_omit_load_extension": "",
 		"sqlite_dbstat":              "",
+		"osusergo":                   "",
 	}
 )
 
@@ -132,6 +133,7 @@ func TagsList() []string {
 		tags = tags[1:]
 	}
 
+	tags = slices.Compact(tags)
 	return tags
 }
 


### PR DESCRIPTION
Avoid:

    /_/GOROOT/src/os/user/cgo_lookup_cgo.go:45:(.text+0x54): warning: Using 'getgrgid_r' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking