### PR TITLE
chore(gui): lazy-render collapsed panels to reduce watcher count

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -686,8 +686,8 @@
                 <div class="panel-title-text">{{deviceName(deviceCfg)}}</div>
               </h4>
             </button>
-            <div id="device-this" class="panel-collapse collapse in">
-              <div class="panel-body less-padding">
+            <div id="device-this" class="panel-collapse collapse in" lazy-collapse>
+              <div class="panel-body less-padding" ng-if="lazyReady">
                 <table class="table table-condensed table-striped table-auto">
                   <tbody>
                     <tr>

--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -410,8 +410,8 @@
                     </div>
                   </h4>
                 </button>
-                <div id="folder-{{$parent.$index}}-{{$index}}" class="panel-collapse collapse">
-                  <div class="panel-body less-padding">
+                <div id="folder-{{$parent.$index}}-{{$index}}" class="panel-collapse collapse" lazy-collapse>
+                  <div class="panel-body less-padding" ng-if="lazyReady">
                     <table class="table table-condensed table-striped table-auto">
                       <tbody>
                         <tr class="visible-xs">
@@ -805,8 +805,8 @@
                       <div class="panel-title-text">{{deviceName(deviceCfg)}}</div>
                     </h4>
                   </button>
-                  <div id="device-{{$parent.$index}}-{{$index}}" class="panel-collapse collapse">
-                    <div class="panel-body less-padding">
+                  <div id="device-{{$parent.$index}}-{{$index}}" class="panel-collapse collapse" lazy-collapse>
+                    <div class="panel-body less-padding" ng-if="lazyReady">
                       <table class="table table-condensed table-striped table-auto">
                         <tbody>
                           <tr class="visible-xs">
@@ -1083,6 +1083,7 @@
   <script type="text/javascript" src="syncthing/core/popoverDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/syncthingController.js"></script>
   <script type="text/javascript" src="syncthing/core/tooltipDirective.js"></script>
+  <script type="text/javascript" src="syncthing/core/lazyCollapseDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/uncamelFilter.js"></script>
   <script type="text/javascript" src="syncthing/core/uniqueFolderDirective.js"></script>
   <script type="text/javascript" src="syncthing/core/validDeviceidDirective.js"></script>

--- a/gui/default/syncthing/core/lazyCollapseDirective.js
+++ b/gui/default/syncthing/core/lazyCollapseDirective.js
@@ -3,15 +3,21 @@ angular.module('syncthing.core')
         return {
             restrict: 'A',
             link: function (scope, element) {
-                // Start collapsed: content is not rendered until first expand.
-                // Once expanded, content stays in DOM (Bootstrap needs it for
-                // the collapse animation). This avoids thousands of idle
-                // watchers for panels that are never opened.
+                // Render panel content only while expanded. Collapsed panels
+                // contribute zero watchers. Bootstrap's show/hidden events
+                // fire before/after the animation, so the DOM is present
+                // during the transition.
                 scope.lazyReady = element.hasClass('in');
 
                 $(element).on('show.bs.collapse', function () {
                     scope.$apply(function () {
                         scope.lazyReady = true;
+                    });
+                });
+
+                $(element).on('hidden.bs.collapse', function () {
+                    scope.$apply(function () {
+                        scope.lazyReady = false;
                     });
                 });
             }

--- a/gui/default/syncthing/core/lazyCollapseDirective.js
+++ b/gui/default/syncthing/core/lazyCollapseDirective.js
@@ -1,0 +1,19 @@
+angular.module('syncthing.core')
+    .directive('lazyCollapse', function () {
+        return {
+            restrict: 'A',
+            link: function (scope, element) {
+                // Start collapsed: content is not rendered until first expand.
+                // Once expanded, content stays in DOM (Bootstrap needs it for
+                // the collapse animation). This avoids thousands of idle
+                // watchers for panels that are never opened.
+                scope.lazyReady = element.hasClass('in');
+
+                $(element).on('show.bs.collapse', function () {
+                    scope.$apply(function () {
+                        scope.lazyReady = true;
+                    });
+                });
+            }
+        };
+    });


### PR DESCRIPTION
## Summary

Adds a `lazyCollapse` directive that renders panel body content only while expanded. Collapsed panels contribute zero watchers — content is added to the DOM on expand (`show.bs.collapse`) and removed after the collapse animation completes (`hidden.bs.collapse`).

**Before:** ~13,155 watchers (all panels rendered in DOM, even when collapsed)
**After:** ~4,055 watchers with all panels collapsed (69% reduction)

Opening a panel adds ~100 watchers; closing it reclaims them. The remaining ~4k watchers are panel headers and AngularJS infrastructure (expression caching, i18n) — the minimum for 77 folders + 10 devices.

## Problem

On instances with many folders and devices (e.g. 77 folders, 10+ devices), the AngularJS digest cycle evaluates thousands of watchers on every cycle, even for panels the user never opens. The main contributors are:

- `ng-repeat="device in otherDevices(folder.devices)"` — rendered for every folder, even collapsed ones
- `ng-repeat="folderID in deviceFolders(deviceCfg)"` — rendered for every device, even collapsed ones

## Solution

- New `lazyCollapse` directive on `.panel-collapse` elements (folders, devices, and "This Device")
- `show.bs.collapse` sets `lazyReady = true` (content renders before expand animation)
- `hidden.bs.collapse` sets `lazyReady = false` (content removed after collapse animation)
- Inner `.panel-body` wrapped with `ng-if="lazyReady"`
- Panels that start expanded (`.in` class, e.g. "This Device") initialize with `lazyReady = true`
- No visual or functional change for the user

## Changes

- `gui/default/syncthing/core/lazyCollapseDirective.js` — new directive (23 lines)
- `gui/default/index.html` — add `lazy-collapse` to all three panel types (folders, external devices, "This Device"), `ng-if="lazyReady"` on panel bodies, load directive script

## Test plan

- Tested with 77 folders, 10+ devices — watcher count drops from ~13k to ~4k
- Expanding panels renders content, collapsing removes it from DOM
- Re-expanding after collapse works normally
- "This Device" panel starts expanded, collapsing removes content
- Dark/light theme switching works
- Watcher count returns to baseline after closing all panels