### PR TITLE
fix(versioner): keep the folder marker during empty-dir cleanup (fixes #8783)

### DIFF
--- a/lib/versioner/empty_dir_tracker.go
+++ b/lib/versioner/empty_dir_tracker.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/syncthing/syncthing/internal/slogutil"
+	"github.com/syncthing/syncthing/lib/config"
 	"github.com/syncthing/syncthing/lib/fs"
 )
 
@@ -20,6 +21,13 @@ type emptyDirTracker map[string]struct{}
 
 func (t emptyDirTracker) addDir(path string) {
 	if path == "." {
+		return
+	}
+	// Never treat a folder marker (".stfolder" by default) as a removable
+	// empty directory. A versions path can itself be, or contain, another
+	// shared folder; removing its marker stops that folder from syncing.
+	// See https://github.com/syncthing/syncthing/issues/8783.
+	if filepath.Base(path) == config.DefaultMarkerName {
 		return
 	}
 	t[path] = struct{}{}

--- a/lib/versioner/empty_dir_tracker_test.go
+++ b/lib/versioner/empty_dir_tracker_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	"github.com/d4l3k/messagediff"
+
+	"github.com/syncthing/syncthing/lib/config"
 )
 
 // TestEmptyDirs models the following .stversions structure:
@@ -72,5 +74,39 @@ func TestEmptyDirs(t *testing.T) {
 	result := dirTracker.emptyDirs()
 	if diff, equal := messagediff.PrettyDiff(expected, result); !equal {
 		t.Errorf("Incorrect empty directories list; got %v, expected %v\n%v", result, expected, diff)
+	}
+}
+
+// TestEmptyDirsKeepsFolderMarker verifies that a folder marker (".stfolder"
+// by default) is never treated as a removable empty directory. A versions
+// path can itself be, or contain, another shared folder; removing its marker
+// stops that folder from syncing. See #8783.
+func TestEmptyDirsKeepsFolderMarker(t *testing.T) {
+	paths := []struct {
+		path   string
+		isFile bool
+	}{
+		{".", false},
+		{config.DefaultMarkerName, false}, // empty folder marker at the versions root
+		{filepath.Join("sub", config.DefaultMarkerName), false}, // empty folder marker in a subdirectory
+		{"remove", false}, // a genuinely empty, removable directory
+	}
+
+	// Only the genuinely empty directory should be reported for removal; the
+	// folder markers must be kept.
+	expected := []string{filepath.FromSlash("remove")}
+
+	dirTracker := make(emptyDirTracker)
+	for _, p := range paths {
+		if p.isFile {
+			dirTracker.addFile(filepath.FromSlash(p.path))
+		} else {
+			dirTracker.addDir(filepath.FromSlash(p.path))
+		}
+	}
+
+	result := dirTracker.emptyDirs()
+	if diff, equal := messagediff.PrettyDiff(expected, result); !equal {
+		t.Errorf("Folder marker should be kept; got %v, expected %v\n%v", result, expected, diff)
 	}
 }


### PR DESCRIPTION
### Purpose

Fixes #8783.

The versioner cleanup walks the versions directory and removes any empty directories left behind after expiring old versions (emptyDirTracker, used by the simple, staggered and trashcan versioners). When a versions path is itself, or contains, another shared folder, that walk also encounters the folder marker (".stfolder" by default). Being an empty directory, the marker is removed — which stops the affected folder from syncing, exactly as reported in #8783 and confirmed by @tomasz1986.

This change excludes the folder marker from the empty-directory tracker so it is never removed. It is handled centrally in `emptyDirTracker.addDir`, so all three versioners are covered. The change only ever deletes *less* than before, so it cannot remove any real versioned data.

### Testing

Added `TestEmptyDirsKeepsFolderMarker`, which fails on `main` (the marker directories are reported for removal) and passes with this change. The existing `TestEmptyDirs` and the rest of `go test ./lib/versioner/` pass; `go vet` and `gofmt` are clean.

### Documentation

No user-visible API/protocol change; no docs update needed.

---
Disclosure: this change was prepared with AI assistance (Claude), reflected in the commit's `Co-Authored-By` trailer. It has been reviewed, built, and tested by me, and I take responsibility for it.
