### PR TITLE
fix(model): release lock before cluster config reads (fixes #10798)

### DIFF
--- a/lib/model/model.go
+++ b/lib/model/model.go
@@ -2360,17 +2360,24 @@ func (m *model) scheduleConnectionPromotion() {
 // be called after adding new connections, and after closing a primary
 // device connection.
 func (m *model) promoteConnections() {
-	// Slice of actions to take on connections after releasing the main
-	// mutex. We do this so that we do not perform blocking network actions
-	// inside the loop, and also to avoid a possible deadlock with calling
-	// Start() on connections that are already executing a Close() with a
-	// callback into the model...
-	var postLockActions []func()
+	type promotion struct {
+		deviceID    protocol.DeviceID
+		primary     protocol.Connection
+		secondaries []protocol.Connection
+	}
+
+	// Collect the connections that need work while holding the model mutex,
+	// then build cluster configs and perform network actions after releasing
+	// it. Cluster config generation reads from the database and can block while
+	// waiting for a database connection.
+	var promotions []promotion
 
 	m.mut.Lock()
 
 	for deviceID, connIDs := range m.deviceConnIDs {
-		cm, passwords := m.generateClusterConfigRLocked(deviceID)
+		var p promotion
+		p.deviceID = deviceID
+
 		if m.promotedConnID[deviceID] != connIDs[0] {
 			// The previously promoted connection is not the current
 			// primary; we should promote the primary connection to be the
@@ -2378,14 +2385,7 @@ func (m *model) promoteConnections() {
 			// it, which will cause the other side to start sending us index
 			// messages there. (On our side, we manage index handlers based
 			// on where we get ClusterConfigs from the peer.)
-			conn := m.connections[connIDs[0]]
-			l.Debugf("Promoting connection to %s at %s", deviceID.Short(), conn)
-			postLockActions = append(postLockActions, func() {
-				if conn.Statistics().StartedAt.IsZero() {
-					conn.Start()
-				}
-				conn.ClusterConfig(cm, passwords)
-			})
+			p.primary = m.connections[connIDs[0]]
 			m.promotedConnID[deviceID] = connIDs[0]
 		}
 
@@ -2394,18 +2394,32 @@ func (m *model) promoteConnections() {
 		for _, connID := range connIDs[1:] {
 			conn := m.connections[connID]
 			if conn.Statistics().StartedAt.IsZero() {
-				postLockActions = append(postLockActions, func() {
-					conn.Start()
-					conn.ClusterConfig(&protocol.ClusterConfig{Secondary: true}, passwords)
-				})
+				p.secondaries = append(p.secondaries, conn)
 			}
+		}
+
+		if p.primary != nil || len(p.secondaries) > 0 {
+			promotions = append(promotions, p)
 		}
 	}
 
 	m.mut.Unlock()
 
-	for _, action := range postLockActions {
-		action()
+	for _, p := range promotions {
+		cm, passwords := m.generateClusterConfig(p.deviceID)
+
+		if p.primary != nil {
+			l.Debugf("Promoting connection to %s at %s", p.deviceID.Short(), p.primary)
+			if p.primary.Statistics().StartedAt.IsZero() {
+				p.primary.Start()
+			}
+			p.primary.ClusterConfig(cm, passwords)
+		}
+
+		for _, conn := range p.secondaries {
+			conn.Start()
+			conn.ClusterConfig(&protocol.ClusterConfig{Secondary: true}, passwords)
+		}
 	}
 }
 
@@ -2570,11 +2584,16 @@ func (m *model) numHashers(folder string) int {
 // set of folder passwords for the given peer device
 func (m *model) generateClusterConfig(device protocol.DeviceID) (*protocol.ClusterConfig, map[string]string) {
 	m.mut.RLock()
-	defer m.mut.RUnlock()
-	return m.generateClusterConfigRLocked(device)
+	encryptionPasswordTokens := make(map[string][]byte, len(m.folderEncryptionPasswordTokens))
+	for folder, token := range m.folderEncryptionPasswordTokens {
+		encryptionPasswordTokens[folder] = bytes.Clone(token)
+	}
+	m.mut.RUnlock()
+
+	return m.generateClusterConfigWithTokens(device, encryptionPasswordTokens)
 }
 
-func (m *model) generateClusterConfigRLocked(device protocol.DeviceID) (*protocol.ClusterConfig, map[string]string) {
+func (m *model) generateClusterConfigWithTokens(device protocol.DeviceID, encryptionPasswordTokens map[string][]byte) (*protocol.ClusterConfig, map[string]string) {
 	message := &protocol.ClusterConfig{}
 	folders := m.cfg.FolderList()
 	passwords := make(map[string]string, len(folders))
@@ -2583,7 +2602,7 @@ func (m *model) generateClusterConfigRLocked(device protocol.DeviceID) (*protoco
 			continue
 		}
 
-		encryptionToken, hasEncryptionToken := m.folderEncryptionPasswordTokens[folderCfg.ID]
+		encryptionToken, hasEncryptionToken := encryptionPasswordTokens[folderCfg.ID]
 		if folderCfg.Type == config.FolderTypeReceiveEncrypted && !hasEncryptionToken {
 			// We haven't gotten a token for us yet and without one the other
 			// side can't validate us - pretend we don't have the folder yet.

--- a/lib/model/model_test.go
+++ b/lib/model/model_test.go
@@ -3608,6 +3608,69 @@ func TestClusterConfigOnFolderUnpause(t *testing.T) {
 	})
 }
 
+type blockingIndexIDDB struct {
+	db.DB
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (b *blockingIndexIDDB) GetIndexID(folder string, device protocol.DeviceID) (protocol.IndexID, error) {
+	b.once.Do(func() {
+		close(b.entered)
+		<-b.release
+	})
+	return b.DB.GetIndexID(folder, device)
+}
+
+func TestPromoteConnectionsReleasesModelLockBeforeDatabaseRead(t *testing.T) {
+	wcfg, _ := newDefaultCfgWrapper(t)
+	m := newModel(t, wcfg, myID, nil)
+	defer cleanupModel(m)
+
+	blockedDB := &blockingIndexIDDB{
+		DB:      m.sdb,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	m.sdb = blockedDB
+
+	m.AddConnection(newFakeConnection(device1, m), protocol.Hello{})
+
+	promotionDone := make(chan struct{})
+	go func() {
+		m.promoteConnections()
+		close(promotionDone)
+	}()
+
+	select {
+	case <-blockedDB.entered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for cluster config database read")
+	}
+
+	lockAcquired := make(chan struct{})
+	go func() {
+		m.mut.Lock()
+		m.mut.Unlock()
+		close(lockAcquired)
+	}()
+
+	select {
+	case <-lockAcquired:
+	case <-time.After(time.Second):
+		close(blockedDB.release)
+		t.Fatal("model mutex remained locked during cluster config database read")
+	}
+
+	close(blockedDB.release)
+	select {
+	case <-promotionDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connection promotion")
+	}
+}
+
 func TestAddFolderCompletion(t *testing.T) {
 	// Empty folders are always 100% complete.
 	comp := newFolderCompletion(db.Counts{}, db.Counts{}, 0, remoteFolderValid)


### PR DESCRIPTION
### Purpose

Avoid holding the model mutex while connection promotion waits for cluster-config database reads.

`promoteConnections` previously generated every device's cluster config while `m.mut` was held. `GetIndexID` and `GetDeviceSequence` can wait for a SQLite connection, so one exhausted folder database pool could block unrelated model operations such as adding or closing connections.

This change snapshots the connections needing promotion while holding `m.mut`, releases the mutex, then generates cluster configs and performs the existing connection actions. `generateClusterConfig` now copies the lock-protected encryption-token map before database access instead of retaining the model read lock throughout those reads.

### Testing

- Added `TestPromoteConnectionsReleasesModelLockBeforeDatabaseRead`, which blocks `GetIndexID`, verifies the model mutex can still be acquired, then releases the database call and verifies promotion completes.
- `go test ./lib/model -run TestPromoteConnectionsReleasesModelLockBeforeDatabaseRead -count=1`
- `go test ./lib/model -run Test(ClusterConfigOnFolderPause|ClusterConfigOnFolderUnpause|PromoteConnectionsReleasesModelLockBeforeDatabaseRead)$ -count=1`
- `go test ./lib/model -count=1`
- `gofmt -d lib/model/model.go lib/model/model_test.go`
- `git diff --check`

### Documentation

No documentation changes are required; this changes internal locking only.