### PR TITLE
fix(sqlite): update last migration to set schema version, counts

### DIFF
--- a/internal/db/sqlite/basedb.go
+++ b/internal/db/sqlite/basedb.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	currentSchemaVersion = 5
+	currentSchemaVersion = 6
 	applicationIDMain    = 0x53546d6e // "STmn", Syncthing main database
 	applicationIDFolder  = 0x53546664 // "STfd", Syncthing folder database
 )

--- a/internal/db/sqlite/sql/migrations/folder/06-zero-size-dirs.sql
+++ b/internal/db/sqlite/sql/migrations/folder/06-zero-size-dirs.sql
@@ -10,3 +10,7 @@ UPDATE files
     SET size = 0
     WHERE type != 0
 ;
+UPDATE counts
+    SET size = 0
+    WHERE type != 0
+;


### PR DESCRIPTION
The counts needs to be modified manually since we're not running triggers during migrations. The schema version needed to be bumped.
