### PR TITLE
fix: Reduce memory and unnecessary map growth during scanning

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -680,6 +680,9 @@ func (f *folder) scanSubdirsChangedAndNew(ctx context.Context, subDirs []string,
 		fchan = scanner.Walk(scanCtx, scanConfig)
 	}
 
+	// Tracks names participating in successful rename detection within the
+	// current update batch. We intentionally don't track every scanned file,
+	// only consumed rename sources and destinations.
 	alreadyUsedOrExisting := make(map[string]struct{})
 	for res := range fchan {
 		if res.Err != nil {
@@ -687,6 +690,7 @@ func (f *folder) scanSubdirsChangedAndNew(ctx context.Context, subDirs []string,
 			continue
 		}
 
+		flushRenameTracking := batch.updateBatch.Full()
 		if err := batch.FlushIfFull(); err != nil {
 			// Prevent a race between the scan aborting due to context
 			// cancellation and releasing the snapshot in defer here.
@@ -694,6 +698,12 @@ func (f *folder) scanSubdirsChangedAndNew(ctx context.Context, subDirs []string,
 			for range fchan {
 			}
 			return changes, err
+		}
+		if flushRenameTracking {
+			// Rename tracking only needs to deduplicate source/destination use
+			// while updates are buffered. Once flushed, persisted state keeps
+			// rename source consumption correct, so we can safely reset.
+			clear(alreadyUsedOrExisting)
 		}
 
 		if ok, err := batch.Update(res.File); err != nil {
@@ -899,7 +909,6 @@ loop:
 		}
 
 		if fi.Name == file.Name {
-			alreadyUsedOrExisting[fi.Name] = struct{}{}
 			continue
 		}
 
@@ -922,8 +931,6 @@ loop:
 			continue
 		}
 
-		alreadyUsedOrExisting[fi.Name] = struct{}{}
-
 		if !osutil.IsDeleted(f.mtimefs, fi.Name) {
 			continue
 		}
@@ -935,6 +942,8 @@ loop:
 		}
 		nf.SetDeleted(f.shortID)
 		nf.LocalFlags = f.localFlags
+		alreadyUsedOrExisting[fi.Name] = struct{}{}
+		alreadyUsedOrExisting[file.Name] = struct{}{}
 		found = true
 		break
 	}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3344,6 +3344,53 @@ func TestRenameSameFile(t *testing.T) {
 	}
 }
 
+func TestFindRenameDoesNotReuseConsumedSource(t *testing.T) {
+	wcfg, fcfg := newDefaultCfgWrapper(t)
+	m := setupModel(t, wcfg)
+	defer cleanupModel(m)
+
+	ffs := fcfg.Filesystem()
+	writeFile(t, ffs, "a", []byte("same"))
+	writeFile(t, ffs, "b", []byte("same"))
+
+	m.ScanFolders()
+
+	must(t, ffs.Rename("a", "x"))
+	must(t, osutil.Copy(fs.CopyRangeMethodStandard, ffs, ffs, "x", "y"))
+
+	runner, ok := m.folderRunners.Get(fcfg.ID)
+	if !ok {
+		t.Fatal("folder runner missing")
+	}
+	sf := runner.(*sendReceiveFolder).folder
+
+	probe, ok, err := m.model.CurrentFolderFile(fcfg.ID, "b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("source file missing in db")
+	}
+
+	used := make(map[string]struct{})
+
+	firstProbe := probe
+	firstProbe.Name = "x"
+	nf, found := sf.findRename(t.Context(), firstProbe, used)
+	if !found {
+		t.Fatal("expected rename source for x")
+	}
+	if nf.Name != "a" {
+		t.Fatalf("expected a as rename source, got %q", nf.Name)
+	}
+
+	secondProbe := probe
+	secondProbe.Name = "y"
+	if _, found := sf.findRename(t.Context(), secondProbe, used); found {
+		t.Fatal("rename source was reused for a second destination")
+	}
+}
+
 func TestBlockListMap(t *testing.T) {
 	wcfg, fcfg := newDefaultCfgWrapper(t)
 	m := setupModel(t, wcfg)


### PR DESCRIPTION
### Purpose

- Reduce memory and unnecessary map growth during scanning by avoiding recording every scanned filename and only tracking names that actually participate in renames.
- Prevent reuse of a rename source for multiple destinations within the same buffered update window and keep rename-consumption semantics correct while minimizing tracked state.
- Make rename-tracking scoped to the batch/flush window so the map does not grow unbounded across long scans.

### Description
- In `scanSubdirsChangedAndNew` replaced eager insertion of scanned/self-matching names with a map that only tracks names consumed by successful rename detection, and added a comment documenting the intent.
- After a pending `FileInfoBatch` flush boundary the rename-tracking map is reset by detecting `updateBatch.Full()` before `FlushIfFull()` and clearing the map when a flush occurs, with an inline correctness note.
- In `findRename` removed the insertion on self-match (`fi.Name == file.Name`) and avoided marking non-deleted or otherwise unsuitable candidates as used, and only mark the source and destination names in the tracking map when a rename match is actually accepted.
- Added `TestFindRenameDoesNotReuseConsumedSource` to `model_test.go` to assert that a rename source consumed for one destination is not reused for a second destination with identical content.

### Testing
- Ran `go test ./lib/model -run 'TestRenameSameFile|TestFindRenameDoesNotReuseConsumedSource'` and the tests passed (ok).
- The change compiles and existing targeted rename-related tests exercised the modified logic successfully.

Note: This bug and fix was found and produced by Codex using `gpt-5.3-codex`.