### PR TITLE
gui: fallback to folder ID when label is empty in remove dialog

### DIFF
--- a/gui/default/syncthing/folder/removeFolderDialogView.html
+++ b/gui/default/syncthing/folder/removeFolderDialogView.html
@@ -1,6 +1,6 @@
 <modal id="remove-folder-confirmation" status="warning" icon="fas fa-question-circle" heading="{{'Remove Folder' | translate}}" large="no" closeable="yes">
   <div class="modal-body">
-    <p translate translate-value-label="{{currentFolder.label}}">
+    <p translate translate-value-label="{{currentFolder.label || currentFolder.id}}">
       Are you sure you want to remove folder {%label%}?
     </p>
     <p translate>


### PR DESCRIPTION
## Summary

Fixes issue #10458: When removing a folder without a Folder Label, the confirmation dialog now shows the folder ID instead of an empty string.

### Before
> Are you sure you want to remove folder **?**

### After  
> Are you sure you want to remove folder **dnjdr-hssze**?

### Changes

Modified `gui/default/syncthing/folder/removeFolderDialogView.html`:
```html
<!-- Before -->
<p translate translate-value-label="{{currentFolder.label}}">

<!-- After -->
<p translate translate-value-label="{{currentFolder.label || currentFolder.id}}">
```

The template now uses `currentFolder.label || currentFolder.id` as a fallback, so when the label is empty, the folder ID is displayed instead.

### Testing

1. Create a folder without a label
2. Open the folder edit dialog
3. Click remove
4. Verify the confirmation dialog shows the folder ID instead of blank

Fixes #10458
