### PR TITLE
lib/protocol: add FileInfo.WireSize to avoid protobuf allocations

### DIFF
--- a/lib/model/fileinfobatch.go
+++ b/lib/model/fileinfobatch.go
@@ -8,7 +8,6 @@ package model
 
 import (
 	"github.com/syncthing/syncthing/lib/protocol"
-	"google.golang.org/protobuf/proto"
 )
 
 // How many files to send in each Index/IndexUpdate message.
@@ -47,7 +46,7 @@ func (b *FileInfoBatch) Append(f protocol.FileInfo) {
 		b.infos = make([]protocol.FileInfo, 0, MaxBatchSizeFiles)
 	}
 	b.infos = append(b.infos, f)
-	b.size += proto.Size(f.ToWire(true))
+	b.size += f.WireSize(true)
 }
 
 func (b *FileInfoBatch) Full() bool {

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/syncthing/syncthing/internal/protoutil"
 	"github.com/syncthing/syncthing/lib/fs"
 	"github.com/syncthing/syncthing/lib/osutil"
@@ -405,7 +403,7 @@ func writeEncryptionTrailer(file protocol.FileInfo, writer io.WriterAt) (int64, 
 }
 
 func encryptionTrailerSize(file protocol.FileInfo) int64 {
-	return int64(proto.Size(file.ToWire(false))) + 4 // XXX: Inefficient
+	return int64(file.WireSize(false)) + 4
 }
 
 // Progress returns the momentarily progress for the puller

--- a/lib/protocol/wiresize.go
+++ b/lib/protocol/wiresize.go
@@ -1,0 +1,198 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package protocol
+
+func (f FileInfo) WireSize(withInternalFields bool) int {
+	if f.truncated && !(f.IsDeleted() || f.IsInvalid() || f.IsIgnored()) {
+		panic("bug: must not serialize truncated file info")
+	}
+
+	size := 0
+	size += sizeStringField(1, f.Name)
+	size += sizeEnumField(2, int(f.Type))
+	size += sizeInt64Field(3, f.Size)
+	size += sizeUint32Field(4, f.Permissions)
+	size += sizeInt64Field(5, f.ModifiedS)
+	size += sizeBoolField(6, f.Deleted)
+	size += sizeBoolField(7, f.IsInvalid())
+	size += sizeBoolField(8, f.NoPermissions)
+	size += sizeMessageField(9, f.Version.wireSize())
+	size += sizeInt64Field(10, f.Sequence)
+	size += sizeInt32Field(11, int(f.ModifiedNs))
+	size += sizeUint64Field(12, uint64(f.ModifiedBy))
+	size += sizeInt32Field(13, int(f.RawBlockSize))
+	size += sizeMessageField(14, f.Platform.wireSize())
+	for _, block := range f.Blocks {
+		size += sizeMessageField(16, block.wireSize())
+	}
+	size += sizeBytesField(17, f.SymlinkTarget)
+	size += sizeBytesField(18, f.BlocksHash)
+	size += sizeBytesField(19, f.Encrypted)
+	size += sizeBytesField(20, f.PreviousBlocksHash)
+
+	if withInternalFields {
+		size += sizeUint32Field(1000, uint32(f.LocalFlags))
+		size += sizeInt32Field(1003, f.EncryptionTrailerSize)
+	}
+
+	return size
+}
+
+func (v Vector) wireSize() int {
+	size := 0
+	for _, counter := range v.Counters {
+		size += sizeMessageField(1, counter.wireSize())
+	}
+	return size
+}
+
+func (c Counter) wireSize() int {
+	return sizeUint64Field(1, uint64(c.ID)) + sizeUint64Field(2, c.Value)
+}
+
+func (b BlockInfo) wireSize() int {
+	return sizeInt64Field(1, b.Offset) +
+		sizeInt32Field(2, b.Size) +
+		sizeBytesField(3, b.Hash)
+}
+
+func (p PlatformData) wireSize() int {
+	size := 0
+	if p.Unix != nil {
+		size += sizeMessageField(1, p.Unix.wireSize())
+	}
+	if p.Windows != nil {
+		size += sizeMessageField(2, windowsDataWireSize(p.Windows))
+	}
+	if p.Linux != nil {
+		size += sizeMessageField(3, p.Linux.wireSize())
+	}
+	if p.Darwin != nil {
+		size += sizeMessageField(4, p.Darwin.wireSize())
+	}
+	if p.FreeBSD != nil {
+		size += sizeMessageField(5, p.FreeBSD.wireSize())
+	}
+	if p.NetBSD != nil {
+		size += sizeMessageField(6, p.NetBSD.wireSize())
+	}
+	return size
+}
+
+func (u *UnixData) wireSize() int {
+	if u == nil {
+		return 0
+	}
+	return sizeStringField(1, u.OwnerName) +
+		sizeStringField(2, u.GroupName) +
+		sizeInt32Field(3, u.UID) +
+		sizeInt32Field(4, u.GID)
+}
+
+func windowsDataWireSize(w *WindowsData) int {
+	if w == nil {
+		return 0
+	}
+	return sizeStringField(1, w.OwnerName) +
+		sizeBoolField(2, w.OwnerIsGroup)
+}
+
+func (x *XattrData) wireSize() int {
+	if x == nil {
+		return 0
+	}
+	size := 0
+	for _, attr := range x.Xattrs {
+		size += sizeMessageField(1, attr.wireSize())
+	}
+	return size
+}
+
+func (a Xattr) wireSize() int {
+	return sizeStringField(1, a.Name) +
+		sizeBytesField(2, a.Value)
+}
+
+func sizeMessageField(field int, messageSize int) int {
+	return sizeTag(field) + sizeUvarint(messageSize) + messageSize
+}
+
+func sizeStringField(field int, value string) int {
+	if value == "" {
+		return 0
+	}
+	return sizeTag(field) + sizeUvarint(len(value)) + len(value)
+}
+
+func sizeBytesField(field int, value []byte) int {
+	if len(value) == 0 {
+		return 0
+	}
+	return sizeTag(field) + sizeUvarint(len(value)) + len(value)
+}
+
+func sizeBoolField(field int, value bool) int {
+	if !value {
+		return 0
+	}
+	return sizeTag(field) + 1
+}
+
+func sizeEnumField(field int, value int) int {
+	return sizeInt32Field(field, value)
+}
+
+func sizeUint32Field(field int, value uint32) int {
+	if value == 0 {
+		return 0
+	}
+	return sizeTag(field) + sizeUvarint(int(value))
+}
+
+func sizeUint64Field(field int, value uint64) int {
+	if value == 0 {
+		return 0
+	}
+	return sizeTag(field) + sizeVarint(value)
+}
+
+func sizeInt32Field(field int, value int) int {
+	if value == 0 {
+		return 0
+	}
+	if value < 0 {
+		return sizeTag(field) + 10
+	}
+	return sizeTag(field) + sizeUvarint(value)
+}
+
+func sizeInt64Field(field int, value int64) int {
+	if value == 0 {
+		return 0
+	}
+	if value < 0 {
+		return sizeTag(field) + 10
+	}
+	return sizeTag(field) + sizeVarint(uint64(value))
+}
+
+func sizeTag(field int) int {
+	return sizeUvarint(field << 3)
+}
+
+func sizeUvarint(value int) int {
+	return sizeVarint(uint64(value)) //nolint:gosec // G115: value is a non-negative length or field index
+}
+
+func sizeVarint(value uint64) int {
+	size := 1
+	for value >= 0x80 {
+		value >>= 7
+		size++
+	}
+	return size
+}

--- a/lib/protocol/wiresize_test.go
+++ b/lib/protocol/wiresize_test.go
@@ -12,12 +12,68 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+func TestFileInfoWireSizeMatchesProtoSize(t *testing.T) {
+	cases := []FileInfo{
+		{},
+		{
+			Name:      "file.txt",
+			Size:      12345,
+			ModifiedS: 1710000000,
+			Sequence:  7,
+			Version: Vector{Counters: []Counter{
+				{ID: 1, Value: 10},
+				{ID: 2, Value: 20},
+			}},
+			Blocks: []BlockInfo{
+				{Offset: 0, Size: 128 << 10, Hash: make([]byte, 32)},
+				{Offset: 128 << 10, Size: 128 << 10, Hash: make([]byte, 32)},
+			},
+			Permissions:  0o644,
+			ModifiedNs:   123456789,
+			RawBlockSize: 128 << 10,
+			BlocksHash:   make([]byte, 32),
+			Platform: PlatformData{
+				Unix: &UnixData{
+					OwnerName: "alice",
+					GroupName: "staff",
+					UID:       1000,
+					GID:       1000,
+				},
+				Linux: &XattrData{
+					Xattrs: []Xattr{
+						{Name: "user.comment", Value: []byte("hello")},
+					},
+				},
+			},
+		},
+		{
+			Name:                  "link",
+			Type:                  FileInfoTypeSymlink,
+			SymlinkTarget:         []byte("../dst"),
+			LocalFlags:            FlagLocalIgnored | FlagLocalMustRescan,
+			EncryptionTrailerSize: 42,
+			Deleted:               true,
+			NoPermissions:         true,
+		},
+	}
+
+	for _, tc := range cases {
+		for _, withInternalFields := range []bool{false, true} {
+			got := tc.WireSize(withInternalFields)
+			want := proto.Size(tc.ToWire(withInternalFields))
+			if got != want {
+				t.Fatalf("WireSize(%v)=%d != proto.Size=%d for %#v", withInternalFields, got, want, tc)
+			}
+		}
+	}
+}
+
 func BenchmarkFileInfoSize(b *testing.B) {
 	fi := benchmarkFileInfo()
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = proto.Size(fi.ToWire(true))
+		_ = fi.WireSize(true)
 	}
 }
 

