### PR TITLE
fix: do not always start temporary API server during migration

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -479,7 +479,11 @@ func (c *serveCmd) syncthingMain() {
 		})
 	}
 
-	if err := syncthing.TryMigrateDatabase(ctx, c.DBDeleteRetentionInterval, cfgWrapper.GUI().Address()); err != nil {
+	var tempApiAddress string = ""
+	if cfgWrapper.GUI().Enabled {
+		tempApiAddress = cfgWrapper.GUI().Address()
+	}
+	if err := syncthing.TryMigrateDatabase(ctx, c.DBDeleteRetentionInterval, tempApiAddress); err != nil {
 		slog.Error("Failed to migrate old-style database", slogutil.Error(err))
 		os.Exit(1)
 	}


### PR DESCRIPTION
### Purpose

Disable the temporary API during migration when GUI is not enabled (the temporary API server is then not expected to be used).

This also allows callers of TryMigrateDatabase to decide whether the temporary API server should be started or not. That's useful for the iOS app.

Note, the address "" is valid as far as http.Server is concerned, but it interprets it as `:80`, which is different from Syncthing config's default `127.0.0.1:8384`. Hence users who really want `:80` should specify that as the GUI address explicitly anyway.

### Testing

n/a, it builds.

### Screenshots

n/a

### Documentation

n/a (I think the temporary API is not documented currently?)

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.