### PR TITLE
Resume interrupted receive-encrypted downloads

### DIFF
--- a/lib/fs/sparse_other.go
+++ b/lib/fs/sparse_other.go
@@ -1,0 +1,16 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build !windows && !linux && !darwin && !freebsd
+
+package fs
+
+// SetSparse is unsupported on this platform.
+func SetSparse(File) {}
+
+// NextHole is unsupported on this platform (no exposed hole-detection API such
+// as SEEK_HOLE), so the caller falls back to reusing nothing.
+func NextHole(File, int64) (int64, bool) { return 0, false }

--- a/lib/fs/sparse_seekhole.go
+++ b/lib/fs/sparse_seekhole.go
@@ -1,0 +1,28 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build linux || darwin || freebsd
+
+package fs
+
+import "golang.org/x/sys/unix"
+
+// SetSparse marks a file sparse so unwritten regions become holes. No-op here:
+// Truncate already does this on sparse-capable filesystems (ext4, APFS, UFS).
+// Where it doesn't (HFS+), NextHole finds no hole and the caller refuses reuse.
+func SetSparse(File) {}
+
+// NextHole returns the next hole at or after offset via SEEK_HOLE (see
+// lseek(2)). EOF counts as a hole, so a fully allocated file, or any file on a
+// filesystem without hole support, returns its size. False only if SEEK_HOLE
+// fails. Uses Seek, so it moves the file offset; pass a dedicated descriptor.
+func NextHole(f File, offset int64) (int64, bool) {
+	pos, err := f.Seek(offset, unix.SEEK_HOLE)
+	if err != nil {
+		return 0, false
+	}
+	return pos, true
+}

--- a/lib/fs/sparse_windows.go
+++ b/lib/fs/sparse_windows.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//go:build windows
+
+package fs
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// FSCTL control codes, see learn.microsoft.com "Sparse Files".
+const (
+	fsctlSetSparse            = 0x000900C4 // FSCTL_SET_SPARSE
+	fsctlQueryAllocatedRanges = 0x000940CF // FSCTL_QUERY_ALLOCATED_RANGES
+)
+
+type fileAllocatedRangeBuffer struct {
+	FileOffset int64
+	Length     int64
+}
+
+// SetSparse marks the file sparse via FSCTL_SET_SPARSE; NTFS won't make a
+// Truncate'd file sparse on its own. Best effort: filesystems without sparse
+// support (FAT, exFAT, some network mounts) are left as-is, and NextHole then
+// returns false.
+func SetSparse(f File) {
+	bf, ok := unwrap(f).(basicFile)
+	if !ok {
+		return
+	}
+	var ret uint32
+	_ = windows.DeviceIoControl(windows.Handle(bf.Fd()), fsctlSetSparse, nil, 0, nil, 0, &ret, nil)
+}
+
+// NextHole returns the next hole at or after offset via
+// FSCTL_QUERY_ALLOCATED_RANGES (the Windows SEEK_HOLE). It first checks the file
+// is actually sparse: a non-sparse file reports every range allocated, so it
+// returns false rather than let the caller infer presence. EOF counts as a hole.
+func NextHole(f File, offset int64) (int64, bool) {
+	bf, ok := unwrap(f).(basicFile)
+	if !ok {
+		return 0, false
+	}
+	handle := windows.Handle(bf.Fd())
+
+	var info windows.ByHandleFileInformation
+	if err := windows.GetFileInformationByHandle(handle, &info); err != nil {
+		return 0, false
+	}
+	if info.FileAttributes&windows.FILE_ATTRIBUTE_SPARSE_FILE == 0 {
+		return 0, false // not sparse; see doc comment
+	}
+	size := int64(info.FileSizeHigh)<<32 | int64(info.FileSizeLow)
+	if offset >= size {
+		return offset, true // at or beyond EOF is a hole
+	}
+
+	in := fileAllocatedRangeBuffer{FileOffset: offset, Length: size - offset}
+	out := make([]fileAllocatedRangeBuffer, 64)
+	var ret uint32
+	err := windows.DeviceIoControl(handle, fsctlQueryAllocatedRanges,
+		(*byte)(unsafe.Pointer(&in)), uint32(unsafe.Sizeof(in)),
+		(*byte)(unsafe.Pointer(&out[0])), uint32(len(out))*uint32(unsafe.Sizeof(out[0])),
+		&ret, nil)
+	// ERROR_MORE_DATA only means there are more ranges than fit the buffer; the
+	// first returned range is still valid and is all we need.
+	if err != nil && err != windows.ERROR_MORE_DATA {
+		return 0, false
+	}
+	n := int(ret) / int(unsafe.Sizeof(out[0]))
+	if n == 0 || out[0].FileOffset > offset {
+		return offset, true // hole at offset
+	}
+	// Allocated region covers offset; the next hole is at its end.
+	return out[0].FileOffset + out[0].Length, true
+}

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -1136,6 +1136,10 @@ func (f *sendReceiveFolder) handleFile(ctx context.Context, file protocol.FileIn
 
 	if f.Type != config.FolderTypeReceiveEncrypted {
 		blocks, reused = f.reuseBlocks(ctx, blocks, reused, file, tempName)
+	} else if !f.DisableSparseFiles {
+		// Resume via sparse-allocation detection; needs a pre-allocated sparse
+		// temp, so it is skipped when sparse files are disabled.
+		blocks, reused = f.reuseBlocksEncrypted(blocks, reused, file, tempName)
 	}
 
 	// The sharedpullerstate will know which flags to use when opening the
@@ -1207,6 +1211,66 @@ func (f *sendReceiveFolder) reuseBlocks(ctx context.Context, blocks []protocol.B
 		}
 	}
 
