### PR TITLE
fix(fs): only apply case option to fakefs in stress test

### DIFF
--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -156,7 +156,7 @@ func testCaseFSStat(t *testing.T, fsys Filesystem) {
 
 func BenchmarkWalkCaseFakeFS100k(b *testing.B) {
 	const entries = 100_000
-	fsys, paths, err := fakefsForBenchmark(entries, 0)
+	fsys, paths, err := fakefsForTest(entries, 0)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -260,7 +260,7 @@ func TestStressCaseFS(t *testing.T) {
 		t.Skip("long test")
 	}
 
-	fsys, paths, err := fakefsForBenchmark(10_000, 0)
+	fsys, paths, err := fakefsForTest(10_000, 0, &OptionDetectCaseConflicts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -326,8 +326,8 @@ func doubleWalkFSWithOtherOps(fsys Filesystem, paths []string, otherOpEvery int,
 	return nil
 }
 
-func fakefsForBenchmark(nfiles int, latency time.Duration) (Filesystem, []string, error) {
-	fsys := NewFilesystem(FilesystemTypeFake, fmt.Sprintf("fakefsForBenchmark?files=%d&insens=true&latency=%s", nfiles, latency), &OptionDetectCaseConflicts{})
+func fakefsForTest(nfiles int, latency time.Duration, opts ...Option) (Filesystem, []string, error) {
+	fsys := NewFilesystem(FilesystemTypeFake, fmt.Sprintf("fakefsForBenchmark?files=%d&insens=true&latency=%s", nfiles, latency), opts...)
 
 	var paths []string
 	if err := fsys.Walk("/", func(path string, info FileInfo, err error) error {


### PR DESCRIPTION
### Purpose

Fixes a regression introduced in #10439, mentioned in [a comment](https://github.com/syncthing/syncthing/pull/10439#issuecomment-3436515824) made by @imsodin:

> That might not be the greatest way to do this, but nevertheless it afaik means that the benchmarks now do case checking once when it shouldn't happen at all, and twice otherwise.

### Testing

Benchmarks do approximately as well as before the regression, and I think most of the differences are random chance:

```
                                             │ ../oldold.txt │             ../new.txt             │
                                             │    sec/op     │   sec/op     vs base               │
WalkCaseFakeFS100k/rawfs-8                       654.6m ± 1%   652.6m ± 3%       ~ (p=0.971 n=10)
WalkCaseFakeFS100k/casefs-8                       1.049 ± 2%    1.071 ± 3%       ~ (p=0.190 n=10)
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8      1.053 ± 3%    1.081 ± 5%       ~ (p=0.165 n=10)
geomean                                          897.7m        910.8m       +1.46%

                                             │ ../oldold.txt │              ../new.txt               │
                                             │    B/entry    │   B/entry     vs base                 │
WalkCaseFakeFS100k/rawfs-8                      1.274Ki ± 0%   1.274Ki ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-8                     1.771Ki ± 0%   1.771Ki ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8    1.772Ki ± 0%   1.772Ki ± 0%       ~ (p=1.000 n=10) ¹
geomean                                         1.587Ki        1.587Ki       +0.00%
¹ all samples are equal

                                             │ ../oldold.txt  │               ../new.txt                │
                                             │ DirNames/entry │ DirNames/entry  vs base                 │
WalkCaseFakeFS100k/rawfs-8                        512.5m ± 0%      512.5m ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-8                        1.025 ± 0%       1.025 ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8       1.025 ± 0%       1.025 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                           813.5m           813.5m       +0.00%
¹ all samples are equal

                                             │ ../oldold.txt │              ../new.txt              │
                                             │  DirNames/op  │ DirNames/op  vs base                 │
WalkCaseFakeFS100k/rawfs-8                       51.25k ± 0%   51.25k ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-8                      102.5k ± 0%   102.5k ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8     102.5k ± 0%   102.5k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                          81.35k        81.35k       +0.00%
¹ all samples are equal

                                             │ ../oldold.txt │              ../new.txt              │
                                             │  Lstat/entry  │ Lstat/entry  vs base                 │
WalkCaseFakeFS100k/rawfs-8                        5.535 ± 0%    5.535 ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-8                       5.535 ± 0%    5.535 ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8      5.540 ± 0%    5.540 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                           5.537         5.537       +0.00%
¹ all samples are equal

                                             │ ../oldold.txt │              ../new.txt              │
                                             │   Lstat/op    │  Lstat/op    vs base                 │
WalkCaseFakeFS100k/rawfs-8                       553.5k ± 0%   553.5k ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-8                      553.5k ± 0%   553.5k ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8     554.0k ± 0%   554.0k ± 0%       ~ (p=1.000 n=10) ¹
geomean                                          553.7k        553.7k       +0.00%
¹ all samples are equal

                                             │ ../oldold.txt │              ../new.txt               │
                                             │ allocs/entry  │ allocs/entry  vs base                 │
WalkCaseFakeFS100k/rawfs-8                        19.00 ± 0%     19.00 ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-8                       35.35 ± 0%     35.35 ± 0%       ~ (p=1.000 n=10) ¹
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8      35.38 ± 0%     35.38 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                           28.75          28.75       +0.00%
¹ all samples are equal

                                             │ ../oldold.txt │             ../new.txt             │
                                             │   sec/entry   │  sec/entry   vs base               │
WalkCaseFakeFS100k/rawfs-8                       4.328µ ± 1%   4.315µ ± 3%       ~ (p=0.971 n=10)
WalkCaseFakeFS100k/casefs-8                      6.936µ ± 2%   7.082µ ± 3%       ~ (p=0.171 n=10)
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8     6.965µ ± 3%   7.147µ ± 5%       ~ (p=0.165 n=10)
geomean                                          5.935µ        6.022µ       +1.46%

                                             │ ../oldold.txt │             ../new.txt              │
                                             │     B/op      │     B/op      vs base               │
WalkCaseFakeFS100k/rawfs-8                      188.3Mi ± 0%   188.3Mi ± 0%  -0.00% (p=0.006 n=10)
WalkCaseFakeFS100k/casefs-8                     261.5Mi ± 0%   261.5Mi ± 0%       ~ (p=0.142 n=10)
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8    261.7Mi ± 0%   261.7Mi ± 0%       ~ (p=0.315 n=10)
geomean                                         234.4Mi        234.4Mi       -0.00%

                                             │ ../oldold.txt │             ../new.txt             │
                                             │   allocs/op   │  allocs/op   vs base               │
WalkCaseFakeFS100k/rawfs-8                       2.873M ± 0%   2.873M ± 0%  -0.00% (p=0.026 n=10)
WalkCaseFakeFS100k/casefs-8                      5.346M ± 0%   5.346M ± 0%       ~ (p=0.136 n=10)
WalkCaseFakeFS100k/casefs-otherOpEvery1000-8     5.351M ± 0%   5.351M ± 0%       ~ (p=0.305 n=10)
geomean                                          4.348M        4.348M       -0.00%
```
