### PR TITLE
fix(folder): check if context canceled when scanning (fixes #10363)

### DIFF
--- a/lib/model/folder.go
+++ b/lib/model/folder.go
@@ -975,10 +975,13 @@ func (f *folder) scanTimerFired(ctx context.Context) error {
 	select {
 	case <-f.initialScanFinished:
 	default:
-		if err != nil {
-			f.sl.ErrorContext(ctx, "Failed initial scan", slogutil.Error(err))
-		} else {
+		switch {
+		case err == nil:
 			f.sl.InfoContext(ctx, "Completed initial scan")
+		case errors.Is(err, context.Canceled):
+			// Suppressed: context was canceled (e.g. by user)
+		default:
+			f.sl.ErrorContext(ctx, "Failed initial scan", slogutil.Error(err))
 		}
 		close(f.initialScanFinished)
 	}


### PR DESCRIPTION
During initial folder scan and the scan is interrupted with a context.Canceled error, it was previously logged as a "Failed initial scan" error, which can be misleading

The change adds a explicit check for context.Canceled and silently ignores it (fixes #10363)