### PR TITLE
fix(versioner): use umask defaults for .stversions dirs (fixes #10532)

### DIFF
--- a/lib/versioner/simple_test.go
+++ b/lib/versioner/simple_test.go
@@ -256,3 +256,117 @@ func TestArchiveFoldersCreationPermission(t *testing.T) {
 		t.Errorf("földer2 permissions %v, want %v", folder2VersionsInfo.Mode(), folder2Perms)
 	}
 }
+
+func TestArchiveUnderRestrictiveVersionDir(t *testing.T) {
+	// Test that an archive below a .stversions directory left at 0o555 by
+	// prior source-perm mirroring still succeeds, with the directory mode
+	// restored afterwards. (issue #10532)
+	if build.IsWindows {
+		t.Skip("Skipping on Windows")
+		return
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("Skipping as root: DAC permission checks are bypassed")
+		return
+	}
+	dir := t.TempDir()
+	versionsDir := t.TempDir()
+
+	cfg := config.FolderConfiguration{
+		FilesystemType: config.FilesystemTypeBasic,
+		Path:           dir,
+		Versioning: config.VersioningConfiguration{
+			FSPath: versionsDir,
+			FSType: config.FilesystemTypeBasic,
+			Params: map[string]string{
+				"keep": "2",
+			},
+		},
+	}
+	vfs := cfg.Filesystem()
+	v := newSimple(cfg)
+
+	// Source tree: folder/sub/file. Sub gets a non-default mode so we
+	// can verify the mirroring continues to work for new dirs.
+	folder := filepath.Join(dir, "folder")
+	sub := filepath.Join(folder, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rel := filepath.Join("folder", "sub", "file")
+	f, err := vfs.Create(rel)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	subPerms := os.FileMode(0o750)
+	if err := os.Chmod(sub, subPerms); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate .stversions/folder at 0o555 to mimic the pathological
+	// state where prior mirroring left an intermediate version directory
+	// without owner-write.
+	versionedFolder := filepath.Join(versionsDir, "folder")
+	if err := os.Mkdir(versionedFolder, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	folderPerms := os.FileMode(0o555)
+	if err := os.Chmod(versionedFolder, folderPerms); err != nil {
+		t.Fatal(err)
+	}
+	// Restore owner-write so t.TempDir cleanup can remove the tree.
+	t.Cleanup(func() { _ = os.Chmod(versionedFolder, 0o755) })
+
+	if err := v.Archive(rel); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+
+	// The pre-existing folder dir must be back at 0o555.
+	info, err := os.Stat(versionedFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != folderPerms {
+		t.Errorf("folder restored mode %v, want %v", info.Mode().Perm(), folderPerms)
+	}
+
+	// The newly created sub dir under it must mirror the source mode.
+	versionedSub := filepath.Join(versionedFolder, "sub")
+	info, err = os.Stat(versionedSub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != subPerms {
+		t.Errorf("sub mode %v, want %v", info.Mode().Perm(), subPerms)
+	}
+
+	// And the file must have landed inside it.
+	entries, err := os.ReadDir(versionedSub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("found %d entries in sub version dir, want 1", len(entries))
+	}
+
+	// Archive another file under the same path to exercise the
+	// chmod-restore cycle a second time, with both folder and sub now
+	// pre-existing at their restored modes.
+	rel2 := filepath.Join("folder", "sub", "file2")
+	f2, err := vfs.Create(rel2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f2.Close()
+	if err := v.Archive(rel2); err != nil {
+		t.Fatalf("second archive: %v", err)
+	}
+	info, err = os.Stat(versionedFolder)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != folderPerms {
+		t.Errorf("folder mode after second archive %v, want %v", info.Mode().Perm(), folderPerms)
+	}
+}

--- a/lib/versioner/util.go
+++ b/lib/versioner/util.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -167,73 +166,64 @@ func archiveFile(method fs.CopyRangeMethod, srcFs, dstFs fs.Filesystem, filePath
 
 	file := filepath.Base(filePath)
 	inFolderPath := filepath.Dir(filePath)
-	err = dupDirTree(srcFs, dstFs, inFolderPath)
-	if err != nil {
-		l.Debugln("archiving", filePath, err)
+	return inWritableVersionDir(srcFs, dstFs, inFolderPath, func() error {
+		now := time.Now()
+		ver := tagger(file, now.Format(TimeFormat))
+		dst := filepath.Join(inFolderPath, ver)
+		l.Debugln("archiving", filePath, "moving to", dst)
+		err := osutil.RenameOrCopy(method, srcFs, dstFs, filePath, dst)
+		mtime := info.ModTime()
+		// If it's a trashcan versioner type thing, then it does not have version time in the name
+		// so use mtime for that.
+		if ver == file {
+			mtime = now
+		}
+		_ = dstFs.Chtimes(dst, mtime, mtime)
 		return err
-	}
-
-	now := time.Now()
-
-	ver := tagger(file, now.Format(TimeFormat))
-	dst := filepath.Join(inFolderPath, ver)
-	l.Debugln("archiving", filePath, "moving to", dst)
-	err = osutil.RenameOrCopy(method, srcFs, dstFs, filePath, dst)
-
-	mtime := info.ModTime()
-	// If it's a trashcan versioner type thing, then it does not have version time in the name
-	// so use mtime for that.
-	if ver == file {
-		mtime = now
-	}
-
-	_ = dstFs.Chtimes(dst, mtime, mtime)
-
-	return err
+	})
 }
 
-func dupDirTree(srcFs, dstFs fs.Filesystem, folderPath string) error {
-	// Return early if the folder already exists.
-	_, err := dstFs.Stat(folderPath)
-	if err == nil || !fs.IsNotExist(err) {
-		return err
-	}
-	hadParent := true
-	for i := range folderPath {
-		if os.IsPathSeparator(folderPath[i]) {
-			// If the parent folder didn't exist, then this folder doesn't exist
-			// so we can skip the check
-			if hadParent {
-				_, err := dstFs.Stat(folderPath[:i])
-				if err == nil {
-					continue
-				}
-				if !fs.IsNotExist(err) {
-					return err
-				}
-			}
-			hadParent = false
-			err := dupDirWithPerms(srcFs, dstFs, folderPath[:i])
-			if err != nil {
-				return err
-			}
+// inWritableVersionDir calls fn after making each directory along
+// folderPath writable, so the archive can put files into them even when
+// source-perm mirroring would have left them read-only (e.g. 0o555 from
+// receive-only enforcement). The original modes are put back when fn
+// returns; newly-created directories take the source-tree mode so we
+// keep #10105's mirroring but don't get stuck for #10532.
+func inWritableVersionDir(srcFs, dstFs fs.Filesystem, folderPath string, fn func() error) error {
+	// If chmod fails on the way out we log and continue. At that point
+	// we've already nudged the filesystem state and the error from fn
+	// (if any) is what we actually want to return to the caller.
+	restore := func(path string, mode fs.FileMode) {
+		if err := dstFs.Chmod(path, mode); err != nil && !fs.IsNotExist(err) {
+			slog.Warn("Failed to restore directory permissions after gaining write access", slogutil.FilePath(path), slogutil.Error(err))
 		}
 	}
-	return dupDirWithPerms(srcFs, dstFs, folderPath)
-}
 
-func dupDirWithPerms(srcFs, dstFs fs.Filesystem, folderPath string) error {
-	srcStat, err := srcFs.Stat(folderPath)
-	if err != nil {
-		return err
+	var path string
+	for _, part := range fs.PathComponents(folderPath) {
+		path = filepath.Join(path, part)
+		info, err := dstFs.Stat(path)
+		switch {
+		case fs.IsNotExist(err):
+			target := fs.FileMode(0o755)
+			if srcStat, srcErr := srcFs.Stat(path); srcErr == nil {
+				target = srcStat.Mode()
+			}
+			if err := dstFs.Mkdir(path, 0o700); err != nil {
+				return err
+			}
+			defer restore(path, target)
+		case err != nil:
+			return err
+		case info.Mode()&0o200 == 0:
+			m := info.Mode()
+			if err := dstFs.Chmod(path, m|0o700); err != nil {
+				return err
+			}
+			defer restore(path, m)
+		}
 	}
-	// If we call Mkdir with srcStat.Mode(), we won't get the expected perms because of umask
-	// So, we create the folder with 0700, and then change the perms to the srcStat.Mode()
-	err = dstFs.Mkdir(folderPath, 0o700)
-	if err != nil {
-		return err
-	}
-	return dstFs.Chmod(folderPath, srcStat.Mode())
+	return fn()
 }
 
 func restoreFile(method fs.CopyRangeMethod, src, dst fs.Filesystem, filePath string, versionTime time.Time, tagger fileTagger) error {


### PR DESCRIPTION
### Purpose

Fix #10532. The source-perm mirroring from #10105 left each `.stversions` directory at the source-tree mode. For receive-only folders, where we force content directories to 0o555, that means the version directory itself ends up non-writable, and the next archive that wants to mkdir below it or rename a file into it then fails with `mkdir: permission denied`.

The archive operation now runs inside a new `inWritableVersionDir` helper, in the same spirit as `inWritableDir` (`lib/model/util.go`) and `withPreparedTarget` (`lib/osutil/osutil.go`) elsewhere. It walks the path under `.stversions`, makes each directory along it owner-writable for the duration of the archive call, and puts the original modes back afterwards. Newly-created directories take the source-tree mode on restore so we keep the mirroring; existing ones go back to whatever they were.

`.stversions` subdirectories already at 0o555 from older versions of this code will be unstuck the next time an archive runs through them.

### Testing

`go test ./lib/versioner/...` on Linux as a non-root user.

The existing `TestArchiveFoldersCreationPermission` still passes, so the mirroring behaviour is preserved.

A new `TestArchiveUnderRestrictiveVersionDir` pre-populates `.stversions/folder` at 0o555 and archives a file at `folder/sub/file` underneath it, then archives a second file in the same path to run through the chmod-restore cycle again with both dirs already in place. The test skips when run as root, since DAC permission checks don't kick in for root and the bug can't be reproduced there.

It fails on unpatched main with `mkdir ...: permission denied` and passes with the change.

### Documentation

No user-visible change beyond restoring versioning for receive-only folders. No docs update needed.

## Authorship

Your name and email will be added automatically to the AUTHORS file based on the commit metadata.
