### PR TITLE
chore(model): improve block pull scheduler

### DIFF
--- a/lib/model/deviceactivity.go
+++ b/lib/model/deviceactivity.go
@@ -8,47 +8,102 @@ package model
 
 import (
 	"sync"
+	"time"
 
 	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+const (
+	assumedRate = 1 << 20       // 1 MiB/s
+	minimumRate = 128 << 10 / 8 // 128 KiB/s
 )
 
 // deviceActivity tracks the number of outstanding requests per device and can
 // answer which device is least busy. It is safe for use from multiple
 // goroutines.
 type deviceActivity struct {
-	act map[protocol.DeviceID]int
-	mut sync.Mutex
+	act  map[protocol.DeviceID]int   // device ID -> outstanding bytes
+	rate map[protocol.DeviceID][]int // device ID -> bytes/s
+	mut  sync.Mutex
 }
 
 func newDeviceActivity() *deviceActivity {
 	return &deviceActivity{
-		act: make(map[protocol.DeviceID]int),
+		act:  make(map[protocol.DeviceID]int),
+		rate: make(map[protocol.DeviceID][]int),
 	}
 }
 
-// Returns the index of the least busy device, or -1 if all are too busy.
+// Returns the index of the least busy device, or -1 if there are no
+// available devices.
 func (m *deviceActivity) leastBusy(availability []Availability) int {
-	m.mut.Lock()
-	low := 2<<30 - 1
 	best := -1
-	for i := range availability {
-		if usage := m.act[availability[i].ID]; usage < low {
-			low = usage
+	var shortestQueue float64
+
+	m.mut.Lock()
+	for i, a := range availability {
+		if wt := m.waitTimeLocked(a.ID); shortestQueue == 0 || wt < shortestQueue {
+			shortestQueue = wt
 			best = i
 		}
 	}
 	m.mut.Unlock()
+
 	return best
 }
 
-func (m *deviceActivity) using(availability Availability) {
+func (m *deviceActivity) using(id protocol.DeviceID, bytes int) {
 	m.mut.Lock()
-	m.act[availability.ID]++
+	m.act[id] += bytes
 	m.mut.Unlock()
 }
 
-func (m *deviceActivity) done(availability Availability) {
+func (m *deviceActivity) done(id protocol.DeviceID, bytes int, dur time.Duration) {
 	m.mut.Lock()
-	m.act[availability.ID]--
+	m.act[id] -= bytes
+	if dur > 0 {
+		rate := int(float64(bytes) / dur.Seconds())
+		m.rate[id] = appendRate(m.rate[id], rate, 10)
+	}
 	m.mut.Unlock()
+}
+
+// waitTimeLocked returns how long we'll need to wait for the currently
+// queued requests for the given device to resolve.
+func (m *deviceActivity) waitTimeLocked(id protocol.DeviceID) float64 {
+	rate := 0
+	if len(m.rate[id]) > 0 {
+		// rate is average observed device rate in bytes per second
+		for _, r := range m.rate[id] {
+			rate += r
+		}
+		rate /= len(m.rate[id])
+		if rate < minimumRate {
+			// Letting the rate get too low means we'll never schedule a
+			// block on the device, which also means we'd never update the
+			// rate. Set a lower boundary.
+			rate = minimumRate
+		}
+	} else {
+		// We have no rate stats yet; assume a rate so we have something to
+		// calculate with, and so that we are likely to at least schedule a
+		// block to this device to measure the rate.
+		rate = assumedRate
+	}
+
+	// Calculate how long the current request queue is, in seconds. We add a
+	// constant overhead factor so that the queue time remains dependent on
+	// the observed rate even when there are no currently outstanding
+	// requests, and so that we never return a zero wait time.
+	return float64(m.act[id]+protocol.MinBlockSize) / float64(rate)
+}
+
+func appendRate(l []int, r int, maxL int) []int {
+	if len(l) >= maxL {
+		copy(l, l[1:])
+		l[len(l)-1] = r
+	} else {
+		l = append(l, r)
+	}
+	return l
 }

--- a/lib/model/deviceactivity.go
+++ b/lib/model/deviceactivity.go
@@ -7,6 +7,7 @@
 package model
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -22,15 +23,21 @@ const (
 // answer which device is least busy. It is safe for use from multiple
 // goroutines.
 type deviceActivity struct {
-	act  map[protocol.DeviceID]int   // device ID -> outstanding bytes
-	rate map[protocol.DeviceID][]int // device ID -> bytes/s
+	act  map[protocol.DeviceID]int             // device ID -> outstanding bytes
+	rate map[protocol.DeviceID][]usageInterval // device ID -> usage, sorted by end time
 	mut  sync.Mutex
+}
+
+type usageInterval struct {
+	start time.Time
+	end   time.Time
+	rate  float64
 }
 
 func newDeviceActivity() *deviceActivity {
 	return &deviceActivity{
 		act:  make(map[protocol.DeviceID]int),
-		rate: make(map[protocol.DeviceID][]int),
+		rate: make(map[protocol.DeviceID][]usageInterval),
 	}
 }
 
@@ -52,43 +59,48 @@ func (m *deviceActivity) leastBusy(availability []Availability) int {
 	return best
 }
 
-func (m *deviceActivity) using(id protocol.DeviceID, bytes int) {
+type token struct {
+	id    protocol.DeviceID
+	bytes int
+	start time.Time
+}
+
+func (m *deviceActivity) using(id protocol.DeviceID, bytes int, start time.Time) token {
 	m.mut.Lock()
 	m.act[id] += bytes
 	m.mut.Unlock()
+	return token{id: id, bytes: bytes, start: start}
 }
 
-func (m *deviceActivity) done(id protocol.DeviceID, bytes int, dur time.Duration) {
+func (m *deviceActivity) done(tok token, end time.Time) {
 	m.mut.Lock()
-	m.act[id] -= bytes
-	if dur > 0 {
-		rate := int(float64(bytes) / dur.Seconds())
-		m.rate[id] = appendRate(m.rate[id], rate, 10)
-	}
+	m.act[tok.id] -= tok.bytes
+	m.rate[tok.id] = appendRate(m.rate[tok.id], tok, end, 10)
+	m.mut.Unlock()
+}
+
+func (m *deviceActivity) skip(tok token) {
+	m.mut.Lock()
+	m.act[tok.id] -= tok.bytes
 	m.mut.Unlock()
 }
 
 // waitTimeLocked returns how long we'll need to wait for the currently
 // queued requests for the given device to resolve.
 func (m *deviceActivity) waitTimeLocked(id protocol.DeviceID) float64 {
-	rate := 0
+	var rate float64 = assumedRate
+	var secs float64
 	if len(m.rate[id]) > 0 {
-		// rate is average observed device rate in bytes per second
-		for _, r := range m.rate[id] {
-			rate += r
+		sr := sliceRates(m.rate[id])
+		for _, usage := range sr {
+			dur := usage.end.Sub(usage.start).Seconds()
+			rate += usage.rate * dur
+			secs += dur
 		}
-		rate /= len(m.rate[id])
+		rate /= secs
 		if rate < minimumRate {
-			// Letting the rate get too low means we'll never schedule a
-			// block on the device, which also means we'd never update the
-			// rate. Set a lower boundary.
 			rate = minimumRate
 		}
-	} else {
-		// We have no rate stats yet; assume a rate so we have something to
-		// calculate with, and so that we are likely to at least schedule a
-		// block to this device to measure the rate.
-		rate = assumedRate
 	}
 
 	// Calculate how long the current request queue is, in seconds. We add a
@@ -98,12 +110,78 @@ func (m *deviceActivity) waitTimeLocked(id protocol.DeviceID) float64 {
 	return float64(m.act[id]+protocol.MinBlockSize) / float64(rate)
 }
 
-func appendRate(l []int, r int, maxL int) []int {
+func sliceRates(intvs []usageInterval) []usageInterval {
+	farFuture := time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+	intvs = slices.Clone(intvs)
+	slices.SortFunc(intvs, func(a, b usageInterval) int { return a.start.Compare(b.start) })
+
+	t0 := intvs[0].start
+	var rates []usageInterval
+
+	var n int
+	for {
+		n++
+		if n > 100 {
+			break
+		}
+
+		t1 := farFuture
+		for i := range intvs {
+			intv := &intvs[i]
+			if intv.rate == 0 {
+				continue
+			}
+			if !intv.end.After(t0) {
+				intv.rate = 0
+				continue
+			}
+			if intv.start.After(t0) && intv.start.Before(t1) {
+				t1 = intv.start
+				continue
+			}
+			if intv.end.After(t0) && intv.end.Before(t1) {
+				t1 = intv.end
+			}
+		}
+		if t1.Equal(farFuture) {
+			break
+		}
+
+		var rate float64
+		for _, intv := range intvs {
+			if intv.rate == 0 {
+				continue
+			}
+			if !intv.start.After(t0) && !intv.end.Before(t1) {
+				rate += intv.rate
+			}
+		}
+
+		if rate > 0 {
+			rates = append(rates, usageInterval{
+				start: t0,
+				end:   t1,
+				rate:  rate,
+			})
+		}
+
+		t0 = t1
+	}
+
+	return rates
+}
+
+func appendRate(l []usageInterval, tok token, end time.Time, maxL int) []usageInterval {
+	intv := usageInterval{
+		start: tok.start,
+		end:   end,
+		rate:  float64(tok.bytes) / end.Sub(tok.start).Seconds(),
+	}
 	if len(l) >= maxL {
 		copy(l, l[1:])
-		l[len(l)-1] = r
+		l[len(l)-1] = intv
 	} else {
-		l = append(l, r)
+		l = append(l, intv)
 	}
 	return l
 }

--- a/lib/model/deviceactivity_test.go
+++ b/lib/model/deviceactivity_test.go
@@ -7,7 +7,9 @@
 package model
 
 import (
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/syncthing/syncthing/lib/protocol"
 )
@@ -17,44 +19,85 @@ func TestDeviceActivity(t *testing.T) {
 	n1 := Availability{protocol.DeviceID([32]byte{5, 6, 7, 8}), true}
 	n2 := Availability{protocol.DeviceID([32]byte{9, 10, 11, 12}), false}
 	devices := []Availability{n0, n1, n2}
-	na := newDeviceActivity()
 
-	if lb := na.leastBusy(devices); lb != 0 {
-		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
-	}
-	if lb := na.leastBusy(devices); lb != 0 {
-		t.Errorf("Least busy device should still be n0 (%v) not %v", n0, lb)
-	}
+	t.Run("basic", func(t *testing.T) {
+		na := newDeviceActivity()
 
-	lb := na.leastBusy(devices)
-	na.using(devices[lb])
-	if lb := na.leastBusy(devices); lb != 1 {
-		t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
-	}
-	lb = na.leastBusy(devices)
-	na.using(devices[lb])
-	if lb := na.leastBusy(devices); lb != 2 {
-		t.Errorf("Least busy device should be n2 (%v) not %v", n2, lb)
-	}
+		// making blocks take the assumed rate means we take device rate out
+		// of the equation for this test, basing it only on the number of
+		// outstanding blocks
+		blockDur := time.Second * protocol.MinBlockSize / assumedRate
 
-	lb = na.leastBusy(devices)
-	na.using(devices[lb])
-	if lb := na.leastBusy(devices); lb != 0 {
-		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
-	}
+		if lb := na.leastBusy(devices); lb != 0 {
+			t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
+		}
+		if lb := na.leastBusy(devices); lb != 0 {
+			t.Errorf("Least busy device should still be n0 (%v) not %v", n0, lb)
+		}
 
-	na.done(n1)
-	if lb := na.leastBusy(devices); lb != 1 {
-		t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
-	}
+		lb := na.leastBusy(devices)
+		na.using(devices[lb].ID, protocol.MinBlockSize)
+		if lb := na.leastBusy(devices); lb != 1 {
+			t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
+		}
+		lb = na.leastBusy(devices)
+		na.using(devices[lb].ID, protocol.MinBlockSize)
+		if lb := na.leastBusy(devices); lb != 2 {
+			t.Errorf("Least busy device should be n2 (%v) not %v", n2, lb)
+		}
 
-	na.done(n2)
-	if lb := na.leastBusy(devices); lb != 1 {
-		t.Errorf("Least busy device should still be n1 (%v) not %v", n1, lb)
-	}
+		lb = na.leastBusy(devices)
+		na.using(devices[lb].ID, protocol.MinBlockSize)
+		if lb := na.leastBusy(devices); lb != 0 {
+			t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
+		}
 
-	na.done(n0)
-	if lb := na.leastBusy(devices); lb != 0 {
-		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
-	}
+		na.done(n1.ID, protocol.MinBlockSize, blockDur)
+		if lb := na.leastBusy(devices); lb != 1 {
+			t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
+		}
+
+		na.done(n2.ID, protocol.MinBlockSize, blockDur)
+		if lb := na.leastBusy(devices); lb != 1 {
+			t.Errorf("Least busy device should still be n1 (%v) not %v", n1, lb)
+		}
+
+		na.done(n0.ID, protocol.MinBlockSize, blockDur)
+		if lb := na.leastBusy(devices); lb != 0 {
+			t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
+		}
+	})
+
+	t.Run("rateBased", func(t *testing.T) {
+		na := newDeviceActivity()
+
+		// n0 has proven to be quick, averaging ten blocks per second
+		na.using(n0.ID, protocol.MinBlockSize)
+		na.done(n0.ID, protocol.MinBlockSize, time.Second/10)
+
+		// n1 is a bit slower, averaging two blocks per second
+		na.using(n1.ID, protocol.MinBlockSize)
+		na.done(n1.ID, protocol.MinBlockSize, time.Second/2)
+
+		// n2 is a yet slower, averaging one block per second
+		na.using(n2.ID, protocol.MinBlockSize)
+		na.done(n2.ID, protocol.MinBlockSize, time.Second/1)
+
+		// Request one hundred blocks, and observe the distribution
+		count := make([]int, 3)
+		for range 100 {
+			idx := na.leastBusy(devices)
+			count[idx]++
+			na.using(devices[idx].ID, protocol.MinBlockSize)
+		}
+
+		// n0 should have been assigned 10/13 ~= 78% of the blocks
+		// n1 should have been assigned 2/13 ~= 15% of the blocks
+		// n2 should have been assigned 1/13 ~= 7% of the blocks
+		exp := []int{78, 15, 7}
+
+		if !slices.Equal(count, exp) {
+			t.Error("Unexpected results", count)
+		}
+	})
 }

--- a/lib/model/deviceactivity_test.go
+++ b/lib/model/deviceactivity_test.go
@@ -27,6 +27,7 @@ func TestDeviceActivity(t *testing.T) {
 		// of the equation for this test, basing it only on the number of
 		// outstanding blocks
 		blockDur := time.Second * protocol.MinBlockSize / assumedRate
+		start := time.Now()
 
 		if lb := na.leastBusy(devices); lb != 0 {
 			t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
@@ -36,33 +37,34 @@ func TestDeviceActivity(t *testing.T) {
 		}
 
 		lb := na.leastBusy(devices)
-		na.using(devices[lb].ID, protocol.MinBlockSize)
+		t0 := na.using(devices[lb].ID, protocol.MinBlockSize, start)
 		if lb := na.leastBusy(devices); lb != 1 {
 			t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
 		}
+
 		lb = na.leastBusy(devices)
-		na.using(devices[lb].ID, protocol.MinBlockSize)
+		t1 := na.using(devices[lb].ID, protocol.MinBlockSize, start)
 		if lb := na.leastBusy(devices); lb != 2 {
 			t.Errorf("Least busy device should be n2 (%v) not %v", n2, lb)
 		}
 
 		lb = na.leastBusy(devices)
-		na.using(devices[lb].ID, protocol.MinBlockSize)
+		t2 := na.using(devices[lb].ID, protocol.MinBlockSize, start)
 		if lb := na.leastBusy(devices); lb != 0 {
 			t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
 		}
 
-		na.done(n1.ID, protocol.MinBlockSize, blockDur)
+		na.done(t1, start.Add(blockDur))
 		if lb := na.leastBusy(devices); lb != 1 {
 			t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
 		}
 
-		na.done(n2.ID, protocol.MinBlockSize, blockDur)
+		na.done(t2, start.Add(blockDur))
 		if lb := na.leastBusy(devices); lb != 1 {
 			t.Errorf("Least busy device should still be n1 (%v) not %v", n1, lb)
 		}
 
-		na.done(n0.ID, protocol.MinBlockSize, blockDur)
+		na.done(t0, start.Add(blockDur))
 		if lb := na.leastBusy(devices); lb != 0 {
 			t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
 		}
@@ -70,25 +72,26 @@ func TestDeviceActivity(t *testing.T) {
 
 	t.Run("rateBased", func(t *testing.T) {
 		na := newDeviceActivity()
+		start := time.Now()
 
 		// n0 has proven to be quick, averaging ten blocks per second
-		na.using(n0.ID, protocol.MinBlockSize)
-		na.done(n0.ID, protocol.MinBlockSize, time.Second/10)
+		t0 := na.using(n0.ID, protocol.MinBlockSize, start)
+		na.done(t0, start.Add(time.Second/10))
 
 		// n1 is a bit slower, averaging two blocks per second
-		na.using(n1.ID, protocol.MinBlockSize)
-		na.done(n1.ID, protocol.MinBlockSize, time.Second/2)
+		t1 := na.using(n1.ID, protocol.MinBlockSize, start)
+		na.done(t1, start.Add(time.Second/2))
 
 		// n2 is a yet slower, averaging one block per second
-		na.using(n2.ID, protocol.MinBlockSize)
-		na.done(n2.ID, protocol.MinBlockSize, time.Second/1)
+		t3 := na.using(n2.ID, protocol.MinBlockSize, start)
+		na.done(t3, start.Add(time.Second/1))
 
 		// Request one hundred blocks, and observe the distribution
 		count := make([]int, 3)
 		for range 100 {
 			idx := na.leastBusy(devices)
 			count[idx]++
-			na.using(devices[idx].ID, protocol.MinBlockSize)
+			na.using(devices[idx].ID, protocol.MinBlockSize, start)
 		}
 
 		// n0 should have been assigned 10/13 ~= 78% of the blocks
@@ -100,4 +103,29 @@ func TestDeviceActivity(t *testing.T) {
 			t.Error("Unexpected results", count)
 		}
 	})
+}
+
+func TestRateSlicing(t *testing.T) {
+	s := []usageInterval{
+		{
+			start: time.Unix(100000000, 0),
+			end:   time.Unix(100001000, 0),
+			rate:  100,
+		},
+		{
+			start: time.Unix(100000500, 0),
+			end:   time.Unix(100002500, 0),
+			rate:  125,
+		},
+		{
+			start: time.Unix(100002000, 0),
+			end:   time.Unix(100003000, 0),
+			rate:  150,
+		},
+	}
+
+	// t.Log(s)
+	res := sliceRates(s)
+	_ = res
+	// t.Log(res)
 }

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1596,12 +1596,15 @@ loop:
 
 		// Fetch the block, while marking the selected device as in use so that
 		// leastBusy can select another device when someone else asks.
-		activity.using(selected)
+		activity.using(selected.ID, state.block.Size)
 		var buf []byte
 		blockNo := int(state.block.Offset / int64(state.file.BlockSize()))
+		t0 := time.Now()
 		buf, lastError = f.model.RequestGlobal(ctx, selected.ID, f.folderID, state.file.Name, blockNo, state.block.Offset, state.block.Size, state.block.Hash, selected.FromTemporary)
-		activity.done(selected)
-		if lastError != nil {
+		if lastError == nil {
+			activity.done(selected.ID, state.block.Size, time.Since(t0))
+		} else {
+			activity.done(selected.ID, state.block.Size, 0)
 			f.sl.DebugContext(ctx, "Block request returned error", slogutil.FilePath(state.file.Name), "offset", state.block.Offset, "size", state.block.Size, "device", selected.ID.Short(), slogutil.Error(lastError))
 			continue
 		}

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1596,15 +1596,14 @@ loop:
 
 		// Fetch the block, while marking the selected device as in use so that
 		// leastBusy can select another device when someone else asks.
-		activity.using(selected.ID, state.block.Size)
 		var buf []byte
 		blockNo := int(state.block.Offset / int64(state.file.BlockSize()))
-		t0 := time.Now()
+		tok := activity.using(selected.ID, state.block.Size, time.Now())
 		buf, lastError = f.model.RequestGlobal(ctx, selected.ID, f.folderID, state.file.Name, blockNo, state.block.Offset, state.block.Size, state.block.Hash, selected.FromTemporary)
 		if lastError == nil {
-			activity.done(selected.ID, state.block.Size, time.Since(t0))
+			activity.done(tok, time.Now())
 		} else {
-			activity.done(selected.ID, state.block.Size, 0)
+			activity.skip(tok)
 			f.sl.DebugContext(ctx, "Block request returned error", slogutil.FilePath(state.file.Name), "offset", state.block.Offset, "size", state.block.Size, "device", selected.ID.Short(), slogutil.Error(lastError))
 			continue
 		}


### PR DESCRIPTION
The current scheduler is based only on the number of outstanding blocks towards each device. This will, in the long run and under most circumstances, result in using maximum throughput from each device. However, it means that when we start pulling (in each iteration) we'll distribute blocks equally regardless of device speed, and will keep requesting blocks from slower devices when we don't have to. E.g., if we need four blocks and have two devices, we will almost always schedule two blocks for each device, even if one device is 100 times faster to respond.

This change improves the selection:

- remember the last ten block download times and calculate average download rate by device
- track the amount of outstanding request bytes per device
- for a new block request, select the device with the shortest queue (in seconds)
