### PR TITLE
chore(gui): add id and name to Stay logged in checkbox for password managers

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -354,7 +354,7 @@
 
           <div class="form-group">
             <label>
-              <input type="checkbox" ng-model="login.stayLoggedIn" >&nbsp;<span translate>Stay logged in</span>
+              <input type="checkbox" id="stayLoggedIn" name="stayLoggedIn" ng-model="login.stayLoggedIn" >&nbsp;<span translate>Stay logged in</span>
             </label>
           </div>
 


### PR DESCRIPTION
# Purpose
Add `id` and `name` to the login form’s "_Stay logged in_" checkbox so password managers (e.g. Bitwarden) can detect and save it. They need a stable identifier. `ng-model` alone is not enough.


