### PR TITLE
fix(tlsutil): support HTTP/2 on GUI/API connections

### DIFF
--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -83,6 +83,8 @@ func SecureDefaultWithTLS12() *tls.Config {
 		// We've put some thought into this choice and would like it to
 		// matter.
 		PreferServerCipherSuites: true,
+		// We support HTTP/2 and HTTP/1.1
+		NextProtos: []string{"h2", "http/1.1"},
 
 		ClientSessionCache: tls.NewLRUClientSessionCache(0),
 	}


### PR DESCRIPTION
By not setting ALPN we were implicitly rejecting HTTP/2, completely unnecessarily.

Tested with my browser and with curl.

```
jb@jbo-m3wl72rv:../syncthing/syncthing % curl -skv https://localhost:8081/ > /dev/null
* Host localhost:8081 was resolved.
...
* ALPN: curl offers h2,http/1.1
...
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=syncthing
*  start date: Sep 14 22:23:35 2014 GMT
*  expire date: Dec 31 23:59:59 2049 GMT
*  issuer: CN=syncthing
*  SSL certificate verify result: self-signed certificate (18), continuing anyway.
*   Certificate level 0: Public key type RSA (3072/128 Bits/secBits), signed using sha256WithRSAEncryption
* Connected to localhost (127.0.0.1) port 8081
* using HTTP/2
* [HTTP/2] [1] OPENED stream for https://localhost:8081/
```
