### PR TITLE
lib/model, gui: add option to auto-create .stignore-shared

### DIFF
--- a/gui/default/assets/lang/lang-en.json
+++ b/gui/default/assets/lang/lang-en.json
@@ -43,6 +43,7 @@
     "Authentication Required": "Authentication Required",
     "Authors": "Authors",
     "Auto Accept": "Auto Accept",
+    "Auto-create shared ignore file (.stignore-shared)": "Auto-create shared ignore file (.stignore-shared)",
     "Automatic Crash Reporting": "Automatic Crash Reporting",
     "Automatic upgrade now offers the choice between stable releases and release candidates.": "Automatic upgrade now offers the choice between stable releases and release candidates.",
     "Automatic upgrades": "Automatic upgrades",

--- a/gui/default/syncthing/folder/editFolderModalView.html
+++ b/gui/default/syncthing/folder/editFolderModalView.html
@@ -207,6 +207,10 @@
             <label>
               <input type="checkbox" ng-model="currentFolder._addIgnores" >&nbsp;<span translate>Add ignore patterns</span>
             </label>
+            <br />
+            <label>
+              <input type="checkbox" ng-model="currentFolder.autoCreateSharedIgnore" >&nbsp;<span translate>Auto-create shared ignore file (.stignore-shared)</span>
+            </label>
             <p translate class="help-block">Ignore patterns can only be added after the folder is created. If checked, an input field to enter ignore patterns will be presented after saving.</p>
           </div>
           <div ng-switch-default>

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -68,6 +68,7 @@ type FolderConfiguration struct {
 	Hashers                 int                         `json:"hashers" xml:"hashers"`
 	Order                   PullOrder                   `json:"order" xml:"order"`
 	IgnoreDelete            bool                        `json:"ignoreDelete" xml:"ignoreDelete"`
+	AutoCreateSharedIgnore  bool                        `json:"autoCreateSharedIgnore" xml:"autoCreateSharedIgnore" restart:"false"`
 	ScanProgressIntervalS   int                         `json:"scanProgressIntervalS" xml:"scanProgressIntervalS"`
 	PullerPauseS            int                         `json:"pullerPauseS" xml:"pullerPauseS"`
 	PullerDelayS            float64                     `json:"pullerDelayS" xml:"pullerDelayS" default:"1"`

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -297,6 +297,7 @@ func (m *model) initFolders(cfg config.Configuration) error {
 	clusterConfigDevices := make(deviceIDSet, len(cfg.Devices))
 	for _, folderCfg := range cfg.Folders {
 		if folderCfg.Paused {
+			m.maybeCreateSharedIgnoreFiles(folderCfg)
 			folderCfg.CreateRoot()
 			continue
 		}
@@ -336,6 +337,8 @@ func (m *model) fatal(err error) {
 
 // Need to hold lock on m.mut when calling this.
 func (m *model) addAndStartFolderLocked(cfg config.FolderConfiguration, cacheIgnoredFiles bool) {
+	m.maybeCreateSharedIgnoreFiles(cfg)
+
 	ignores := ignore.New(cfg.Filesystem(), ignore.WithCache(cacheIgnoredFiles))
 	if cfg.Type != config.FolderTypeReceiveEncrypted {
 		if err := ignores.Load(".stignore"); err != nil && !fs.IsNotExist(err) {
@@ -2258,6 +2261,78 @@ func (m *model) setIgnores(cfg config.FolderConfiguration, content []string) err
 	return nil
 }
 
+func (m *model) maybeCreateSharedIgnoreFiles(cfg config.FolderConfiguration) {
+	if !cfg.AutoCreateSharedIgnore || cfg.Type == config.FolderTypeReceiveEncrypted {
+		return
+	}
+	if err := createSharedIgnoreFiles(cfg); err != nil {
+		slog.Error("Failed to create shared ignore files", cfg.LogAttr(), slogutil.Error(err))
+	}
+}
+
+func createSharedIgnoreFiles(cfg config.FolderConfiguration) error {
+	err := cfg.CheckPath()
+	if errors.Is(err, config.ErrPathMissing) {
+		if err = cfg.CreateRoot(); err != nil {
+			return fmt.Errorf("failed to create folder root: %w", err)
+		}
+		err = cfg.CheckPath()
+	}
+	if err != nil && !errors.Is(err, config.ErrMarkerMissing) {
+		return err
+	}
+
+	ffs := cfg.Filesystem()
+	if err := createIgnoreFileIfMissing(ffs, ".stignore", []string{
+		"!/.stignore-shared",
+		"#include .stignore-shared",
+	}); err != nil {
+		return fmt.Errorf("failed to create .stignore: %w", err)
+	}
+	if err := createEmptyFileIfMissing(ffs, ".stignore-shared"); err != nil {
+		return fmt.Errorf("failed to create .stignore-shared: %w", err)
+	}
+
+	return nil
+}
+
+func createIgnoreFileIfMissing(filesystem fs.Filesystem, path string, content []string) error {
+	fd, err := filesystem.OpenFile(path, fs.OptWriteOnly|fs.OptCreate|fs.OptExclusive, 0o666)
+	if fs.IsExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	wr := osutil.LineEndingsWriter(fd)
+	for _, line := range content {
+		if _, err = fmt.Fprintln(wr, line); err != nil {
+			break
+		}
+	}
+	if closeErr := fd.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return err
+	}
+
+	filesystem.Hide(path)
+	return nil
+}
+
+func createEmptyFileIfMissing(filesystem fs.Filesystem, path string) error {
+	fd, err := filesystem.OpenFile(path, fs.OptWriteOnly|fs.OptCreate|fs.OptExclusive, 0o666)
+	if fs.IsExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	return fd.Close()
+}
+
 // OnHello is called when an device connects to us.
 // This allows us to extract some information from the Hello message
 // and add it to a list of known devices ahead of any checks.
@@ -2982,6 +3057,7 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 		if _, ok := fromFolders[folderID]; !ok {
 			// A folder was added.
 			if cfg.Paused {
+				m.maybeCreateSharedIgnoreFiles(cfg)
 				slog.Info("Paused folder", cfg.LogAttr())
 			} else {
 				slog.Info("Adding folder", cfg.LogAttr())
@@ -3006,7 +3082,14 @@ func (m *model) CommitConfiguration(from, to config.Configuration) bool {
 		}
 
 		if fromCfg.Paused && toCfg.Paused {
+			if !fromCfg.AutoCreateSharedIgnore && toCfg.AutoCreateSharedIgnore {
+				m.maybeCreateSharedIgnoreFiles(toCfg)
+			}
 			continue
+		}
+
+		if !fromCfg.AutoCreateSharedIgnore && toCfg.AutoCreateSharedIgnore {
+			m.maybeCreateSharedIgnoreFiles(toCfg)
 		}
 
 		// This folder exists on both sides. Settings might have changed.

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -1651,6 +1651,83 @@ func TestEmptyIgnores(t *testing.T) {
 	}
 }
 
+func TestCreateSharedIgnoreFiles(t *testing.T) {
+	fcfg := config.FolderConfiguration{
+		ID:             "sharedIgnores",
+		Path:           srand.String(32) + "?content=true",
+		FilesystemType: config.FilesystemTypeFake,
+	}
+	ffs := fcfg.Filesystem()
+
+	must(t, createSharedIgnoreFiles(fcfg))
+
+	if got := normalizedFileString(t, ffs, ".stignore"); got != "!/.stignore-shared\n#include .stignore-shared\n" {
+		t.Errorf("unexpected .stignore content: %q", got)
+	}
+	if got := normalizedFileString(t, ffs, ".stignore-shared"); got != "" {
+		t.Errorf("unexpected .stignore-shared content: %q", got)
+	}
+}
+
+func TestCreateSharedIgnoreFilesDoesNotOverwrite(t *testing.T) {
+	fcfg := config.FolderConfiguration{
+		ID:             "sharedIgnoresExisting",
+		Path:           srand.String(32) + "?content=true",
+		FilesystemType: config.FilesystemTypeFake,
+	}
+	ffs := fcfg.Filesystem()
+	writeFile(t, ffs, ".stignore", []byte("custom\n"))
+	writeFile(t, ffs, ".stignore-shared", []byte("shared\n"))
+
+	must(t, createSharedIgnoreFiles(fcfg))
+
+	if got := normalizedFileString(t, ffs, ".stignore"); got != "custom\n" {
+		t.Errorf("unexpected .stignore content: %q", got)
+	}
+	if got := normalizedFileString(t, ffs, ".stignore-shared"); got != "shared\n" {
+		t.Errorf("unexpected .stignore-shared content: %q", got)
+	}
+}
+
+func TestAutoCreateSharedIgnoreFilesForPausedNewFolder(t *testing.T) {
+	w, cancel := newConfigWrapper(config.New(myID))
+	defer cancel()
+	m := setupModel(t, w)
+	defer cleanupModel(m)
+
+	fcfg := newFolderConfiguration(w, "sharedIgnoresPaused", "shared ignores", config.FilesystemTypeFake, srand.String(32)+"?content=true")
+	fcfg.Paused = true
+	fcfg.AutoCreateSharedIgnore = true
+	waiter, err := w.Modify(func(cfg *config.Configuration) {
+		cfg.SetFolder(fcfg)
+	})
+	must(t, err)
+	waiter.Wait()
+
+	ffs := fcfg.Filesystem()
+	if got := normalizedFileString(t, ffs, ".stignore"); got != "!/.stignore-shared\n#include .stignore-shared\n" {
+		t.Errorf("unexpected .stignore content: %q", got)
+	}
+	if got := normalizedFileString(t, ffs, ".stignore-shared"); got != "" {
+		t.Errorf("unexpected .stignore-shared content: %q", got)
+	}
+}
+
+func normalizedFileString(t testing.TB, filesystem fs.Filesystem, name string) string {
+	t.Helper()
+	return strings.ReplaceAll(string(readFile(t, filesystem, name)), "\r\n", "\n")
+}
+
+func readFile(t testing.TB, filesystem fs.Filesystem, name string) []byte {
+	t.Helper()
+	fd, err := filesystem.Open(name)
+	must(t, err)
+	defer fd.Close()
+	data, err := io.ReadAll(fd)
+	must(t, err)
+	return data
+}
+
 func waitForState(t *testing.T, sub events.Subscription, folder, expected string) {
 	t.Helper()
 	timeout := time.After(5 * time.Second)


### PR DESCRIPTION
Fixes #10665

**What this PR does / why we need it:**
This PR adds a user-friendly option during folder creation to automatically generate a shared ignore file setup. It introduces a checkbox in the UI that, when enabled, initializes the `.stignore` file with an include directive for a newly created `.stignore-shared` file.

**Specific Changes:**
*   **GUI:** Added an "Auto-create shared ignore file" checkbox to the folder creation modal (`editFolderModalView.html`), bound to the new config field. Added localization string to `lang-en.json`.
*   **Config:** Introduced `AutoCreateSharedIgnore` boolean to `FolderConfiguration`.
*   **Model Logic:** Updated folder initialization in `model.go` to safely create `.stignore` (containing `!/.stignore-shared` and `#include .stignore-shared`) and an empty `.stignore-shared` file.
*   **Testing:** Added coverage in `model_test.go` to ensure files are created correctly, do not overwrite existing files, and handle paused folder states appropriately. 

**Testing Performed:**
*   `go test ./lib/model/...` passes cleanly.
*   Built and verified the UI behavior locally.