### PR TITLE
feat(cli): add config and key health check commands (fixes #10767)

### DIFF
--- a/cmd/syncthing/cli/health.go
+++ b/cmd/syncthing/cli/health.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"crypto/tls"
+	"fmt"
+
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
+)
+
+type configHealthCommand struct{}
+
+func (*configHealthCommand) Run() error {
+	cfgFile := locations.Get(locations.ConfigFile)
+	if _, _, err := config.Load(cfgFile, protocol.EmptyDeviceID, events.NoopLogger); err != nil {
+		return fmt.Errorf("checking configuration %q: %w", cfgFile, err)
+	}
+	return prettyPrintJSON(struct {
+		Config string `json:"config"`
+		Status string `json:"status"`
+	}{cfgFile, "ok"})
+}
+
+type keyHealthCommand struct{}
+
+func (*keyHealthCommand) Run() error {
+	certFile, keyFile := locations.Get(locations.CertFile), locations.Get(locations.KeyFile)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return fmt.Errorf("checking certificate and key: %w", err)
+	}
+	return prettyPrintJSON(struct {
+		Cert     string `json:"cert"`
+		Key      string `json:"key"`
+		DeviceID string `json:"deviceID"`
+		Status   string `json:"status"`
+	}{certFile, keyFile, protocol.NewDeviceID(cert.Certificate[0]).String(), "ok"})
+}

--- a/cmd/syncthing/cli/health_test.go
+++ b/cmd/syncthing/cli/health_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) 2026 The Syncthing Authors.
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this file,
+// You can obtain one at https://mozilla.org/MPL/2.0/.
+
+package cli
+
+import (
+	"os"
+	"testing"
+
+	"github.com/syncthing/syncthing/lib/config"
+	"github.com/syncthing/syncthing/lib/events"
+	"github.com/syncthing/syncthing/lib/locations"
+	"github.com/syncthing/syncthing/lib/protocol"
+	"github.com/syncthing/syncthing/lib/syncthing"
+)
+
+func TestConfigHealthCommand(t *testing.T) {
+	t.Run("valid config passes", func(t *testing.T) {
+		setConfigBaseDir(t, t.TempDir())
+		cfgFile := locations.Get(locations.ConfigFile)
+		if err := config.Wrap(cfgFile, config.New(protocol.EmptyDeviceID), protocol.EmptyDeviceID, events.NoopLogger).Save(); err != nil {
+			t.Fatal(err)
+		}
+		if err := (&configHealthCommand{}).Run(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing config fails", func(t *testing.T) {
+		setConfigBaseDir(t, t.TempDir())
+		if err := (&configHealthCommand{}).Run(); err == nil {
+			t.Fatal("expected an error for a missing config, got nil")
+		}
+	})
+
+	t.Run("malformed config fails", func(t *testing.T) {
+		setConfigBaseDir(t, t.TempDir())
+		if err := os.WriteFile(locations.Get(locations.ConfigFile), []byte("<configuration>"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := (&configHealthCommand{}).Run(); err == nil {
+			t.Fatal("expected an error for a malformed config, got nil")
+		}
+	})
+}
+
+func TestKeyHealthCommand(t *testing.T) {
+	t.Run("valid key pair passes", func(t *testing.T) {
+		setConfigBaseDir(t, t.TempDir())
+		if _, err := syncthing.GenerateCertificate(locations.Get(locations.CertFile), locations.Get(locations.KeyFile)); err != nil {
+			t.Fatal(err)
+		}
+		if err := (&keyHealthCommand{}).Run(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing key pair fails", func(t *testing.T) {
+		setConfigBaseDir(t, t.TempDir())
+		if err := (&keyHealthCommand{}).Run(); err == nil {
+			t.Fatal("expected an error for a missing key pair, got nil")
+		}
+	})
+}
+
+func setConfigBaseDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := locations.GetBaseDir(locations.ConfigBaseDir)
+	if err := locations.SetBaseDir(locations.ConfigBaseDir, dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := locations.SetBaseDir(locations.ConfigBaseDir, orig); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/cmd/syncthing/cli/show.go
+++ b/cmd/syncthing/cli/show.go
@@ -18,6 +18,9 @@ type showCommand struct {
 	Discovery    struct{}       `cmd:"" help:"Show the discovered addresses of remote devices (from cache of the running syncthing instance)"`
 	Usage        struct{}       `cmd:"" help:"Show usage report"`
 	Pending      pendingCommand `cmd:"" help:"Pending subcommand group"`
+
+	ConfigHealth configHealthCommand `cmd:"" help:"Check the configuration file syntax (does not require a running instance)"`
+	KeyHealth    keyHealthCommand    `cmd:"" help:"Check the device certificate and key (does not require a running instance)"`
 }
 
 func (*showCommand) Run(ctx Context, kongCtx *kong.Context) error {


### PR DESCRIPTION
### Purpose

Adds two standalone CLI commands to validate a Syncthing installation without a running instance, as requested in #10767:
- `syncthing cli show config-health` checks that the configuration file can be loaded and parsed.
- `syncthing cli show key-health` checks that the device certificate and key are present and form a valid pair.

Both commands output the results in a pretty-printed JSON format.

### Testing

Adds `cmd/syncthing/cli/health_test.go` covering valid / missing / malformed config and valid / missing key pair.

Fixes #10767