### PR TITLE
fix(api): redact device encryption passwords in support bundle config

### DIFF
--- a/lib/api/support_bundle.go
+++ b/lib/api/support_bundle.go
@@ -26,7 +26,7 @@ func getRedactedConfig(s *service) config.Configuration {
 
 	for folderIdx, folderCfg := range rawConf.Folders {
 		for deviceIdx, deviceCfg := range folderCfg.Devices {
-			if len(deviceCfg.EncryptionPassword) > 0 {
+			if deviceCfg.EncryptionPassword != "" {
 				rawConf.Folders[folderIdx].Devices[deviceIdx].EncryptionPassword = "REDACTED"
 			}
 		}


### PR DESCRIPTION
### Purpose

Redact device encryption passwords in the config included in the support bundle.

### Testing

None

### Screenshots

n/a

### Documentation

n/a

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

