### PR TITLE
fix(ignore): handle pattern resulting in empty string

### DIFF
--- a/lib/ignore/ignore.go
+++ b/lib/ignore/ignore.go
@@ -92,7 +92,7 @@ func (p Pattern) allowsSkippingIgnoredDirs() bool {
 	if p.result.IsIgnored() {
 		return true
 	}
-	if p.pattern[0] != '/' {
+	if p.pattern == "" || p.pattern[0] != '/' {
 		return false
 	}
 	// A "/**" at the end is allowed and doesn't have any bearing on the
@@ -412,6 +412,10 @@ func parseLine(line string) ([]Pattern, error) {
 		patterns[0] = pattern
 
 		line = line[3:]
+		if line == "" {
+			// Pattern was exactly "**/", already covered by patterns[0].
+			return patterns[:1], nil
+		}
 		pattern.pattern = line
 		pattern.match, err = glob.Compile(line, '/')
 		if err != nil {

--- a/lib/ignore/ignore_test.go
+++ b/lib/ignore/ignore_test.go
@@ -299,6 +299,17 @@ func TestCommentsAndBlankLines(t *testing.T) {
 	}
 }
 
+func TestNegatedGlobstarOnly(t *testing.T) {
+	testFs := newTestFS()
+
+	pats := New(testFs)
+	if err := pats.Parse(bytes.NewBufferString("!**/\n"), ".stignore"); err != nil {
+		t.Fatal(err)
+	}
+	// Must not panic on an empty pattern component.
+	pats.Match("foo")
+}
+
 var result ignoreresult.R
 
 func BenchmarkMatch(b *testing.B) {


### PR DESCRIPTION
Minor fix to avoid a panic in ignore matching.