### PR TITLE
fix(beacon): don't join multicast groups on non-multicast interfaces (fixes #10497)

### DIFF
--- a/lib/beacon/multicast.go
+++ b/lib/beacon/multicast.go
@@ -129,6 +129,11 @@ func readMulticasts(ctx context.Context, outbox chan<- recv, addr string) error 
 	pconn := ipv6.NewPacketConn(conn)
 	joined := 0
 	for _, intf := range intfs {
+		if intf.Flags&net.FlagMulticast == 0 {
+			slog.DebugContext(ctx, "Not joining multicast group on non-multicast interface", "name", intf.Name, slog.String("flags", intf.Flags.String()))
+			continue
+		}
+
 		err := pconn.JoinGroup(&intf, &net.UDPAddr{IP: gaddr.IP})
 		if err != nil {
 			l.Debugln("IPv6 join", intf.Name, "failed:", err)


### PR DESCRIPTION
### Purpose

Fixes #10497.

### Testing

Joining the multicast group is skipped on the loopback interface (which doesn't have the multicast flag set in my case) but done on the interfaces that have the multicast flag set.

```
2025-12-17 19:10:52 DBG Not joining multicast group on non-multicast interface (name=lo flags=up|loopback|running log.pkg=beacon log.src.file=multicast.go log.src.line=133)
2025-12-17 19:10:52 DBG IPv6 join enp1s0 success (log.pkg=beacon log.src.file=multicast.go log.src.line=141)
2025-12-17 19:10:52 DBG IPv6 join wlp2s0 success (log.pkg=beacon log.src.file=multicast.go log.src.line=141)
```