### PR TITLE
lib/protocol, lib/scanner: fix 64-bit atomic alignment panics on 32-bit archs

### DIFF
--- a/lib/protocol/counting.go
+++ b/lib/protocol/counting.go
@@ -13,11 +13,11 @@ import (
 )
 
 type countingReader struct {
-	io.Reader
-
-	idString string
 	tot      atomic.Int64 // bytes
 	last     atomic.Int64 // unix nanos
+
+	io.Reader
+	idString string
 }
 
 var (
@@ -41,11 +41,11 @@ func (c *countingReader) Last() time.Time {
 }
 
 type countingWriter struct {
-	io.Writer
-
-	idString string
 	tot      atomic.Int64 // bytes
 	last     atomic.Int64 // unix nanos
+
+	io.Writer
+	idString string
 }
 
 func (c *countingWriter) Write(bs []byte) (int, error) {

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -681,10 +681,10 @@ func (w *walker) String() string {
 // A byteCounter gets bytes added to it via Update() and then provides the
 // Total() and one minute moving average Rate() in bytes per second.
 type byteCounter struct {
-	metrics.EWMA
-
 	total atomic.Int64
-	stop  chan struct{}
+
+	metrics.EWMA
+	stop chan struct{}
 }
 
 func newByteCounter() *byteCounter {


### PR DESCRIPTION
Fixes #10601

### What this PR does / why we need it:
This PR resolves the `fatal error: found bad pointer in Go heap` panics occurring on 32-bit architectures (like `armhf` / 386) after the recent updates. 

In Go, 32-bit architectures require 64-bit atomic variables to be strictly 8-byte aligned. With the recent transition to `atomic.Int64` (introduced during the Go 1.25/1.26 modernization), any struct containing these fields must have them declared at the very top of the struct. If they follow a 32-bit field (like a standard `int` or `bool` on a 32-bit OS), the alignment breaks and triggers a heap panic.

### Specific Changes:
* **`lib/protocol/counting.go`**: Reordered `countingReader` and `countingWriter` structs to place the `tot` and `last` `atomic.Int64` fields at the top.
* **`lib/scanner/walk.go`**: Reordered the `byteCounter` struct to place `total atomic.Int64` at the top.
* Audited `lib/protocol/bufferpool.go` and confirmed its atomic fields are already correctly aligned.

### Testing Performed:
* Compiled cleanly against 32-bit targets using `GOOS=linux GOARCH=arm go build ./...`
* Verified native compilation and local tests pass.