### PR TITLE
chore: deflake TestRecvOnlyRevertNeeds

### DIFF
--- a/lib/model/folder_recvonly_test.go
+++ b/lib/model/folder_recvonly_test.go
@@ -123,10 +123,12 @@ func TestRecvOnlyRevertNeeds(t *testing.T) {
 	oldData := []byte("hello\n")
 	knownFiles := setupKnownFiles(t, ffs, oldData)
 
-	// Send and index update for the known stuff
+	// Send an index update for the known stuff. Update the local index
+	// prior to getting index data from the remote device, so we avoid a
+	// pull starting and causing race flakiness for the rest of the test.
 
-	must(t, m.Index(conn, &protocol.Index{Folder: "ro", Files: knownFiles}))
 	f.updateLocalsFromScanning(knownFiles)
+	must(t, m.Index(conn, &protocol.Index{Folder: "ro", Files: knownFiles}))
 
 	// Scan the folder.
 


### PR DESCRIPTION
There was a rare, tricky race condition in the setup, where a pull could get started, find the blocks from the file we injected in updateLocalsFromScanning, copy them into a temp file, then fail the pull because the file was already in place. Then later, after the revert, another pull would start, find the temp file and reuse it, making it so needed=0 instead of the expected needed>0 the test checks for.

This avoids all that by setting the local index data prior to getting it from the "remote" device, thus avoiding the initial pull and temp file creation etc.
