### PR TITLE
db: reset index ID when dropping folder files (fixes #10469)

### DIFF
--- a/internal/db/sqlite/db_indexid_test.go
+++ b/internal/db/sqlite/db_indexid_test.go
@@ -78,4 +78,43 @@ func TestIndexIDs(t *testing.T) {
 			t.Fatal("should get the ID we set")
 		}
 	})
+
+	t.Run("DropAllFilesClearsOtherDeviceID", func(t *testing.T) {
+		t.Parallel()
+
+		device := protocol.DeviceID{99}
+		newID := protocol.NewIndexID()
+
+		if err := db.Update("drop-index-id", device, []protocol.FileInfo{
+			genFile("test1", 1, 1),
+		}); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := db.SetIndexID("drop-index-id", device, newID); err != nil {
+			t.Fatal(err)
+		}
+
+		again, err := db.GetIndexID("drop-index-id", device)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if again != newID {
+			t.Log(again, newID)
+			t.Fatal("should get the ID we set")
+		}
+
+		if err := db.DropAllFiles("drop-index-id", device); err != nil {
+			t.Fatal(err)
+		}
+
+		dropped, err := db.GetIndexID("drop-index-id", device)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if dropped != 0 {
+			t.Log(dropped)
+			t.Fatal("should clear the ID when dropping all files")
+		}
+	})
 }

--- a/internal/db/sqlite/folderdb_update.go
+++ b/internal/db/sqlite/folderdb_update.go
@@ -235,6 +235,13 @@ func (s *folderDB) DropAllFiles(device protocol.DeviceID) error {
 	defer tx.Rollback() //nolint:errcheck
 	txp := &txPreparedStmts{Tx: tx}
 
+	if _, err := tx.Exec(`
+		DELETE FROM indexids
+		WHERE device_idx = ?
+	`, deviceIdx); err != nil {
+		return wrap(err)
+	}
+
 	// Drop all the file entries
 
 	result, err := tx.Exec(`


### PR DESCRIPTION
### Purpose

`DropAllFiles` removes a device's file rows, but it left the device's persisted index ID and sequence in `indexids`. When a folder is unshared and later reshared, that stale index ID can make the peer look like it still has a valid delta base, matching #10469.

This removes the device's `indexids` row in the same transaction as the file drop. The existing global/need recalculation is still skipped when no file rows were removed.

### Testing

- `go test ./internal/db/sqlite -run TestIndexIDs -count=1`
- `go test ./internal/db/sqlite -count=1`
- `go test ./internal/db/... -count=1`
- `git diff --check`

### Documentation

Not user visible; no docs change needed.
