### PR TITLE
fix(upgrade): properly close response body on non-2xx status

### DIFF
--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -101,6 +101,8 @@ func FetchLatestReleases(releasesURL, current string) []Release {
 		slog.Warn("Failed to fetch latest release information", slogutil.Error(err))
 		return nil
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode > 299 {
 		slog.Warn("Failed to fetch latest release information", slogutil.Error(resp.Status))
 		return nil
@@ -111,7 +113,6 @@ func FetchLatestReleases(releasesURL, current string) []Release {
 	if err != nil {
 		slog.Warn("Failed to decode latest release information", slogutil.Error(err))
 	}
-	resp.Body.Close()
 
 	return rels
 }


### PR DESCRIPTION
Fixes #10635

In `FetchLatestReleases`, when `upgradeClientGet` succeeds but the server responds with a status code > 299, the function was returning nil without closing `resp.Body`. This prevents the underlying TCP connection from being returned to the HTTP client's connection pool, leaking a connection (and the associated draining goroutine) on every failed upgrade check.

The fix moves the `resp.Body.Close()` to a `defer` right after the successful `Do()` call, so all return paths—including the new non-2xx early return—are covered. The later explicit `resp.Body.Close()` at the end of the success path is then removed as it's redundant.

Spotted while reading through HTTP client usage patterns in the codebase.