### PR TITLE
fix(structutil): support unsigned default values

### DIFF
--- a/lib/structutil/structutil.go
+++ b/lib/structutil/structutil.go
@@ -49,12 +49,19 @@ func SetDefaults(data any) {
 			case string:
 				f.SetString(v)
 
-			case int, uint32, int32, int64, uint64:
+			case int, int32, int64:
 				i, err := strconv.ParseInt(v, 10, 64)
 				if err != nil {
 					panic(err)
 				}
 				f.SetInt(i)
+
+			case uint, uint32, uint64:
+				i, err := strconv.ParseUint(v, 10, 64)
+				if err != nil {
+					panic(err)
+				}
+				f.SetUint(i)
 
 			case float64, float32:
 				i, err := strconv.ParseFloat(v, 64)

--- a/lib/structutil/structutil_test.go
+++ b/lib/structutil/structutil_test.go
@@ -55,6 +55,26 @@ func TestSetDefaults(t *testing.T) {
 	}
 }
 
+func TestSetDefaultsUnsignedInts(t *testing.T) {
+	x := &struct {
+		A uint   `default:"1"`
+		B uint32 `default:"2"`
+		C uint64 `default:"3"`
+	}{}
+
+	SetDefaults(x)
+
+	if x.A != 1 {
+		t.Errorf("uint failed: %d", x.A)
+	}
+	if x.B != 2 {
+		t.Errorf("uint32 failed: %d", x.B)
+	}
+	if x.C != 3 {
+		t.Errorf("uint64 failed: %d", x.C)
+	}
+}
+
 func TestFillNillSlices(t *testing.T) {
 	// Nil
 	x := &struct {


### PR DESCRIPTION

**Repo:** syncthing/syncthing (⭐ 66000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +28/-1

## What
This change fixes `lib/structutil.SetDefaults` so struct fields tagged with numeric defaults are initialized correctly when the field type is unsigned. The implementation now parses signed and unsigned integer kinds separately, using `strconv.ParseUint` and `reflect.Value.SetUint` for `uint`, `uint32`, and `uint64`. A regression test was added to cover unsigned default-tagged fields.

## Why
Before this patch, `SetDefaults` grouped signed and unsigned integer types together and always called `SetInt`, which panics for unsigned reflect kinds. Any config or API struct that introduced a `default:"..."` tag on an unsigned field would fail at runtime during default initialization. This patch makes the helper behave correctly for the integer types it already claims to support and locks the behavior down with a focused test.

## Testing
Verified with `GOCACHE=/tmp/syncthing-gocache go test ./lib/structutil` from the repository root. The package test passed, including the new regression coverage for unsigned integer defaults.

## Risk
Low / The change is narrowly scoped to default parsing for unsigned integer fields and is covered by a dedicated package test.
