### PR TITLE
feat(gui): add connected applications tab to about dialog

### DIFF
--- a/gui/default/syncthing/core/aboutModalView.html
+++ b/gui/default/syncthing/core/aboutModalView.html
@@ -23,6 +23,7 @@
       <li class="active"><a data-toggle="tab" href="#about-authors" translate>Authors</a></li>
       <li><a data-toggle="tab" href="#about-includes" translate>Included Software</a></li>
       <li><a data-toggle="tab" href="#about-paths" translate>Paths</a></li>
+      <li><a data-toggle="tab" href="#about-connections" translate>Connected Applications</a></li>
     </ul>
     <div class="tab-content">
 
@@ -148,6 +149,34 @@ Jakob Borg, Audrius Butkevicius, Simon Frei, Tomasz Wilczyński, Alexander Graf,
             </tr>
           </tbody>
         </table>
+      </div>
+
+      <div id="about-connections" class="tab-pane">
+        <p ng-if="!authenticated" translate>
+          Log in to see connected applications.
+        </p>
+        <div ng-if="authenticated">
+          <p translate>Applications currently connected to this Syncthing instance:</p>
+          <table ng-if="about.connectedApplications.length > 0" class="table table-striped table-auto">
+            <thead>
+              <tr>
+                <th translate>Device</th>
+                <th translate>Application</th>
+                <th translate>Connection Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr ng-repeat="app in about.connectedApplications">
+                <td>{{ app.deviceName }}</td>
+                <td>{{ app.clientVersion }}</td>
+                <td>{{ app.type }}</td>
+              </tr>
+            </tbody>
+          </table>
+          <p ng-if="about.connectedApplications.length === 0" class="text-muted" translate>
+            No remote devices are currently connected.
+          </p>
+        </div>
       </div>
 
     </div>

--- a/gui/default/syncthing/core/syncthingController.js
+++ b/gui/default/syncthing/core/syncthingController.js
@@ -1651,13 +1651,34 @@ angular.module('syncthing.core')
 
         $scope.about = {
             paths: {},
+            connectedApplications: [],
             refreshPaths: function () {
                 $http.get(urlbase + '/system/paths').success(function (data) {
                     $scope.about.paths = data;
                 }).error($scope.emitHTTPError);
             },
+            refreshConnectedApplications: function () {
+                var apps = [];
+                for (var deviceID in $scope.connections) {
+                    if (!$scope.connections.hasOwnProperty(deviceID)) {
+                        continue;
+                    }
+                    var conn = $scope.connections[deviceID];
+                    if (conn.connected) {
+                        var deviceCfg = $scope.devices[deviceID];
+                        apps.push({
+                            deviceID: deviceID,
+                            deviceName: $scope.deviceName(deviceCfg),
+                            clientVersion: conn.clientVersion || 'Unknown',
+                            type: conn.type || 'Unknown'
+                        });
+                    }
+                }
+                $scope.about.connectedApplications = apps;
+            },
             show: function () {
                 $scope.about.refreshPaths();
+                $scope.about.refreshConnectedApplications();
                 showModal('#about');
             },
         };


### PR DESCRIPTION
## Summary
This PR fixes #1964 by adding a "Connected Applications" tab to the About dialog.

## Changes
- Added new "Connected Applications" tab in the About dialog modal
- Displays a table showing currently connected remote devices with:
  - Device name
  - Client application/version (e.g., "Syncthing v1.27.0")
  - Connection type (e.g., "tcp-client", "relay-client")
- Shows a helpful message when no devices are connected
- Requires authentication to view (consistent with other tabs)
- Uses existing connection data from the API, no backend changes needed

## Test plan
- [x] Build passes
- [x] All existing tests pass
- [ ] Manual testing: Open About dialog, verify "Connected Applications" tab appears and shows connected devices

🤖 Generated with [Claude Code](https://claude.ai/code)