### PR TITLE
chore(db): avoid rowid for blocks and blocklists

### DIFF
--- a/internal/db/sqlite/sql/schema/folder/50-blocks.sql
+++ b/internal/db/sqlite/sql/schema/folder/50-blocks.sql
@@ -14,7 +14,7 @@
 CREATE TABLE IF NOT EXISTS blocklists (
     blocklist_hash BLOB NOT NULL PRIMARY KEY,
     blprotobuf BLOB NOT NULL
-) STRICT
+) STRICT, WITHOUT ROWID
 ;
 
 -- Blocks
@@ -30,5 +30,5 @@ CREATE TABLE IF NOT EXISTS blocks (
     size INTEGER NOT NULL,
     PRIMARY KEY (hash, blocklist_hash, idx),
     FOREIGN KEY(blocklist_hash) REFERENCES blocklists(blocklist_hash) ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED
-) STRICT
+) STRICT, WITHOUT ROWID
 ;


### PR DESCRIPTION
### Purpose

Noticed "large" autgenerated indices on blocks and blocklists in https://forum.syncthing.net/t/database-or-disk-is-full-might-be-syncthing-might-be-qnap/24930/7

They both have a primary key and don't need rowids

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

