### PR TITLE
build: fix hash failure by limiting globbing

### DIFF
--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -1079,7 +1079,7 @@ jobs:
       - name: Prepare context dir
         run: |
           mkdir ctx
-          mv bin script ctx
+          mv bin/* script ctx
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
The glob in `**/go.sum` fails in some builds because there are a lot of files in `**` due to things like the zig cache directory. We can be more specific. Also, avoid a huge build context sent to Docker for the container builds.