### PR TITLE
lib/model: use transfer performance as tie-breaker in peer selection

### DIFF
--- a/lib/model/deviceactivity.go
+++ b/lib/model/deviceactivity.go
@@ -8,6 +8,7 @@ package model
 
 import (
 	"sync"
+	"time"
 
 	"github.com/syncthing/syncthing/lib/protocol"
 )
@@ -16,29 +17,65 @@ import (
 // answer which device is least busy. It is safe for use from multiple
 // goroutines.
 type deviceActivity struct {
-	act map[protocol.DeviceID]int
-	mut sync.Mutex
+	act        map[protocol.DeviceID]int
+	perf       map[protocol.DeviceID]devicePerformance
+	roundRobin int
+	mut        sync.Mutex
+}
+
+type devicePerformance struct {
+	requests     int
+	nanosPerByte float64
 }
 
 func newDeviceActivity() *deviceActivity {
 	return &deviceActivity{
-		act: make(map[protocol.DeviceID]int),
+		act:  make(map[protocol.DeviceID]int),
+		perf: make(map[protocol.DeviceID]devicePerformance),
 	}
 }
 
 // Returns the index of the least busy device, or -1 if all are too busy.
 func (m *deviceActivity) leastBusy(availability []Availability) int {
 	m.mut.Lock()
+	defer m.mut.Unlock()
+
 	low := 2<<30 - 1
 	best := -1
-	for i := range availability {
-		if usage := m.act[availability[i].ID]; usage < low {
+	bestPerf := devicePerformance{}
+	bestPerfOK := false
+	start := 0
+	if len(availability) > 0 {
+		start = m.roundRobin % len(availability)
+		m.roundRobin++
+	}
+	for offset := range availability {
+		i := (start + offset) % len(availability)
+		usage := m.act[availability[i].ID]
+		if usage < low {
 			low = usage
 			best = i
+			bestPerf, bestPerfOK = m.perf[availability[i].ID]
+			continue
+		}
+		if usage != low {
+			continue
+		}
+		perf, perfOK := m.perf[availability[i].ID]
+		if betterDevicePerformance(perf, perfOK, bestPerf, bestPerfOK) {
+			best = i
+			bestPerf = perf
+			bestPerfOK = perfOK
 		}
 	}
-	m.mut.Unlock()
 	return best
+}
+
+func betterDevicePerformance(a devicePerformance, aOK bool, b devicePerformance, bOK bool) bool {
+	if !aOK || !bOK {
+		return false
+	}
+	return a.nanosPerByte < b.nanosPerByte
 }
 
 func (m *deviceActivity) using(availability Availability) {
@@ -50,5 +87,23 @@ func (m *deviceActivity) using(availability Availability) {
 func (m *deviceActivity) done(availability Availability) {
 	m.mut.Lock()
 	m.act[availability.ID]--
+	m.mut.Unlock()
+}
+
+func (m *deviceActivity) success(availability Availability, duration time.Duration, bytes int) {
+	if duration <= 0 || bytes <= 0 {
+		return
+	}
+
+	m.mut.Lock()
+	perf := m.perf[availability.ID]
+	sample := float64(duration.Nanoseconds()) / float64(bytes)
+	if perf.requests == 0 {
+		perf.nanosPerByte = sample
+	} else {
+		perf.nanosPerByte = perf.nanosPerByte*0.8 + sample*0.2
+	}
+	perf.requests++
+	m.perf[availability.ID] = perf
 	m.mut.Unlock()
 }

--- a/lib/model/deviceactivity_test.go
+++ b/lib/model/deviceactivity_test.go
@@ -22,25 +22,26 @@ func TestDeviceActivity(t *testing.T) {
 	if lb := na.leastBusy(devices); lb != 0 {
 		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
 	}
-	if lb := na.leastBusy(devices); lb != 0 {
-		t.Errorf("Least busy device should still be n0 (%v) not %v", n0, lb)
+	if lb := na.leastBusy(devices); lb != 1 {
+		t.Errorf("Least busy device should rotate to n1 (%v) not %v", n1, lb)
+	}
+	if lb := na.leastBusy(devices); lb != 2 {
+		t.Errorf("Least busy device should rotate to n2 (%v) not %v", n2, lb)
 	}
 
-	lb := na.leastBusy(devices)
-	na.using(devices[lb])
+	na.using(n0)
 	if lb := na.leastBusy(devices); lb != 1 {
 		t.Errorf("Least busy device should be n1 (%v) not %v", n1, lb)
 	}
-	lb = na.leastBusy(devices)
-	na.using(devices[lb])
+
+	na.using(n1)
 	if lb := na.leastBusy(devices); lb != 2 {
 		t.Errorf("Least busy device should be n2 (%v) not %v", n2, lb)
 	}
 
-	lb = na.leastBusy(devices)
-	na.using(devices[lb])
-	if lb := na.leastBusy(devices); lb != 0 {
-		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
+	na.using(n2)
+	if lb := na.leastBusy(devices); lb != 2 {
+		t.Errorf("Least busy device should rotate to n2 (%v) not %v", n2, lb)
 	}
 
 	na.done(n1)
@@ -54,7 +55,21 @@ func TestDeviceActivity(t *testing.T) {
 	}
 
 	na.done(n0)
-	if lb := na.leastBusy(devices); lb != 0 {
-		t.Errorf("Least busy device should be n0 (%v) not %v", n0, lb)
+	if lb := na.leastBusy(devices); lb != 2 {
+		t.Errorf("Least busy device should rotate to n2 (%v) not %v", n2, lb)
+	}
+}
+
+func TestDeviceActivityPrefersFasterTemporaryPeer(t *testing.T) {
+	completeSlow := Availability{protocol.DeviceID([32]byte{1, 2, 3, 4}), false}
+	partialFast := Availability{protocol.DeviceID([32]byte{5, 6, 7, 8}), true}
+	devices := []Availability{completeSlow, partialFast}
+	na := newDeviceActivity()
+
+	na.success(completeSlow, 10_000_000, 1000)
+	na.success(partialFast, 1_000_000, 1000)
+
+	if lb := na.leastBusy(devices); lb != 1 {
+		t.Errorf("Least busy device should be fast partial peer (%v) not %v", partialFast, lb)
 	}
 }

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1608,9 +1608,11 @@ loop:
 		// Fetch the block, while marking the selected device as in use so that
 		// leastBusy can select another device when someone else asks.
 		activity.using(selected)
+		requestStarted := time.Now()
 		var buf []byte
 		blockNo := int(state.block.Offset / int64(state.file.BlockSize()))
 		buf, lastError = f.model.RequestGlobal(ctx, selected.ID, f.folderID, state.file.Name, blockNo, state.block.Offset, state.block.Size, state.block.Hash, selected.FromTemporary)
+		requestDuration := time.Since(requestStarted)
 		activity.done(selected)
 		if lastError != nil {
 			f.sl.DebugContext(ctx, "Block request returned error", slogutil.FilePath(state.file.Name), "offset", state.block.Offset, "size", state.block.Size, "device", selected.ID.Short(), slogutil.Error(lastError))
@@ -1629,6 +1631,7 @@ loop:
 			f.sl.DebugContext(ctx, "Block hash mismatch", slogutil.FilePath(state.file.Name), "offset", state.block.Offset, "size", state.block.Size)
 			continue
 		}
+		activity.success(selected, requestDuration, len(buf))
 
 		// Save the block data we got from the cluster
 		err = f.limitedWriteAt(ctx, fd, buf, state.block.Offset)


### PR DESCRIPTION
Fixes #10677

### Overview
This PR addresses the issue where a new or empty device favors slow, 100% complete peers over faster, partial peers. 

### The Problem
The root cause was identified in the interaction between `fileAvailabilityRLocked` and the `leastBusy` selection logic. Currently, `fileAvailabilityRLocked` appends complete-file holders to the candidate list before partial peers. Since `leastBusy` (in `deviceactivity.go`) only compared the count of outstanding requests, it would consistently pick the first available candidate in "cold tie" situations (where everyone has 0 requests). This essentially hardcoded a preference for complete devices regardless of their actual throughput.

### Changes
- **lib/model/folder_sendrecv.go**: Integrated performance measurement (nanoseconds-per-byte) for successful `RequestGlobal` block fetches after hash verification.
- **lib/model/deviceactivity.go**: Updated the selection logic to use the observed $ns/byte$ as a tie-breaker when peers have an equal number of outstanding requests. Added a rotation mechanism for unknown or equal-performing peers to prevent static bias.
- **lib/model/deviceactivity_test.go**: Added unit tests simulating a "Slow Complete" vs. "Fast Partial" scenario. The tests verify that the puller correctly migrates requests toward the faster partial peer once performance data is sampled.

### Testing Performed
- Verified with `go test ./lib/model/...`.
- Ran internal benchmarks (`BenchmarkRequestOut`, `BenchmarkRequestInSingleFile`) to ensure no significant regression in the puller's hot path.
- Local manual verification shows that block requests now distribute based on peer speed rather than their position in the availability list.