+	return blocks, reused
+}
+
+// reuseBlocksEncrypted resumes an interrupted receive-encrypted download by
+// reusing blocks already in the temp. Encrypted blocks are opaque and can't be
+// hash-verified (the block "hash" is an encryption token), so reuseBlocks is
+// unusable; instead a block counts as present when its byte range is fully
+// allocated, each block being written with a single WriteAt that leaves a hole
+// in any unwritten tail.
+//
+// Reused blocks can't be verified locally, so two rules keep it safe:
+//   - Size: only a temp matching this version's on-disk size is reused. A
+//     same-size in-place edit can't be told apart and is caught when a trusted
+//     device reads the file back.
+//   - No holes: if the scan finds no hole at all, reuse is refused. A
+//     half-written temp on a filesystem without hole support (HFS+, FAT,
+//     network mounts) reads as fully allocated, indistinguishable from a
+//     complete one, and reusing it would splice in un-downloaded regions.
+func (f *sendReceiveFolder) reuseBlocksEncrypted(blocks []protocol.BlockInfo, reused []int, file protocol.FileInfo, tempName string) ([]protocol.BlockInfo, []int) {
+	fd, err := f.mtimefs.Open(tempName)
+	if err != nil {
+		return blocks, reused // no temp; nothing to reuse
+	}
+	defer fd.Close()
+
+	// Size guard: the temp is pre-allocated to onDiskSize, so a mismatch is a
+	// different version and must not be reused unverified.
+	if info, err := fd.Stat(); err != nil || info.Size() != onDiskSize(file) {
+		return blocks, reused
+	}
+
+	present := make([]bool, len(file.Blocks))
+	holeFound := false
+	for i, block := range file.Blocks {
+		if block.Size <= 0 {
+			continue
+		}
+		hole, ok := fs.NextHole(fd, block.Offset)
+		if !ok {
+			return blocks, reused // no hole detection here; reuse nothing
+		}
+		// Present iff the whole range is allocated (next hole is at/after end).
+		present[i] = hole >= block.Offset+int64(block.Size)
+		if !present[i] {
+			holeFound = true
+		}
+	}
+
+	if !holeFound {
+		return blocks, reused // no holes: refuse reuse, see doc comment
+	}
+
+	blocks = blocks[:0]
+	for i, block := range file.Blocks {
+		if present[i] {
+			reused = append(reused, i)
+		} else {
+			blocks = append(blocks, block)
+		}
+	}
 	return blocks, reused
 }
 

