### PR TITLE
fix(pmp): return nil on all GetExternalAddress errors (fixes #10486)

### DIFF
--- a/lib/pmp/pmp.go
+++ b/lib/pmp/pmp.go
@@ -56,8 +56,10 @@ func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device 
 		}
 		if strings.Contains(err.Error(), "Timed out") {
 			slog.Debug("Timeout trying to get external address, assume no NAT-PMP available")
-			return nil
+		} else {
+			l.Debugln("Failed to get external address from NAT-PMP gateway", err)
 		}
+		return nil
 	}
 
 	var localIP net.IP


### PR DESCRIPTION
## Summary

Fixes #10486

In `Discover()`, when `GetExternalAddress()` returns an error that is neither `context.Canceled` nor a timeout, the code falls through the error handling block without returning `nil`. This means a `wrapper` device is created and returned for a gateway that doesn't actually support NAT-PMP (e.g. routers that respond with PCP version 2 packets instead of PMP).

This causes Syncthing to keep sending PMP requests to a non-PMP gateway and may also prevent UPnP from being tried as a fallback.

The fix restructures the error handling so that **all** error paths return `nil`. Non-timeout errors are now logged at debug level for easier troubleshooting.

## Changes

- `lib/pmp/pmp.go`: Move `return nil` outside the inner `if` blocks so it covers all error cases. Added a debug log message for non-timeout errors.

## Testing

Reviewed the control flow to confirm that after this change:
- `context.Canceled` -> returns `nil` (unchanged)
- Timeout error -> logs at debug, returns `nil` (unchanged)
- Any other error (e.g. PCP version mismatch) -> now logs at debug and returns `nil` (previously fell through)