### PR TITLE
fix(stdiscosrv): use fmt.Println for version output (fixes #10523)

### DIFF
--- a/cmd/stdiscosrv/main.go
+++ b/cmd/stdiscosrv/main.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -95,11 +96,11 @@ func main() {
 		level = slog.LevelDebug
 	}
 	slogutil.SetDefaultLevel(level)
-
-	slog.Info(build.LongVersionFor("stdiscosrv"))
 	if cli.Version {
+		fmt.Println(build.LongVersionFor("stdiscosrv"))
 		return
 	}
+	slog.Info(build.LongVersionFor("stdiscosrv"))
 
 	buildInfo.WithLabelValues(build.Version, runtime.Version(), build.User, build.Date.UTC().Format("2006-01-02T15:04:05Z")).Set(1)
 


### PR DESCRIPTION
### Purpose

This PR fixes #10523 by changing the `--version` output in `stdiscosrv` from using the logging framework to a standard `fmt.Println`. The previous use of the logging framework added timestamps and log levels (e.g., `2026-01-16 ... INF`) to the version string, which made it difficult for scripts to parse the version number. Using `fmt.Println` ensures a clean output consistent with the relay server.

### Testing

I have verified this change locally on Linux amd64:
- **Command**: `./stdiscosrv --version`
- **Previous Output**: `2026-01-16 10:40:53 INF stdiscosrv unknown-dev ...`
- **New Output**: `stdiscosrv unknown-dev "Hafnium Hornet" (go1.25.1 linux-amd64) ...`

The code has also been verified with `go fmt ./cmd/stdiscosrv/...` and `go vet ./cmd/stdiscosrv/...`.

### Screenshots
<img width="959" height="179" alt="image" src="https://github.com/user-attachments/assets/5287b3da-b7b8-407b-93f3-f9ad6f79d7ae" />
