### PR TITLE
fix(db): count receive-only changed items for local device only (fixes #10553)

### DIFF
--- a/internal/db/sqlite/folderdb_counts.go
+++ b/internal/db/sqlite/folderdb_counts.go
@@ -54,7 +54,7 @@ func (s *folderDB) CountReceiveOnlyChanged() (db.Counts, error) {
 	var res []countsRow
 	err := s.stmt(`
 		SELECT s.type, s.count, s.size, s.local_flags, s.deleted FROM counts s
-		WHERE local_flags & {{.FlagLocalReceiveOnly}} != 0
+		WHERE s.device_idx = {{.LocalDeviceIdx}} AND s.local_flags & {{.FlagLocalReceiveOnly}} != 0
 	`).Select(&res)
 	if err != nil {
 		return db.Counts{}, wrap(err)


### PR DESCRIPTION
### Purpose
Fixes a mismatch where the “Locally Changed Items” count for Receive Encrypted folders could include rows belonging to non-local devices, resulting in a non-zero count while the GUI list of locally changed items appeared empty ([#10553](https://github.com/syncthing/syncthing/issues/10553)).

In this situation, the folder would report one locally changed item, but the list would contain no entries.

---

### Root Cause
`CountReceiveOnlyChanged()` did not restrict results to the local device. As a result, rows with `FlagLocalReceiveOnly` from other devices could be included in the aggregate count.

The GUI list of locally changed items, however, only reflects local device entries, causing a count/list inconsistency.

---

### Changes Made
- Restrict `CountReceiveOnlyChanged()` to rows where `device_idx` corresponds to the local device.
- Add a regression test verifying that only local device rows are included in the receive-only changed count.

This ensures the count and the GUI list remain consistent.

---

### Testing
Added a unit test that:
- Inserts one receive-only-changed file for the local device.
- Inserts one receive-only-changed file for a remote device.
- Verifies that only the local device entry contributes to the count.

All tests pass.