### PR TITLE
fix(db): only vacuum database on startup when a migration script was actually run

### DIFF
--- a/internal/db/sqlite/basedb.go
+++ b/internal/db/sqlite/basedb.go
@@ -110,6 +110,7 @@ func openBase(path string, maxConns int, pragmas, schemaScripts, migrationScript
 			}
 			if int(n) > ver.SchemaVersion {
 				slog.Info("Applying database migration", slogutil.FilePath(db.baseName), slog.String("script", scr))
+				shouldVacuum = true
 				return true
 			}
 			return false
@@ -118,7 +119,6 @@ func openBase(path string, maxConns int, pragmas, schemaScripts, migrationScript
 			if err := db.runScripts(tx, script, filter); err != nil {
 				return nil, wrap(err)
 			}
-			shouldVacuum = true
 		}
 	}
 


### PR DESCRIPTION
### Purpose

https://github.com/syncthing/syncthing/blob/4ad3f076910e79914bd5956450691352594f5b87/internal/db/sqlite/basedb.go#L123

@calmh it appears shouldVacuum is always true, even when no migration script had to be run. This increases startup time significantly since 2.0.4.

### Testing

n/a

### Screenshots

n/a

### Documentation

n/a

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

