### PR TITLE
fix(syncthing): do not perform CPU benchmark on startup unless logging enabled

### DIFF
--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -163,8 +163,10 @@ func (a *App) startup() error {
 	}
 
 	if slog.Default().Enabled(context.Background(), slog.LevelInfo) {
-		perf := ur.CpuBench(context.Background(), 3, 150*time.Millisecond)
-		slog.Info("Measured hashing performance", "perf", fmt.Sprintf("%.02f MB/s", perf))
+		go func() {
+			perf := ur.CpuBench(context.Background(), 3, 150*time.Millisecond)
+			slog.Info("Measured hashing performance", "perf", fmt.Sprintf("%.02f MB/s", perf))
+		}()
 	}
 
 	if a.opts.ResetDeltaIdxs {

--- a/lib/syncthing/syncthing.go
+++ b/lib/syncthing/syncthing.go
@@ -162,8 +162,10 @@ func (a *App) startup() error {
 		}()
 	}
 
-	perf := ur.CpuBench(context.Background(), 3, 150*time.Millisecond)
-	slog.Info("Measured hashing performance", "perf", fmt.Sprintf("%.02f MB/s", perf))
+	if slog.Default().Enabled(context.Background(), slog.LevelInfo) {
+		perf := ur.CpuBench(context.Background(), 3, 150*time.Millisecond)
+		slog.Info("Measured hashing performance", "perf", fmt.Sprintf("%.02f MB/s", perf))
+	}
 
 	if a.opts.ResetDeltaIdxs {
 		slog.Info("Reinitializing delta index IDs")


### PR DESCRIPTION
### Purpose

On startup, a CPU benchmark is performed that delays start by 3*150ms. This is not a long time but also quite unnecessary, and especially on mobile eats the battery unnecessarily.

This change only executes the benchmark if the logging level INFO is enabled. If it is not enabled, the result is not going anywhere. If a tree falls in a forest and no one is around to hear it, does it make a sound?

### Testing

Built & tested with Synctrain on macOS

### Screenshots

n/a

### Documentation

n/a

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

