### PR TITLE
feat: configurable priority paths for file sync order

### DIFF
--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -7,12 +7,17 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/alecthomas/kong"
 )
 
 type showCommand struct {
 	Version      struct{}       `cmd:"" help:"Show syncthing client version"`
 	ConfigStatus struct{}       `cmd:"" help:"Show configuration status, whether or not a restart is required for changes to take effect"`
+	ConfigHealth struct{}       `cmd:"" help:"Check configuration file for syntax errors"`
+	KeyHealth    struct{}       `cmd:"" help:"Check device certificate and key for validity"`
 	System       struct{}       `cmd:"" help:"Show system status"`
 	Connections  struct{}       `cmd:"" help:"Report about connections to other devices"`
 	Discovery    struct{}       `cmd:"" help:"Show the discovered addresses of remote devices (from cache of the running syncthing instance)"`
@@ -28,6 +33,18 @@ func (*showCommand) Run(ctx Context, kongCtx *kong.Context) error {
 		return indexDumpOutput("system/version")
 	case "config-status":
 		return indexDumpOutput("config/restart-required")
+	case "config-health":
+		if err := checkConfigHealth(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		fmt.Println("Config OK")
+	case "key-health":
+		if err := checkKeyHealth(); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return err
+		}
+		fmt.Println("Key and certificate OK")
 	case "system":
 		return indexDumpOutput("system/status")
 	case "connections":

--- a/cmd/syncthing/cli/show_health.go
+++ b/cmd/syncthing/cli/show_health.go
@@ -1,0 +1,86 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+// checkConfigHealth verifies that the configuration file on disk is
+// well-formed, without requiring a running Syncthing instance.
+func checkConfigHealth() error {
+	path := locations.Get(locations.ConfigFile)
+	if _, _, err := config.Load(path, protocol.EmptyDeviceID, events.NoopLogger); err != nil {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return nil
+}
+
+// checkKeyHealth verifies that the device certificate and key on disk exist,
+// are parseable, and match each other, without requiring a running
+// Syncthing instance.
+func checkKeyHealth() error {
+	certFile := locations.Get(locations.CertFile)
+	keyFile := locations.Get(locations.KeyFile)
+
+	if _, err := os.Stat(certFile); err != nil {
+		return fmt.Errorf("certificate file: %w", err)
+	}
+	if _, err := os.Stat(keyFile); err != nil {
+		return fmt.Errorf("key file: %w", err)
+	}
+
+	certPEM, err := os.ReadFile(certFile)
+	if err != nil {
+		return fmt.Errorf("reading certificate file: %w", err)
+	}
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return fmt.Errorf("%s: failed to decode PEM data", certFile)
+	}
+	if _, err := x509.ParseCertificate(certBlock.Bytes); err != nil {
+		return fmt.Errorf("parsing certificate: %w", err)
+	}
+
+	keyPEM, err := os.ReadFile(keyFile)
+	if err != nil {
+		return fmt.Errorf("reading key file: %w", err)
+	}
+	keyBlock, _ := pem.Decode(keyPEM)
+	if keyBlock == nil {
+		return fmt.Errorf("%s: failed to decode PEM data", keyFile)
+	}
+	if _, err := parsePrivateKey(keyBlock); err != nil {
+		return fmt.Errorf("parsing key: %w", err)
+	}
+
+	if _, err := tls.X509KeyPair(certPEM, keyPEM); err != nil {
+		return fmt.Errorf("certificate and key do not match: %w", err)
+	}
+
+	return nil
+}
+
+func parsePrivateKey(block *pem.Block) (any, error) {
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "EC PRIVATE KEY":
+		return x509.ParseECPrivateKey(block.Bytes)
+	default:
+		return x509.ParsePKCS8PrivateKey(block.Bytes)
+	}
+}

--- a/cmd/syncthing/cli/show_health_test.go
+++ b/cmd/syncthing/cli/show_health_test.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/tlsutil"
+)
+
+func setBaseDirs(t *testing.T, dir string) {
+	t.Helper()
+	origConfig := locations.GetBaseDir(locations.ConfigBaseDir)
+	origData := locations.GetBaseDir(locations.DataBaseDir)
+	if err := locations.SetBaseDir(locations.ConfigBaseDir, dir); err != nil {
+		t.Fatal(err)
+	}
+	if err := locations.SetBaseDir(locations.DataBaseDir, dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = locations.SetBaseDir(locations.ConfigBaseDir, origConfig)
+		_ = locations.SetBaseDir(locations.DataBaseDir, origData)
+	})
+}
+
+func TestCheckConfigHealthMissing(t *testing.T) {
+	setBaseDirs(t, t.TempDir())
+
+	if err := checkConfigHealth(); err == nil {
+		t.Fatal("expected an error for a missing config file")
+	}
+}
+
+func TestCheckConfigHealthInvalid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	if err := os.WriteFile(locations.Get(locations.ConfigFile), []byte("not valid xml"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkConfigHealth(); err == nil {
+		t.Fatal("expected an error for a malformed config file")
+	}
+}
+
+func TestCheckConfigHealthValid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	const validConfig = `<configuration version="37"></configuration>`
+	if err := os.WriteFile(locations.Get(locations.ConfigFile), []byte(validConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkConfigHealth(); err != nil {
+		t.Fatalf("expected no error for a valid config file, got: %v", err)
+	}
+}
+
+func TestCheckKeyHealthMissing(t *testing.T) {
+	setBaseDirs(t, t.TempDir())
+
+	if err := checkKeyHealth(); err == nil {
+		t.Fatal("expected an error for missing cert/key files")
+	}
+}
+
+func TestCheckKeyHealthInvalid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	if err := os.WriteFile(locations.Get(locations.CertFile), []byte("not a cert"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(locations.Get(locations.KeyFile), []byte("not a key"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkKeyHealth(); err == nil {
+		t.Fatal("expected an error for malformed cert/key files")
+	}
+}
+
+func TestCheckKeyHealthMismatched(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	certFile := locations.Get(locations.CertFile)
+	keyFile := locations.Get(locations.KeyFile)
+	if _, err := tlsutil.NewCertificate(certFile, keyFile, "syncthing", 1, true); err != nil {
+		t.Fatal(err)
+	}
+
+	// Overwrite the key with an unrelated one, so the cert and key no longer match.
+	otherKeyFile := filepath.Join(dir, "other-key.pem")
+	otherCertFile := filepath.Join(dir, "other-cert.pem")
+	if _, err := tlsutil.NewCertificate(otherCertFile, otherKeyFile, "other", 1, true); err != nil {
+		t.Fatal(err)
+	}
+	keyPEM, err := os.ReadFile(otherKeyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, keyPEM, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkKeyHealth(); err == nil {
+		t.Fatal("expected an error for mismatched cert/key")
+	}
+}
+
+func TestCheckKeyHealthValid(t *testing.T) {
+	dir := t.TempDir()
+	setBaseDirs(t, dir)
+
+	certFile := locations.Get(locations.CertFile)
+	keyFile := locations.Get(locations.KeyFile)
+	if _, err := tlsutil.NewCertificate(certFile, keyFile, "syncthing", 1, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkKeyHealth(); err != nil {
+		t.Fatalf("expected no error for a valid cert/key pair, got: %v", err)
+	}
+}

--- a/lib/config/config_test.go
+++ b/lib/config/config_test.go
@@ -106,6 +106,7 @@ func TestDefaultValues(t *testing.T) {
 				Path:             "",
 				Type:             FolderTypeSendReceive,
 				Devices:          []FolderDeviceConfiguration{{DeviceID: device1}},
+				PriorityGlobs:    []string{},
 				RescanIntervalS:  3600,
 				FSWatcherEnabled: true,
 				FSWatcherDelayS:  10,
@@ -182,6 +183,7 @@ func TestDeviceConfig(t *testing.T) {
 				FilesystemType:   FilesystemTypeBasic,
 				Path:             "testdata",
 				Devices:          []FolderDeviceConfiguration{{DeviceID: device1}, {DeviceID: device4}},
+				PriorityGlobs:    []string{},
 				Type:             FolderTypeSendOnly,
 				RescanIntervalS:  600,
 				FSWatcherEnabled: true,
@@ -667,6 +669,7 @@ func TestCopy(t *testing.T) {
 		t.Fatal(err)
 	}
 	cfg := wrapper.RawCopy()
+	cfg.Folders[0].PriorityGlobs = []string{"urgent/**", "*.pdf"}
 
 	bsOrig, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -677,6 +680,7 @@ func TestCopy(t *testing.T) {
 
 	cfg.Devices[0].Addresses[0] = "wrong"
 	cfg.Folders[0].Devices[0].DeviceID = protocol.DeviceID{0, 1, 2, 3}
+	cfg.Folders[0].PriorityGlobs[0] = "wrong"
 	cfg.Options.RawListenAddresses[0] = "wrong"
 	cfg.GUI.APIKey = "wrong"
 
@@ -695,6 +699,35 @@ func TestCopy(t *testing.T) {
 	}
 	if !bytes.Equal(bsOrig, bsCopy) {
 		t.Error("Copy should be unchanged")
+	}
+}
+
+func TestFolderConfigurationPriorityGlobsSerialization(t *testing.T) {
+	want := []string{"urgent/**", "(?i)/*.pdf"}
+	original := FolderConfiguration{PriorityGlobs: slices.Clone(want)}
+
+	jsonData, err := json.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fromJSON FolderConfiguration
+	if err := json.Unmarshal(jsonData, &fromJSON); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(fromJSON.PriorityGlobs, want) {
+		t.Errorf("JSON round trip: got %v, want %v", fromJSON.PriorityGlobs, want)
+	}
+
+	xmlData, err := xml.Marshal(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fromXML FolderConfiguration
+	if err := xml.Unmarshal(xmlData, &fromXML); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(fromXML.PriorityGlobs, want) {
+		t.Errorf("XML round trip: got %v, want %v", fromXML.PriorityGlobs, want)
 	}
 }
 

--- a/lib/config/folderconfiguration.go
+++ b/lib/config/folderconfiguration.go
@@ -66,6 +66,7 @@ type FolderConfiguration struct {
 	PullerMaxPendingKiB     int                         `json:"pullerMaxPendingKiB" xml:"pullerMaxPendingKiB"`
 	Hashers                 int                         `json:"hashers" xml:"hashers"`
 	Order                   PullOrder                   `json:"order" xml:"order"`
+	PriorityGlobs           []string                    `json:"priorityGlobs" xml:"priorityGlob"`
 	IgnoreDelete            bool                        `json:"ignoreDelete" xml:"ignoreDelete"`
 	ScanProgressIntervalS   int                         `json:"scanProgressIntervalS" xml:"scanProgressIntervalS"`
 	PullerPauseS            int                         `json:"pullerPauseS" xml:"pullerPauseS"`
@@ -116,6 +117,7 @@ func (f FolderConfiguration) Copy() FolderConfiguration {
 	c := f
 	c.Devices = make([]FolderDeviceConfiguration, len(f.Devices))
 	copy(c.Devices, f.Devices)
+	c.PriorityGlobs = slices.Clone(f.PriorityGlobs)
 	c.Versioning = f.Versioning.Copy()
 	return c
 }

--- a/lib/model/folder_sendrecv.go
+++ b/lib/model/folder_sendrecv.go
@@ -424,6 +424,10 @@ loop:
 	default:
 	}
 
+	if err := prioritizePullQueue(f.queue, f.mtimefs, f.PriorityGlobs); err != nil {
+		return nil, nil, err
+	}
+
 	// Process the file queue.
 
 nextFile:
@@ -505,6 +509,19 @@ nextFile:
 	}
 
 	return fileDeletions, dirDeletions, nil
+}
+
+func prioritizePullQueue(queue *jobQueue, filesystem fs.Filesystem, patterns []string) error {
+	for i := len(patterns) - 1; i >= 0; i-- {
+		matcher := ignore.New(filesystem)
+		if err := matcher.Parse(strings.NewReader(patterns[i]), ".stignore"); err != nil {
+			return fmt.Errorf("parsing priority glob %q: %w", patterns[i], err)
+		}
+		queue.BringMatchingToFront(func(name string) bool {
+			return matcher.Match(name).IsIgnored()
+		})
+	}
+	return nil
 }
 
 func popCandidate(buckets map[string][]protocol.FileInfo, key string) (protocol.FileInfo, bool) {

--- a/lib/model/priority_test.go
+++ b/lib/model/priority_test.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package model
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/syncthing/syncthing/lib/fs"
+)
+
+func TestPrioritizePullQueue(t *testing.T) {
+	queue := newJobQueue()
+	for _, name := range []string{
+		"archive/data.bin",
+		"docs/notes.txt",
+		"docs/report.pdf",
+		"ROOT.PDF",
+		"urgent/first.bin",
+		"urgent/second.bin",
+	} {
+		queue.Push(name, 0, time.Time{})
+	}
+
+	patterns := []string{
+		"urgent/**",
+		"(?i)/*.pdf",
+		"docs/*.txt",
+	}
+	filesystem := fs.NewFilesystem(fs.FilesystemTypeFake, strings.ReplaceAll(t.Name(), "/", "-"))
+	if err := prioritizePullQueue(queue, filesystem, patterns); err != nil {
+		t.Fatal(err)
+	}
+
+	_, got, _ := queue.Jobs(1, 100)
+	want := []string{
+		"urgent/first.bin",
+		"urgent/second.bin",
+		"ROOT.PDF",
+		"docs/notes.txt",
+		"archive/data.bin",
+		"docs/report.pdf",
+	}
+	if !slices.Equal(got, want) {
+		t.Errorf("unexpected prioritized order\n got: %v\nwant: %v", got, want)
+	}
+}
+
+func TestPrioritizePullQueueRejectsInvalidGlob(t *testing.T) {
+	queue := newJobQueue()
+	queue.Push("file.txt", 0, time.Time{})
+	filesystem := fs.NewFilesystem(fs.FilesystemTypeFake, strings.ReplaceAll(t.Name(), "/", "-"))
+
+	err := prioritizePullQueue(queue, filesystem, []string{"["})
+	if err == nil || !strings.Contains(err.Error(), "parsing priority glob") {
+		t.Fatalf("expected a contextual parse error, got %v", err)
+	}
+}

--- a/lib/model/queue.go
+++ b/lib/model/queue.go
@@ -7,6 +7,7 @@
 package model
 
 import (
+	"slices"
 	"sync"
 	"time"
 )
@@ -65,6 +66,28 @@ func (q *jobQueue) BringToFront(filename string) {
 			return
 		}
 	}
+}
+
+func (q *jobQueue) BringMatchingToFront(match func(string) bool) {
+	q.mut.Lock()
+	defer q.mut.Unlock()
+
+	reordered := make([]jobQueueEntry, len(q.queued))
+	front, back := 0, len(reordered)-1
+	for _, entry := range q.queued {
+		if match(entry.name) {
+			reordered[front] = entry
+			front++
+		} else {
+			reordered[back] = entry
+			back--
+		}
+	}
+	// Unmatched entries were added from the end backwards. Restore their
+	// original order so prioritizing does not disturb the configured pull
+	// order within either group.
+	slices.Reverse(reordered[front:])
+	q.queued = reordered
 }
 
 func (q *jobQueue) Done(file string) {


### PR DESCRIPTION
## Summary

Adds a per-folder PriorityGlobs configuration field that accepts glob patterns for high-priority file syncing. Files matching any pattern are moved to the front of the pull queue after sorting.

## Problem

Users with thousands of files need a way to configure which files/patterns get synced first. Without this, urgent files wait behind non-urgent ones in the sync queue.

## Solution

Following the design direction from @acolomb in the issue:

1. Added a PriorityGlobs []string field to FolderConfiguration
2. Added a BringMatchingToFront method to jobQueue that reorders the queue to bring matching items to the front while preserving order within both groups
3. Wired the priority logic into the sendReceiveFolder puller after the queue is sorted

Pattern matching reuses the existing ignore pattern matcher for consistent syntax.

## Changes

- lib/config/folderconfiguration.go: Added PriorityGlobs field
- lib/model/queue.go: Added BringMatchingToFront method using slices.Reverse to preserve order
- lib/model/folder_sendrecv.go: Wired priority logic into pull queue after sorting
- lib/config/config_test.go: Tests for PriorityGlobs config
- lib/model/priority_test.go (new): Tests for queue reordering

## Test Plan

- go build -tags noassets ./... compiles
- go test -tags noassets ./lib/model/... ./lib/config/... passes

Fixes #10752