--- a/lib/model/folder_sendrecv_encreuse_stress_test.go
+++ b/lib/model/folder_sendrecv_encreuse_stress_test.go
@@ -1,0 +1,103 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Stress and property tests for encrypted temp-file reuse: randomized presence
+// patterns and edge cases. Shared helpers live in the sibling _encreuse_test.go.
+
+package model
+
+import (
+	"math/rand"
+	"slices"
+	"sort"
+	"testing"
+)
+
+// TestReuseBlocksEncryptedRandomized hammers the reuse logic with random
+// presence patterns and asserts reuse matches wantReuse.
+func TestReuseBlocksEncryptedRandomized(t *testing.T) {
+	f := realFSFolder(t)
+
+	rng := rand.New(rand.NewSource(0xC0DECAFE))
+	for iter := 0; iter < 200; iter++ {
+		n := 1 + rng.Intn(16)
+		tail := 0
+		if rng.Intn(2) == 0 {
+			tail = 1 + rng.Intn(encBlockSize-1)
+		}
+		file := buildEncFile("randfile", n, tail)
+
+		present := make([]bool, len(file.Blocks))
+		for i := range present {
+			present[i] = rng.Intn(2) == 0
+		}
+		tempName := writeSparseTemp(t, f, file, present)
+
+		download, reused := runReuse(f, file, tempName)
+		sort.Ints(reused)
+
+		wantReused, wantDL := wantReuse(file, present)
+		if !slices.Equal(reused, wantReused) {
+			t.Fatalf("iter %d n=%d tail=%d present=%v: reused=%v want=%v", iter, n, tail, present, reused, wantReused)
+		}
+		if got := downloadOffsets(download); !slices.Equal(got, wantDL) {
+			t.Fatalf("iter %d n=%d tail=%d: download=%v want=%v", iter, n, tail, got, wantDL)
+		}
+
+		f.mtimefs.Remove(tempName)
+	}
+}
+
+// TestReuseBlocksEncryptedEdges covers structural corner cases one at a time.
+func TestReuseBlocksEncryptedEdges(t *testing.T) {
+	f := realFSFolder(t)
+
+	allFalse := func(n int) []bool { return make([]bool, n) }
+	lastHole := func(n int) []bool { b := allTrue(n); b[n-1] = false; return b }
+
+	cases := []struct {
+		name    string
+		nFull   int
+		tail    int
+		present func(n int) []bool
+	}{
+		{"single-block-present", 1, 0, allTrue},
+		{"single-block-hole", 1, 0, allFalse},
+		{"all-holes", 8, 0, allFalse},
+		{"first-block-hole", 4, 0, func(n int) []bool { b := allTrue(n); b[0] = false; return b }},
+		{"last-block-hole", 4, 0, lastHole},
+		{"alternating", 8, 0, func(n int) []bool {
+			b := make([]bool, n)
+			for i := range b {
+				b[i] = i%2 == 0
+			}
+			return b
+		}},
+		{"partial-tail-present", 3, 777, allTrue},
+		{"partial-tail-hole", 3, 777, lastHole},
+		{"tiny-tail-present", 0, 17, allTrue},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			file := buildEncFile("edge"+tc.name[:1], tc.nFull, tc.tail)
+			present := tc.present(len(file.Blocks))
+			tempName := writeSparseTemp(t, f, file, present)
+
+			download, reused := runReuse(f, file, tempName)
+			sort.Ints(reused)
+
+			wantReused, _ := wantReuse(file, present)
+			if !slices.Equal(reused, wantReused) {
+				t.Errorf("%s: reused=%v want=%v", tc.name, reused, wantReused)
+			}
+			if len(download)+len(reused) != len(file.Blocks) {
+				t.Errorf("%s: download(%d)+reused(%d) != total(%d)", tc.name, len(download), len(reused), len(file.Blocks))
+			}
+			f.mtimefs.Remove(tempName)
+		})
+	}
+}

