### PR TITLE
feat(gui): show restart message during auto-upgrade

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -749,6 +749,10 @@ func autoUpgrade(cfg config.Wrapper, app *syncthing.App, evLogger events.Logger)
 		}
 		sub.Unsubscribe()
 		slog.Error("Automatically upgraded, restarting in 1 minute", slog.String("newVersion", rel.Tag))
+		evLogger.Log(events.UpgradeStarted, map[string]string{
+			"from": build.Version,
+			"to":   rel.Tag,
+		})
 		time.Sleep(time.Minute)
 		app.Stop(svcutil.ExitUpgrade)
 		return

--- a/gui/default/syncthing/core/eventService.js
+++ b/gui/default/syncthing/core/eventService.js
@@ -94,6 +94,7 @@ angular.module('syncthing.core')
             FOLDER_SCAN_PROGRESS: 'FolderScanProgress',   // Emitted every ScanProgressIntervalS seconds, indicating how far into the scan it is at.
             FOLDER_PAUSED: 'FolderPaused',   // Emitted when a folder is paused
             FOLDER_RESUMED: 'FolderResumed',   // Emitted when a folder is resumed
+            UPGRADE_STARTED: 'UpgradeStarted',   // Emitted when an automatic upgrade has been performed and the system will restart
 
             start: function () {
                 $http.get(urlbase + '/events?limit=1')

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -222,6 +222,12 @@ angular.module('syncthing.core')
             }
         });
 
+        $scope.$on(Events.UPGRADE_STARTED, function (event, arg) {
+            console.log('UpgradeStarted', arg);
+            restarting = true;
+            showModal('#restarting');
+        });
+
         $scope.$on('HTTPError', function (event, arg) {
             // Emitted when a HTTP call fails. We use the status code to try
             // to figure out what's wrong.

--- a/lib/events/events.go
+++ b/lib/events/events.go
@@ -57,6 +57,7 @@ const (
 	ListenAddressesChanged
 	LoginAttempt
 	Failure
+	UpgradeStarted
 
 	AllEvents = (1 << iota) - 1
 )
@@ -134,6 +135,8 @@ func (t EventType) String() string {
 		return "FolderWatchStateChanged"
 	case Failure:
 		return "Failure"
+	case UpgradeStarted:
+		return "UpgradeStarted"
 	default:
 		return "Unknown"
 	}
@@ -221,6 +224,8 @@ func UnmarshalEventType(s string) EventType {
 		return FolderWatchStateChanged
 	case "Failure":
 		return Failure
+	case "UpgradeStarted":
+		return UpgradeStarted
 	default:
 		return 0
 	}

--- a/man/syncthing-event-api.7
+++ b/man/syncthing-event-api.7
@@ -1087,6 +1087,28 @@ ready to start exchanging data with other devices.
 .EE
 .UNINDENT
 .UNINDENT
+.SS UpgradeStarted
+.sp
+Emitted when an automatic upgrade has been performed and Syncthing is
+about to restart.  The event contains information about the old and new
+versions.
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.EX
+{
+    \(dqid\(dq: 14,
+    \(dqglobalID\(dq: 14,
+    \(dqtype\(dq: \(dqUpgradeStarted\(dq,
+    \(dqtime\(dq: \(dq2024\-01\-15T10:30:00.123456789+01:00\(dq,
+    \(dqdata\(dq: {
+        \(dqfrom\(dq: \(dqv1.27.2\(dq,
+        \(dqto\(dq: \(dqv1.27.3\(dq
+    }
+}
+.EE
+.UNINDENT
+.UNINDENT
 .SS StateChanged
 .sp
 Emitted when a folder changes state. Possible states are \fBidle\fP,


### PR DESCRIPTION
## Summary
This PR fixes #1248 by showing "Syncthing is restarting" instead of "Connection Error" when an automatic upgrade triggers a restart.

## Changes
- Add new `UpgradeStarted` event type in `lib/events/events.go`
- Emit `UpgradeStarted` event in `cmd/syncthing/main.go` when auto-upgrade completes and restart is imminent
- Add event handler in `gui/default/syncthing/core/eventService.js` to register the new event
- Add listener in `gui/default/syncthing/core/syncthingController.js` to show the restarting dialog when the event is received
- Document the new event in `man/syncthing-event-api.7`

## Test plan
- [x] Code compiles successfully
- [x] Existing events tests pass
- [ ] Manual test: trigger auto-upgrade and verify "Syncthing is restarting" dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)