### PR TITLE
fix(gui): add bottom margin to folder action buttons for wrapped spacing

### DIFF
--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -554,6 +554,6 @@ html[lang|="ko"] i {
     user-select: all;
 }
 
-.pull-right .btn {
+.pull-right:not(.panel-footer .pull-right) .btn {
     margin-bottom: 10px;
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -445,6 +445,20 @@ ul.three-columns li, ul.two-columns li {
         -moz-column-count: 1;
         column-count: 1;
     }
+      /* All buttons, except panel headings, get bottom margin, as they
+       won't fit beside each other anymore. Reduce footer padding to
+       compensate for the margin. */
+    .btn:not(.panel-heading),
+    .btn:not(.panel-heading) + .btn:not(.panel-heading) {
+        margin-bottom: 10px;
+    }
+    
+    .panel-footer {
+        padding-bottom: 0;
+    }
+    .modal-footer {
+        padding-bottom: 5px;
+    }
 }
 
 @media (max-width:479px) {
@@ -475,20 +489,6 @@ ul.three-columns li, ul.two-columns li {
         display: block;
         max-width: 100%;
         width: 100%;
-    }
-
-    /* All buttons, except panel headings, get bottom margin, as they
-       won't fit beside each other anymore. Reduce footer padding to
-       compensate for the margin. */
-    .btn:not(.panel-heading),
-    .btn:not(.panel-heading) + .btn:not(.panel-heading) {
-        margin-bottom: 10px;
-    }
-    .panel-footer {
-        padding-bottom: 0;
-    }
-    .modal-footer {
-        padding-bottom: 5px;
     }
 
     table.table-auto td,
@@ -552,8 +552,4 @@ html[lang|="ko"] i {
 .select-on-click {
     -webkit-user-select: all;
     user-select: all;
-}
-
-.pull-right:not(.panel-footer .pull-right) .btn {
-    margin-bottom: 10px;
 }

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -553,3 +553,7 @@ html[lang|="ko"] i {
     -webkit-user-select: all;
     user-select: all;
 }
+
+.pull-right .btn {
+    margin-bottom: 5px;
+}

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -555,5 +555,5 @@ html[lang|="ko"] i {
 }
 
 .pull-right .btn {
-    margin-bottom: 5px;
+    margin-bottom: 10px;
 }


### PR DESCRIPTION
### Purpose

adds a bottom margin to buttons inside panel footers, ensuring a
comfortable gap between wrapped button rows. (Fixes #10689 )

### Testing

I have tested it manually on various different resolutions. Confirmed no regression on desktop width (buttons remain unchanged, margins only appear when wrapping)

How the reviewer can test:
- Run Syncthing with the updated GUI 
- Change the language to Ukrainian.
- Narrow the browser window below ~1280px width
- Observe the vertical gap between wrapped button rows

### Screenshots

Before:

<img width="615" height="112" alt="image" src="https://github.com/user-attachments/assets/ff5c486b-accb-472c-90cd-a41a7b7de879" />

After:

<img width="624" height="121" alt="image" src="https://github.com/user-attachments/assets/98c47341-343f-4ca3-a1c8-bbd78f621c9e" />

### Documentation

N/A

## Authorship


