### PR TITLE
fix(fs): store `getExpireAdd` mutex in `caseCache` (fixes #9836)

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -400,7 +400,7 @@ type defaultRealCaser struct {
 }
 
 type caseCache struct {
-	lru.TwoQueueCache[string, *caseNode]
+	*lru.TwoQueueCache[string, *caseNode]
 
 	mut sync.Mutex
 }
@@ -412,7 +412,7 @@ func newCaseCache() *caseCache {
 		panic(err)
 	}
 	return &caseCache{
-		TwoQueueCache: *cache,
+		TwoQueueCache: cache,
 	}
 }
 


### PR DESCRIPTION
In #9701 there was a change that put the mutex used for `getExpireAdd` directly in `defaultRealCaser`, which is erroneous because multiple filesystems can share the same `caseCache`.

### Purpose

Fixes #9836 and [Slow sync sending files from Android](https://forum.syncthing.net/t/slow-sync-sending-files-from-android/24208?u=marbens). There may be other issues caused by `getExpireAdd` conflicting with itself, though.

### Testing

Unit tests pass and the case cache and conflict detection _seem_ to behave correctly.


