### PR TITLE
build: allow inotify on Android amd64 (ref #8710)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	golang.org/x/crypto v0.53.0
 	golang.org/x/exp v0.0.0-20260611194520-c48552f49976
 	golang.org/x/net v0.56.0
-	golang.org/x/sys v0.46.0
+	golang.org/x/sys v0.47.0
 	golang.org/x/text v0.38.0
 	golang.org/x/time v0.15.0
 	google.golang.org/protobuf v1.36.11

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 h1:FjUup8XrRy7lv+XHONi6KKUSizeF2NnVrTnz/HhbohQ=
 golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/lib/fs/basicfs_watch.go
+++ b/lib/fs/basicfs_watch.go
@@ -4,11 +4,10 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build !(solaris && !cgo) && !(darwin && !cgo) && !(darwin && kqueue) && !(android && amd64)
+//go:build !(solaris && !cgo) && !(darwin && !cgo) && !(darwin && kqueue)
 // +build !solaris cgo
 // +build !darwin cgo
 // +build !darwin !kqueue
-// +build !android !amd64
 
 package fs
 

--- a/lib/fs/basicfs_watch_unsupported.go
+++ b/lib/fs/basicfs_watch_unsupported.go
@@ -4,8 +4,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this file,
 // You can obtain one at http://mozilla.org/MPL/2.0/.
 
-//go:build (solaris && !cgo) || (darwin && !cgo) || (android && amd64) || (darwin && kqueue)
-// +build solaris,!cgo darwin,!cgo android,amd64 darwin,kqueue
+//go:build (solaris && !cgo) || (darwin && !cgo) || (darwin && kqueue)
+// +build solaris,!cgo darwin,!cgo darwin,kqueue
 
 package fs
 


### PR DESCRIPTION
ad0044fec863cfabce06e0335fa303a3eefa646f previously disabled it due to seccomp crashes. This was caused by `golang.org/x/sys`'s `unix.EpollWait` function using the `epoll_wait` syscall instead of the `epoll_pwait` syscall. bionic libc implements the `epoll_wait` C wrapper function in terms of the `epoll_pwait` syscall, so this never affected C code.

`golang.org/x/sys` switched to the `epoll_pwait` syscall in 2016, but only for arm64. As of v0.47.0, it now uses `epoll_pwait` for all architectures.

Upstream bug: https://github.com/golang/go/issues/80080
Upstream fix: https://go-review.googlesource.com/c/sys/+/792700
Upstream arm64 fix from 2016: https://go-review.googlesource.com/c/sys/+/21971

---

With this change, Syncthing no longer crashes when inotify is allowed and enabled in the Android emulator when run inside an app context. (The seccomp policies do not affect execution under `adb shell`.)

This is the crash that occurs if inotify is enabled without the v0.47.0 update:
```
2026-07-08 10:59:36.711202 -0400 F/DEBUG   (16538): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
2026-07-08 10:59:36.711219 -0400 F/DEBUG   (16538): Build fingerprint: 'google/sdk_gphone16k_x86_64/emu64xa16k:17/CE2A.260420.019/15611780:userdebug/dev-keys'
2026-07-08 10:59:36.711224 -0400 F/DEBUG   (16538): Kernel Release: '6.12.58-android16-6-gccafb60de224-ab14828483'
2026-07-08 10:59:36.711226 -0400 F/DEBUG   (16538): Revision: '0'
2026-07-08 10:59:36.711228 -0400 F/DEBUG   (16538): ABI: 'x86_64'
2026-07-08 10:59:36.711230 -0400 F/DEBUG   (16538): Timestamp: 2026-07-08 10:59:36.617348693-0400
2026-07-08 10:59:36.711232 -0400 F/DEBUG   (16538): Process uptime: 2s
2026-07-08 10:59:36.711234 -0400 F/DEBUG   (16538): Page size: 16384 bytes
2026-07-08 10:59:36.711236 -0400 F/DEBUG   (16538): Executable: /system/bin/app_process64
2026-07-08 10:59:36.711239 -0400 F/DEBUG   (16538): Cmdline: com.chiller3.basicsync.debug
2026-07-08 10:59:36.711241 -0400 F/DEBUG   (16538): pid: 16502, ppid: 436, tid: 16531, name: Thread-6  >>> com.chiller3.basicsync.debug <<<
2026-07-08 10:59:36.711243 -0400 F/DEBUG   (16538): uid: 10231
2026-07-08 10:59:36.711886 -0400 F/DEBUG   (16538): signal 31 (SIGSYS), code 1 (SYS_SECCOMP), fault addr --------
2026-07-08 10:59:36.711899 -0400 F/DEBUG   (16538): Cause: seccomp prevented call to disallowed x86_64 system call 232
2026-07-08 10:59:36.711908 -0400 F/DEBUG   (16538):     rax 00000000000000e8  rbx 0000000000000078  rcx 00007372d956826e  rdx 0000000000000001
2026-07-08 10:59:36.711912 -0400 F/DEBUG   (16538):     r8  0000000000000000  r9  0000000000000000  r10 ffffffffffffffff  r11 0000000000000206
2026-07-08 10:59:36.712123 -0400 F/DEBUG   (16538):     r12 0000737291cc5d00  r13 000025897adcad20  r14 000025897abc7c20  r15 ffffffffffffffff
2026-07-08 10:59:36.712134 -0400 F/DEBUG   (16538):     rdi 0000000000000078  rsi 000025897af9ef7c
2026-07-08 10:59:36.712137 -0400 F/DEBUG   (16538):     rbp 000025897af9ee28  rsp 000025897af9ede8  rip 00007372d956826e  err 0000000000000000
2026-07-08 10:59:36.712139 -0400 F/DEBUG   (16538): 1 total frames
2026-07-08 10:59:36.712141 -0400 F/DEBUG   (16538): backtrace:
2026-07-08 10:59:36.712145 -0400 F/DEBUG   (16538):       #00 pc 0000000000d2826e  /data/app/~~s99umF1bl81-VDLSDwy30g==/com.chiller3.basicsync.debug-5Lq8YsTwbMz_SXt-F_uHaQ==/base.apk (offset 0x2e4c000)
2026-07-08 10:59:36.712431 -0400 F/DEBUG   (16538): Note: To display stack pointer information, use the pbtombstone tool:
2026-07-08 10:59:36.712443 -0400 F/DEBUG   (16538):         pbtombstone --display-sp tombstone_XX.pb
```