### PR TITLE
fix(fs, scanner): don't abort scan when scanned item vanishes during walk (fixes #10465)

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -327,7 +327,11 @@ func (f *caseFilesystem) Walk(root string, walkFn WalkFunc) error {
 	// to pick up external changes, for which caching is undesirable.
 	f.dropCache()
 	if err := f.checkCase(root); err != nil {
-		return err
+		// The error must be filtered by the walk function, like all other
+		// errors arising while walking: the root may legitimately have
+		// vanished since the walk was requested, which the walk function
+		// may want to tolerate (e.g. the scanner does).
+		return walkFn(root, nil, err)
 	}
 	return f.Filesystem.Walk(root, walkFn)
 }

--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -154,6 +154,60 @@ func testCaseFSStat(t *testing.T, fsys Filesystem) {
 	}
 }
 
+// vanishedRealCaser mimics an item existing when it is lstat'ed, but having
+// vanished by the time its real casing is resolved against the parent's
+// directory listing (https://github.com/syncthing/syncthing/issues/10465).
+type vanishedRealCaser struct{}
+
+func (vanishedRealCaser) realCase(_ string) (string, error) { return "", ErrNotExist }
+
+func (vanishedRealCaser) dropCache() {}
+
+func TestCaseFSWalkRootVanished(t *testing.T) {
+	// An item vanishing between the walk being requested and its casing
+	// being checked must be reported to the walk function, like all other
+	// errors arising while walking, not returned directly.
+
+	fsys := newFakeFilesystem(t.Name())
+	fd, err := fsys.Create("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fd.Close()
+
+	testFs := &caseFilesystem{
+		Filesystem: fsys,
+		realCaser:  vanishedRealCaser{},
+	}
+
+	calls := 0
+	err = testFs.Walk("foo", func(path string, info FileInfo, err error) error {
+		calls++
+		if path != "foo" {
+			t.Errorf(`walk function got path %q, expected "foo"`, path)
+		}
+		if info != nil {
+			t.Errorf("walk function got info %v, expected nil", info)
+		}
+		if !IsNotExist(err) {
+			t.Errorf("walk function got error %v, expected a not-exist error", err)
+		}
+		return nil // tolerate the vanished item, like the scanner does
+	})
+	if calls != 1 {
+		t.Errorf("walk function called %d times, expected 1", calls)
+	}
+	if err != nil {
+		t.Errorf("Walk returned error %v, expected nil as the walk function tolerated the error", err)
+	}
+
+	// A walk function passing the error on must still surface it.
+	err = testFs.Walk("foo", func(_ string, _ FileInfo, err error) error { return err })
+	if !IsNotExist(err) {
+		t.Errorf("Walk returned error %v, expected a not-exist error", err)
+	}
+}
+
 func BenchmarkWalkCaseFakeFS100k(b *testing.B) {
 	const entries = 100_000
 	fsys, paths, err := fakefsForTest(entries, 0)

--- a/lib/scanner/walk.go
+++ b/lib/scanner/walk.go
@@ -269,7 +269,8 @@ func (w *walker) scan(ctx context.Context, toHashChan chan<- protocol.FileInfo, 
 func isWarnableError(err error) bool {
 	return err != nil &&
 		!errors.Is(err, fs.SkipDir) && // intentional skip
-		!errors.Is(err, context.Canceled) // folder restarting
+		!errors.Is(err, context.Canceled) && // folder restarting
+		!fs.IsNotExist(err) // item vanished before we got to scan it, e.g. after a watcher event
 }
 
 func (w *walker) walkAndHashFiles(ctx context.Context, toHashChan chan<- protocol.FileInfo, finishedChan chan<- ScanResult) fs.WalkFunc {

--- a/lib/scanner/walk_test.go
+++ b/lib/scanner/walk_test.go
@@ -829,17 +829,56 @@ func TestIssue4841(t *testing.T) {
 // TestNotExistingError reproduces https://github.com/syncthing/syncthing/issues/5385
 func TestNotExistingError(t *testing.T) {
 	sub := "notExisting"
-	testFs := newTestFs()
-	if _, err := testFs.Lstat(sub); !fs.IsNotExist(err) {
-		t.Fatalf("Lstat returned error %v, while nothing should exist there.", err)
+
+	testWalk := func(t *testing.T, testFs fs.Filesystem) {
+		t.Helper()
+		if _, err := testFs.Lstat(sub); !fs.IsNotExist(err) {
+			t.Fatalf("Lstat returned error %v, while nothing should exist there.", err)
+		}
+
+		cfg, cancel := testConfig()
+		defer cancel()
+		cfg.Filesystem = testFs
+		cfg.Subs = []string{sub}
+		fchan := Walk(context.TODO(), cfg)
+		for f := range fchan {
+			t.Fatalf("Expected no result from scan, got %v", f)
+		}
 	}
 
-	cfg, cancel := testConfig()
-	defer cancel()
-	cfg.Subs = []string{sub}
-	fchan := Walk(context.TODO(), cfg)
-	for f := range fchan {
-		t.Fatalf("Expected no result from scan, got %v", f)
+	t.Run("basic", func(t *testing.T) {
+		testWalk(t, newTestFs())
+	})
+	// The case filesystem checks the walk root before walking
+	// (https://github.com/syncthing/syncthing/issues/10465)
+	t.Run("case", func(t *testing.T) {
+		testWalk(t, newTestFs(new(fs.OptionDetectCaseConflicts)))
+	})
+}
+
+func TestIsWarnableError(t *testing.T) {
+	testFs := newTestFs()
+	_, lstatErr := testFs.Lstat("notExisting")
+	if lstatErr == nil {
+		t.Fatal("expected an error from Lstat on a non-existing item")
+	}
+
+	cases := []struct {
+		err      error
+		warnable bool
+	}{
+		{nil, false},
+		{fs.SkipDir, false},
+		{context.Canceled, false},
+		{fmt.Errorf("wrapped: %w", context.Canceled), false},
+		{fs.ErrNotExist, false},
+		{lstatErr, false},
+		{errors.New("something bad happened"), true},
+	}
+	for _, tc := range cases {
+		if res := isWarnableError(tc.err); res != tc.warnable {
+			t.Errorf("isWarnableError(%v) == %v, expected %v", tc.err, res, tc.warnable)
+		}
 	}
 }
 


### PR DESCRIPTION
### Purpose

Fixes #10465.

When the filesystem watcher schedules a scan of an item and that item is deleted again before the scan runs, the scan can abort with:

    Aborted scan due to an unexpected error: file does not exist

and a failure event is emitted. As noted in the issue, this kind of error should not bubble out of the scan: the walk callback already deliberately ignores vanished items, but this particular error takes a path that bypasses the callback.

The error comes from the case filesystem: `caseFilesystem.Walk` checks the casing of the walk root before walking and returns any error directly, instead of routing it through the walk function. In the race window where the item still exists when it is lstat'ed but is gone by the time its real casing is resolved against the parent's directory listing, `realCase` returns a bare `fs.ErrNotExist` — whose text is exactly "file does not exist", matching the reports (a syscall ENOENT would read "no such file or directory" instead).

### Changes

- `lib/fs`: `caseFilesystem.Walk` now passes a case-check error on the walk root to the walk function, like all other errors arising while walking (and like `walkFilesystem.Walk` already does when lstat of the root fails). The scanner's existing tolerance of vanished items then applies. As a consequence, a case conflict on the walk root is now reported as a path-specific scan error (failed items in the GUI) instead of aborting the scan, consistent with how other per-path errors are handled.
- `lib/scanner`: `isWarnableError` additionally treats not-exist errors returned from the walk as not warnable, mirroring the walk callback's existing behavior for vanished items.

### Testing

- New `TestCaseFSWalkRootVanished` simulates the race deterministically (lstat succeeds, real-case resolution fails) and asserts the error is delivered to the walk function rather than returned. Before this change it fails with `Walk returned error file does not exist`.
- `TestNotExistingError` now also runs with the case filesystem enabled, and the new `TestIsWarnableError` covers the scanner-side filter.
- `lib/fs` and `lib/scanner` suites pass, also with `-race`.
- Manually verified on a live instance (macOS, case-insensitive APFS): requesting a scan of an existing file using wrong casing previously logged "Aborted scan due to an unexpected error" from the scanner and recorded nothing for the path; with this change the conflict shows up under `/rest/folder/errors` for that path and the scan completes. Watcher-driven create/delete flows behave as before, and several thousand racing create/delete plus sub-scan request cycles produced no aborted scans.
