### PR TITLE
fix(fs): apply alwaysOpenFlags in DirNames to prevent symlink traversal (fixes #10755)

### DIFF
--- a/lib/fs/basicfs.go
+++ b/lib/fs/basicfs.go
@@ -222,11 +222,7 @@ func (f *BasicFilesystem) Stat(name string) (FileInfo, error) {
 }
 
 func (f *BasicFilesystem) DirNames(name string) ([]string, error) {
-	name, err := f.rooted(name)
-	if err != nil {
-		return nil, err
-	}
-	fd, err := os.OpenFile(name, OptReadOnly, 0o777)
+	fd, err := f.OpenFile(name, OptReadOnly, 0o777)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What

`DirNames` in `lib/fs/basicfs.go` called `os.OpenFile` directly, bypassing the `BasicFilesystem.OpenFile` wrapper where `alwaysOpenFlags` (`O_NOFOLLOW` on Unix) is applied.

A symlink whose final path component points to a directory would be silently followed by `DirNames`, listing the target directory's contents — inconsistent with the hardening introduced for `Open`/`Create` in #10739.

## Why

`alwaysOpenFlags = syscall.O_NOFOLLOW` (Unix) is defined in `basicfs_unix.go` and applied at line 252 of `basicfs.go` inside `OpenFile`. Any method that calls `os.OpenFile` directly bypasses this flag.

## Fix

Route `DirNames` through `f.OpenFile` instead of `os.OpenFile`. The explicit `f.rooted()` call is also removed since `f.OpenFile` already calls it internally.

```diff
-func (f *BasicFilesystem) DirNames(name string) ([]string, error) {
-	name, err := f.rooted(name)
-	if err != nil {
-		return nil, err
-	}
-	fd, err := os.OpenFile(name, OptReadOnly, 0o777)
+	fd, err := f.OpenFile(name, OptReadOnly, 0o777)
```

## Testing

- Existing `TestDirNames` tests continue to pass
- On Unix: `DirNames` on a path whose final component is a symlink-to-directory should now return `ELOOP` or `ENOTDIR` instead of silently listing the symlink target

Identified via static analysis of the diff introduced by #10739.