### PR TITLE
fix(gui): don't getch usage report preview unnecessarily on GUI load

### DIFF
--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -187,13 +187,14 @@ angular.module('syncthing.core')
                     $scope.version = data;
                 }).error($scope.emitHTTPError);
 
-                $http.get(urlbase + '/svc/report').success(function (data) {
-                    $scope.reportData = data;
-                    if ($scope.system && $scope.config.options.urAccepted > -1 && $scope.config.options.urSeen < $scope.system.urVersionMax && $scope.config.options.urAccepted < $scope.system.urVersionMax) {
-                        // Usage reporting format has changed, prompt the user to re-accept.
+                if ($scope.system && $scope.config.options.urAccepted > -1 && $scope.config.options.urSeen < $scope.system.urVersionMax && $scope.config.options.urAccepted < $scope.system.urVersionMax) {
+                    // Usage reporting decision has not been taken or format
+                    // has changed, prompt the user to (re-)accept.
+                    $http.get(urlbase + '/svc/report').success(function (data) {
+                        $scope.reportData = data;
                         showModal('#ur');
-                    }
-                }).error($scope.emitHTTPError);
+                    }).error($scope.emitHTTPError);
+                }
 
                 $http.get(urlbase + '/system/upgrade').success(function (data) {
                     $scope.upgradeInfo = data;


### PR DESCRIPTION
IMHO the logic here was inverted. The only use for the report data is to show a preview when we ask the user whether they want to participate in usage reporting. However, the GUI would first load the report data and then consider whether we wanted to show that dialog or not. Instead, only load if it we're going to show the dialog.
