### PR TITLE
fix(cmd): restore --version flag for compatibility

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -227,7 +227,7 @@ func main() {
 	parser.FatalIfErrorf(err)
 
 	if entrypoint.VersionFlag {
-		versionCmd{}.Run()
+		_ = versionCmd{}.Run()
 		return
 	}
 


### PR DESCRIPTION
### Purpose

This was lost / replaced when introducing the "version" command.  However, the documentation still lists the flag - actually under the serve command, but that can be omitted.  Common convention for CLI programs is to accept it as a flag.

### Testing

```
$ bin/syncthing --help
Usage: syncthing <command> [flags]

Flags:
  -h, --help           Show context-sensitive help.
  -C, --config=PATH    Set configuration directory (config and keys) ($STCONFDIR)
  -D, --data=PATH      Set data directory (database and logs) ($STDATADIR)
  -H, --home=PATH      Set configuration and data directory ($STHOMEDIR)
      --version        Show current version, then exit

Commands:
  serve                  Run Syncthing (default)
  cli                    Command line interface for Syncthing
  browser                Open GUI in browser, then exit
  decrypt                Decrypt or verify an encrypted folder
  device-id              Show device ID, then exit
  generate               Generate key and config, then exit
  paths                  Show configuration paths, then exit
  upgrade                Perform or check for upgrade, then exit
  version                Show current version, then exit
  debug                  Various debugging commands
  install-completions    Print commands to install shell completions

Run "syncthing <command> --help" for more information on a command.
```

```
$ bin/syncthing --version
syncthing v2.0.3-dev.2.g0f47e944-restore-version-flag "Hafnium Hornet" (go1.24.0 linux-amd64) acolomb@riddo 2025-08-18 19:25:31 UTC
```

### Documentation

Already / *still* listed in the docs under Command Line Operation.