### PR TITLE
gui: add icon legend to Out of Sync Items modal

### DIFF
--- a/gui/default/syncthing/transfer/neededFilesModalView.html
+++ b/gui/default/syncthing/transfer/neededFilesModalView.html
@@ -14,6 +14,13 @@
       <hr />
     </div>
 
+    <div id="action-legend" class="text-muted small" style="margin-bottom: 8px;">
+      <strong><span translate>Legend</span>:&nbsp;</strong>
+      <span class="far fa-fw fa-arrow-alt-circle-down"></span>&nbsp;<span translate>Sync</span>&ensp;
+      <span class="fas fa-fw fa-asterisk"></span>&nbsp;<span translate>Update</span>&ensp;
+      <span class="far fa-fw fa-trash-alt"></span>&nbsp;<span translate>Delete</span>
+    </div>
+
     <table class="table table-striped table-condensed">
 
       <tr dir-paginate="f in needed.items | itemsPerPage: needed.perpage" current-page="needed.page" total-items="model[neededFolder].needTotalItems" pagination-id="needed">


### PR DESCRIPTION
Closes #2436 (partially — the icon legend part of the request).

### Problem

The Out of Sync Items modal showed icons next to each file (download arrow, asterisk, trash) with no explanation of what they mean. Users had to guess that the arrow means "Sync", the asterisk means "Update", and the trash means "Delete".

### Fix

Added a small legend row above the file table using the same icons and labels already defined in `$scope.needIcons` / `$scope.needActions` in the controller:

- `far fa-arrow-alt-circle-down` → Sync
- `fas fa-asterisk` → Update
- `far fa-trash-alt` → Delete

The legend is styled as muted small text (`text-muted small`) so it doesn't compete visually with the file list. It follows the existing `#download-legend` pattern already used for the progress bar legend above it.

### Files changed

- `gui/default/syncthing/transfer/neededFilesModalView.html` — legend block added, no other changes