### PR TITLE
fix(db): remove temp_store = MEMORY pragmas

### DIFF
--- a/internal/db/sqlite/db_open.go
+++ b/internal/db/sqlite/db_open.go
@@ -52,8 +52,6 @@ func Open(path string, opts ...Option) (*DB, error) {
 		"journal_mode = WAL",
 		"optimize = 0x10002",
 		"auto_vacuum = INCREMENTAL",
-		"default_temp_store = MEMORY",
-		"temp_store = MEMORY",
 	}
 	schemas := []string{
 		"sql/schema/common/*",
@@ -99,8 +97,6 @@ func Open(path string, opts ...Option) (*DB, error) {
 func OpenForMigration(path string) (*DB, error) {
 	pragmas := []string{
 		"journal_mode = OFF",
-		"default_temp_store = MEMORY",
-		"temp_store = MEMORY",
 		"foreign_keys = 0",
 		"synchronous = 0",
 		"locking_mode = EXCLUSIVE",

--- a/internal/db/sqlite/folderdb_open.go
+++ b/internal/db/sqlite/folderdb_open.go
@@ -25,8 +25,6 @@ func openFolderDB(folder, path string, deleteRetention time.Duration) (*folderDB
 		"journal_mode = WAL",
 		"optimize = 0x10002",
 		"auto_vacuum = INCREMENTAL",
-		"default_temp_store = MEMORY",
-		"temp_store = MEMORY",
 	}
 	schemas := []string{
 		"sql/schema/common/*",
@@ -64,8 +62,6 @@ func openFolderDB(folder, path string, deleteRetention time.Duration) (*folderDB
 func openFolderDBForMigration(folder, path string, deleteRetention time.Duration) (*folderDB, error) {
 	pragmas := []string{
 		"journal_mode = OFF",
-		"default_temp_store = MEMORY",
-		"temp_store = MEMORY",
 		"foreign_keys = 0",
 		"synchronous = 0",
 		"locking_mode = EXCLUSIVE",


### PR DESCRIPTION
This reduces database migration memory usage in my test scenario from 2.1 GB to 170 MB (native), or 3.8 GB to 440 MB (modernc). In principle I don't think we're causing many temp tables to be generated anyway in normal usage, but if we do and someone can benchmark a performance difference, we can add a tunable. I ran the database benchmark before and after and didn't see a difference above the noise level.
