### PR TITLE
fix(strelaypoolsrv): snapshot relays before saving (fixes #10799)

### DIFF
--- a/cmd/infra/strelaypoolsrv/main.go
+++ b/cmd/infra/strelaypoolsrv/main.go
@@ -542,9 +542,12 @@ found:
 	knownRelays = append(knownRelays, request.relay)
 	evictionTimers[request.relay.uri.Host] = time.AfterFunc(evictionTime, evict(request.relay))
 
+	// Save outside the lock, but copy the backing array while it is protected.
+	// Other request processors and eviction timers mutate knownRelays in place.
+	relays := copyRelays(knownRelays)
 	mut.Unlock()
 
-	if err := saveRelays(knownRelaysFile, knownRelays); err != nil {
+	if err := saveRelays(knownRelaysFile, relays); err != nil {
 		log.Println("Failed to write known relays: " + err.Error())
 	}
 
@@ -613,6 +616,10 @@ func saveRelays(file string, relays []*relay) error {
 		content += relay.uri.String() + "\n"
 	}
 	return os.WriteFile(file, []byte(content), 0o666)
+}
+
+func copyRelays(relays []*relay) []*relay {
+	return append([]*relay(nil), relays...)
 }
 
 func createTestCertificate() tls.Certificate {

--- a/cmd/infra/strelaypoolsrv/main_test.go
+++ b/cmd/infra/strelaypoolsrv/main_test.go
@@ -104,3 +104,14 @@ func TestSlimURL(t *testing.T) {
 		}
 	}
 }
+
+func TestCopyRelays(t *testing.T) {
+	relays := []*relay{{URL: "first"}, {URL: "second"}}
+	copied := copyRelays(relays)
+
+	relays[0] = &relay{URL: "replacement"}
+
+	if copied[0].URL != "first" {
+		t.Fatalf("copy aliases the source backing array: got %q", copied[0].URL)
+	}
+}


### PR DESCRIPTION
### Purpose

Fixes #10799. `handleRelayTest` released `mut` before `saveRelays` iterated over `knownRelays`, allowing request processors and eviction callbacks to mutate the shared backing array concurrently. The change copies the relay slice while holding the lock, then writes the immutable snapshot after releasing it.

### Testing

- `go test ./cmd/infra/strelaypoolsrv`
- `go vet ./cmd/infra/strelaypoolsrv`
- `go test -race ./cmd/infra/strelaypoolsrv` (not runnable locally: the Windows environment has no CGO C compiler)

### Documentation

Not user visible; no documentation change required.