### PR TITLE
chore(rand): Replace by ChaCha8 seeded from crypto.Reader

### DIFF
--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -31,7 +31,7 @@ var (
 	defaultSecureSource = newSecureSource()
 
 	// defaultSecureRand is a math/rand/v2.Rand based on the secure source.
-	defaultSecureRand = mrand.New(defaultSecureSource)
+	defaultSecureRand = mrand.New(defaultSecureSource) //nolint:gosec
 )
 
 // String returns a cryptographically secure random string of characters
@@ -49,6 +49,7 @@ func String(l int) string {
 
 // Int63 returns a cryptographically secure random int63.
 func Int63() int64 {
+	// rand/v2 renames Int63 to Int64. The return value is still always >=0.
 	return defaultSecureRand.Int64()
 }
 

--- a/lib/rand/random.go
+++ b/lib/rand/random.go
@@ -10,12 +10,12 @@ package rand
 
 import (
 	"io"
-	mathRand "math/rand"
+	mrand "math/rand/v2"
 	"reflect"
 	"strings"
 )
 
-// Reader is the standard crypto/rand.Reader with added buffering.
+// Reader produces cryptographically secure, uniformly random bytes.
 var Reader = defaultSecureSource
 
 func Read(p []byte) (int, error) {
@@ -30,8 +30,8 @@ var (
 	// math/rand.Source.
 	defaultSecureSource = newSecureSource()
 
-	// defaultSecureRand is a math/rand.Rand based on the secure source.
-	defaultSecureRand = mathRand.New(defaultSecureSource)
+	// defaultSecureRand is a math/rand/v2.Rand based on the secure source.
+	defaultSecureRand = mrand.New(defaultSecureSource)
 )
 
 // String returns a cryptographically secure random string of characters
@@ -42,14 +42,14 @@ func String(l int) string {
 	sb.Grow(l)
 
 	for range l {
-		sb.WriteByte(randomCharset[defaultSecureRand.Intn(len(randomCharset))])
+		sb.WriteByte(randomCharset[defaultSecureRand.IntN(len(randomCharset))])
 	}
 	return sb.String()
 }
 
 // Int63 returns a cryptographically secure random int63.
 func Int63() int64 {
-	return defaultSecureSource.Int63()
+	return defaultSecureRand.Int64()
 }
 
 // Uint64 returns a cryptographically secure strongly random uint64.
@@ -60,7 +60,7 @@ func Uint64() uint64 {
 // Intn returns, as an int, a cryptographically secure non-negative
 // random number in [0,n). It panics if n <= 0.
 func Intn(n int) int {
-	return defaultSecureRand.Intn(n)
+	return defaultSecureRand.IntN(n)
 }
 
 // Shuffle the order of elements in slice.

--- a/lib/rand/securesource.go
+++ b/lib/rand/securesource.go
@@ -32,10 +32,6 @@ func newSecureSource() *secureSource {
 	return s
 }
 
-func (*secureSource) Seed(int64) {
-	panic("SecureSource is not seedable")
-}
-
 func (s *secureSource) Read(p []byte) (int, error) {
 	s.mut.Lock()
 	defer s.mut.Unlock()

--- a/lib/rand/securesource.go
+++ b/lib/rand/securesource.go
@@ -7,56 +7,44 @@
 package rand
 
 import (
-	"bufio"
-	"crypto/rand"
-	"encoding/binary"
-	"io"
+	crand "crypto/rand"
+	mrand "math/rand/v2"
 	"sync"
 )
 
-// The secureSource is a math/rand.Source + io.Reader that reads bytes from
-// crypto/rand.Reader. It means we can use the convenience functions
-// provided by math/rand.Rand on top of a secure source of numbers. It is
+// The secureSource is a secure math/rand/v2.Source + io.Reader that is seeded
+// from crypto/rand.Reader. It means we can use the convenience functions
+// provided by math/rand/v2.Rand on top of a secure source of numbers. It is
 // concurrency safe for ease of use.
 type secureSource struct {
-	rd  io.Reader
+	cha mrand.ChaCha8
 	mut sync.Mutex
-	buf [8]byte
 }
 
 func newSecureSource() *secureSource {
-	return &secureSource{
-		// Using buffering on top of the rand.Reader increases our
-		// performance by about 20%, even though it means we must use
-		// locking.
-		rd: bufio.NewReader(rand.Reader),
+	s := new(secureSource)
+	var seed [32]byte
+	_, err := crand.Read(seed[:])
+	if err != nil {
+		panic("initializing crypto RNG: " + err.Error())
 	}
+	s.cha.Seed(seed)
+	return s
 }
 
 func (*secureSource) Seed(int64) {
 	panic("SecureSource is not seedable")
 }
 
-func (s *secureSource) Int63() int64 {
-	return int64(s.Uint64() & (1<<63 - 1))
-}
-
 func (s *secureSource) Read(p []byte) (int, error) {
 	s.mut.Lock()
 	defer s.mut.Unlock()
-	return s.rd.Read(p)
+	return s.cha.Read(p)
 }
 
 func (s *secureSource) Uint64() uint64 {
-	// Read eight bytes of entropy from the buffered, secure random number
-	// generator. The buffered reader isn't concurrency safe, so we lock
-	// around that.
 	s.mut.Lock()
-	defer s.mut.Unlock()
-
-	_, err := io.ReadFull(s.rd, s.buf[:])
-	if err != nil {
-		panic("randomness failure: " + err.Error())
-	}
-	return binary.LittleEndian.Uint64(s.buf[:])
+	x := s.cha.Uint64()
+	s.mut.Unlock()
+	return x
 }

--- a/lib/rand/securesource_test.go
+++ b/lib/rand/securesource_test.go
@@ -18,16 +18,16 @@ func TestSecureSource(t *testing.T) {
 
 	// Create a new source and sample values from it.
 	s := newSecureSource()
-	res0 := make([]int64, nsamples)
+	res0 := make([]uint64, nsamples)
 	for i := range res0 {
-		res0[i] = s.Int63()
+		res0[i] = s.Uint64()
 	}
 
 	// Do it again
 	s = newSecureSource()
-	res1 := make([]int64, nsamples)
+	res1 := make([]uint64, nsamples)
 	for i := range res1 {
-		res1[i] = s.Int63()
+		res1[i] = s.Uint64()
 	}
 
 	// There should (statistically speaking) be no repetition of the values,
@@ -54,10 +54,9 @@ func TestSecureSource(t *testing.T) {
 		}
 	}
 
-	// Count how many times each bit was set. On average each bit ought to
-	// be set in half of the samples, except the topmost bit which must
-	// never be set (int63). We raise an alarm if a single bit is set in
-	// fewer than 1/3 of the samples or more often than 2/3 of the samples.
+	// Count how many times each bit was set. On average each bit ought to be
+	// set in half of the samples. We raise an alarm if a single bit is set
+	// in fewer than 1/3 of the samples or more often than 2/3 of the samples.
 	var bits [64]int
 	for _, v := range res0 {
 		for i := range bits {
@@ -68,29 +67,21 @@ func TestSecureSource(t *testing.T) {
 		}
 	}
 	for bit, count := range bits {
-		switch bit {
-		case 63:
-			// The topmost bit is never set
-			if count != 0 {
-				t.Errorf("The topmost bit was set %d times in %d samples (should be 0)", count, nsamples)
-			}
-		default:
-			if count < nsamples/3 {
-				t.Errorf("Bit %d was set only %d times out of %d", bit, count, nsamples)
-			}
-			if count > nsamples/3*2 {
-				t.Errorf("Bit %d was set fully %d times out of %d", bit, count, nsamples)
-			}
+		if count < nsamples/3 {
+			t.Errorf("Bit %d was set only %d times out of %d", bit, count, nsamples)
+		}
+		if count > nsamples/3*2 {
+			t.Errorf("Bit %d was set fully %d times out of %d", bit, count, nsamples)
 		}
 	}
 }
 
-var sink int64
+var sink uint64
 
 func BenchmarkSecureSource(b *testing.B) {
 	s := newSecureSource()
 	for i := 0; i < b.N; i++ {
-		sink = s.Int63()
+		sink = s.Uint64()
 	}
 	b.ReportAllocs()
 }


### PR DESCRIPTION
This is as secure as the old code, but significantly faster:

```
goos: linux
goarch: amd64
pkg: github.com/syncthing/syncthing/lib/rand
cpu: Intel(R) Core(TM) i7-3770K CPU @ 3.50GHz
               │     old      │                cha8                 │
               │    sec/op    │   sec/op     vs base                │
String-8         1702.5n ± 1%   685.5n ± 1%  -59.73% (p=0.000 n=20)
SecureSource-8    42.32n ± 0%   17.39n ± 0%  -58.90% (p=0.000 n=20)
geomean           268.4n        109.2n       -59.32%
```