### PR TITLE
fix(syncthing): apply folder migrations with temporary API/GUI server

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -442,8 +442,8 @@ func (c *serveCmd) syncthingMain() {
 		os.Exit(1)
 	}
 
-	ctx, cancelMigratingAPI := context.WithCancel(context.Background())
-	defer cancelMigratingAPI()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// earlyService is a supervisor that runs the services needed for or
 	// before app startup; the event logger, and the config service.
@@ -479,7 +479,7 @@ func (c *serveCmd) syncthingMain() {
 		})
 	}
 
-	migratingAPICtx, cancelMigratingAPI := context.WithCancel(ctx)
+	migratingAPICtx, migratingAPICancel := context.WithCancel(ctx)
 	if cfgWrapper.GUI().Enabled {
 		// Start a temporary API server during the migration. It will wait
 		// startDelay until actually starting, so that if we quickly pass
@@ -503,7 +503,7 @@ func (c *serveCmd) syncthingMain() {
 		os.Exit(1)
 	}
 
-	cancelMigratingAPI() // we're done with the temporary API server
+	migratingAPICancel() // we're done with the temporary API server
 
 	// Check if auto-upgrades is possible, and if yes, and it's enabled do an initial
 	// upgrade immediately. The auto-upgrade routine can only be started

--- a/internal/db/sqlite/db_open.go
+++ b/internal/db/sqlite/db_open.go
@@ -86,6 +86,10 @@ func Open(path string, opts ...Option) (*DB, error) {
 		slog.Warn("Failed to clean dropped folders", slogutil.Error(err))
 	}
 
+	if err := db.startFolderDatabases(); err != nil {
+		return nil, wrap(err)
+	}
+
 	return db, nil
 }
 

--- a/internal/db/sqlite/db_update.go
+++ b/internal/db/sqlite/db_update.go
@@ -7,6 +7,7 @@
 package sqlite
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -72,6 +73,22 @@ func (s *DB) cleanDroppedFolders() error {
 			} else {
 				slog.Info("Cleaned out database file for old, dropped folder", slogutil.FilePath(base))
 			}
+		}
+	}
+	return nil
+}
+
+// startFolderDatabases loads all existing folder databases, thus causing
+// migrations to apply.
+func (s *DB) startFolderDatabases() error {
+	ids, err := s.ListFolders()
+	if err != nil {
+		return wrap(err)
+	}
+	for _, id := range ids {
+		_, err := s.getFolderDB(id, false)
+		if err != nil && !errors.Is(err, errNoSuchFolder) {
+			return wrap(err)
 		}
 	}
 	return nil

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -191,10 +191,6 @@ func (a *App) startup() error {
 		if _, ok := cfgFolders[folder]; !ok {
 			slog.Info("Cleaning metadata for dropped folder", "folder", folder)
 			a.sdb.DropFolder(folder)
-		} else {
-			// Open the folder database, causing it to apply migrations
-			// early when appropriate.
-			_, _ = a.sdb.GetDeviceSequence(folder, protocol.LocalDeviceID)
 		}
 	}
 


### PR DESCRIPTION
This adds an explicit open of all folder databases to when we open the main database, thus causing any required migrations to apply. Since this is just after the main migration step we have the opportunity to use the database migration API/GUI server to report back status.

I set a start delay of five seconds for the temporary server in question, so that during a normal startup it usually won't even start. Only when a longer running migration is in progress will it become available to show what's going on.