### PR TITLE
chore: Fixed some function names mismatch in comments

### DIFF
--- a/lib/signature/signature.go
+++ b/lib/signature/signature.go
@@ -174,7 +174,7 @@ type signature struct {
 	R, S *big.Int
 }
 
-// marhalSignature returns ASN.1 encoded bytes for the given integers,
+// marshalSignature returns ASN.1 encoded bytes for the given integers,
 // suitable for PEM encoding.
 func marshalSignature(r, s *big.Int) ([]byte, error) {
 	sig := signature{

--- a/lib/tlsutil/tlsutil.go
+++ b/lib/tlsutil/tlsutil.go
@@ -58,7 +58,7 @@ var (
 	}
 )
 
-// SecureDefault returns a tls.Config with reasonable, secure defaults set.
+// SecureDefaultTLS13 returns a tls.Config with reasonable, secure defaults set.
 // This variant allows only TLS 1.3.
 func SecureDefaultTLS13() *tls.Config {
 	return &tls.Config{

--- a/lib/watchaggregator/aggregator.go
+++ b/lib/watchaggregator/aggregator.go
@@ -378,7 +378,7 @@ func (a *aggregator) notify(oldEvents map[string]*aggregatedEvent, out chan<- []
 	}
 }
 
-// popOldEvents finds events that should be scheduled for scanning recursively in dirs,
+// popOldEventsTo finds events that should be scheduled for scanning recursively in dirs,
 // removes those events and empty eventDirs and returns a map with all the removed
 // events referenced by their filesystem path
 func (a *aggregator) popOldEventsTo(to map[string]*aggregatedEvent, dir *eventDir, dirPath string, currTime time.Time, delayRem bool) {


### PR DESCRIPTION
### Purpose

Fixed some function names mismatch in comments

### Testing

No need.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

