### PR TITLE
fix: stuck dialing loop after machine sleep/wake

### DIFF
--- a/lib/connections/quic_listen.go
+++ b/lib/connections/quic_listen.go
@@ -102,7 +102,7 @@ func (t *quicListener) serve(ctx context.Context) error {
 	}
 	defer udpConn.Close()
 
-	quicTransport := &quic.Transport{Conn: udpConn}
+	quicTransport := &quic.Transport{Conn: newQUICUDPConn(udpConn)}
 	defer quicTransport.Close()
 
 	svc := stun.New(t.cfg, t, &transportPacketConn{tran: quicTransport})

--- a/lib/connections/quic_misc.go
+++ b/lib/connections/quic_misc.go
@@ -14,6 +14,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/url"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -26,6 +27,8 @@ var quicConfig = &quic.Config{
 	MaxIdleTimeout:  30 * time.Second,
 	KeepAlivePeriod: 15 * time.Second,
 }
+
+const quicUDPWriteTimeout = 10 * time.Second
 
 func quicNetwork(uri *url.URL) string {
 	switch uri.Scheme {
@@ -74,6 +77,47 @@ func transportConnUnspecified(conn any) bool {
 	addr := tran.Conn.LocalAddr()
 	ip, err := osutil.IPFromAddr(addr)
 	return err == nil && ip.IsUnspecified()
+}
+
+// quicUDPConn bounds writes made by quic-go to the UDP socket. On some
+// platforms a socket can get stuck writing after sleep/wake, and quic-go waits
+// for pending writes while tearing down timed-out dials.
+type quicUDPConn struct {
+	*net.UDPConn
+
+	writeMut sync.Mutex
+	timeout  time.Duration
+}
+
+func newQUICUDPConn(conn *net.UDPConn) *quicUDPConn {
+	return &quicUDPConn{
+		UDPConn: conn,
+		timeout: quicUDPWriteTimeout,
+	}
+}
+
+func (c *quicUDPConn) WriteTo(p []byte, addr net.Addr) (int, error) {
+	c.writeMut.Lock()
+
+	_ = c.UDPConn.SetWriteDeadline(time.Now().Add(c.timeout))
+	defer func() {
+		_ = c.UDPConn.SetWriteDeadline(time.Time{})
+		c.writeMut.Unlock()
+	}()
+
+	return c.UDPConn.WriteTo(p, addr)
+}
+
+func (c *quicUDPConn) WriteMsgUDP(p, oob []byte, addr *net.UDPAddr) (int, int, error) {
+	c.writeMut.Lock()
+
+	_ = c.UDPConn.SetWriteDeadline(time.Now().Add(c.timeout))
+	defer func() {
+		_ = c.UDPConn.SetWriteDeadline(time.Time{})
+		c.writeMut.Unlock()
+	}()
+
+	return c.UDPConn.WriteMsgUDP(p, oob, addr)
 }
 
 // A transportPacketConn is a net.PacketConn that uses a quic.Transport.

--- a/lib/connections/service.go
+++ b/lib/connections/service.go
@@ -84,6 +84,7 @@ const (
 	shortLivedConnectionThreshold = 5 * time.Second
 	dialMaxParallel               = 64
 	dialMaxParallelPerDevice      = 8
+	dialRoundTimeout              = 2 * time.Minute
 	maxNumConnections             = 128 // the maximum number of connections we maintain to any given device
 )
 
@@ -602,7 +603,6 @@ func (s *service) dialDevices(ctx context.Context, now time.Time, cfg config.Con
 	dialWG := new(sync.WaitGroup)
 	dialCtx, dialCancel := context.WithCancel(ctx)
 	defer func() {
-		dialWG.Wait()
 		dialCancel()
 	}()
 	for _, entry := range queue {
@@ -629,6 +629,27 @@ func (s *service) dialDevices(ctx context.Context, now time.Time, cfg config.Con
 			}
 			numConnsMut.Unlock()
 		})
+	}
+
+	dialRoundDone := make(chan struct{})
+	go func() {
+		dialWG.Wait()
+		close(dialRoundDone)
+	}()
+
+	timer := time.NewTimer(dialRoundTimeout)
+	defer timer.Stop()
+
+	select {
+	case <-dialRoundDone:
+	case <-ctx.Done():
+		dialCancel()
+	case <-timer.C:
+		// Individual dialers should observe their context deadlines. If one
+		// wedges in lower-level cleanup despite that, keep the connection loop
+		// alive so other devices and transports continue to get attempts.
+		slog.WarnContext(ctx, "Dial round did not complete; continuing connection loop")
+		dialCancel()
 	}
 }
 
