### PR TITLE
lib/upgrade: close response body on non-2xx status (fixes #10635)

### DIFF
--- a/lib/upgrade/upgrade_supported.go
+++ b/lib/upgrade/upgrade_supported.go
@@ -101,6 +101,7 @@ func FetchLatestReleases(releasesURL, current string) []Release {
 		slog.Warn("Failed to fetch latest release information", slogutil.Error(err))
 		return nil
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode > 299 {
 		slog.Warn("Failed to fetch latest release information", slogutil.Error(resp.Status))
 		return nil
@@ -111,7 +112,6 @@ func FetchLatestReleases(releasesURL, current string) []Release {
 	if err != nil {
 		slog.Warn("Failed to decode latest release information", slogutil.Error(err))
 	}
-	resp.Body.Close()
 
 	return rels
 }


### PR DESCRIPTION
## Linked Issue
Closes #10635

## Description
`FetchLatestReleases` in `lib/upgrade/upgrade_supported.go` returned `nil` when the server responded with a non-2xx status code without closing the response body. Per the Go `net/http` docs, failing to close the body prevents the HTTP client from reusing the underlying TCP connection.

**Fix**: Move `resp.Body.Close()` to a `defer` statement immediately after the successful `upgradeClientGet` call, so all return paths — including the non-2xx early return, the JSON decode error, and the happy path — close the body. The now-redundant explicit `resp.Body.Close()` before the final return is removed.

This matches the identical pattern already established in `readRelease()` in the same file (line 235).

## Changes
- `lib/upgrade/upgrade_supported.go`: 1 line added (`defer resp.Body.Close()`), 1 line removed (explicit close)

## Type of Change
- [x] Bug fix (non-breaking)

## Testing
- `go test ./lib/upgrade/...` — 4 passed, 0 failed
- `go build ./lib/upgrade/` — clean