### PR TITLE
docs: fix typo writeable -> writable in etc/linux-runit/README.md

### DIFF
--- a/etc/linux-runit/README.md
+++ b/etc/linux-runit/README.md
@@ -6,7 +6,7 @@ other platforms also using runit.
 
  2. Edit the `run` file to set the username to run as, the user's home
     directory and the place where the syncthing binary lives. It is
-    recommended to place it in a directory writeable by the running user
+    recommended to place it in a directory writable by the running user
     so that automatic upgrades work.
 
  3. Copy this directory (containing the edited `run` file and `log` folder) to


### PR DESCRIPTION
Fixes a typo (`writeable` -> `writable`) in the runit README.

```diff
- recommended to place it in a directory writeable by the running user
+ recommended to place it in a directory writable by the running user
```

Signed-off-by: Dodothereal <129273127+Dodothereal@users.noreply.github.com>

---
<sub>Prepared with AI assistance; changes reviewed by the maintainer before submission.</sub>
