### PR TITLE
fix: on Windows don't allocate console if not opened inside one

### DIFF
--- a/assets/windows/syncthing.exe.manifest
+++ b/assets/windows/syncthing.exe.manifest
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application>
+    <windowsSettings>
+      <consoleAllocationPolicy xmlns="http://schemas.microsoft.com/SMI/2024/WindowsSettings">detached</consoleAllocationPolicy>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/build.go
+++ b/build.go
@@ -733,9 +733,17 @@ func shouldBuildSyso(dir string) (string, error) {
 
 	// See https://github.com/josephspurrier/goversioninfo#command-line-flags
 	// For manifest see https://learn.microsoft.com/en-us/windows/console/console-allocation-policy
-	arm := strings.HasPrefix(goarch, "arm")
-	a64 := strings.Contains(goarch, "64")
-	if _, err := runError("goversioninfo", "-manifest=assets/windows/syncthing.exe.manifest", "-o", sysoPath, fmt.Sprintf("-arm=%v", arm), fmt.Sprintf("-64=%v", a64)); err != nil {
+	isARM := strings.HasPrefix(goarch, "arm")
+	is64Bit := strings.Contains(goarch, "64")
+
+	args := []string{
+		"-manifest=assets/windows/syncthing.exe.manifest", // console-allocation-policy
+		"-o", sysoPath, // output path
+		fmt.Sprintf("-arm=%v", isARM),
+		fmt.Sprintf("-64=%v", is64Bit),
+	}
+
+	if _, err := runError("goversioninfo", args...); err != nil {
 		return "", errors.New("failed to create " + sysoPath + ": " + err.Error())
 	}
 

--- a/build.go
+++ b/build.go
@@ -732,9 +732,10 @@ func shouldBuildSyso(dir string) (string, error) {
 	sysoPath := filepath.Join(dir, "cmd", "syncthing", "resource.syso")
 
 	// See https://github.com/josephspurrier/goversioninfo#command-line-flags
+	// For manifest see https://learn.microsoft.com/en-us/windows/console/console-allocation-policy
 	arm := strings.HasPrefix(goarch, "arm")
 	a64 := strings.Contains(goarch, "64")
-	if _, err := runError("goversioninfo", "-o", sysoPath, fmt.Sprintf("-arm=%v", arm), fmt.Sprintf("-64=%v", a64)); err != nil {
+	if _, err := runError("goversioninfo", "-manifest=assets/windows/syncthing.exe.manifest", "-o", sysoPath, fmt.Sprintf("-arm=%v", arm), fmt.Sprintf("-64=%v", a64)); err != nil {
 		return "", errors.New("failed to create " + sysoPath + ": " + err.Error())
 	}
 

--- a/cmd/syncthing/hideconsole_windows.go
+++ b/cmd/syncthing/hideconsole_windows.go
@@ -7,5 +7,5 @@
 package main
 
 type buildSpecificOptions struct {
-	HideConsole bool `name:"no-console" help:"Hide console window" env:"STHIDECONSOLE"`
+	HideConsole bool `name:"no-console" help:"Hide console window (Always enabled on Windows 11 24H2 and later)" env:"STHIDECONSOLE"`
 }


### PR DESCRIPTION
### Purpose

This change allows Syncthing to be launched from Explorer without showing a console window, while preserving the existing command-line behavior.
Previously, launching syncthing.exe from Explorer would always allocate a console window, which could only be hidden later by using `--no-console`. It was not possible to avoid console allocation entirely without introducing other issues.

On Windows 24H2 and later a new application manifest allows us to achieve it. See [console allocation policy](https://learn.microsoft.com/en-us/windows/console/console-allocation-policy)
This manifest is built into a syso-file by `goversioninfo`, which is already used to generate Windows resource files consumed by the Go compiler.

**Note1:** On Windows 24H2 and later, no console is allocated when Syncthing is launched from Explorer, even if `--no-console` is set to `False`. It can still be used as a CLI tool as usual if you call it from console.

**Note2:** The content of the manifest file may not be formatted. Even a `newline` would break it.

### Testing

Tested on Windows 11 25H2: No console visible from explorer. CLI works as usual.

### Screenshots

N/A

### Documentation

N/A

## Authorship

Name: Elias @Shablone
Email: [1elias.bauer@gmail.com](mailto:1elias.bauer@gmail.com)
