### PR TITLE
fix(strelaysrv): properly use bind address for outgoing requests (fixes #10658)

### DIFF
--- a/cmd/strelaysrv/main.go
+++ b/cmd/strelaysrv/main.go
@@ -71,9 +71,13 @@ var (
 
 // httpClient is the HTTP client we use for outbound requests. It has a
 // timeout and may get further options set during initialization.
-var httpClient = &http.Client{
-	Timeout: 30 * time.Second,
-}
+var (
+	httpTransport = &http.Transport{}
+	httpClient    = &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: httpTransport,
+	}
+)
 
 func main() {
 	log.SetFlags(log.Lshortfile | log.LstdFlags)
@@ -132,9 +136,7 @@ func main() {
 		// also come from that address.
 		laddr.Port = 0
 		boundDialer := &net.Dialer{LocalAddr: laddr}
-		httpClient.Transport = &http.Transport{
-			DialContext: boundDialer.DialContext,
-		}
+		httpTransport.DialContext = boundDialer.DialContext
 	}
 
 	log.Println(longVer)
@@ -161,6 +163,11 @@ func main() {
 		if err != nil {
 			log.Fatalln("Failed to generate X509 key pair:", err)
 		}
+	}
+
+	// Outgoing HTTPS requests may use our certificate for authentication
+	httpTransport.TLSClientConfig = &tls.Config{
+		Certificates: []tls.Certificate{cert},
 	}
 
 	tlsCfg := &tls.Config{
@@ -277,7 +284,7 @@ func main() {
 	for _, pool := range pools {
 		pool = strings.TrimSpace(pool)
 		if len(pool) > 0 {
-			go poolHandler(pool, uri, mapping, cert)
+			go poolHandler(pool, uri, mapping)
 		}
 	}
 

--- a/cmd/strelaysrv/pool.go
+++ b/cmd/strelaysrv/pool.go
@@ -31,7 +31,7 @@ func poolHandler(pool string, uri *url.URL, mapping mapping) {
 			uriCopy.String(),
 		})
 
-		resp, err := httpClient.Post(pool, "application/json", &b)
+		resp, err := httpClient.Post(pool, "application/json", &b) //nolint:noctx
 		if err != nil {
 			log.Printf("Error joining pool %v: HTTP request: %v", pool, err)
 			time.Sleep(time.Minute)

--- a/cmd/strelaysrv/pool.go
+++ b/cmd/strelaysrv/pool.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/json"
 	"io"
 	"log"
@@ -17,7 +16,7 @@ const (
 	httpStatusEnhanceYourCalm = 429
 )
 
-func poolHandler(pool string, uri *url.URL, mapping mapping, ownCert tls.Certificate) {
+func poolHandler(pool string, uri *url.URL, mapping mapping) {
 	if debug {
 		log.Println("Joining", pool)
 	}
@@ -32,24 +31,7 @@ func poolHandler(pool string, uri *url.URL, mapping mapping, ownCert tls.Certifi
 			uriCopy.String(),
 		})
 
-		poolUrl, err := url.Parse(pool)
-		if err != nil {
-			log.Printf("Could not parse pool url '%s': %v", pool, err)
-		}
-
-		client := http.DefaultClient
-		if poolUrl.Scheme == "https" {
-			// Sent our certificate in join request
-			client = &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{
-						Certificates: []tls.Certificate{ownCert},
-					},
-				},
-			}
-		}
-
-		resp, err := client.Post(pool, "application/json", &b)
+		resp, err := httpClient.Post(pool, "application/json", &b)
 		if err != nil {
 			log.Printf("Error joining pool %v: HTTP request: %v", pool, err)
 			time.Sleep(time.Minute)


### PR DESCRIPTION
This was lost in #7217 a while back.
