### PR TITLE
fix(syncthing): properly upgrade via REST when Syncthing is running (fixes #10697)

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -915,10 +915,14 @@ func (u upgradeCmd) Run() error {
 		case err != nil && !os.IsNotExist(err):
 			slog.Error("Failed to lock for upgrade", slogutil.Error(err))
 			os.Exit(1)
-		case locked:
-			err = upgradeViaRest()
-		default:
+		case locked || os.IsNotExist(err):
+			// We got the lock, or the config directory didn't exist, so we
+			// can do a direct upgrade
 			err = upgrade.To(release)
+		default:
+			// We didn't get the lock, because Syncthing was running, so
+			// upgrade via REST.
+			err = upgradeViaRest()
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
The locking logic for upgrades got inverted in the lockfile changes. If we got the lock it means Syncthing wasn't already running, so we can do a direct upgrade. If we failed to get the lock it means Syncthing was running and we should tell the REST interface to do the upgrade.