### PR TITLE
fix: typos in comments

### DIFF
--- a/cmd/syncthing/decrypt/decrypt.go
+++ b/cmd/syncthing/decrypt/decrypt.go
@@ -240,7 +240,7 @@ func (c *CLI) decryptFile(encFi *protocol.FileInfo, plainFi *protocol.FileInfo, 
 		// Verify the hash against the plaintext block info
 		if !scanner.Validate(dec, plainBlock.Hash) {
 			// The block decrypted correctly but fails the hash check. This
-			// is odd and unexpected, but it it's still a valid block from
+			// is odd and unexpected, but it's still a valid block from
 			// the source. The file might have changed while we pulled it?
 			err := fmt.Errorf("plaintext block %d (%d bytes) failed validation after decryption", i, plainBlock.Size)
 			if c.Continue {

--- a/lib/model/folder_sendrecv_windows.go
+++ b/lib/model/folder_sendrecv_windows.go
@@ -31,7 +31,7 @@ func (f *sendReceiveFolder) syncOwnership(file *protocol.FileInfo, path string) 
 }
 
 func lookupUserAndGroup(name string, group bool) (string, string, error) {
-	// Look up either the the user or the group, returning the other kind as
+	// Look up either the user or the group, returning the other kind as
 	// blank. This might seem an odd maneuver, but it matches what Chown
 	// wants as input and hides the ugly nested if:s down here.
 


### PR DESCRIPTION
Fix typos: `it it's` → `it's`, `the the` → `the`