### PR TITLE
fix(policy): only allow approvals by non-author contributors

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -52,7 +52,7 @@ approval_rules:
         - syncthing/maintainers
     options:
       ignore_update_merges: true
-      allow_contributor: true
+      allow_non_author_contributor: true
 
   # Regular pull requests require approval by an active contributor
   - name: is approved by a syncthing contributor
@@ -62,7 +62,7 @@ approval_rules:
         - syncthing/contributors
     options:
       ignore_update_merges: true
-      allow_contributor: true
+      allow_non_author_contributor: true
 
   # Changes to some files (translations, dependencies, compatibility) do not
   # require approval if they were proposed by a contributor and have a


### PR DESCRIPTION
This replaces `allow_contributor` with `allow_non_author_contributor`, because the former allows authors to approve their own pull requests.

From https://github.com/syncthing/syncthing/pull/9818#issue-2651431707:

> This adds `allow_contributor: true` which allows approvals by contributors to the PR (**but still not the author themself**, which is a different thing).

This statement conflicts with [the policybot README](https://github.com/palantir/policy-bot/blob/c013552248d2a99911207fa5c0045428ac073fa2/README.md), which says:

> If true, the approvals of someone who has committed to the pull request are
> considered when calculating the status.
> **The pull request author is considered a contributor.**