### PR TITLE
fix(upnp): guard against out of index string access

### DIFF
--- a/lib/upnp/upnp.go
+++ b/lib/upnp/upnp.go
@@ -554,7 +554,7 @@ func replaceRawPath(u *url.URL, rp string) {
 			q = fs[1]
 		}
 
-		if p[0] == '/' {
+		if p != "" && p[0] == '/' {
 			u.Path = p
 		} else {
 			u.Path += p

--- a/lib/upnp/upnp_test.go
+++ b/lib/upnp/upnp_test.go
@@ -79,3 +79,16 @@ func TestControlURLParsing(t *testing.T) {
 		t.Error("URL normalization of", subject, "failed; expected", expected, "got", u.String())
 	}
 }
+
+func TestControlURLParsingQueryOnly(t *testing.T) {
+	rootURL := "http://192.168.243.1:80/igd.xml"
+
+	u, _ := url.Parse(rootURL)
+	subject := "?control=WANCommonIFC1"
+	expected := "http://192.168.243.1:80/igd.xml?control=WANCommonIFC1"
+	replaceRawPath(u, subject)
+
+	if u.String() != expected {
+		t.Error("URL normalization of", subject, "failed; expected", expected, "got", u.String())
+	}
+}


### PR DESCRIPTION
Broken responses may have empty path component.