### PR TITLE
chore(syncthing): open URLs via Windows API instead via cmd.exe

### DIFF
--- a/cmd/syncthing/openurl_windows.go
+++ b/cmd/syncthing/openurl_windows.go
@@ -9,8 +9,27 @@
 
 package main
 
-import "os/exec"
+import "golang.org/x/sys/windows"
 
 func openURL(url string) error {
-	return exec.Command("cmd.exe", "/C", "start "+url).Run()
+	urlPtr, err := windows.UTF16PtrFromString(url)
+	if err != nil {
+		return err
+	}
+
+	verbPtr, err := windows.UTF16PtrFromString("open")
+	if err != nil {
+		return err
+	}
+
+	err = windows.ShellExecute(
+		0,       // hwnd
+		verbPtr, // operation
+		urlPtr,  // file
+		nil,     // parameters
+		nil,     // directory
+		windows.SW_SHOWNORMAL,
+	)
+
+	return err
 }


### PR DESCRIPTION
### Purpose
On Windows replace `cmd.exe /C start` with direct `ShellExecute` API for opening the webpage.

The previous implementation used `exec.Command("cmd.exe", "/C", "start "+url)` which spawns two extra processes (cmd.exe → start).  Launching cmd.exe resulted in a shortly visible terminal.

Both
-`start`
-and another alternative `exec.Command("rundll32", "url.dll,FileProtocolHandler", url).Start()` 
are just wrappers for `ShellExecute`. So this implementation is even more direct

### Testing

I executed the compiled syncthing.exe on Windows 11, both from explorer and console. The webpage opened as expected.

### Screenshots

N/A.

### Documentation

N/A

## Authorship

Name: Elias @Shablone
Email: [1elias.bauer@gmail.com](mailto:1elias.bauer@gmail.com)
