### PR TITLE
feat(api): magic token authentication from `syncthing browse`

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -11,6 +11,7 @@ import (
 	"cmp"
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -319,7 +320,24 @@ func openGUI() error {
 		return err
 	}
 	if guiCfg := cfg.GUI(); guiCfg.Enabled {
-		if err := openURL(guiCfg.URL()); err != nil {
+		guiUrl := guiCfg.URL()
+		if guiCfg.IsAuthEnabled() {
+			r, err := http.NewRequest(http.MethodPost, guiCfg.URL()+"rest/auth/logintoken", nil)
+			if err != nil {
+				return err
+			}
+			resp, err := makeRestCall(cfg, r)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			var data map[string]string
+			if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+				return err
+			}
+			guiUrl += "?token=" + data["token"]
+		}
+		if err := openURL(guiUrl); err != nil {
 			return err
 		}
 	} else {
@@ -375,19 +393,7 @@ func checkUpgrade() (upgrade.Release, error) {
 	return release, nil
 }
 
-func upgradeViaRest() error {
-	cfg, err := loadOrDefaultConfig()
-	if err != nil {
-		return err
-	}
-
-	u, err := url.Parse(cfg.GUI().URL())
-	if err != nil {
-		return err
-	}
-	u.Path = path.Join(u.Path, "rest/system/upgrade")
-	target := u.String()
-	r, _ := http.NewRequest(http.MethodPost, target, nil)
+func makeRestCall(cfg config.Wrapper, r *http.Request) (*http.Response, error) {
 	r.Header.Set("X-Api-Key", cfg.GUI().APIKey)
 
 	tr := &http.Transport{
@@ -401,19 +407,38 @@ func upgradeViaRest() error {
 	}
 	resp, err := client.Do(r)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		bs, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		return errors.New(string(bs))
+		return nil, errors.New(string(bs))
 	}
 
+	return resp, nil
+}
+
+func upgradeViaRest() error {
+	cfg, err := loadOrDefaultConfig()
+	if err != nil {
+		return err
+	}
+
+	u, err := url.Parse(cfg.GUI().URL())
+	if err != nil {
+		return err
+	}
+	u.Path = path.Join(u.Path, "rest/system/upgrade")
+	target := u.String()
+	r, _ := http.NewRequest(http.MethodPost, target, nil)
+
+	resp, err := makeRestCall(cfg, r)
+	if err != nil {
+		resp.Body.Close()
+	}
 	return err
 }
 
@@ -600,7 +625,11 @@ func (c *serveCmd) syncthingMain() {
 	if cfgWrapper.Options().StartBrowser && !c.NoBrowser && !c.InternalRestarting {
 		// Can potentially block if the utility we are invoking doesn't
 		// fork, and just execs, hence keep it in its own routine.
-		go func() { _ = openURL(cfgWrapper.GUI().URL()) }()
+		go func() {
+			if err := openGUI(); err != nil {
+				slog.Error("Failed to open in browser", slogutil.Error(err))
+			}
+		}()
 	}
 
 	status := app.Wait()

--- a/lib/api/api.go
+++ b/lib/api/api.go
@@ -378,6 +378,8 @@ func (s *service) Serve(ctx context.Context) error {
 
 		// Logout is a no-op without a valid session cookie, so /noauth/ is fine here
 		restMux.Handler(http.MethodPost, "/rest/noauth/auth/logout", http.HandlerFunc(authMW.handleLogout))
+
+		restMux.Handler(http.MethodPost, "/rest/auth/logintoken", http.HandlerFunc(authMW.newLoginToken))
 	}
 
 	// Redirect to HTTPS if we are supposed to

--- a/lib/api/api_auth.go
+++ b/lib/api/api_auth.go
@@ -126,6 +126,7 @@ func isNoAuthPath(path string, metricsWithoutAuth bool) bool {
 
 type basicAuthAndSessionMiddleware struct {
 	tokenCookieManager *tokenCookieManager
+	loginTokens        *tokenManager
 	guiCfg             config.GUIConfiguration
 	ldapCfg            config.LDAPConfiguration
 	next               http.Handler
@@ -135,6 +136,7 @@ type basicAuthAndSessionMiddleware struct {
 func newBasicAuthAndSessionMiddleware(tokenCookieManager *tokenCookieManager, guiCfg config.GUIConfiguration, ldapCfg config.LDAPConfiguration, next http.Handler, evLogger events.Logger) *basicAuthAndSessionMiddleware {
 	return &basicAuthAndSessionMiddleware{
 		tokenCookieManager: tokenCookieManager,
+		loginTokens:        newTokenManager("logintokens", nil, 10*time.Second, 5),
 		guiCfg:             guiCfg,
 		ldapCfg:            ldapCfg,
 		next:               next,
@@ -143,6 +145,10 @@ func newBasicAuthAndSessionMiddleware(tokenCookieManager *tokenCookieManager, gu
 }
 
 func (m *basicAuthAndSessionMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if m.tryTokenLogin(w, r) {
+		return
+	}
+
 	if hasValidAPIKeyHeader(r, m.guiCfg) {
 		m.next.ServeHTTP(w, r)
 		return
@@ -222,9 +228,31 @@ func attemptBasicAuth(r *http.Request, guiCfg config.GUIConfiguration, ldapCfg c
 	return "", false
 }
 
+func (m *basicAuthAndSessionMiddleware) tryTokenLogin(w http.ResponseWriter, r *http.Request) bool {
+	query := r.URL.Query()
+	if m.loginTokens.Consume(r.URL.Query().Get("token")) {
+		if !m.tokenCookieManager.hasValidSession(r) {
+			m.tokenCookieManager.createSession("", false, w, r)
+		}
+	}
+
+	if query.Has("token") {
+		query.Del("token")
+		r.URL.RawQuery = query.Encode()
+		http.Redirect(w, r, r.URL.String(), http.StatusTemporaryRedirect)
+		return true
+	}
+	return false
+}
+
 func (m *basicAuthAndSessionMiddleware) handleLogout(w http.ResponseWriter, r *http.Request) {
 	m.tokenCookieManager.destroySession(w, r)
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (m *basicAuthAndSessionMiddleware) newLoginToken(w http.ResponseWriter, r *http.Request) {
+	token := m.loginTokens.New()
+	sendJSON(w, map[string]string{"token": token})
 }
 
 func auth(username string, password string, guiCfg config.GUIConfiguration, ldapCfg config.LDAPConfiguration) bool {

--- a/lib/api/api_auth_test.go
+++ b/lib/api/api_auth_test.go
@@ -150,6 +150,17 @@ func TestTokenManager(t *testing.T) {
 	if tm.Check(t3) {
 		t.Errorf("token %q should be invalid", t3)
 	}
+
+	// The token should become invalid after consuming it
+	if !tm.Consume(t1) {
+		t.Errorf("token %q should be valid", t3)
+	}
+	if tm.Check(t1) {
+		t.Errorf("token %q should be invalid", t3)
+	}
+	if tm.Consume(t1) {
+		t.Errorf("token %q should be invalid", t3)
+	}
 }
 
 func TestTokenManagerNoExpiry(t *testing.T) {
@@ -176,6 +187,23 @@ func TestTokenManagerNoExpiry(t *testing.T) {
 	clock.wind(365 * 24 * time.Hour)
 	if !tm.Check(token) {
 		t.Fatal("token should still be valid after long time when no-expiry is enabled")
+	}
+}
+
+func TestTokenManagerNoDB(t *testing.T) {
+	t.Parallel()
+
+	clock := &mockClock{now: time.Now()}
+	tm := newTokenManager("testTokensNoDB", nil, 24*time.Hour, 3)
+	tm.timeNow = clock.Now
+
+	token := tm.New()
+	if !tm.Check(token) {
+		t.Errorf("token %q should be valid", token)
+	}
+	clock.wind(25 * time.Hour)
+	if tm.Check(token) {
+		t.Errorf("token %q should be invalid", token)
 	}
 }
 

--- a/lib/api/api_test.go
+++ b/lib/api/api_test.go
@@ -980,6 +980,85 @@ func TestHtmlFormLogin(t *testing.T) {
 	})
 }
 
+func TestTokenLogin(t *testing.T) {
+	t.Parallel()
+
+	cfg := newMockedConfig()
+	cfg.GUIReturns(config.GUIConfiguration{
+		User:                "üser",
+		Password:            "$2a$10$IdIZTxTg/dCNuNEGlmLynOjqg4B1FvDKuIV5e0BB3pnWVHNb8.GSq", // bcrypt of "räksmörgås" in UTF-8
+		APIKey:              testAPIKey,
+		SendBasicAuthPrompt: false,
+	})
+	baseURL := startHTTP(t, cfg)
+
+	acquireToken := func() string {
+		resp := httpRequest(http.MethodPost, baseURL+"/rest/auth/logintoken", nil, "", "", testAPIKey, "", "", "", nil, t)
+		var body map[string]string
+
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			t.Errorf("Unexpected json decoding failure %v", err)
+		}
+		return body["token"]
+	}
+
+	tryLoadWithToken := func(token string) *http.Response {
+		client := http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+		req, err := http.NewRequest(http.MethodGet, baseURL+"/?token="+token, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !(resp.StatusCode >= 300 && resp.StatusCode <= 399) {
+			t.Errorf("Expected redirect, got %+v", resp)
+		}
+		if resp.Header.Get("Location") != "/" {
+			t.Errorf("Expected redirect to /, got %+v", resp)
+		}
+		return resp
+	}
+
+	t.Run("Invalid token is redirected away without logging in", func(t *testing.T) {
+		t.Parallel()
+
+		resp := tryLoadWithToken("aaaaaaa")
+		if hasSessionCookie(resp.Cookies()) {
+			t.Errorf("Unexpected session cookie for invalid token")
+		}
+	})
+
+	t.Run("Token auth works", func(t *testing.T) {
+		t.Parallel()
+
+		token := acquireToken()
+		resp := tryLoadWithToken(token)
+		fmt.Printf("%+v\n", resp)
+		if !hasSessionCookie(resp.Cookies()) {
+			t.Errorf("Expected session cookie for valid token")
+		}
+	})
+
+	t.Run("Logout removes the session cookie", func(t *testing.T) {
+		token := acquireToken()
+		resp := tryLoadWithToken(token)
+		if !hasSessionCookie(resp.Cookies()) {
+			t.Errorf("Expected session cookie for valid token")
+		}
+
+		logoutResp := httpPost(baseURL+"/rest/noauth/auth/logout", nil, resp.Cookies(), t)
+		if !hasDeleteSessionCookie(logoutResp.Cookies()) {
+			t.Errorf("Expected session cookie to be deleted for logout request")
+		}
+	})
+}
+
 func TestApiCache(t *testing.T) {
 	t.Parallel()
 

--- a/lib/api/tokenmanager.go
+++ b/lib/api/tokenmanager.go
@@ -40,8 +40,10 @@ const defaultSessionCookieDurationS = 7 * 24 * 60 * 60
 
 func newTokenManager(key string, miscDB *db.Typed, lifetime time.Duration, maxItems int) *tokenManager {
 	var tokens apiproto.TokenSet
-	if bs, ok, _ := miscDB.Bytes(key); ok {
-		_ = proto.Unmarshal(bs, &tokens) // best effort
+	if miscDB != nil {
+		if bs, ok, _ := miscDB.Bytes(key); ok {
+			_ = proto.Unmarshal(bs, &tokens) // best effort
+		}
 	}
 	if tokens.Tokens == nil {
 		tokens.Tokens = make(map[string]int64)
@@ -62,6 +64,30 @@ func (m *tokenManager) Check(token string) bool {
 	m.mut.Lock()
 	defer m.mut.Unlock()
 
+	if !m.check(token) {
+		return false
+	}
+
+	// Give the token further life.
+	m.tokens.Tokens[token] = m.newExpiryNanos()
+	m.saveLocked()
+	return true
+}
+
+func (m *tokenManager) Consume(token string) bool {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+
+	if !m.check(token) {
+		return false
+	}
+
+	// Consume the token.
+	delete(m.tokens.Tokens, token)
+	return true
+}
+
+func (m *tokenManager) check(token string) bool {
 	expires, ok := m.tokens.Tokens[token]
 	if !ok {
 		return false
@@ -71,10 +97,6 @@ func (m *tokenManager) Check(token string) bool {
 		m.saveLocked() // removes expired tokens
 		return false
 	}
-
-	// Give the token further life.
-	m.tokens.Tokens[token] = m.newExpiryNanos()
-	m.saveLocked()
 	return true
 }
 
@@ -136,6 +158,10 @@ func (m *tokenManager) saveLocked() {
 		}
 	}
 
+	if m.miscDB == nil {
+		return
+	}
+
 	// Postpone saving until one second of inactivity.
 	if m.saveTimer == nil {
 		m.saveTimer = time.AfterFunc(time.Second, m.scheduledSave)
@@ -145,6 +171,10 @@ func (m *tokenManager) saveLocked() {
 }
 
 func (m *tokenManager) scheduledSave() {
+	if m.miscDB == nil {
+		return
+	}
+
 	m.mut.Lock()
 	defer m.mut.Unlock()
 


### PR DESCRIPTION
### Purpose

Syncthing's authentication options have seemed sort of lacking to me for a while. I can choose between no authentication (and now the admin interface is accessible to theoretically every website I visit), or password authentication (why do I need a password? it's all on one computer!). This PR adds magic tokens with which the `syncthing browse` and `syncthing serve` commands can magically log you in.

I hope that adding this and refining it enough will make it eventually possible to change the default from "zero auth" to "token auth only".

### Testing

Some unit tests, and manually tested using syncthing browser and syncthing serve, both of which create a token when they open the browser.

### Documentation

TODO