### PR TITLE
fix(lib) : Fixed issue where default values overwrote existing JSON struct fields (fixes #10389)

### DIFF
--- a/lib/structutil/structutil.go
+++ b/lib/structutil/structutil.go
@@ -27,6 +27,9 @@ func SetDefaults(data any) {
 
 		v := tag.Get("default")
 		if len(v) > 0 {
+			if !f.IsZero() {
+				continue
+			}
 			if f.CanInterface() {
 				if parser, ok := f.Interface().(defaultParser); ok {
 					if err := parser.ParseDefault(v); err != nil {

--- a/lib/structutil/structutil_test.go
+++ b/lib/structutil/structutil_test.go
@@ -55,6 +55,32 @@ func TestSetDefaults(t *testing.T) {
 	}
 }
 
+func TestSetDefaultsSkipNonZeroFields(t *testing.T) {
+	type Test struct {
+		A int  `default:"100"`
+		B bool `default:"true"`
+	}
+
+	x := &Test{
+		A: 20,
+	}
+
+	SetDefaults(x)
+	if x.A != 20 {
+		t.Error("int failed")
+	} else if x.B != true {
+		t.Error("bool failed")
+	}
+
+	x = &Test{}
+	SetDefaults(x)
+	if x.A != 100 {
+		t.Error("int failed")
+	} else if x.B != true {
+		t.Error("bool failed")
+	}
+}
+
 func TestFillNillSlices(t *testing.T) {
 	// Nil
 	x := &struct {


### PR DESCRIPTION
Signed-off-by : Prashant Shukla prashantshukla933@gmail.com

### Purpose
Fixes the issue where default values defined in JSON struct were being overwritten into fields even though those fields already had some value.

### Testing
Tested the bug as mentioned in the issue and verified it locally. Also added a unit test to make sure SetDefaults() works correctly.

