### PR TITLE
chore(model): don't check file availability early on sync

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -491,15 +491,6 @@ nextFile:
 			continue nextFile
 		}
 
-		// Verify there is some availability for the file before we start
-		// processing it
-		devices := f.model.fileAvailability(f.FolderConfiguration, fi)
-		if len(devices) == 0 {
-			f.newPullError(fileName, errNotAvailable)
-			f.queue.Done(fileName)
-			continue
-		}
-
 		// Verify we have space to handle the file before we start
 		// creating temp files etc.
 		if err := f.CheckAvailableSpace(uint64(fi.Size)); err != nil { //nolint:gosec

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2870,12 +2870,6 @@ func (m *model) blockAvailabilityRLocked(cfg config.FolderConfiguration, file pr
 	return candidates
 }
 
-func (m *model) fileAvailability(cfg config.FolderConfiguration, file protocol.FileInfo) []Availability {
-	m.mut.RLock()
-	defer m.mut.RUnlock()
-	return m.fileAvailabilityRLocked(cfg, file)
-}
-
 func (m *model) fileAvailabilityRLocked(cfg config.FolderConfiguration, file protocol.FileInfo) []Availability {
 	var availabilities []Availability
 	devs, err := m.sdb.GetGlobalAvailability(cfg.ID, file.Name)


### PR DESCRIPTION
There's simply no point: We are doing it later when actually pulling the blocks anyway. It might even by syncable even if no remote is available copying blocks locally. Also deleting code is fun.
