### PR TITLE
chore(upnp): remove incorrect embedding of nat.Service (fixes #10426)

### DIFF
--- a/lib/upnp/igd_service.go
+++ b/lib/upnp/igd_service.go
@@ -56,8 +56,6 @@ type IGDService struct {
 	URN       string
 	LocalIPv4 net.IP
 	Interface *net.Interface
-
-	nat.Service
 }
 
 // AddPinhole adds an IPv6 pinhole in accordance to http://upnp.org/specs/gw/UPnP-gw-WANIPv6FirewallControl-v1-Service.pdf


### PR DESCRIPTION
Revert the embedding of `nat.Service` (which contains the mutex) within `IGDService`. That happened in
https://github.com/syncthing/syncthing/pull/9010 and wasn't necessary/based on a misconception, see:
https://github.com/syncthing/syncthing/pull/9010#discussion_r1323658323

Signed-off-by: Simon Frei <freisim93@gmail.com>