### PR TITLE
lib/pmp: return nil on all gateway probe errors in Discover (fixes #10486)

### DIFF
--- a/lib/pmp/pmp.go
+++ b/lib/pmp/pmp.go
@@ -58,6 +58,8 @@ func Discover(ctx context.Context, renewal, timeout time.Duration) []nat.Device 
 			slog.Debug("Timeout trying to get external address, assume no NAT-PMP available")
 			return nil
 		}
+		l.Debugln("Failed to get external address, assume no NAT-PMP available", err)
+		return nil
 	}
 
 	var localIP net.IP


### PR DESCRIPTION
## Linked Issue
Closes #10486

## Description
The `Discover()` function in `lib/pmp/pmp.go` handles two specific errors from the NAT-PMP gateway probe — `context.Canceled` and `"Timed out"` — but falls through for any other error, continuing as if discovery succeeded. This means a router that responds with an error (e.g. PCP version 2 packets rejected by go-nat-pmp) silently returns a `Device` wrapper, masking the failure and potentially blocking UPnP from being tried.

**Fix**: Add a fallthrough `return nil` with a debug log inside the outer `if err != nil` block, after the two named-error branches. This covers all remaining error cases.

```go
// Before
if err != nil {
    if errors.Is(err, context.Canceled) {
        return nil
    }
    if strings.Contains(err.Error(), "Timed out") {
        slog.Debug("Timeout trying to get external address, assume no NAT-PMP available")
        return nil
    }
}  // <-- fell through on any other error

// After
if err != nil {
    if errors.Is(err, context.Canceled) {
        return nil
    }
    if strings.Contains(err.Error(), "Timed out") {
        slog.Debug("Timeout trying to get external address, assume no NAT-PMP available")
        return nil
    }
    l.Debugln("Failed to get external address, assume no NAT-PMP available", err)
    return nil
}
```

## Changes
- `lib/pmp/pmp.go`: 2 lines added (debug log + return nil)

## Type of Change
- [x] Bug fix (non-breaking)

## Testing
- `go build ./lib/pmp/` — clean
- `go vet ./lib/pmp/` — no issues
- `go test ./lib/pmp/...` — passes (package has no unit tests by design; `empty_test.go` is a placeholder)