### PR TITLE
chore(model): increase default value for num hashers

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2548,13 +2548,6 @@ func (m *model) DelayScan(folder string, next time.Duration) {
 func (m *model) numHashers(folder string) int {
 	m.mut.RLock()
 	folderCfg := m.folderCfgs[folder]
-	numFolders := max(1, len(m.folderCfgs))
-	// MaxFolderConcurrency already limits the number of scanned folders, so
-	// prefer it over the overall number of folders to avoid limiting performance
-	// further for no reason.
-	if concurrency := m.cfg.Options().MaxFolderConcurrency(); concurrency > 0 {
-		numFolders = min(numFolders, concurrency)
-	}
 	m.mut.RUnlock()
 
 	if folderCfg.Hashers > 0 {
@@ -2562,21 +2555,15 @@ func (m *model) numHashers(folder string) int {
 		return folderCfg.Hashers
 	}
 
-	numCpus := runtime.GOMAXPROCS(-1)
-	if build.IsWindows || build.IsDarwin || build.IsIOS || build.IsAndroid {
-		// Interactive operating systems; don't load the system too heavily by
-		// default.
-		numCpus = max(1, numCpus/4)
+	numCPUs := runtime.GOMAXPROCS(-1)
+	switch {
+	case build.IsWindows || build.IsIOS || build.IsAndroid:
+		// Use a quarter of the CPU cores on interactive or constrained OSes
+		return max(1, numCPUs/4)
+	default:
+		// Otherwise use up to half
+		return max(1, numCPUs/2)
 	}
-
-	// For other operating systems and architectures, lets try to get some
-	// work done... Divide the available CPU cores among the configured
-	// folders.
-	if perFolder := numCpus / numFolders; perFolder > 0 {
-		return perFolder
-	}
-
-	return 1
 }
 
 // generateClusterConfig returns a ClusterConfigMessage that is correct and the


### PR DESCRIPTION
The current default is quite conservative, often resulting in using a single CPU core on Windows and macOS as soon as there are several folders configured. At least on macOS this is wildly inefficient as modern Macs have a fair amount of CPU cores and the OS is good at scheduling non-interactive work on the efficiency cores.

For me, switching the default to disregarding the number of folders (assuming that usually, not all of them will be hashing simultaneously) and increasing the allowed number of cores immediately increases the scan speed by 8x.
