### PR TITLE
fix(fs): preserve adjacent lowercase dedup key (fixes #10823)

### DIFF
--- a/lib/fs/casefs.go
+++ b/lib/fs/casefs.go
@@ -499,7 +499,7 @@ func newCaseNode(name string, filesystem Filesystem) *caseNode {
 		lower := UnicodeLowercaseNormalized(n)
 		if lower != lastLower {
 			node.lowerToReal[lower] = n
-			lastLower = n
+			lastLower = lower
 		}
 	}
 

--- a/lib/fs/casefs_test.go
+++ b/lib/fs/casefs_test.go
@@ -110,6 +110,31 @@ func testRealCaseSensitive(t *testing.T, fsys Filesystem) {
 	}
 }
 
+type caseNodeTestFilesystem struct {
+	*errorFilesystem
+	names []string
+}
+
+func (fs *caseNodeTestFilesystem) DirNames(string) ([]string, error) {
+	return fs.names, nil
+}
+
+func TestNewCaseNodeKeepsFirstAdjacentLowercaseMatch(t *testing.T) {
+	fsys := &caseNodeTestFilesystem{
+		errorFilesystem: new(errorFilesystem),
+		names:           []string{"File.txt", "file.txt"},
+	}
+
+	node := newCaseNode(".", fsys)
+
+	if node.err != nil {
+		t.Fatal(node.err)
+	}
+	if got := node.lowerToReal["file.txt"]; got != "File.txt" {
+		t.Fatalf("lowercase lookup = %q, want first adjacent entry %q", got, "File.txt")
+	}
+}
+
 func TestCaseFSStat(t *testing.T) {
 	// Verify that a Stat() lookup behaves in a case sensitive manner
 	// regardless of the underlying fs.


### PR DESCRIPTION
### Purpose

Fixes #10823.

`newCaseNode` intended to skip repeated lowercase directory entries when adjacent entries normalize to the same lowercase key. The cache now stores the lowercase key in `lastLower`, so the dedup check compares values in the same normalized form.

### Testing

- `go test ./lib/fs -run TestNewCaseNodeKeepsFirstAdjacentLowercaseMatch -count=1`
- `go test ./lib/fs -count=1`
- `git diff --check`

### Documentation

No documentation changes necessary; this is an internal case-cache correctness fix.
