### PR TITLE
fix(db): migrate device statistics from LevelDB

### DIFF
--- a/internal/db/olddb/lowlevel.go
+++ b/internal/db/olddb/lowlevel.go
@@ -7,10 +7,12 @@
 package olddb
 
 import (
+	"bytes"
 	"encoding/binary"
 	"time"
 
 	"github.com/syncthing/syncthing/internal/db/olddb/backend"
+	"github.com/syncthing/syncthing/lib/protocol"
 )
 
 // deprecatedLowlevel is the lowest level database interface. It has a very simple
@@ -63,6 +65,30 @@ func (db *deprecatedLowlevel) IterateMtimes(fn func(folder, name string, ondisk,
 			continue
 		}
 		if err := fn(string(folderID), string(name), ondisk, virtual); err != nil {
+			return err
+		}
+	}
+	return it.Error()
+}
+
+func (db *deprecatedLowlevel) IterateDeviceStatistics(fn func(device protocol.DeviceID, key string, value []byte) error) error {
+	it, err := db.NewPrefixIterator([]byte{KeyTypeDeviceStatistic})
+	if err != nil {
+		return err
+	}
+	defer it.Release()
+
+	deviceStringLen := len(protocol.LocalDeviceID.String())
+	for it.Next() {
+		key := it.Key()[keyPrefixLen:]
+		if len(key) <= deviceStringLen {
+			continue
+		}
+		device, err := protocol.DeviceIDFromString(string(key[:deviceStringLen]))
+		if err != nil {
+			continue
+		}
+		if err := fn(device, string(key[deviceStringLen:]), bytes.Clone(it.Value())); err != nil {
 			return err
 		}
 	}

--- a/internal/db/olddb/lowlevel_test.go
+++ b/internal/db/olddb/lowlevel_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package olddb
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/syncthing/syncthing/internal/db/olddb/backend"
+	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func TestIterateDeviceStatistics(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "index-v0.14.0.db")
+	ldb, err := leveldb.OpenFile(path, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	device1 := protocol.NewDeviceID([]byte("device1"))
+	device2 := protocol.NewDeviceID([]byte("device2"))
+	entries := map[string][]byte{
+		device1.String() + "lastSeen":         []byte("last seen value"),
+		device1.String() + "lastConnDuration": []byte("connection duration value"),
+		device2.String() + "lastSeen":         []byte("other last seen value"),
+		device2.String() + "lastConnDuration": []byte("other connection duration value"),
+	}
+	for key, value := range entries {
+		if err := ldb.Put(append([]byte{KeyTypeDeviceStatistic}, key...), value, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Malformed keys in the same namespace must not prevent valid statistics
+	// from being migrated.
+	if err := ldb.Put([]byte{KeyTypeDeviceStatistic, 'x'}, []byte("invalid"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := ldb.Put([]byte{KeyTypeFolderStatistic, 'x'}, []byte("other namespace"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := ldb.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	be, err := backend.OpenLevelDBRO(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer be.Close()
+	ll, err := NewLowlevel(be)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string][]byte)
+	err = ll.IterateDeviceStatistics(func(device protocol.DeviceID, key string, value []byte) error {
+		got[device.String()+key] = value
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, entries) {
+		t.Errorf("unexpected device statistics: got %v, want %v", got, entries)
+	}
+
+	// Returned values must not alias iterator-owned memory.
+	for key, value := range got {
+		if !bytes.Equal(value, entries[key]) {
+			t.Errorf("value for %q changed after iteration: got %q, want %q", key, value, entries[key])
+		}
+	}
+}

--- a/lib/syncthing/utils.go
+++ b/lib/syncthing/utils.go
@@ -275,6 +275,13 @@ func TryMigrateDatabase(ctx context.Context, deleteRetention time.Duration) erro
 		slog.Warn("Failed to migrate mtimes", slogutil.Error(err))
 	}
 
+	slog.Info("Migrating device statistics...")
+	if err := ll.IterateDeviceStatistics(func(device protocol.DeviceID, key string, value []byte) error {
+		return db.NewTyped(sdb, "devicestats/"+device.String()).PutBytes(key, value)
+	}); err != nil {
+		slog.Warn("Failed to migrate device statistics", slogutil.Error(err))
+	}
+
 	_ = miscDB.PutTime("migrated-from-leveldb-at", time.Now())
 	_ = miscDB.PutString("migrated-from-leveldb-by", build.LongVersion)
 

--- a/lib/syncthing/utils_test.go
+++ b/lib/syncthing/utils_test.go
@@ -1,0 +1,71 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package syncthing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/syncthing/syncthing/internal/db"
+	"github.com/syncthing/syncthing/internal/db/olddb"
+	"github.com/syncthing/syncthing/internal/db/sqlite"
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func TestTryMigrateDatabaseMigratesDeviceStatistics(t *testing.T) {
+	originalDataDir := locations.GetBaseDir(locations.DataBaseDir)
+	if err := locations.SetBaseDir(locations.DataBaseDir, t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := locations.SetBaseDir(locations.DataBaseDir, originalDataDir); err != nil {
+			t.Error(err)
+		}
+	})
+
+	legacyDB, err := leveldb.OpenFile(locations.Get(locations.LegacyDatabase), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	device := protocol.NewDeviceID([]byte("test device"))
+	want := time.Date(2025, 10, 17, 7, 50, 47, 0, time.UTC)
+	value, err := want.MarshalBinary()
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := append([]byte{olddb.KeyTypeDeviceStatistic}, device.String()...)
+	key = append(key, "lastSeen"...)
+	if err := legacyDB.Put(key, value, nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := TryMigrateDatabase(context.Background(), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	sdb, err := sqlite.Open(locations.Get(locations.Database))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sdb.Close()
+	got, ok, err := db.NewTyped(sdb, "devicestats/"+device.String()).Time("lastSeen")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("last seen time was not migrated")
+	}
+	if !got.Equal(want) {
+		t.Errorf("unexpected last seen time: got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
### Purpose

Preserve device statistics when migrating the legacy LevelDB database to SQLite. The migration previously copied file data and virtual mtimes but omitted the per-device key-value namespace, causing disconnected devices to appear as never seen after upgrading to Syncthing 2.x.

The legacy statistics iterator validates and decodes device IDs, then copies each statistic into the corresponding SQLite namespace. This preserves both `lastSeen` and `lastConnDuration` values.

Fixes #10431.

### Testing

- Added a legacy database iterator test covering multiple devices, statistics, malformed keys, and namespace isolation.
- Added an end-to-end LevelDB-to-SQLite migration test that verifies the migrated `lastSeen` timestamp.
- `go test ./...`
- `go run build.go lint`

### Documentation

No documentation changes are needed; this restores existing upgrade behavior without changing configuration, API, or protocol semantics.