### PR TITLE
chore(config, connections): use same reconnection interval for QUIC and TCP (fixes #10507)

### DIFF
--- a/lib/config/config.go
+++ b/lib/config/config.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	OldestHandledVersion = 10
-	CurrentVersion       = 51
+	CurrentVersion       = 52
 	MaxRescanIntervalS   = 365 * 24 * 60 * 60
 )
 

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -62,7 +62,7 @@ func TestDefaultValues(t *testing.T) {
 			LocalAnnMCAddr:            "[ff12::8384]:21027",
 			MaxSendKbps:               0,
 			MaxRecvKbps:               0,
-			ReconnectIntervalS:        60,
+			ReconnectIntervalS:        20,
 			RelaysEnabled:             true,
 			RelayReconnectIntervalM:   10,
 			StartBrowser:              true,

--- a/lib/config/migrations.go
+++ b/lib/config/migrations.go
@@ -30,6 +30,7 @@ import (
 // put the newest on top for readability.
 var (
 	migrations = migrationSet{
+		{52, migrateToConfigV52},
 		{51, migrateToConfigV51},
 		{50, migrateToConfigV50},
 		{37, migrateToConfigV37},
@@ -99,6 +100,11 @@ func (m migration) apply(cfg *Configuration) {
 		m.convert(cfg)
 	}
 	cfg.Version = m.targetVersion
+}
+
+func migrateToConfigV52(cfg *Configuration) {
+	oldQuicInterval := max(cfg.Options.ReconnectIntervalS/3, 10)
+	cfg.Options.ReconnectIntervalS = min(cfg.Options.ReconnectIntervalS, oldQuicInterval)
 }
 
 func migrateToConfigV51(cfg *Configuration) {

--- a/lib/config/migrations_test.go
+++ b/lib/config/migrations_test.go
@@ -34,3 +34,25 @@ func TestMigrateCrashReporting(t *testing.T) {
 		}
 	}
 }
+
+func TestMigrateReconnectInterval(t *testing.T) {
+	cases := []struct {
+		oldInterval         int
+		expectedNewInterval int
+	}{
+		{oldInterval: 60, expectedNewInterval: 20},
+		{oldInterval: 120, expectedNewInterval: 40},
+		{oldInterval: 25, expectedNewInterval: 10},
+		{oldInterval: 5, expectedNewInterval: 5},
+	}
+
+	for i, tc := range cases {
+		cfg := Configuration{Version: 51, Options: OptionsConfiguration{ReconnectIntervalS: tc.oldInterval}}
+		migrationsMut.Lock()
+		migrations.apply(&cfg)
+		migrationsMut.Unlock()
+		if cfg.Options.ReconnectIntervalS != tc.expectedNewInterval {
+			t.Errorf("%d: unexpected result, ReconnectIntervalS: %v != %v", i, cfg.Options.ReconnectIntervalS, tc.expectedNewInterval)
+		}
+	}
+}

--- a/lib/config/optionsconfiguration.go
+++ b/lib/config/optionsconfiguration.go
@@ -28,7 +28,7 @@ type OptionsConfiguration struct {
 	LocalAnnMCAddr              string   `json:"localAnnounceMCAddr" xml:"localAnnounceMCAddr" default:"[ff12::8384]:21027"`
 	MaxSendKbps                 int      `json:"maxSendKbps" xml:"maxSendKbps"`
 	MaxRecvKbps                 int      `json:"maxRecvKbps" xml:"maxRecvKbps"`
-	ReconnectIntervalS          int      `json:"reconnectionIntervalS" xml:"reconnectionIntervalS" default:"60"`
+	ReconnectIntervalS          int      `json:"reconnectionIntervalS" xml:"reconnectionIntervalS" default:"20"`
 	RelaysEnabled               bool     `json:"relaysEnabled" xml:"relaysEnabled" default:"true"`
 	RelayReconnectIntervalM     int      `json:"relayReconnectIntervalM" xml:"relayReconnectIntervalM" default:"10"`
 	StartBrowser                bool     `json:"startBrowser" xml:"startBrowser" default:"true"`

--- a/lib/config/testdata/overridenvalues.xml
+++ b/lib/config/testdata/overridenvalues.xml
@@ -1,4 +1,4 @@
-<configuration version="34">
+<configuration version="52">
     <options>
         <listenAddress>tcp://:23000</listenAddress>
         <allowDelete>false</allowDelete>

--- a/lib/connections/quic_dial.go
+++ b/lib/connections/quic_dial.go
@@ -99,16 +99,9 @@ func (d *quicDialer) Dial(ctx context.Context, _ protocol.DeviceID, uri *url.URL
 type quicDialerFactory struct{}
 
 func (quicDialerFactory) New(opts config.OptionsConfiguration, tlsCfg *tls.Config, registry *registry.Registry, lanChecker *lanChecker) genericDialer {
-	// So the idea is that we should probably try dialing every 20 seconds.
-	// However it would still be nice if this was adjustable/proportional to ReconnectIntervalS
-	// But prevent something silly like 1/3 = 0 etc.
-	quicInterval := opts.ReconnectIntervalS / 3
-	if quicInterval < 10 {
-		quicInterval = 10
-	}
 	return &quicDialer{
 		commonDialer: commonDialer{
-			reconnectInterval: time.Duration(quicInterval) * time.Second,
+			reconnectInterval: time.Duration(opts.ReconnectIntervalS) * time.Second,
 			tlsCfg:            tlsCfg,
 			lanChecker:        lanChecker,
 			lanPriority:       opts.ConnectionPriorityQUICLAN,


### PR DESCRIPTION
Closes #10513, closes syncthing/docs#982.

### Purpose

Fixes #10507. Also theoretically increases the chances of TCP hole punching success.

### Testing

unit

