### PR TITLE
feat(cli): add config-health and key-health commands

### DIFF
--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -7,12 +7,17 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/alecthomas/kong"
 )
 
 type showCommand struct {
 	Version      struct{}       `cmd:"" help:"Show syncthing client version"`
 	ConfigStatus struct{}       `cmd:"" help:"Show configuration status, whether or not a restart is required for changes to take effect"`
+	ConfigHealth struct{}       `cmd:"" help:"Check configuration file for syntax errors"`
+	KeyHealth    struct{}       `cmd:"" help:"Check device certificate and key for validity"`
 	System       struct{}       `cmd:"" help:"Show system status"`
 	Connections  struct{}       `cmd:"" help:"Report about connections to other devices"`
 	Discovery    struct{}       `cmd:"" help:"Show the discovered addresses of remote devices (from cache of the running syncthing instance)"`
@@ -28,6 +33,18 @@ func (*showCommand) Run(ctx Context, kongCtx *kong.Context) error {
 		return indexDumpOutput("system/version")
 	case "config-status":
 		return indexDumpOutput("config/restart-required")
+	case "config-health":
+		if err := checkConfigHealth(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		fmt.Println("Config OK")
+	case "key-health":
+		if err := checkKeyHealth(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		fmt.Println("Key and certificate OK")
 	case "system":
 		return indexDumpOutput("system/status")
 	case "connections":

--- a/cmd/syncthing/cli/show_health.go
+++ b/cmd/syncthing/cli/show_health.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+// checkConfigHealth verifies that the configuration file on disk is
+// well-formed, without requiring a running Syncthing instance.
+func checkConfigHealth() error {
+	path := locations.Get(locations.ConfigFile)
+	if _, _, err := config.Load(path, protocol.EmptyDeviceID, events.NoopLogger); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}
+
+// checkKeyHealth verifies that the device certificate and key on disk exist,
+// are parseable, and match each other, without requiring a running
+// Syncthing instance.
+func checkKeyHealth() error {
+	certFile := locations.Get(locations.CertFile)
+	keyFile := locations.Get(locations.KeyFile)
+
+	if _, err := os.Stat(certFile); err != nil {
+		return fmt.Errorf("certificate file: %w", err)
+	}
+	if _, err := os.Stat(keyFile); err != nil {
+		return fmt.Errorf("key file: %w", err)
+	}
+
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return fmt.Errorf("reading certificate file: %w", err)
+	}
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return fmt.Errorf("%s: failed to decode PEM data", certFile)
+	}
+	if _, err := x509.ParseCertificate(certBlock.Bytes); err != nil {
+		return fmt.Errorf("parsing certificate: %w", err)
+	}
+
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return fmt.Errorf("reading key file: %w", err)
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return fmt.Errorf("%s: failed to decode PEM data", keyFile)
+	}
+	if _, err := parsePrivateKey(keyBlock); err != nil {
+		return fmt.Errorf("parsing key: %w", err)
+	}
+
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		return fmt.Errorf("certificate and key do not match: %w", err)
+	}
+
+	return nil
+}
+
+func parsePrivateKey(block *pem.Block) (any, error) {
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	default:
+		return x509.ParsePKCS8PrivateKey(block.Bytes)
+	}
+}