--- a/lib/model/folder_sendrecv_encreuse_test.go
+++ b/lib/model/folder_sendrecv_encreuse_test.go
@@ -1,0 +1,222 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+// Tests for resumable temp-file reuse on receive-encrypted folders. Shared
+// helpers used by these and the stress tests (in the _stress_test.go file) live
+// here.
+
+package model
+
+import (
+	"bytes"
+	"slices"
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/fs"
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+const encBlockSize = 131072 // 128 KiB, matching the block-size fixtures.
+
+// realFSFolder returns a sendReceiveFolder backed by a real temp-dir filesystem.
+// Sparse/SEEK_HOLE detection needs a real filesystem, not the in-memory fake, so
+// the test is skipped where the platform/filesystem cannot detect holes.
+func realFSFolder(t *testing.T) *sendReceiveFolder {
+	t.Helper()
+	_, f := setupSendReceiveFolder(t)
+	f.mtimefs = fs.NewFilesystem(fs.FilesystemTypeBasic, t.TempDir())
+	if !holeDetectionSupported(t, f) {
+		t.Skip("sparse hole detection unavailable on this platform/filesystem")
+	}
+	return f
+}
+
+// holeDetectionSupported reports whether f's filesystem can detect sparse holes.
+func holeDetectionSupported(t *testing.T, f *sendReceiveFolder) bool {
+	t.Helper()
+	name := fs.TempName("holeprobe")
+	fd, err := f.mtimefs.Create(name)
+	must(t, err)
+	fs.SetSparse(fd)
+	must(t, fd.Truncate(1<<20))
+	_, ok := fs.NextHole(fd, 0)
+	fd.Close()
+	f.mtimefs.Remove(name)
+	return ok
+}
+
+// buildEncFile makes a FileInfo of n full 128 KiB blocks plus an optional
+// partial tail block of tailSize bytes (0 = none). Hashes are unique per block
+// so nothing collides.
+func buildEncFile(name string, n, tailSize int) protocol.FileInfo {
+	var blks []protocol.BlockInfo
+	var off int64
+	for i := 0; i < n; i++ {
+		h := make([]byte, 32)
+		h[0] = byte(i + 1)
+		h[1] = name[len(name)-1]
+		blks = append(blks, protocol.BlockInfo{Offset: off, Size: encBlockSize, Hash: h})
+		off += encBlockSize
+	}
+	if tailSize > 0 {
+		blks = append(blks, protocol.BlockInfo{Offset: off, Size: tailSize, Hash: []byte{0xee}})
+		off += int64(tailSize)
+	}
+	return protocol.FileInfo{Name: name, Blocks: blks, Size: off}
+}
+
+// writeSparseTemp creates a full-size sparse temp for file and writes (allocates)
+// exactly the blocks whose index is true in present, returning the temp name.
+func writeSparseTemp(t *testing.T, f *sendReceiveFolder, file protocol.FileInfo, present []bool) string {
+	t.Helper()
+	tempName := fs.TempName(file.Name)
+	fd, err := f.mtimefs.Create(tempName)
+	must(t, err)
+	fs.SetSparse(fd)
+	must(t, fd.Truncate(file.Size))
+	for i, blk := range file.Blocks {
+		if present[i] && blk.Size > 0 {
+			if _, err := fd.WriteAt(bytes.Repeat([]byte{0xab}, int(blk.Size)), blk.Offset); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+	must(t, fd.Sync())
+	fd.Close()
+	return tempName
+}
+
+// runReuse runs reuseBlocksEncrypted on file's temp, returning the blocks still
+// to download and the indices reused from the temp.
+func runReuse(f *sendReceiveFolder, file protocol.FileInfo, tempName string) ([]protocol.BlockInfo, []int) {
+	blocks := append([]protocol.BlockInfo{}, file.Blocks...)
+	reused := make([]int, 0, len(file.Blocks))
+	return f.reuseBlocksEncrypted(blocks, reused, file, tempName)
+}
+
+// wantReuse returns the indices reuseBlocksEncrypted should reuse and the block
+// offsets it should re-fetch, given which blocks are present in the temp. When
+// no block is a hole nothing is reused (the no-hole fail-safe) and every block
+// is re-fetched.
+func wantReuse(file protocol.FileInfo, present []bool) (reused []int, download []int64) {
+	anyHole := slices.Contains(present, false)
+	for i, p := range present {
+		if anyHole && p {
+			reused = append(reused, i)
+		} else {
+			download = append(download, file.Blocks[i].Offset)
+		}
+	}
+	return reused, download
+}
+
+// downloadOffsets is the list of offsets in a download block list.
+func downloadOffsets(blocks []protocol.BlockInfo) []int64 {
+	offs := make([]int64, len(blocks))
+	for i, b := range blocks {
+		offs[i] = b.Offset
+	}
+	return offs
+}
+
+func allTrue(n int) []bool {
+	s := make([]bool, n)
+	for i := range s {
+		s[i] = true
+	}
+	return s
+}
+
+// A partially-downloaded encrypted temp (some blocks written, some sparse holes)
+// must be reused: written blocks are kept, holes are re-fetched, and the temp is
+// not deleted.
+func TestReuseBlocksEncryptedSparse(t *testing.T) {
+	f := realFSFolder(t)
+	file := buildEncFile("encfile", 8, 0)
+	present := []bool{true, true, true, true, false, false, false, false}
+	tempName := writeSparseTemp(t, f, file, present)
+
+	download, reused := runReuse(f, file, tempName)
+
+	wantReused, wantDL := wantReuse(file, present)
+	if !slices.Equal(reused, wantReused) {
+		t.Errorf("reused = %v, want %v", reused, wantReused)
+	}
+	if got := downloadOffsets(download); !slices.Equal(got, wantDL) {
+		t.Errorf("download offsets = %v, want %v", got, wantDL)
+	}
+	if _, err := f.mtimefs.Stat(tempName); err != nil {
+		t.Errorf("temp file must NOT be deleted on reuse: %v", err)
+	}
+}
+
+// With no temp file present, nothing is reused and all blocks are downloaded.
+func TestReuseBlocksEncryptedNoTemp(t *testing.T) {
+	_, f := setupSendReceiveFolder(t)
+	file := buildEncFile("encfile2", 3, 0)
+
+	download, reused := runReuse(f, file, fs.TempName(file.Name))
+
+	if len(reused) != 0 || len(download) != 3 {
+		t.Errorf("no-temp: reused=%v download=%d, want reused=[] download=3", reused, len(download))
+	}
+}
+
+// Reuse must never cross files: fileB (no temp of its own) must not reuse
+// fileA's partially-written temp. reuseBlocksEncrypted only opens this file's
+// own temp, but assert it so a regression can't leak data between files.
+func TestReuseBlocksEncryptedNoCrossFile(t *testing.T) {
+	f := realFSFolder(t)
+	fileA := buildEncFile("fileA", 8, 0)
+	fileB := buildEncFile("fileB", 8, 0) // identical layout, different name
+	writeSparseTemp(t, f, fileA, []bool{true, true, true, true, false, false, false, false})
+
+	download, reused := runReuse(f, fileB, fs.TempName(fileB.Name))
+
+	if len(reused) != 0 {
+		t.Errorf("CROSS-FILE REUSE: fileB reused %d blocks from fileA's temp (must be 0)", len(reused))
+	}
+	if len(download) != len(fileB.Blocks) {
+		t.Errorf("fileB download = %d blocks, want all %d", len(download), len(fileB.Blocks))
+	}
+}
+
+// A temp with no holes is refused (see reuseBlocksEncrypted): it can't be told
+// apart from a half-written temp on a filesystem without hole support. Writing
+// every block fully allocates the temp, doubling as the non-sparse fallback.
+func TestReuseBlocksEncryptedNoHoles(t *testing.T) {
+	f := realFSFolder(t)
+	file := buildEncFile("allfile", 8, 0)
+	tempName := writeSparseTemp(t, f, file, allTrue(len(file.Blocks)))
+
+	download, reused := runReuse(f, file, tempName)
+
+	if len(reused) != 0 {
+		t.Errorf("reused %d blocks, want 0 (no hole found -> refuse reuse)", len(reused))
+	}
+	if len(download) != len(file.Blocks) {
+		t.Errorf("download = %d blocks, want all %d (re-fetch everything)", len(download), len(file.Blocks))
+	}
+}
+
+// A temp whose size does not match the file (a leftover from a different, here
+// one-block-longer, version under the same name) must not be reused, since
+// encrypted blocks can't be content-verified.
+func TestReuseBlocksEncryptedWrongSize(t *testing.T) {
+	f := realFSFolder(t)
+	file := buildEncFile("verfile", 8, 0)
+	bigger := buildEncFile("verfile", 9, 0) // same name => same temp path, larger size
+	tempName := writeSparseTemp(t, f, bigger, []bool{true, true, true, true, false, false, false, false, false})
+
+	download, reused := runReuse(f, file, tempName)
+
+	if len(reused) != 0 {
+		t.Errorf("size-mismatched temp must not be reused, reused=%v", reused)
+	}
+	if len(download) != len(file.Blocks) {
+		t.Errorf("download = %d, want all %d", len(download), len(file.Blocks))
+	}
+}

--- a/lib/model/sharedpullerstate.go
+++ b/lib/model/sharedpullerstate.go
@@ -199,11 +199,10 @@ func (s *sharedPullerState) tempFileInWritableDir(_ string) error {
 	// Don't truncate symlink files, as that will mean that the path will
 	// contain a bunch of nulls.
 	if s.sparse && !s.file.IsSymlink() {
-		size := s.file.Size
-		// Trailer added to encrypted files
-		if len(s.file.Encrypted) > 0 {
-			size += encryptionTrailerSize(s.file)
-		}
+		// Mark sparse before sizing so unwritten regions are real holes; this
+		// lets an interrupted pull resume (see reuseBlocksEncrypted, SetSparse).
+		fs.SetSparse(fd)
+		size := onDiskSize(s.file)
 		// Truncate sets the size of the file. This creates a sparse file or a
 		// space reservation, depending on the underlying filesystem.
 		if err := fd.Truncate(size); err != nil {
@@ -406,6 +405,17 @@ func writeEncryptionTrailer(file protocol.FileInfo, writer io.WriterAt) (int64, 
 
 func encryptionTrailerSize(file protocol.FileInfo) int64 {
 	return int64(proto.Size(file.ToWire(false))) + 4 // XXX: Inefficient
+}
+
+// onDiskSize is the size a fully written temp occupies: the plaintext size plus
+// the encryption trailer for receive-encrypted files. The temp is pre-allocated
+// to it, so reuseBlocksEncrypted uses it to match a temp to this file version.
+func onDiskSize(file protocol.FileInfo) int64 {
+	size := file.Size
+	if len(file.Encrypted) > 0 {
+		size += encryptionTrailerSize(file)
+	}
+	return size
 }
 
 // Progress returns the momentarily progress for the puller


### PR DESCRIPTION
### Purpose

On a receive-encrypted folder, an interrupted download of a large file currently
restarts from the beginning. Block reuse is skipped for encrypted folders, so a
pull that dies partway through re-fetches every block on the next attempt. For
big files (media masters, disk images) over a slow or flaky link, that can mean
never finishing. This change lets such a download resume from where it stopped.

### Why reuse is skipped today

On an encrypted device the block "hash" is an encryption token, not a SHA-256 of
the on-disk bytes, so a reused block can't be verified by content. The normal
`reuseBlocks` path relies on that verification, so it's correctly disabled for
encrypted folders.

### The fix

Reuse blocks by sparse-file allocation instead of by hash. Each block is written
with a single `WriteAt`, so a block whose byte range is fully allocated (no hole)
was written by a previous pull and can be kept. A partial or missing block leaves
a hole and is re-fetched. Two commits:

1. `lib/fs`: small per-platform `SetSparse` / `NextHole` helpers. `SEEK_HOLE` on
   Linux, the BSDs and macOS; `FSCTL_SET_SPARSE` + `FSCTL_QUERY_ALLOCATED_RANGES`
   on Windows (NTFS won't make a `Truncate`d file sparse on its own); a safe
   "unsupported" stub elsewhere. The encrypted temp is pre-allocated to its full
   size so unwritten regions are real holes.
2. `lib/model`: `reuseBlocksEncrypted`, called from `handleFile` for encrypted
   folders.

### Why it's safe

Reused blocks can't be verified locally, so two rules guard it:

- **Size.** Only a temp whose on-disk size matches this file version is reused
  (it's created at that size). A different version is re-fetched from scratch. A
  same-size in-place edit can't be told apart and is caught the same way any
  inconsistent block is: when a trusted device reads the file back and verifies
  it.
- **No holes.** If the scan finds no hole at all, reuse is refused. A half-written
  temp on a filesystem without hole support reads as fully allocated,
  indistinguishable from a complete one, so reusing it could splice in regions
  that were never downloaded. Refusing falls back to the current restart-from-zero
  behaviour.

Reuse only ever touches the file's own temp, never another file's, so an
untrusted device can't reconstruct one file from another's data.

This is not a security change. It doesn't weaken the encryption trust model: the
untrusted device only reuses ciphertext it already holds for that same file,
nothing is newly trusted as correct, and the trusted side still verifies
plaintext on read-back. It only avoids re-downloading.

### Platform behaviour

Resume engages where the filesystem reports holes, and degrades to today's
behaviour where it doesn't:

| Filesystem | Behaviour |
|---|---|
| ext4, xfs, btrfs, APFS, UFS, NTFS | resume |
| HFS+, FAT/exFAT, many network mounts | refuse, restart from zero (unchanged) |
| `DisableSparseFiles` set | reuse skipped entirely |

### Testing

- Unit, randomized property (200 iterations), and edge-case tests for
  `reuseBlocksEncrypted`, including the no-hole and size-mismatch fail-safes.
- Race detector clean, `go vet` clean, builds on all CI targets (linux, darwin,
  freebsd, netbsd, openbsd, dragonfly, solaris, illumos, windows).
- Checked on real filesystems: ext4, NTFS, and APFS + HFS+. On APFS hole
  detection is exact; on HFS+ `SEEK_HOLE` returns ENOTSUP, so reuse is refused as
  designed.
- End to end: a 240 MB file pushed to an untrusted receive-encrypted device,
  killed repeatedly mid-transfer. Each restart resumed from the previous point,
  the transfer completed, and the decrypted result matched the original byte for
  byte.

Both commits are bisectable: the first builds and passes on its own.