@@ -1120,7 +1141,9 @@ func (s *service) dialParallel(ctx context.Context, deviceID protocol.DeviceID, 
 		res := make(chan internalConn, len(tgts))
 		wg := sync.WaitGroup{}
 		for _, tgt := range tgts {
-			sema.Take(1)
+			if err := sema.TakeWithContext(ctx, 1); err != nil {
+				return internalConn{}, false
+			}
 			wg.Go(func() {
 				defer sema.Give(1)
 				conn, err := tgt.Dial(ctx)


### PR DESCRIPTION
### Purpose

This PR contains a possible fix for an issue I've been experiencing on macOS (running Syncthing inside Synctrain) where the dialing loop appears to become stuck after several sleep/wake cycles of the machine.

Normally, devices will reconnect in a matter of seconds after waking my MacBook up from sleep. This is helped by the fact that Synctrain triggers device pause/unpause at this moment, which triggers Syncthing to attempt a reconnect straight away. However, after some time, Syncthing simply fails to connect to any device anymore. At this point it does not log any connection attempts. As the device is also configured for incoming connections, this possibly is stuck too. The `/rest/system/status` endpoint (which at that point still works fine) only shows error messages for connection attempts made long ago. 

Manually pausing/unpausing devices, changing the listening addresses, et cetera, does not fix this. After a restart, peers instantly connect.

In the goroutine pprof taken at the moment where the loop is supposedly stuck, a stack involving dialDevices waiting for a `Destroy` function in `quic-go` stands out to me. 

<img width="544" height="407" alt="image" src="https://github.com/user-attachments/assets/5b3362df-2f77-4dab-b8d3-d510cb596abe" />

After some digging (with the help of Codex), the following sequence seems likely to cause this issue:

1. service.connect calls dialDevices.
2. dialDevices starts a batch of dial goroutines, then blocks at dialWG.Wait() in lib/connections/service.go (line 605)
3. One QUIC dial times out or is canceled.
4. Inside quic-go, Transport.doDial handles ctx.Done() by calling conn.destroy(nil), then waiting for conn.ctx.Done(). That destroy never completes, so quicDialer.Dial never returns.
5. Syncthing’s dial waitgroup never completes.
6. The connect loop never reaches its next iteration, so lastDialStatus freezes forever.

The hypothesis is that this is caused by macOS sleep/wake leaving the reused QUIC listener transport in a bad state. Syncthing dials QUIC using the registered listener transport when available, rather than always using a fresh UDP socket (lib/connections/quic_dial.go (line 59). That reuse is useful for NAT traversal, but it means a wedged QUIC transport can wedge all future connection attempts.

The proposed fix is twofold and contained in two separate commits:

* Add a timeout for a single 'dial round' to ensure it completes within a reasonable time (and also 'Take' the semaphore in a cancellable way)
* Attempt QUIC dialing with a fresh socket if the existing one appears stuck. 

### Testing

I have made a special build of Synctrain using this PR's changes, we'll know in a few days if this issue still exists (I can't trigger it manually).

### Screenshots

n/a

### Documentation

n/a

## Authorship

Your name and email will be added automatically to the AUTHORS file
based on the commit metadata.

[syncthing-goroutines-darwin-arm64-v2.1.2-194852.pprof.zip](https://github.com/user-attachments/files/30240745/syncthing-goroutines-darwin-arm64-v2.1.2-194852.pprof.zip)

