### PR TITLE
gui: abbreviate large file/directory counts in Local State (Total)

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -732,8 +732,8 @@
                       <th><span class="fas fa-fw fa-home"></span>&nbsp;<span translate>Local State (Total)</span></th>
                       <td class="text-right">
                           <span tooltip data-original-title="{{localStateTotal.files | alwaysNumber | localeNumber}} {{'files' | translate}}, {{ localStateTotal.directories | alwaysNumber | localeNumber}} {{'directories' | translate}}, ~{{ localStateTotal.bytes | binary}}B">
-                            <span class="far fa-copy"></span>&nbsp;{{localStateTotal.files | alwaysNumber | localeNumber}}&ensp;
-                            <span class="far fa-folder"></span>&nbsp;{{localStateTotal.directories| alwaysNumber | localeNumber}}&ensp;
+                            <span class="far fa-copy"></span>&nbsp;{{localStateTotal.files | alwaysNumber | metric}}&ensp;
+                            <span class="far fa-folder"></span>&nbsp;{{localStateTotal.directories | alwaysNumber | metric}}&ensp;
                             <span class="far fa-hdd"></span>&nbsp;~{{localStateTotal.bytes | binary}}B
                           </span>
                       </td>


### PR DESCRIPTION
Closes #5703.

### Problem

In the "This Device" panel, the Local State (Total) row shows raw locale-formatted numbers for file and directory counts (e.g. `491,796` files, `24,614` folders). On narrow viewports or when counts are very large, the numbers get truncated with `…` and become unreadable without hovering.

The tooltip already shows the exact full counts — but the visible text was using the same unabbreviated format.

### Fix

Changed the visible file and directory count in the Local State (Total) row from `| alwaysNumber | localeNumber` to `| alwaysNumber | metric`. This uses the existing `metricFilter` (already used for bandwidth rates elsewhere in the same template) to produce compact abbreviated values like `0.4M` or `24K`.

The tooltip retains `| localeNumber` so hovering still shows the precise count.

Disk usage (`localStateTotal.bytes`) already uses `| binary` which abbreviates correctly — no change needed there.

### Files changed

- `gui/default/index.html` — 2 filter changes in the Local State (Total) row only