### PR TITLE
fix: pin 20 unpinned action(s),extract 1 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build-infra-dockers.yaml
+++ b/.github/workflows/build-infra-dockers.yaml
@@ -40,13 +40,13 @@ jobs:
           check-latest: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -60,10 +60,10 @@ jobs:
           done
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set Docker tags (all branches)
         run: |
@@ -77,7 +77,7 @@ jobs:
           echo "TAGS=$tags" >> $GITHUB_ENV
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           file: ./Dockerfile.${{ matrix.pkg }}

--- a/.github/workflows/build-syncthing.yaml
+++ b/.github/workflows/build-syncthing.yaml
@@ -190,7 +190,7 @@ jobs:
           go-version: "~1.25.7" # temporarily stay on Go 1.25 due to linker error on Go 1.26
           cache: false
 
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
 
       - uses: actions/cache@v4
         with:
@@ -249,7 +249,7 @@ jobs:
           }
 
       - name: Sign files with Trusted Signing
-        uses: azure/trusted-signing-action@v0.5.1
+        uses: azure/trusted-signing-action@0d74250c661747df006298d0fb49944c10f16e03 # v0.5.1
         with:
           azure-tenant-id: ${{ secrets.AZURE_TRUSTED_SIGNING_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_ID }}
@@ -299,7 +299,7 @@ jobs:
           go-version: ${{ needs.facts.outputs.go-version }}
           cache: false
 
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
 
       - uses: actions/cache@v4
         with:
@@ -350,7 +350,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Build syncthing in OmniOS VM
-        uses: vmactions/omnios-vm@v1
+        uses: vmactions/omnios-vm@68da93c6d9812b29fc90c5b5141b093f84a590fb # v1
         with:
           envs: "VERSION GO_VERSION CGO_ENABLED"
           usesh: true
@@ -723,7 +723,7 @@ jobs:
           go-version: ${{ needs.facts.outputs.go-version }}
           cache: false
 
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@eab2afb99481ca09a4e91171a8e0aee0e89bfedd # v1
         with:
           ruby-version: '3.0'
 
@@ -731,7 +731,7 @@ jobs:
         run: |
           gem install fpm
 
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
 
       - uses: actions/cache@v4
         with:
@@ -1016,7 +1016,7 @@ jobs:
           go-version: ${{ needs.facts.outputs.go-version }}
           cache: false
 
-      - uses: mlugg/setup-zig@v2
+      - uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2
 
       - uses: actions/cache@v4
         with:
@@ -1046,23 +1046,23 @@ jobs:
           EXTRA_LDFLAGS: "-linkmode=external -extldflags=-static"
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Set version tags
         run: |
           version=${VERSION#v}
           repo=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
-          ref="${{github.ref_name}}"
+          ref="${REF_NAME}"
           ref=${ref//\//-} # slashes to dashes
 
           # List of tags for ghcr.io
@@ -1081,13 +1081,15 @@ jobs:
           echo Pushing to $tags
           echo "DOCKER_TAGS=$tags" >> $GITHUB_ENV
 
+        env:
+          REF_NAME: ${{github.ref_name}}
       - name: Prepare context dir
         run: |
           mkdir ctx
           mv bin/* script ctx
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ctx
           file: ${{ matrix.dockerfile }}
@@ -1163,7 +1165,7 @@ jobs:
         run: go run build.go assets
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v8
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8
         with:
           only-new-issues: true
 

--- a/.github/workflows/mirrors.yaml
+++ b/.github/workflows/mirrors.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: yesolutions/mirror-action@master
+      - uses: yesolutions/mirror-action@662fce0eced8996f64d7fa264d76cddd84827f33 # master
         with:
           REMOTE: ssh://git@codeberg.org/${{ github.repository }}.git
           GIT_SSH_PRIVATE_KEY: ${{ secrets.CODEBERG_PUSH_KEY }}

--- a/.github/workflows/pr-metadata.yaml
+++ b/.github/workflows/pr-metadata.yaml
@@ -22,6 +22,6 @@ jobs:
     name: Set labels
     runs-on: ubuntu-latest
     steps:
-    - uses: srvaroa/labeler@v1
+    - uses: srvaroa/labeler@9c29ad1ef33d169f9ef33c52722faf47a566bcf3 # v1
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release-syncthing.yaml
+++ b/.github/workflows/release-syncthing.yaml
@@ -53,7 +53,7 @@ jobs:
           git push origin "$NEXT"
 
       - name: Trigger the build
-        uses: benc-uk/workflow-dispatch@v1
+        uses: benc-uk/workflow-dispatch@7a027648b88c2413826b6ddd6c76114894dc5ec4 # v1
         with:
           workflow: build-syncthing.yaml
           ref: refs/tags/${{ env.NEXT }}


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/build-infra-dockers.yaml` | Pinned 5 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/build-syncthing.yaml` | Pinned 12 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/build-syncthing.yaml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/mirrors.yaml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/pr-metadata.yaml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release-syncthing.yaml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/build-syncthing.yaml` | Unpinned Third-Party Action Using Mutable Tag |
| RGS-007 | medium | `.github/workflows/org-members.yaml` | Unpinned Third-Party Action Using Mutable Tag |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.