### PR TITLE
build: trigger nightly build only on syncthing repo

### DIFF
--- a/.github/workflows/trigger-nightly.yaml
+++ b/.github/workflows/trigger-nightly.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
 
   trigger-nightly:
+    if: github.repository_owner == 'syncthing'
     runs-on: ubuntu-latest
     name: Push to release-nightly to trigger build
     steps:


### PR DESCRIPTION
### Purpose

Pushing nightly build fails on other repositories because of missing token permissions, although it can be enabled per user, I do not think it would benefit most of forks to have a specific branch for their nightly releases.
https://github.com/aminvakil/syncthing/actions/runs/17522743557

Users can still benefit from nightly builds on their forks without pushing to specific branch though.
https://github.com/aminvakil/syncthing/actions/runs/17524279505