### PR TITLE
refactor: replace Split in loops with more efficient SplitSeq

### DIFF
--- a/cmd/infra/stcrashreceiver/main.go
+++ b/cmd/infra/stcrashreceiver/main.go
@@ -203,7 +203,7 @@ func loadIgnorePatterns(path string) (*ignorePatterns, error) {
 	}
 
 	var patterns []*regexp.Regexp
-	for _, line := range strings.Split(string(bs), "\n") {
+	for line := range strings.SplitSeq(string(bs), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/internal/db/sqlite/basedb.go
+++ b/internal/db/sqlite/basedb.go
@@ -313,7 +313,7 @@ nextScript:
 		// files on lines containing only a semicolon and execute them
 		// separately. We require it on a separate line because there are
 		// also statement-internal semicolons in the triggers.
-		for _, stmt := range strings.Split(string(bs), "\n;") {
+		for stmt := range strings.SplitSeq(string(bs), "\n;") {
 			if _, err := tx.Exec(s.expandTemplateVars(stmt)); err != nil {
 				if strings.Contains(stmt, "syncthing:ignore-failure") {
 					// We're ok with this failing. Just note it.

--- a/internal/slogutil/leveler.go
+++ b/internal/slogutil/leveler.go
@@ -41,8 +41,8 @@ func SetDefaultLevel(level slog.Level) {
 }
 
 func SetLevelOverrides(sttrace string) {
-	pkgs := strings.Split(sttrace, ",")
-	for _, pkg := range pkgs {
+	pkgs := strings.SplitSeq(sttrace, ",")
+	for pkg := range pkgs {
 		pkg = strings.TrimSpace(pkg)
 		if pkg == "" {
 			continue

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2772,7 +2772,7 @@ func (m *model) GlobalDirectoryTree(folder, prefix string, levels int, dirsOnly 
 
 		parent := root
 		if dir != "." {
-			for _, path := range strings.Split(dir, sep) {
+			for path := range strings.SplitSeq(dir, sep) {
 				child := findByName(parent.Children, path)
 				if child == nil {
 					return nil, fmt.Errorf("could not find child '%s' for path '%s' in parent '%s'", path, f.Name, parent.Name)


### PR DESCRIPTION
### Purpose

strings.SplitSeq (introduced in Go 1.23)  returns a lazy sequence (strings.Seq), allowing gopher to iterate over tokens one by one without creating an intermediate slice.

It significantly reduces memory allocations and can improve performance for long strings.

More info: https://github.com/golang/go/issues/61901


### Testing

Describe what testing has been done, and how the reviewer can test the change
if new tests are not included.

### Screenshots

If this is a GUI change, include screenshots of the change. If not, please
feel free to just delete this section.

### Documentation

If this is a user visible change (including API and protocol changes), add a link here
to the corresponding pull request on https://github.com/syncthing/docs or describe
the documentation changes necessary.

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

