### PR TITLE
cmd/syncthing: set charset=utf-8 on migration API Content-Type (fixes #10499)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -1054,7 +1054,7 @@ func (m migratingAPI) Serve(ctx context.Context) error {
 	srv := &http.Server{
 		Addr: m.addr,
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "text/plain")
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.Write([]byte("*** Database migration in progress ***\n\n"))
 			for _, line := range slogutil.GlobalRecorder.Since(time.Time{}) {
 				_, _ = line.WriteTo(w, slogutil.DefaultLineFormat)


### PR DESCRIPTION
## Linked Issue
Closes #10499

## Description
The `migratingAPI` handler in `cmd/syncthing/main.go` set a bare `text/plain` Content-Type header. Per RFC 2046, omitting the `charset` parameter implies US-ASCII. Syncthing log output may contain non-US-ASCII characters (e.g. Unicode in log messages), so the header should explicitly declare UTF-8.

**Fix**: Change `"text/plain"` to `"text/plain; charset=utf-8"` in `migratingAPI.Serve()`. This is consistent with the regular API's `/rest/system/log.txt` endpoint (`lib/api/api.go:1106`) which already uses the correct value.

## Changes
- `cmd/syncthing/main.go`: 1 character-set qualifier added to Content-Type string

## Type of Change
- [x] Bug fix (non-breaking)

## Testing
- `go test ./cmd/syncthing/...` — 4 passed, 0 failed (using `-tags noassets` for local env)
- `go build ./cmd/syncthing/` — clean (pre-existing `auto.Assets` env constraint unrelated to this fix)