### PR TITLE
fix(sqlite): add _txlock=immediate to modernc implementation

### DIFF
--- a/internal/db/sqlite/db_open_nocgo.go
+++ b/internal/db/sqlite/db_open_nocgo.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	dbDriver      = "sqlite"
-	commonOptions = "_pragma=foreign_keys(1)&_pragma=recursive_triggers(1)&_pragma=synchronous(1)"
+	commonOptions = "_pragma=foreign_keys(1)&_pragma=recursive_triggers(1)&_pragma=synchronous(1)&_txlock=immediate"
 )
 
 func init() {


### PR DESCRIPTION
For symmetry with the CGO variant.

https://pkg.go.dev/modernc.org/sqlite#Driver.Open
