### PR TITLE
chore(gui): include license files for fork-awesome assets

### DIFF
--- a/gui/default/vendor/fork-awesome/css/LICENSE.txt
+++ b/gui/default/vendor/fork-awesome/css/LICENSE.txt
@@ -1,0 +1,9 @@
+License - https://forkaweso.me/Fork-Awesome/license
+
+Copyright 2018 Dave Gandy & Fork Awesome
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/gui/default/vendor/fork-awesome/fonts/LICENSE.txt
+++ b/gui/default/vendor/fork-awesome/fonts/LICENSE.txt
@@ -1,0 +1,1 @@
+The Fork Awesome font is licensed under the SIL OFL 1.1 (http://scripts.sil.org/OFL). Fork Awesome is a fork based of off Font Awesome 4.7.0 by Dave Gandy. More info on licenses at https://forkawesome.github.io


### PR DESCRIPTION
The css and svg files have license headers, but there were no separate license files like the other vendored assets in `gui/default/vendor/*`. This issue came up while we were working on updating and modernizing the syncthing package in Fedora Linux.

This commit copies the existing license headers into separate files to make things easier for license scanning and SCA tools, such as [Go Vendor Tools](https://fedora.gitlab.io/sigs/go/go-vendor-tools/).

* [...]/css/LICENSE.txt is copied from the license header in gui/default/vendor/fork-awesome/css/fork-awesome.css.
* [...]/fonts/LICENSE.txt is copied from the license text in the `<metadata>` tag of gui/default/vendor/fork-awesome/fonts/forkawesome-webfont.svg.

Relates: https://src.fedoraproject.org/rpms/syncthing/pull-request/4
