### PR TITLE
fix(systemd): support overrides for syncOwnership

### DIFF
--- a/etc/linux-systemd/system/syncthing@.service
+++ b/etc/linux-systemd/system/syncthing@.service
@@ -83,10 +83,23 @@ RestrictRealtime=true
 RestrictAddressFamilies=AF_INET AF_INET6 AF_NETLINK AF_UNIX
 # The lifetime limit of (superuser) capabilities that syncthing can acquire.
 # This option _restricts_ capabilities.
-CapabilityBoundingSet=
+#
+# NOTE: This is set to `CAP_CHOWN CAP_FOWNER` to avoid breaking users that have
+# set `AmbientCapabilities=CAP_CHOWN CAP_FOWNER` to enable the `syncOwnership`
+# option as described in:
+#   https://docs.syncthing.net/users/autostart.html#permissions
+#
+# If you do not use the `syncOwnership` option, you can set this to:
+#   CapabilityBoundingSet=
+CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER
 # Start with empty (superuser) capabilities.
 # This option _expands_ capabilities.
 # AmbientCapabilities should equal CapabilityBoundingSet.
+#
+# NOTE: IFF you wish to use the `syncOwnership` option, you must set this to:
+#   AmbientCapabilities=CAP_CHOWN CAP_FOWNER
+# in a systemd drop-in file. Be aware that this gives syncthing the ability to
+# change or ignore file ownership across the entire operating system.
 AmbientCapabilities=
 # Disables `personality` system call; it can be used for privilege escalation.
 LockPersonality=true


### PR DESCRIPTION
Syncthing docs in https://docs.syncthing.net/users/autostart.html#permissions tell the user to set `AmbientCapabilities=CAP_CHOWN CAP_FOWNER` if the user wishes to use the `syncOwnership` option.

https://github.com/syncthing/syncthing/pull/10421 broke `syncOwnership` for users that followed that advice because the PR introduced `CapabilityBoundingSet=` which cancels out any additional capabilities granted with `AmbientCapabilities`.

(`AmbientCapabilities` _adds_ capabilities; `CapabilityBoundingSet` _limits_ maximum capabilities to the specified set. Setting `CapabilityBoundingSet` to an empty list prevents any capabilities from being acquired in any way.)

This PR fixes the breakage by explicitly setting

    CapabilityBoundingSet=CAP_CHOWN CAP_FOWNER

This does _not_ grant any additional access rights to syncthing if the user is not explicitly setting `AmbientCapabilities` as well, but it does loosen the sandbox _a bit_. An attacker compromising the syncthing process could now more easily expand their access to include CAP_CHOWN/CAP_FOWNER even if the user is not setting `AmbientCapabilities`.

### Purpose

Describe the purpose of this change. If there is an existing issue that is
resolved by this pull request, ensure that the commit subject is on the form
`Some short description (fixes #1234)` where 1234 is the issue number.

### Testing

Describe what testing has been done, and how the reviewer can test the change
if new tests are not included.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

