### PR TITLE
fix: set mtime on temp file before rename in performFinish (fixes #10599)

### DIFF
--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1631,6 +1631,12 @@ func (f *sendReceiveFolder) performFinish(file, curFile protocol.FileInfo, hasCu
 		return fmt.Errorf("setting metadata: %w", err)
 	}
 
+	// Set the correct mtime on the temp file before the rename, so that
+	// even if the post-rename Chtimes call fails (e.g. under low
+	// RLIMIT_NOFILE on kqueue systems), the file on disk has the correct
+	// mtime.
+	f.mtimefs.Chtimes(tempName, file.ModTime(), file.ModTime()) // never fails
+
 	if stat, err := f.mtimefs.Lstat(file.Name); err == nil {
 		// There is an old file or directory already in place. We need to
 		// handle that.

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -996,6 +996,44 @@ func TestPullCaseOnlyPerformFinish(t *testing.T) {
 	}
 }
 
+func TestPerformFinishMtime(t *testing.T) {
+	_, f := setupSendReceiveFolder(t)
+	ffs := f.Filesystem()
+
+	name := "mtimefile"
+	contents := []byte("mtime test contents")
+
+	// Write the temp file that performFinish will rename into place.
+	temp := fs.TempName(name)
+	writeFile(t, ffs, temp, contents)
+
+	// Use a specific mtime in the past to verify it gets applied.
+	mtime := time.Unix(1234567890, 0)
+
+	file := protocol.FileInfo{
+		Name:      name,
+		Version:   protocol.Vector{}.Update(device1.Short()),
+		ModifiedS: mtime.Unix(),
+		Size:      int64(len(contents)),
+	}
+
+	dbUpdateChan := make(chan dbUpdateJob, 1)
+	scanChan := make(chan string, 1)
+
+	if err := f.performFinish(file, protocol.FileInfo{}, false, temp, dbUpdateChan, scanChan); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify the final file has the correct mtime.
+	stat, err := ffs.Lstat(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := stat.ModTime().Truncate(time.Second); !got.Equal(mtime) {
+		t.Errorf("mtime mismatch: got %v, want %v", got, mtime)
+	}
+}
+
 func TestPullCaseOnlyDir(t *testing.T) {
 	testPullCaseOnlyDirOrSymlink(t, true)
 }


### PR DESCRIPTION
### Purpose

In `performFinish()`, the mtime is set via `Chtimes` after the rename. Under low `RLIMIT_NOFILE` (e.g. NetBSD/kqueue), the post-rename `Chtimes` can silently fail, leaving files with the wrong mtime — which then confuses receive-only folders.

This adds a `Chtimes` call on the temp file before the rename, so the file on disk already has the correct mtime when moved into place. The existing post-rename `Chtimes` on `file.Name` stays to update the mtimefs database mapping.

Fixes #10599

### Testing

Added `TestPerformFinishMtime` following the existing `TestPullCaseOnlyPerformFinish` pattern. It calls `performFinish()` with a specific mtime and verifies the resulting file has the correct modification time.

### Documentation

No user-visible changes.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.