### PR TITLE
feat(ignore): auto-load .stglobalignore as shared folder ignore patterns

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -8,7 +8,6 @@ package ignore
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
@@ -30,7 +29,16 @@ import (
 	"github.com/syncthing/syncthing/lib/osutil"
 )
 
-const escapePrefix = "#escape"
+const (
+	escapePrefix = "#escape"
+
+	// IgnoreFile is the name of the per-folder ignore pattern file.
+	IgnoreFile = ".stignore"
+
+	// globalIgnoreFile is automatically loaded from the folder root alongside
+	// IgnoreFile. Unlike IgnoreFile it is synced between devices.
+	globalIgnoreFile = ".stglobalignore"
+)
 
 var defaultEscapeChar = '\\'
 
@@ -181,14 +189,25 @@ func (m *Matcher) Load(file string) error {
 
 	fd, info, err := loadIgnoreFile(m.fs, file)
 	if err != nil {
-		m.parseLocked(&bytes.Buffer{}, file)
+		m.applyPatterns(nil, nil, err)
 		return err
 	}
 	defer fd.Close()
 
 	m.changeDetector.Reset()
 
-	err = m.parseLocked(fd, file)
+	// Parse the main ignore file.
+	linesSeen := make(map[string]struct{})
+	lines, patterns, parseErr := parseIgnoreFile(m.fs, fd, file, m.changeDetector, linesSeen)
+
+	// Append patterns from globalIgnoreFile if present. Local patterns are
+	// checked first, so .stignore can override global ones (e.g. a
+	// !.git/config in .stignore overrides .git/** in .stglobalignore).
+	if globalPatterns, gerr := loadParseIncludeFile(m.fs, globalIgnoreFile, m.changeDetector, linesSeen); gerr == nil {
+		patterns = append(patterns, globalPatterns...)
+	}
+
+	err = m.applyPatterns(lines, patterns, parseErr)
 	// If we failed to parse, don't cache, as next time Load is called
 	// we'll pretend it's all good.
 	if err == nil {
@@ -208,7 +227,13 @@ func (m *Matcher) parseLocked(r io.Reader, file string) error {
 	lines, patterns, err := parseIgnoreFile(m.fs, r, file, m.changeDetector, make(map[string]struct{}))
 	// Error is saved and returned at the end. We process the patterns
 	// (possibly blank) anyway.
+	return m.applyPatterns(lines, patterns, err)
+}
 
+// applyPatterns updates the matcher state from a combined set of lines and
+// patterns. lines reflects the raw .stignore content (used by the GUI);
+// patterns is the full evaluated set including any global patterns.
+func (m *Matcher) applyPatterns(lines []string, patterns []Pattern, err error) error {
 	m.lines = lines
 
 	newHash := hashPatterns(patterns)

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -1731,3 +1731,136 @@ func testEscape(t *testing.T, tests []escapeTest, noErrors bool) {
 		}
 	}
 }
+
+// TestGlobalIgnore verifies that .stglobalignore patterns are applied and
+// that local .stignore takes precedence over global patterns on conflict.
+func TestGlobalIgnore(t *testing.T) {
+	t.Run("LocalNegationBeatsGlobalIgnore", func(t *testing.T) {
+		testFS := fs.NewFilesystem(fs.FilesystemTypeFake, rand.String(32)+"?content=true&nostfolder=true")
+
+		// Global ignores the whole .git dir; local carves out config.
+		fs.WriteFile(testFS, ".stglobalignore", []byte(".git/**\n"), 0o666)
+		fs.WriteFile(testFS, ".stignore", []byte("!.git/config\n"), 0o666)
+
+		pats := New(testFS)
+		if err := pats.Load(".stignore"); err != nil {
+			t.Fatal(err)
+		}
+
+		if pats.Match(".git/config").IsIgnored() {
+			t.Error(".git/config should not be ignored (local negation overrides global)")
+		}
+		if !pats.Match(".git/HEAD").IsIgnored() {
+			t.Error(".git/HEAD should be ignored (matched by global pattern)")
+		}
+		if !pats.Match(".git/objects/abc123").IsIgnored() {
+			t.Error(".git/objects/abc123 should be ignored (matched by global pattern)")
+		}
+	})
+
+	t.Run("LocalIgnoreBeatsGlobalNegation", func(t *testing.T) {
+		testFS := fs.NewFilesystem(fs.FilesystemTypeFake, rand.String(32)+"?content=true&nostfolder=true")
+
+		// Local ignores a file that global tries to un-ignore; local wins.
+		fs.WriteFile(testFS, ".stglobalignore", []byte("!secret\n"), 0o666)
+		fs.WriteFile(testFS, ".stignore", []byte("secret\n"), 0o666)
+
+		pats := New(testFS)
+		if err := pats.Load(".stignore"); err != nil {
+			t.Fatal(err)
+		}
+
+		if !pats.Match("secret").IsIgnored() {
+			t.Error("secret should be ignored (local ignore beats global negation)")
+		}
+	})
+}
+
+func TestGlobalIgnoreMissing(t *testing.T) {
+	testFS := fs.NewFilesystem(fs.FilesystemTypeFake, rand.String(32)+"?content=true&nostfolder=true")
+	fs.WriteFile(testFS, ".stignore", []byte("somefile\n"), 0o666)
+
+	// No .stglobalignore — should load without error.
+	pats := New(testFS)
+	if err := pats.Load(".stignore"); err != nil {
+		t.Fatalf("unexpected error loading without .stglobalignore: %v", err)
+	}
+	if !pats.Match("somefile").IsIgnored() {
+		t.Error("somefile should be ignored")
+	}
+}
+
+func TestGlobalIgnoreCacheBusting(t *testing.T) {
+	testFS := fs.NewFilesystem(fs.FilesystemTypeFake, rand.String(32)+"?content=true&nostfolder=true")
+	fs.WriteFile(testFS, ".stignore", []byte(""), 0o666)
+	fs.WriteFile(testFS, ".stglobalignore", []byte("globalfile\n"), 0o666)
+
+	pats := New(testFS, WithCache(true))
+	if err := pats.Load(".stignore"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Populate the cache.
+	pats.Match("globalfile")
+	pats.Match("otherfile")
+	if pats.matches.len() != 2 {
+		t.Fatalf("expected 2 cached results, got %d", pats.matches.len())
+	}
+
+	// Reload with no changes — cache should be preserved.
+	if err := pats.Load(".stignore"); err != nil {
+		t.Fatal(err)
+	}
+	if pats.matches.len() != 2 {
+		t.Fatalf("expected cache to be preserved on unchanged reload, got %d entries", pats.matches.len())
+	}
+
+	// Modify .stglobalignore — cache should be busted.
+	fs.WriteFile(testFS, ".stglobalignore", []byte("otherfile\n"), 0o666)
+	fakeTime := time.Now().Add(5 * time.Second)
+	testFS.Chtimes(".stglobalignore", fakeTime, fakeTime)
+
+	if err := pats.Load(".stignore"); err != nil {
+		t.Fatal(err)
+	}
+	if pats.matches.len() != 0 {
+		t.Fatalf("expected cache to be cleared after .stglobalignore change, got %d entries", pats.matches.len())
+	}
+
+	// Verify new patterns are active.
+	if pats.Match("globalfile").IsIgnored() {
+		t.Error("globalfile should no longer be ignored")
+	}
+	if !pats.Match("otherfile").IsIgnored() {
+		t.Error("otherfile should now be ignored")
+	}
+}
+
+func TestGlobalIgnoreChangeDetection(t *testing.T) {
+	testFS := fs.NewFilesystem(fs.FilesystemTypeFake, rand.String(32)+"?content=true&nostfolder=true")
+	fs.WriteFile(testFS, ".stignore", []byte(""), 0o666)
+	fs.WriteFile(testFS, ".stglobalignore", []byte("globalfile\n"), 0o666)
+
+	pats := New(testFS)
+	if err := pats.Load(".stignore"); err != nil {
+		t.Fatal(err)
+	}
+	if !pats.Match("globalfile").IsIgnored() {
+		t.Error("globalfile should be ignored after initial load")
+	}
+
+	// Update .stglobalignore with a future modtime so change detection fires.
+	fs.WriteFile(testFS, ".stglobalignore", []byte("otherfile\n"), 0o666)
+	fakeTime := time.Now().Add(5 * time.Second)
+	testFS.Chtimes(".stglobalignore", fakeTime, fakeTime)
+
+	if err := pats.Load(".stignore"); err != nil {
+		t.Fatal(err)
+	}
+	if pats.Match("globalfile").IsIgnored() {
+		t.Error("globalfile should no longer be ignored after .stglobalignore update")
+	}
+	if !pats.Match("otherfile").IsIgnored() {
+		t.Error("otherfile should now be ignored after .stglobalignore update")
+	}
+}


### PR DESCRIPTION
### Purpose

Implements automatic loading of a `.stglobalignore` file from the folder root, appending its patterns after the local `.stignore` patterns.

This addresses a long-standing pain point: when a folder syncs to a new host, `.stignore` is not synced (by design), so users must manually recreate their ignore patterns on every new device. The common workaround is to put a `#include .stglobalignore` line in each `.stignore`, but that still requires per-device setup.

With this change:
- Shared ignore patterns go in `.stglobalignore` in the folder root
- `.stglobalignore` syncs between devices like any normal file (it is not in the `IsInternal` list)
- No per-device configuration is needed — the file is picked up automatically on load

**Precedence:** Local `.stignore` patterns are evaluated first, so they can override global ones. A negation in `.stignore` overrides an ignore in `.stglobalignore`, and vice versa.

**Change detection:** `.stglobalignore` is registered with the `ChangeDetector` during load, so modifications trigger a reload on the next scan — identical to how `#include` files are tracked.

**Missing file:** If `.stglobalignore` does not exist the folder loads normally with no error.

Closes #7311
Related: #10208, #2353

### Implementation notes

The global file loading lives entirely in `Load()`, keeping `parseLocked()` as a pure "parse this reader → apply state" function. A new `applyPatterns()` helper was extracted to hold the hash-comparison and state-setting logic, used by both paths.

Two named constants are introduced:
- `IgnoreFile = ".stignore"` (exported — callers in `model.go` etc. can migrate over time)
- `globalIgnoreFile = ".stglobalignore"` (unexported, single definition)

### Testing

Four new tests in `lib/ignore/ignore_test.go`:

- `TestGlobalIgnore/LocalNegationBeatsGlobalIgnore` — global ignores `.git/**`, local negates `.git/config`; verifies local wins
- `TestGlobalIgnore/LocalIgnoreBeatsGlobalNegation` — local ignores a file that global tries to un-ignore; verifies local wins
- `TestGlobalIgnoreMissing` — no `.stglobalignore` present; verifies clean load with no error
- `TestGlobalIgnoreChangeDetection` — modifies `.stglobalignore` with a future modtime; verifies patterns reload correctly

Run with:
```
go test github.com/syncthing/syncthing/lib/ignore -run TestGlobalIgnore -v
```

### Screenshots

No GUI changes.

### Documentation

Docs PR: syncthing/docs#1016

## Authorship

Note: this PR was developed with AI assistance (Claude). The implementation was designed, reviewed, and is understood by me as the submitter. I am responsible for its correctness and accept the DCO accordingly.