### PR TITLE
etc/linux-systemd: Don't start user unit for system users

### DIFF
--- a/etc/linux-systemd/user/syncthing.service
+++ b/etc/linux-systemd/user/syncthing.service
@@ -3,6 +3,7 @@ Description=Syncthing - Open Source Continuous File Synchronization
 Documentation=man:syncthing(1)
 StartLimitIntervalSec=60
 StartLimitBurst=4
+ConditionUser=!@system
 
 [Service]
 Environment="STLOGFORMATTIMESTAMP="


### PR DESCRIPTION
Starting syncthing for system users (like the user running the display manager) is not needed and additional services are always a security risk.

### Testing

Log in as a system user and note that syncthing is not started.

