### PR TITLE
fix(sqlite): actually always insert blocks for local files (fixes #10388)

### DIFF
--- a/internal/db/sqlite/folderdb_update.go
+++ b/internal/db/sqlite/folderdb_update.go
@@ -149,9 +149,9 @@ func (s *folderDB) Update(device protocol.DeviceID, fs []protocol.FileInfo) erro
 			if err != nil {
 				return wrap(err, "marshal blocklist")
 			}
-			if res, err := insertBlockListStmt.Exec(f.BlocksHash, bs); err != nil {
+			if _, err := insertBlockListStmt.Exec(f.BlocksHash, bs); err != nil {
 				return wrap(err, "insert blocklist")
-			} else if aff, _ := res.RowsAffected(); aff != 0 && device == protocol.LocalDeviceID {
+			} else if device == protocol.LocalDeviceID {
 				// Insert all blocks
 				if err := s.insertBlocksLocked(txp, f.BlocksHash, f.Blocks); err != nil {
 					return wrap(err, "insert blocks")


### PR DESCRIPTION
Due to a thinko, this optimisation was wildly incorrect and would read to lack of block reuse when syncing files.

(We do not insert a blocklist per device, but only a single one. We can't use the fact of whether the insert happened as a criteria for inserting blocks.)