--- a/lib/protocol/wiresize_test.go
+++ b/lib/protocol/wiresize_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package protocol
+
+import (
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+)
+
+func BenchmarkFileInfoSize(b *testing.B) {
+	fi := benchmarkFileInfo()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = proto.Size(fi.ToWire(true))
+	}
+}
+
+func benchmarkFileInfo() FileInfo {
+	blocks := make([]BlockInfo, 32)
+	for i := range blocks {
+		blocks[i] = BlockInfo{
+			Offset: int64(i * (128 << 10)),
+			Size:   128 << 10,
+			Hash:   make([]byte, 32),
+		}
+	}
+
+	return FileInfo{
+		Name:               "dir/subdir/file.bin",
+		Size:               int64(len(blocks) * (128 << 10)),
+		ModifiedS:          1710000000,
+		ModifiedBy:         123456789,
+		Version:            Vector{Counters: []Counter{{ID: 1, Value: 10}, {ID: 2, Value: 20}}},
+		Sequence:           99,
+		Blocks:             blocks,
+		BlocksHash:         make([]byte, 32),
+		PreviousBlocksHash: make([]byte, 32),
+		Encrypted:          []byte("enc"),
+		Permissions:        0o644,
+		ModifiedNs:         123456789,
+		RawBlockSize:       128 << 10,
+		LocalFlags:         FlagLocalRemoteInvalid,
+		Platform: PlatformData{
+			Unix: &UnixData{
+				OwnerName: "alice",
+				GroupName: "staff",
+				UID:       1000,
+				GID:       1000,
+			},
+			Linux: &XattrData{
+				Xattrs: []Xattr{
+					{Name: "user.comment", Value: []byte("hello")},
+					{Name: "user.mime", Value: []byte("application/octet-stream")},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
### Purpose

`FileInfoBatch.Append` and `encryptionTrailerSize` only need the serialized size of a `FileInfo`, but used `proto.Size(f.ToWire(...))`, which allocates a full wire message just to measure it. On the index batching and encrypted puller paths this is visible in allocation profiles.

This PR adds `FileInfo.WireSize(withInternalFields bool) int` that walks fields directly and sums protobuf tag/varint/length-prefix sizes without allocating an intermediate message, and switches both hot callers to it.

The change is split into two commits so the benchmark can be run on each to compare:

- `lib/protocol: add benchmark for FileInfo wire size`
- `lib/protocol: avoid protobuf allocations when sizing FileInfo`

### Testing

`TestFileInfoWireSizeMatchesProtoSize` cross-checks `WireSize` against `proto.Size(ToWire(...))` over representative `FileInfo` shapes (empty, full file with blocks/xattrs, symlink with internal flags), with and without internal fields.

The two commits on this branch are arranged so that `BenchmarkFileInfoSize` measures the old path at the first commit and the new path at the second. To reproduce:

```
# before
git checkout <branch>~1   # "lib/protocol: add benchmark for FileInfo wire size"
go test ./lib/protocol/ -run XXX -bench=BenchmarkFileInfoSize -benchmem -count=8 -benchtime=2s > before.txt

# after
git checkout <branch>     # "lib/protocol: avoid protobuf allocations when sizing FileInfo"
go test ./lib/protocol/ -run XXX -bench=BenchmarkFileInfoSize -benchmem -count=8 -benchtime=2s > after.txt

benchstat before.txt after.txt
```

Result on AMD Ryzen 7 7735HS (8 runs):

```
                │   before    │              after              │
                │   sec/op    │   sec/op     vs base            │
FileInfoSize-16   2919.0n ±1%   340.7n ±3%   -88.33% (p=0.000)

                │    B/op     │    B/op      vs base            │
FileInfoSize-16   3.641Ki ±0%   0.000Ki ±0% -100.00% (p=0.000)

                │  allocs/op  │  allocs/op   vs base            │
FileInfoSize-16     44.00 ±0%     0.00 ±0%  -100.00% (p=0.000)
```

### Documentation

Not applicable — internal helper, no user-visible or wire-protocol change.

## Authorship

Your name and email will be added automatically to the AUTHORS file based on the commit metadata.