### PR TITLE
refactor to use maps.Clone

### DIFF
--- a/lib/discover/cache.go
+++ b/lib/discover/cache.go
@@ -7,6 +7,7 @@
 package discover
 
 import (
+	"maps"
 	"sync"
 	"time"
 
@@ -58,9 +59,9 @@ func (c *cache) Get(id protocol.DeviceID) (CacheEntry, bool) {
 
 func (c *cache) Cache() map[protocol.DeviceID]CacheEntry {
 	c.mut.Lock()
-	m := make(map[protocol.DeviceID]CacheEntry, len(c.entries))
-	for k, v := range c.entries {
-		m[k] = v
+	m := maps.Clone(c.entries)
+	if m == nil {
+		m = make(map[protocol.DeviceID]CacheEntry)
 	}
 	c.mut.Unlock()
 	return m


### PR DESCRIPTION
### Purpose

---

## **1. What `maps.Clone` does**
In Go 1.21+, the [`maps` package](https://pkg.go.dev/maps) in the standard library provides:

```go
func Clone[M ~map[K]V, K comparable, V any](m M) M
```

It returns a **shallow copy** of the given map — same keys and values, but a different underlying map object.

Example:
```go
import "maps"

m1 := map[string]int{"a": 1, "b": 2}
m2 := maps.Clone(m1)
```

---

## **2. Why prefer `maps.Clone` over manual `for` loop copying**

### ✅ **a. Less boilerplate**
Manual copy:
```go
m2 := make(map[string]int, len(m1))
for k, v := range m1 {
    m2[k] = v
}
```
With `maps.Clone`:
```go
m2 := maps.Clone(m1)
```
It’s shorter, clearer, and easier to read.

---

### ✅ **b. Correctness and safety**
`maps.Clone` handles:
- **Nil maps** — returns `nil` if the input is `nil` (manual loops often forget this and return an empty map instead).
- **Capacity preallocation** — it preallocates the new map with the same size as the original, which can be slightly more efficient.
- **Type safety** — works with any map type without rewriting loops.

---

### ✅ **c. Standard library trust**
- It’s maintained and tested by the Go team.
- Less chance of subtle bugs (e.g., forgetting to handle `nil` or mismatching types).
- Makes intent explicit: you’re cloning a map, not doing some custom transformation.

---

### ✅ **d. Generic support**
`maps.Clone` is generic — it works with **any** map type:
```go
m1 := map[int]bool{1: true, 2: false}
m2 := maps.Clone(m1)
```
No need to rewrite loops for each key/value type.

---

## **3. When manual copy might still be needed**
- If you want a **deep copy** (e.g., values are slices, maps, or pointers and you want to copy those too).
- If you want to transform keys or values while copying.

---

### **Summary Table**

| Aspect              | `maps.Clone` | Manual `for` loop |
|---------------------|--------------|-------------------|
| Concise             | ✅           | ❌                |
| Handles `nil` map   | ✅           | ❌ (unless coded) |
| Preallocates size   | ✅           | ❌ (unless coded) |
| Generic             | ✅           | ❌                |
| Standardized        | ✅           | ❌                |

---

💡 **Bottom line:**  
Use `maps.Clone` when you just need a straightforward shallow copy of a map. It’s cleaner, safer, and idiomatic in modern Go.

---

If you want, I can also show you **the actual Go source code of `maps.Clone`** so you can see exactly how it works internally. Would you like me to do that?

### Testing

Describe what testing has been done, and how the reviewer can test the change
if new tests are not included.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

