### PR TITLE
perf(ur): reuse http client for usage and failure reports instead of rebuilding per call

### DIFF
--- a/lib/ur/failurereporting.go
+++ b/lib/ur/failurereporting.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"runtime/pprof"
@@ -39,6 +40,18 @@ var (
 	evChanClosed         = "failure event channel closed"
 	invalidEventDataType = "failure event data is not a string"
 )
+
+// failureReportClient is reused across calls to sendFailureReports instead
+// of building a new client (and TLS connection) for every report, since
+// failures can be reported repeatedly in short succession while the
+// instance is unstable.
+var failureReportClient = &http.Client{
+	Transport: &http.Transport{
+		DialContext:     dialer.DialContext,
+		Proxy:           http.ProxyFromEnvironment,
+		TLSClientConfig: tlsutil.SecureDefaultWithTLS12(),
+	},
+}
 
 func FailureDataWithGoroutines(description string) contract.FailureData {
 	var buf strings.Builder
@@ -198,14 +211,6 @@ func sendFailureReports(ctx context.Context, reports []contract.FailureReport, u
 		panic(err)
 	}
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext:     dialer.DialContext,
-			Proxy:           http.ProxyFromEnvironment,
-			TLSClientConfig: tlsutil.SecureDefaultWithTLS12(),
-		},
-	}
-
 	reqCtx, reqCancel := context.WithTimeout(ctx, sendTimeout)
 	defer reqCancel()
 	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, &b)
@@ -215,11 +220,14 @@ func sendFailureReports(ctx context.Context, reports []contract.FailureReport, u
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := failureReportClient.Do(req)
 	if err != nil {
 		slog.WarnContext(ctx, "Failed to send failure report", slogutil.Error(err))
 		return
 	}
+	// Drain the body so the underlying connection can be reused for the
+	// next report instead of being closed and re-established from scratch.
+	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 }
 

--- a/lib/ur/usage_report.go
+++ b/lib/ur/usage_report.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -53,6 +54,10 @@ type Service struct {
 	connectionsService connections.Service
 	noUpgrade          bool
 	forceRun           chan struct{}
+
+	clientMut          sync.Mutex
+	client             *http.Client
+	clientPostInsecure bool
 }
 
 func New(cfg config.Wrapper, m Model, connectionsService connections.Service, noUpgrade bool) *Service {
@@ -358,28 +363,45 @@ func (s *Service) sendUsageReport(ctx context.Context) error {
 		return err
 	}
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			DialContext: dialer.DialContext,
-			Proxy:       http.ProxyFromEnvironment,
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: s.cfg.Options().URPostInsecurely,
-				MinVersion:         tls.VersionTLS12,
-				ClientSessionCache: tls.NewLRUClientSessionCache(0),
-			},
-		},
-	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.cfg.Options().URURL, &b)
 	if err != nil {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	resp, err := client.Do(req)
+	resp, err := s.httpClient(s.cfg.Options().URPostInsecurely).Do(req)
 	if err != nil {
 		return err
 	}
+	// Drain the body so the underlying connection can be reused for the
+	// next report instead of being closed and re-established from scratch.
+	io.Copy(io.Discard, resp.Body)
 	resp.Body.Close()
 	return nil
+}
+
+// httpClient returns a client to use for posting usage reports. The
+// client (and its connection pool) is reused across calls instead of
+// being rebuilt on every report, except when the insecure-post setting
+// changes underneath us, in which case the TLS config it captured is no
+// longer correct and we need a fresh one.
+func (s *Service) httpClient(postInsecurely bool) *http.Client {
+	s.clientMut.Lock()
+	defer s.clientMut.Unlock()
+	if s.client == nil || s.clientPostInsecure != postInsecurely {
+		s.client = &http.Client{
+			Transport: &http.Transport{
+				DialContext: dialer.DialContext,
+				Proxy:       http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: postInsecurely,
+					MinVersion:         tls.VersionTLS12,
+					ClientSessionCache: tls.NewLRUClientSessionCache(0),
+				},
+			},
+		}
+		s.clientPostInsecure = postInsecurely
+	}
+	return s.client
 }
 
 func (s *Service) Serve(ctx context.Context) error {


### PR DESCRIPTION
- `sendUsageReport` and `sendFailureReports` each built a fresh `http.Client`/`http.Transport` on every call instead of reusing one, so no TCP/TLS connection could ever be kept alive across reports.
- Neither function drained the response body before `Close()`, which would have blocked connection reuse even if the client had been shared.
- Cache the client on `Service` for usage reports (rebuilt only if the user-configurable `URPostInsecurely` setting changes at runtime), and share one package-level client for failure reports (its TLS config is static).
- Drain response bodies before `Close()` in both paths so the underlying connection is eligible for reuse.

Fixes #10804

## Test plan
- [x] `go build ./lib/ur/...`
- [x] `go vet ./lib/ur/...`
- [x] Verified with a local `httptest` server + connection-counting listener: 3 report sends → 1 TCP connection after the fix, vs. 3 TCP connections before (reproduced pre-fix behavior via `git stash` to confirm the bug existed)
