### PR TITLE
Skip system filesystems on Linux during folder scan

### DIFF
--- a/lib/scanner/systemfs_linux.go
+++ b/lib/scanner/systemfs_linux.go
@@ -1,0 +1,42 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build linux
+// +build linux
+
+package scanner
+
+import (
+	"os"
+	"syscall"
+)
+
+// isSystemFilesystem checks if a path is mounted on a system filesystem
+// (procfs, sysfs, devtmpfs, etc.) that should not be recursively scanned.
+// Only applies to Linux.
+func isSystemFilesystem(path string) bool {
+	var statfs syscall.Statfs_t
+	if err := syscall.Statfs(path, &statfs); err != nil {
+		// If we can't stat, assume it's not a system filesystem
+		return false
+	}
+
+	// Check against known system filesystem type magic numbers
+	// These are defined in Linux kernel include/linux/magic.h
+	switch uint32(statfs.Type) {
+	case 0x9FA1:     // PROC_SUPER_MAGIC - procfs
+		return true
+	case 0x62656572: // SYSFS_MAGIC - sysfs
+		return true
+	case 0x1021994:  // TMPFS_MAGIC - devtmpfs
+		return true
+	case 0x2:        // MINIX_SUPER_MAGIC (not really system but skip as safety)
+		// We only skip well-known system filesystems
+		return false
+	}
+
+	return false
+}

--- a/lib/scanner/systemfs_other.go
+++ b/lib/scanner/systemfs_other.go
@@ -1,0 +1,15 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !linux
+// +build !linux
+
+package scanner
+
+// isSystemFilesystem is a no-op on non-Linux platforms.
+func isSystemFilesystem(path string) bool {
+	return false
+}

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -418,6 +418,11 @@ func (w *walker) handleItem(ctx context.Context, path string, info fs.FileInfo, 
 		return nil
 
 	case info.IsDir():
+		// Skip system filesystems on Linux (procfs, sysfs, devtmpfs, etc.)
+		if isSystemFilesystem(path) {
+			l.Debugln(w, "skipping system filesystem:", path)
+			return fs.SkipDir
+		}
 		return w.walkDir(ctx, path, info, finishedChan)
 
 	case info.IsRegular():
@@ -765,3 +770,4 @@ func CreateFileInfo(fi fs.FileInfo, name string, filesystem fs.Filesystem, scanO
 
 	return f, nil
 }
+


### PR DESCRIPTION
Fixes #10597

## Description
Do not recursively scan procfs, sysfs, devtmpfs and other system filesystems on Linux. These can be mounted within watched directories (e.g., in chroots or containers) and cause scan errors due to their dynamic nature and special I/O characteristics.

## Implementation
- Added isSystemFilesystem() function to detect system filesystems on Linux using syscall.Statfs and magic numbers from include/linux/magic.h
- No-op stub on non-Linux platforms
- handleItem() in lib/scanner/walk.go skips descending into directories on system filesystems

## Testing
- Builds successfully on Linux
- No-op on macOS/Windows builds