### PR TITLE
docs: fix minor documentation and comment typos

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -246,7 +246,7 @@ func helpHandler(options kong.HelpOptions, ctx *kong.Context) error {
 	}
 	if ctx.Command() == "serve" {
 		// Help was requested for `syncthing serve`, so we add our extra
-		// usage info afte the normal options output.
+		// usage info after the normal options output.
 		fmt.Printf(extraUsage, logPackages())
 	}
 	return nil

--- a/lib/fs/basicfs_watch_test.go
+++ b/lib/fs/basicfs_watch_test.go
@@ -477,12 +477,12 @@ func TestTruncateFileOnly(t *testing.T) {
 	file := createTestFile(name, "file")
 	modifyTestFile(name, file, "syncthing")
 
-	// modified the content to empty use os.WriteFile will first truncate the file
+	// modifying the content to empty using os.WriteFile will first truncate the file
 	// (/os/file.go:696) then write nothing. This logic is also used in many editors,
-	// such as when emptying a file in VSCode or JetBrain
+	// such as when emptying a file in VSCode or JetBrains
 	//
-	// darwin will only modified the inode's metadata, such us mtime, file size, etc.
-	// but would not modified the file directly, so FSEvent 'FSEventsModified' will not
+	// darwin will only modify the inode's metadata, such as mtime, file size, etc.
+	// but would not modify the file directly, so FSEvent 'FSEventsModified' will not
 	// be received
 	//
 	// we should watch the FSEvent 'FSEventsInodeMetaMod' to watch the Inode metadata,

--- a/lib/model/fileinfobatch_test.go
+++ b/lib/model/fileinfobatch_test.go
@@ -32,7 +32,7 @@ func TestFileInfoBatchError(t *testing.T) {
 		t.Fatalf("expected 1, got %d", called)
 	}
 
-	// Flush should fail with an error retur
+	// Flush should fail with an error return
 	errReturn = errors.New("problem")
 	b.Append(protocol.FileInfo{Name: "test"})
 	if err := b.Flush(); err != errReturn {

--- a/lib/model/folder_sendrecv_test.go
+++ b/lib/model/folder_sendrecv_test.go
@@ -347,7 +347,7 @@ func TestDeregisterOnFailInCopy(t *testing.T) {
 
 	m, f := setupSendReceiveFolder(t)
 
-	// Set up our evet subscription early
+	// Set up our event subscription early
 	s := m.evLogger.Subscribe(events.ItemFinished)
 
 	// queue.Done should be called by the finisher routine
@@ -445,7 +445,7 @@ func TestDeregisterOnFailInPull(t *testing.T) {
 
 	m, f := setupSendReceiveFolder(t)
 
-	// Set up our evet subscription early
+	// Set up our event subscription early
 	s := m.evLogger.Subscribe(events.ItemFinished)
 
 	// queue.Done should be called by the finisher routine

--- a/lib/model/folder_sendrecv_windows.go
+++ b/lib/model/folder_sendrecv_windows.go
@@ -31,7 +31,7 @@ func (f *sendReceiveFolder) syncOwnership(file *protocol.FileInfo, path string) 
 }
 
 func lookupUserAndGroup(name string, group bool) (string, string, error) {
-	// Look up either the the user or the group, returning the other kind as
+	// Look up either the user or the group, returning the other kind as
 	// blank. This might seem an odd maneuver, but it matches what Chown
 	// wants as input and hides the ugly nested if:s down here.
 

--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -1311,7 +1311,7 @@ func (m *model) ClusterConfig(conn protocol.Connection, cm *protocol.ClusterConf
 		}
 		m.mut.RUnlock()
 		// In case we've got ClusterConfig, and the connection disappeared
-		// from infront of our nose.
+		// from in front of our nose.
 		if connOK {
 			m.progressEmitter.temporaryIndexSubscribe(conn, tempIndexFolders)
 		}

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -510,7 +510,7 @@ func TestClusterConfigEncrypted(t *testing.T) {
 			Path:           "testdata2",
 			Devices: []config.FolderDeviceConfiguration{
 				{DeviceID: device1, EncryptionPassword: "trololol"}, // not included, untrusted
-				{DeviceID: device2, EncryptionPassword: "trololol"}, // included, is destinationd device
+				{DeviceID: device2, EncryptionPassword: "trololol"}, // included, is destination device
 			},
 		},
 		{

--- a/lib/versioner/simple_test.go
+++ b/lib/versioner/simple_test.go
@@ -189,7 +189,7 @@ func TestArchiveFoldersCreationPermission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// chmod incase umask changes the create permissions
+	// chmod in case umask changes the create permissions
 	err = os.Chmod(folder1Path, folder1Perms)
 	if err != nil {
 		t.Fatal(err)
@@ -202,7 +202,7 @@ func TestArchiveFoldersCreationPermission(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// chmod incase umask changes the create permissions
+	// chmod in case umask changes the create permissions
 	err = os.Chmod(folder2Path, folder2Perms)
 	if err != nil {
 		t.Fatal(err)

--- a/script/next-version.go
+++ b/script/next-version.go
@@ -38,7 +38,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Get the latest "v1.22.3" style tag, excludeing prereleases.
+	// Get the latest "v1.22.3" style tag, excluding prereleases.
 	latestStableTag, err := cmd("git", "describe", "--abbrev=0", "--match", "v[0-9].*", "--exclude", "*-*")
 	if err != nil {
 		fmt.Println(err)

--- a/test/util.go
+++ b/test/util.go
@@ -548,7 +548,7 @@ func symlinksSupported() bool {
 	return err == nil
 }
 
-// checkRemoteInSync checks if the devices associated twith the given processes
+// checkRemoteInSync checks if the devices associated with the given processes
 // are in sync according to the remote status on both sides.
 func checkRemoteInSync(folder string, p1, p2 *rc.Process) error {
 	if inSync, err := p1.RemoteInSync(folder, p2.ID()); err != nil {


### PR DESCRIPTION
### Description
This pull request fixes a series of minor spelling and grammatical typos in source code comments, tests, and scripts. Cleaning up these documentation typos helps keep the codebase polished and readable.

### Changes
Here is the list of files and specific typo fixes included in this PR:

| File | Line | Original text | Corrected text | Description |
| :--- | :--- | :--- | :--- | :--- |
| `cmd/syncthing/main.go` | 249 | `afte` | `after` | Spelling correction |
| `lib/fs/basicfs_watch_test.go` | 480-486 | `modified`, `such us`, `JetBrain` | `modify`, `such as`, `JetBrains` | Correcting verbs and spellings |
| `lib/model/fileinfobatch_test.go` | 35 | `retur` | `return` | Spelling correction |
| `lib/model/folder_sendrecv_test.go` | 350, 448 | `evet` | `event` | Spelling correction |
| `lib/model/folder_sendrecv_windows.go` | 34 | `the the` | `the` | Duplicate word correction |
| `lib/model/model.go` | 1314 | `infront` | `in front` | Space correction |
| `lib/model/model_test.go` | 513 | `destinationd` | `destination` | Spelling correction |
| `lib/versioner/simple_test.go` | 192, 205 | `incase` | `in case` | Space correction |
| `script/next-version.go` | 41 | `excludeing` | `excluding` | Spelling correction |
| `test/util.go` | 551 | `twith` | `with` | Spelling correction |

### Checklist
- [x] Typos are verified against the surrounding context.
- [x] All modifications are limited only to comments, with no changes to functional code or public APIs.