--- a/cmd/syncthing/cli/show_health_test.go
+++ b/cmd/syncthing/cli/show_health_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/tlsutil"
+)
+
+func setBaseDirs(t *testing.T, dir string) {
+	t.Helper()
+	origConfig := locations.GetBaseDir(locations.ConfigBaseDir)
+	origData := locations.GetBaseDir(locations.DataBaseDir)
+	if err := locations.SetBaseDir(locations.ConfigBaseDir, dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := locations.SetBaseDir(locations.DataBaseDir, dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = locations.SetBaseDir(locations.ConfigBaseDir, origConfig)
+		_ = locations.SetBaseDir(locations.DataBaseDir, origData)
+	})
+}
+
+func TestCheckConfigHealthMissing(t *testing.T) {
+	setBaseDirs(t, t.TempDir())
+
+	if err := checkConfigHealth(); err == nil {
+		t.Fatal("expected an error for a missing config file")
+	}
+}
+
+func TestCheckConfigHealthInvalid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	if err := os.WriteFile(locations.Get(locations.ConfigFile), []byte("not valid xml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkConfigHealth(); err == nil {
+		t.Fatal("expected an error for a malformed config file")
+	}
+}
+
+func TestCheckConfigHealthValid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	const validConfig = `<configuration version="37"></configuration>`
+	if err := os.WriteFile(locations.Get(locations.ConfigFile), []byte(validConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkConfigHealth(); err != nil {
+		t.Fatalf("expected no error for a valid config file, got: %v", err)
+	}
+}
+
+func TestCheckKeyHealthMissing(t *testing.T) {
+	setBaseDirs(t, t.TempDir())
+
+	if err := checkKeyHealth(); err == nil {
+		t.Fatal("expected an error for missing cert/key files")
+	}
+}
+
+func TestCheckKeyHealthInvalid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	if err := os.WriteFile(locations.Get(locations.CertFile), []byte("not a cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(locations.Get(locations.KeyFile), []byte("not a key"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkKeyHealth(); err == nil {
+		t.Fatal("expected an error for malformed cert/key files")
+	}
+}
+
+func TestCheckKeyHealthMismatched(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	certFile := locations.Get(locations.CertFile)
+	keyFile := locations.Get(locations.KeyFile)
+	if _, err := tlsutil.NewCertificate(certFile, keyFile, "syncthing", 1, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overwrite the key with an unrelated one, so the cert and key no longer match.
+	otherKeyFile := filepath.Join(dir, "other-key.pem")
+	otherCertFile := filepath.Join(dir, "other-cert.pem")
+	if _, err := tlsutil.NewCertificate(otherCertFile, otherKeyFile, "other", 1, true); err != nil {
+		t.Fatal(err)
+	}
+	keyPEM, err := os.ReadFile(otherKeyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkKeyHealth(); err == nil {
+		t.Fatal("expected an error for mismatched cert/key")
+	}
+}
+
+func TestCheckKeyHealthValid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	certFile := locations.Get(locations.CertFile)
+	keyFile := locations.Get(locations.KeyFile)
+	if _, err := tlsutil.NewCertificate(certFile, keyFile, "syncthing", 1, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkKeyHealth(); err != nil {
+		t.Fatalf("expected no error for a valid cert/key pair, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `syncthing cli show config-health` and `syncthing cli show key-health` commands for validating configuration file syntax and device certificate/key health without requiring a running syncthing instance.

## Problem

When managing widely-deployed Syncthing instances, there is no way to validate the configuration file or check cert/key health from the CLI without running syncthing and checking logs or the web UI. This makes it difficult to catch configuration errors early in deployment pipelines or automation scripts.

## Solution

Two new CLI subcommands under `syncthing cli show`:

- `syncthing cli show config-health` - Loads the config file using the same path resolution as `syncthing serve` and checks for syntax/parse errors. Returns non-zero exit code and prints issues to stderr if any are found.

- `syncthing cli show key-health` - Checks that `cert.pem` and `key.pem` exist at the configured location, parses them as valid PEM files, and verifies they form a valid key pair using `tls.X509KeyPair`. Returns non-zero exit code and prints issues to stderr if any are found.

Both commands respect `--config`, `$STCONFDIR`, `--home`, and `$STHOMEDIR` for path resolution, matching the behavior of other syncthing commands.

## Changes

- `cmd/syncthing/cli/show.go`: Added `ConfigHealth` and `KeyHealth` subcommand structs and dispatch cases
- `cmd/syncthing/cli/show_health.go` (new): Implementation of `configHealth()` and `keyHealth()` functions
- `cmd/syncthing/cli/show_health_test.go` (new): 7 unit tests covering missing/malformed/valid config and missing/malformed/mismatched/valid cert-key pairs

## Test Plan

- `go build -tags noassets ./cmd/syncthing/...` compiles
- `go test -tags noassets ./cmd/syncthing/...` passes (7 test cases)
- Manually tested: missing config/keys exit 1 with stderr messages; after `syncthing generate`, both commands report success with exit 0

Fixes #10767
