### PR TITLE
fix(gui): fix expanding one folder not collapsing others in group

### DIFF
--- a/gui/default/index.html
+++ b/gui/default/index.html
@@ -387,7 +387,7 @@
             </h4>
             <div class="panel-group" id="folders-{{ $index }}">
               <div class="panel panel-default" ng-repeat="folder in groupedFolders">
-                <button class="btn panel-heading" data-toggle="collapse" data-parent="#folders-{{$index}}" data-target="#folder-{{$parent.$index}}-{{$index}}" aria-expanded="false">
+                <button class="btn panel-heading" data-toggle="collapse" data-parent="#folders-{{$parent.$index}}" data-target="#folder-{{$parent.$index}}-{{$index}}" aria-expanded="false">
                   <div class="panel-progress" ng-show="folderStatus(folder) == 'syncing'" ng-attr-style="width: {{syncPercentage(folder.id) | percent}}"></div>
                   <div class="panel-progress" ng-show="folderStatus(folder) == 'scanning' && scanProgress[folder.id] != undefined" ng-attr-style="width: {{scanPercentage(folder.id) | percent}}"></div>
                   <h4 class="panel-title">


### PR DESCRIPTION
Regression introduced after folder groups were added in 6a26d56ad9f3f158c49864e3c49364725b109464

### Purpose

Describe the purpose of this change. If there is an existing issue that is
resolved by this pull request, ensure that the commit subject is on the form
`Some short description (fixes #1234)` where 1234 is the issue number.

### Testing

As a regression this certainly deserves a test, but there are no existing tests for the GUI... Easy to test manually by clicking on your folders and making sure expanding one collapses the others in the same group.