### PR TITLE
fix(api): preserve existing folder config fields on PATCH

### DIFF
--- a/lib/api/confighandler.go
+++ b/lib/api/confighandler.go
@@ -338,7 +338,17 @@ func (c *configMuxBuilder) adjustConfig(w http.ResponseWriter, r *http.Request) 
 }
 
 func (c *configMuxBuilder) adjustFolder(w http.ResponseWriter, r *http.Request, folder config.FolderConfiguration, defaults bool) {
-	if err := unmarshalTo(r.Body, &folder); err != nil {
+	bs, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	// Use type alias to avoid FolderConfiguration.UnmarshalJSON which calls
+	// SetDefaults and resets all fields before applying the JSON body.
+	// This preserves existing field values for fields not present in PATCH.
+	type noCustomUnmarshal config.FolderConfiguration
+	if err := json.Unmarshal(bs, (*noCustomUnmarshal)(&folder)); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
The adjustFolder function uses unmarshalTo which calls json.Unmarshal, which triggers FolderConfiguration.UnmarshalJSON. That custom method calls SetDefaults first, resetting all fields to defaults before the JSON body is applied. This means PATCH requests that only specify a subset of fields (e.g. just paused: true) reset all other fields (RescanIntervalS, CleanupIntervalS, etc.) to their default values.

Fix by using a type alias to bypass the custom UnmarshalJSON method, so only the fields present in the PATCH body are modified.

Fixes #10746