### PR TITLE
chore: use path/filepath for local file system paths

### DIFF
--- a/cmd/stdiscosrv/database.go
+++ b/cmd/stdiscosrv/database.go
@@ -15,7 +15,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -77,7 +77,7 @@ func newInMemoryStore(dir string, flushInterval time.Duration, blobs blob.Store)
 			slog.Error("Failed to find database in blob storage", "error", cerr)
 			return s
 		}
-		fd, cerr := os.Create(path.Join(s.dir, "records.db"))
+		fd, cerr := os.Create(filepath.Join(s.dir, "records.db"))
 		if cerr != nil {
 			slog.Error("Failed to create database file", "error", cerr)
 			return s
@@ -257,7 +257,7 @@ func (s *inMemoryStore) write() (err error) {
 		}
 	}()
 
-	dbf := path.Join(s.dir, "records.db")
+	dbf := filepath.Join(s.dir, "records.db")
 	fd, err := os.Create(dbf + ".tmp")
 	if err != nil {
 		return err
@@ -340,7 +340,7 @@ func (s *inMemoryStore) write() (err error) {
 }
 
 func (s *inMemoryStore) read() (int, error) {
-	fd, err := os.Open(path.Join(s.dir, "records.db"))
+	fd, err := os.Open(filepath.Join(s.dir, "records.db"))
 	if err != nil {
 		return 0, err
 	}

--- a/internal/db/sqlite/db_test.go
+++ b/internal/db/sqlite/db_test.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"iter"
 	"os"
-	"path"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -1168,7 +1167,7 @@ func TestOpenSpecialName(t *testing.T) {
 
 	// Create a "base" dir that is in the way if the path becomes
 	// incorrectly truncated in the next steps.
-	base := path.Join(dir, "test")
+	base := filepath.Join(dir, "test")
 	if err := os.Mkdir(base, 0o755); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
### Purpose

`path` is for slash-separated paths (URLs, BEP protocol); local file system paths should use `path/filepath`. Fixed in `cmd/stdiscosrv/database.go` (3 sites) and `internal/db/sqlite/db_test.go` (1 site).

### Testing

`go build ./cmd/stdiscosrv/...` and `go vet` pass.