### PR TITLE
chore(beacon): more verbose debug logging

### DIFF
--- a/lib/beacon/broadcast.go
+++ b/lib/beacon/broadcast.go
@@ -75,6 +75,7 @@ func writeBroadcasts(ctx context.Context, inbox <-chan []byte, port int) error {
 				if iaddr, ok := addr.(*net.IPNet); ok && len(iaddr.IP) >= 4 && iaddr.IP.IsGlobalUnicast() && iaddr.IP.To4() != nil {
 					baddr := bcast(iaddr)
 					dsts = append(dsts, baddr.IP)
+					slog.Debug("Added broadcast address", slogutil.Address(baddr), "intf", intf.Name, slog.String("intf_flags", intf.Flags.String()))
 				}
 			}
 		}
@@ -83,8 +84,6 @@ func writeBroadcasts(ctx context.Context, inbox <-chan []byte, port int) error {
 			// Fall back to the general IPv4 broadcast address
 			dsts = append(dsts, net.IP{0xff, 0xff, 0xff, 0xff})
 		}
-
-		l.Debugln("addresses:", dsts)
 
 		success := 0
 		for _, ip := range dsts {


### PR DESCRIPTION
### Purpose

So you can see which broadcast addresses are associated with which interfaces.

### Testing

```
2025-12-17 07:14:33 DBG Added broadcast address (address=192.168.10.255/24 intf=wlp2s0 intf_flags=up|broadcast|multicast|running log.pkg=beacon log.src.file=broadcast.go log.src.line=78)
```
