### PR TITLE
fix(stdiscosrv): close file descriptor on flush error in write

### DIFF
--- a/cmd/stdiscosrv/database.go
+++ b/cmd/stdiscosrv/database.go
@@ -306,7 +306,7 @@ func (s *inMemoryStore) write() (err error) {
 	}
 
 	if err := bw.Flush(); err != nil {
-		_ = fd.Close
+		_ = fd.Close()
 		return err
 	}
 	if err := fd.Close(); err != nil {


### PR DESCRIPTION
## Summary

Fixes the error path in `inMemoryStore.write()` after `bw.Flush()` fails: use `fd.Close()` instead of referencing `fd.Close`, so the file descriptor is actually closed.

## Testing

- [ ] `go test ./cmd/stdiscosrv/...` (optional local check)

Conventional commit / DCO: commit includes `Signed-off-by`.