### PR TITLE
fix(gui): improve header and button color contrast (fixes #10488)

### DIFF
--- a/gui/black/assets/css/theme.css
+++ b/gui/black/assets/css/theme.css
@@ -158,20 +158,31 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     background-color: #3498db !important;
 }
 
+.btn-success {
+    color: #fff !important;
+    background-color: #198754 !important;
+}
+
+.btn-success:hover, .btn-success:focus, .btn-success.focus {
+    background-color: #146c43 !important;
+}
+
 .btn-warning {
-    background-color: #c29d0b !important;
+    color: #fff !important;
+    background-color: #806700 !important;
 }
 
 .btn-warning:hover, .btn-warning:focus, .btn-warning.focus {
-    background-color: #f1c40f !important;
+    background-color: #6c5700 !important;
 }
 
 .btn-danger {
+    color: #fff !important;
     background-color: #d62c1a !important;
 }
 
 .btn-danger:hover, .btn-danger:focus, .btn-danger.focus {
-    background-color: #e74c3c !important;
+    background-color: #b62516 !important;
 }
 
 
@@ -188,12 +199,21 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     color: #222 !important;
 }
 
+.alert-success,
+.alert-warning,
+.alert-danger {
+    color: #fff !important;
+}
+
+.alert-success {
+    background-color: #198754 !important;
+}
+
 .alert-warning {
-    color: #222 !important;
+    background-color: #806700 !important;
 }
 
 .alert-danger {
-    color: #222 !important;
     background-color: #d62c1a !important;
 }
 

--- a/gui/dark/assets/css/theme.css
+++ b/gui/dark/assets/css/theme.css
@@ -162,20 +162,31 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     background-color: #3498db !important;
 }
 
+.btn-success {
+    color: #fff !important;
+    background-color: #198754 !important;
+}
+
+.btn-success:hover, .btn-success:focus, .btn-success.focus {
+    background-color: #146c43 !important;
+}
+
 .btn-warning {
-    background-color: #c29d0b !important;
+    color: #fff !important;
+    background-color: #806700 !important;
 }
 
 .btn-warning:hover, .btn-warning:focus, .btn-warning.focus {
-    background-color: #f1c40f !important;
+    background-color: #6c5700 !important;
 }
 
 .btn-danger {
+    color: #fff !important;
     background-color: #d62c1a !important;
 }
 
 .btn-danger:hover, .btn-danger:focus, .btn-danger.focus {
-    background-color: #e74c3c !important;
+    background-color: #b62516 !important;
 }
 
 
@@ -192,12 +203,21 @@ li.hidden-xs:hover, .navbar-link:hover, .navbar-link:focus {
     color: #222 !important;
 }
 
+.alert-success,
+.alert-warning,
+.alert-danger {
+    color: #fff !important;
+}
+
+.alert-success {
+    background-color: #198754 !important;
+}
+
 .alert-warning {
-    color: #222 !important;
+    background-color: #806700 !important;
 }
 
 .alert-danger {
-    color: #222 !important;
     background-color: #d62c1a !important;
 }
 

--- a/gui/default/assets/css/overrides.css
+++ b/gui/default/assets/css/overrides.css
@@ -12,6 +12,19 @@ body {
     overflow-y: scroll;
 }
 
+/* Keep text readable on the bright semantic backgrounds used by light themes. */
+.alert-success,
+.alert-warning,
+.alert-danger,
+.btn-success,
+.btn-warning {
+    color: #000 !important;
+}
+
+.btn-danger {
+    background-color: #d62c1a;
+}
+
 h1, h2, h3, h4, h5 {
     font-family: "Raleway", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     line-height: 1.25;


### PR DESCRIPTION
### Purpose

Improve the contrast of semantic request-dialog headers and buttons in the light, dark, and black GUI themes.

The light theme keeps its bright semantic colors and uses black text for success, warning, and danger alerts plus success/warning buttons. Danger buttons use the existing darker red with white text. The dark themes use darker success, warning, and danger backgrounds with white text.

The lowest enabled-state contrast ratio is 4.509:1, meeting WCAG AA for normal text.

### Testing

- `go run build.go assets`
- `go run build.go build syncthing`
- `git diff --check`
- Checked the base and interactive semantic color pairs with a WCAG contrast calculation; all enabled states are at least 4.5:1.
- Loaded the generated GUI assets in Chromium and verified the computed foreground/background colors for success, warning, and danger alerts and buttons in both light and dark themes.

### Screenshots

Rendered light and dark fixtures locally to verify the complete alert and button combinations. The computed colors matched the intended theme rules and no clipping or layout changes were introduced.

### Documentation

No documentation changes are required; this only corrects existing theme colors.