### PR TITLE
chore(model): Improve memory usage during scan error retention

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -1205,9 +1205,8 @@ func (f *folder) newScanError(path string, err error) {
 		Path: path,
 	})
 	if dropped := len(f.scanErrors) - maxRetainedScanErrors; dropped > 0 {
-		trimmed := make([]FileError, maxRetainedScanErrors)
-		copy(trimmed, f.scanErrors[dropped:])
-		f.scanErrors = trimmed
+		copy(f.scanErrors, f.scanErrors[dropped:])
+		f.scanErrors = f.scanErrors[:maxRetainedScanErrors]
 		f.scanErrorsDropped += dropped
 	}
 	f.errorsMut.Unlock()
@@ -1242,7 +1241,8 @@ func (f *folder) Errors() []FileError {
 	errors = append(errors, f.scanErrors...)
 	if f.scanErrorsDropped > 0 {
 		errors = append(errors, FileError{
-			Err: fmt.Sprintf("scan error list truncated, showing latest %d entries (%d older errors omitted)", maxRetainedScanErrors, f.scanErrorsDropped),
+			Path: "~truncated~",
+			Err:  fmt.Sprintf("scan error list truncated, showing latest %d entries (%d older errors omitted)", scanLen, f.scanErrorsDropped),
 		})
 	}
 	errors = append(errors, f.pullErrors...)

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -40,6 +40,9 @@ import (
 // Arbitrary limit that triggers a warning on kqueue systems
 const kqueueItemCountThreshold = 10000
 
+// Maximum number of scan errors retained per folder.
+const maxRetainedScanErrors = 100
+
 type folder struct {
 	stateTracker
 	config.FolderConfiguration
@@ -71,8 +74,10 @@ type folder struct {
 	pullFailTimer *time.Timer
 
 	scanErrors []FileError
-	pullErrors []FileError
-	errorsMut  sync.Mutex
+	// Number of scan errors dropped due to retention limits.
+	scanErrorsDropped int
+	pullErrors        []FileError
+	errorsMut         sync.Mutex
 
 	doInSyncChan chan syncRequest
 
@@ -1199,6 +1204,12 @@ func (f *folder) newScanError(path string, err error) {
 		Err:  err.Error(),
 		Path: path,
 	})
+	if dropped := len(f.scanErrors) - maxRetainedScanErrors; dropped > 0 {
+		trimmed := make([]FileError, maxRetainedScanErrors)
+		copy(trimmed, f.scanErrors[dropped:])
+		f.scanErrors = trimmed
+		f.scanErrorsDropped += dropped
+	}
 	f.errorsMut.Unlock()
 }
 
@@ -1207,6 +1218,7 @@ func (f *folder) clearScanErrors(subDirs []string) {
 	defer f.errorsMut.Unlock()
 	if len(subDirs) == 0 {
 		f.scanErrors = nil
+		f.scanErrorsDropped = 0
 		return
 	}
 	filtered := f.scanErrors[:0]
@@ -1226,9 +1238,14 @@ func (f *folder) Errors() []FileError {
 	f.errorsMut.Lock()
 	defer f.errorsMut.Unlock()
 	scanLen := len(f.scanErrors)
-	errors := make([]FileError, scanLen+len(f.pullErrors))
-	copy(errors[:scanLen], f.scanErrors)
-	copy(errors[scanLen:], f.pullErrors)
+	errors := make([]FileError, 0, scanLen+len(f.pullErrors)+1)
+	errors = append(errors, f.scanErrors...)
+	if f.scanErrorsDropped > 0 {
+		errors = append(errors, FileError{
+			Err: fmt.Sprintf("scan error list truncated, showing latest %d entries (%d older errors omitted)", maxRetainedScanErrors, f.scanErrorsDropped),
+		})
+	}
+	errors = append(errors, f.pullErrors...)
 	slices.SortFunc(errors, func(a, b FileError) int {
 		return strings.Compare(a.Path, b.Path)
 	})

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -1246,7 +1246,7 @@ func (f *folder) Errors() []FileError {
 	slices.SortFunc(errors, func(a, b FileError) int {
 		return strings.Compare(a.Path, b.Path)
 	})
-	if f.scanErrorsDropped > 0 && scanLen > 0 {
+	if f.scanErrorsDropped > 0 {
 		errors = append([]FileError{{
 			Path: "~truncated~",
 			Err:  fmt.Sprintf("scan error list truncated, showing latest %d entries (%d older errors omitted)", scanLen, f.scanErrorsDropped),

--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -1231,6 +1231,9 @@ outer:
 		filtered = append(filtered, fe)
 	}
 	f.scanErrors = filtered
+	if len(f.scanErrors) == 0 {
+		f.scanErrorsDropped = 0
+	}
 }
 
 func (f *folder) Errors() []FileError {
@@ -1239,16 +1242,16 @@ func (f *folder) Errors() []FileError {
 	scanLen := len(f.scanErrors)
 	errors := make([]FileError, 0, scanLen+len(f.pullErrors)+1)
 	errors = append(errors, f.scanErrors...)
-	if f.scanErrorsDropped > 0 {
-		errors = append(errors, FileError{
-			Path: "~truncated~",
-			Err:  fmt.Sprintf("scan error list truncated, showing latest %d entries (%d older errors omitted)", scanLen, f.scanErrorsDropped),
-		})
-	}
 	errors = append(errors, f.pullErrors...)
 	slices.SortFunc(errors, func(a, b FileError) int {
 		return strings.Compare(a.Path, b.Path)
 	})
+	if f.scanErrorsDropped > 0 && scanLen > 0 {
+		errors = append([]FileError{{
+			Path: "~truncated~",
+			Err:  fmt.Sprintf("scan error list truncated, showing latest %d entries (%d older errors omitted)", scanLen, f.scanErrorsDropped),
+		}}, errors...)
+	}
 	return errors
 }
 

--- a/lib/model/folder_test.go
+++ b/lib/model/folder_test.go
@@ -213,9 +213,15 @@ func TestScanErrorRetention(t *testing.T) {
 
 	errs := f.Errors()
 	truncationMsgs := 0
-	for _, fe := range errs {
+	for i, fe := range errs {
 		if strings.Contains(fe.Err, "truncated") {
 			truncationMsgs++
+			if i != 0 {
+				t.Fatalf("expected truncation indicator first, got index %d", i)
+			}
+			if fe.Path != "~truncated~" {
+				t.Fatalf("unexpected truncation indicator path %q", fe.Path)
+			}
 		}
 	}
 	if truncationMsgs != 1 {
@@ -243,6 +249,34 @@ func TestClearScanErrorsResetsRetentionState(t *testing.T) {
 	for _, fe := range f.Errors() {
 		if strings.Contains(fe.Err, "truncated") {
 			t.Fatalf("unexpected truncation indicator after full clear: %q", fe.Err)
+		}
+	}
+}
+
+func TestClearScanErrorsSelectiveClearResetsRetentionStateWhenAllRetainedErrorsAreRemoved(t *testing.T) {
+	f := &folder{
+		sl: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	for i := 0; i < maxRetainedScanErrors+3; i++ {
+		f.newScanError(fmt.Sprintf("dir/path-%03d", i), errors.New("scan failed"))
+	}
+
+	if got := f.scanErrorsDropped; got != 3 {
+		t.Fatalf("dropped %d scan errors before selective clear, expected 3", got)
+	}
+
+	f.clearScanErrors([]string{"dir"})
+
+	if len(f.scanErrors) != 0 {
+		t.Fatalf("expected no scan errors after selective clear, got %d", len(f.scanErrors))
+	}
+	if f.scanErrorsDropped != 0 {
+		t.Fatalf("expected dropped count reset after selective clear removed all retained errors, got %d", f.scanErrorsDropped)
+	}
+	for _, fe := range f.Errors() {
+		if strings.Contains(fe.Err, "truncated") {
+			t.Fatalf("unexpected truncation indicator after selective clear removed all retained errors: %q", fe.Err)
 		}
 	}
 }

--- a/lib/model/folder_test.go
+++ b/lib/model/folder_test.go
@@ -7,8 +7,12 @@
 package model
 
 import (
+	"errors"
+	"fmt"
+	"log/slog"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/d4l3k/messagediff"
@@ -181,5 +185,63 @@ func TestSetPlatformData(t *testing.T) {
 
 	if err := sr.setPlatformData(fi, "file.tmp"); err != nil {
 		t.Error(err)
+	}
+}
+
+func TestScanErrorRetention(t *testing.T) {
+	f := &folder{
+		sl: slog.Default(),
+	}
+
+	for i := 0; i < maxRetainedScanErrors+7; i++ {
+		f.newScanError(fmt.Sprintf("path-%03d", i), errors.New("scan failed"))
+	}
+
+	if got := len(f.scanErrors); got != maxRetainedScanErrors {
+		t.Fatalf("retained %d scan errors, expected %d", got, maxRetainedScanErrors)
+	}
+	if got := f.scanErrorsDropped; got != 7 {
+		t.Fatalf("dropped %d scan errors, expected 7", got)
+	}
+	if got := f.scanErrors[0].Path; got != "path-007" {
+		t.Fatalf("oldest retained path is %q, expected path-007", got)
+	}
+	if got := f.scanErrors[len(f.scanErrors)-1].Path; got != fmt.Sprintf("path-%03d", maxRetainedScanErrors+6) {
+		t.Fatalf("newest retained path is %q", got)
+	}
+
+	errs := f.Errors()
+	truncationMsgs := 0
+	for _, fe := range errs {
+		if strings.Contains(fe.Err, "truncated") {
+			truncationMsgs++
+		}
+	}
+	if truncationMsgs != 1 {
+		t.Fatalf("expected one truncation indicator, got %d", truncationMsgs)
+	}
+}
+
+func TestClearScanErrorsResetsRetentionState(t *testing.T) {
+	f := &folder{
+		sl: slog.Default(),
+	}
+
+	for i := 0; i < maxRetainedScanErrors+3; i++ {
+		f.newScanError(fmt.Sprintf("path-%03d", i), errors.New("scan failed"))
+	}
+
+	f.clearScanErrors(nil)
+
+	if len(f.scanErrors) != 0 {
+		t.Fatalf("expected no scan errors after full clear, got %d", len(f.scanErrors))
+	}
+	if f.scanErrorsDropped != 0 {
+		t.Fatalf("expected dropped count reset after full clear, got %d", f.scanErrorsDropped)
+	}
+	for _, fe := range f.Errors() {
+		if strings.Contains(fe.Err, "truncated") {
+			t.Fatalf("unexpected truncation indicator after full clear: %q", fe.Err)
+		}
 	}
 }

--- a/lib/model/folder_test.go
+++ b/lib/model/folder_test.go
@@ -9,6 +9,7 @@ package model
 import (
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"path/filepath"
 	"slices"
@@ -190,7 +191,7 @@ func TestSetPlatformData(t *testing.T) {
 
 func TestScanErrorRetention(t *testing.T) {
 	f := &folder{
-		sl: slog.Default(),
+		sl: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	for i := 0; i < maxRetainedScanErrors+7; i++ {
@@ -224,7 +225,7 @@ func TestScanErrorRetention(t *testing.T) {
 
 func TestClearScanErrorsResetsRetentionState(t *testing.T) {
 	f := &folder{
-		sl: slog.Default(),
+		sl: slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	for i := 0; i < maxRetainedScanErrors+3; i++ {


### PR DESCRIPTION
### Motivation

- Prevent unbounded memory growth from accumulating scan errors in `folder.scanErrors` by capping retained entries.
- Ensure user-visible error reporting still communicates when older errors have been truncated.

### Description

- Add a retention cap constant `maxRetainedScanErrors = 100` and a counter field `scanErrorsDropped` on `folder` to track omitted entries.
- Trim oldest entries in `newScanError` when appending causes the slice to exceed the cap and increment `scanErrorsDropped` accordingly.
- Preserve selective behavior of `clearScanErrors`, and reset `scanErrorsDropped` on full clear (`len(subDirs) == 0`).
- Update `Errors()` to include a truncation `FileError` message when older scan errors were dropped so the UI can indicate truncation.
- Add unit tests `TestScanErrorRetention` and `TestClearScanErrorsResetsRetentionState` exercising retention, truncation reporting, and full-clear reset.

### Testing

- Ran `go test ./lib/model -run 'TestScanErrorRetention|TestClearScanErrorsResetsRetentionState'`, and the tests passed.
- The added tests validate retained length, dropped count, truncation indicator presence, and reset behavior after full clear (all assertions succeeded).