### PR TITLE
chore(syncthing): include local db entries in perfstats

### DIFF
--- a/cmd/syncthing/main.go
+++ b/cmd/syncthing/main.go
@@ -424,9 +424,6 @@ func (c *serveCmd) syncthingMain() {
 	if c.DebugProfileHeap {
 		startHeapProfiler()
 	}
-	if c.DebugPerfStats {
-		startPerfStats()
-	}
 
 	// Print our version information up front, so any crash that happens
 	// early etc. will have it available.
@@ -512,6 +509,10 @@ func (c *serveCmd) syncthingMain() {
 	if err != nil {
 		slog.Error("Error opening database", slogutil.Error(err))
 		os.Exit(1)
+	}
+
+	if c.DebugPerfStats {
+		startPerfStats(sdb)
 	}
 
 	migratingAPICancel() // we're done with the temporary API server

--- a/cmd/syncthing/perfstats_unix.go
+++ b/cmd/syncthing/perfstats_unix.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/syncthing/syncthing/internal/db"
 	"github.com/syncthing/syncthing/lib/build"
 	"github.com/syncthing/syncthing/lib/locations"
 	"github.com/syncthing/syncthing/lib/osutil"
@@ -23,11 +24,11 @@ import (
 	"golang.org/x/exp/constraints"
 )
 
-func startPerfStats() {
-	go savePerfStats(fmt.Sprintf("perfstats-%d.csv", syscall.Getpid()))
+func startPerfStats(db db.DB) {
+	go savePerfStats(fmt.Sprintf("perfstats-%d.csv", syscall.Getpid()), db)
 }
 
-func savePerfStats(file string) {
+func savePerfStats(file string, db db.DB) {
 	fd, err := os.Create(file)
 	if err != nil {
 		panic(err)
@@ -42,7 +43,7 @@ func savePerfStats(file string) {
 	syscall.Getrusage(syscall.RUSAGE_SELF, &prevRus)
 	runtime.ReadMemStats(&prevMem)
 
-	fmt.Fprintf(fd, "TIME_S\tCPU_S\tHEAP_KIB\tRSS_KIB\tNETIN_KBPS\tNETOUT_KBPS\tDBSIZE_KIB\n")
+	fmt.Fprintf(fd, "TIME_S\tCPU_S\tHEAP_KIB\tRSS_KIB\tNETIN_KBPS\tNETOUT_KBPS\tDBSIZE_KIB\tDBLOCAL\n")
 
 	for t := range time.NewTicker(250 * time.Millisecond).C {
 		syscall.Getrusage(syscall.RUSAGE_SELF, &curRus)
@@ -55,7 +56,15 @@ func savePerfStats(file string) {
 			rss /= 1024
 		}
 
-		fmt.Fprintf(fd, "%.03f\t%f\t%d\t%d\t%.0f\t%.0f\t%d\n",
+		folders, _ := db.ListFolders()
+		var dbLocal int
+		for _, f := range folders {
+			local, _ := db.CountLocal(f, protocol.LocalDeviceID)
+			dbLocal += local.Files + local.Directories + local.Symlinks
+		}
+
+		fmt.Fprintf(
+			fd, "%.03f\t%f\t%d\t%d\t%.0f\t%.0f\t%d\t%d\n",
 			t.Sub(t0).Seconds(),
 			rate(cpusec(&prevRus), cpusec(&curRus), timeDiff, 1),
 			(curMem.Sys-curMem.HeapReleased)/1024,
@@ -63,6 +72,7 @@ func savePerfStats(file string) {
 			rate(prevIn, in, timeDiff, 1e3),
 			rate(prevOut, out, timeDiff, 1e3),
 			osutil.DirSize(locations.Get(locations.Database))/1024,
+			dbLocal,
 		)
 
 		prevTime = t

--- a/cmd/syncthing/perfstats_unsupported.go
+++ b/cmd/syncthing/perfstats_unsupported.go
@@ -9,5 +9,7 @@
 
 package main
 
-func startPerfStats() {
+import "github.com/syncthing/syncthing/internal/db"
+
+func startPerfStats(_ db.DB) {
 }


### PR DESCRIPTION
As used by the latest few PRs with graphs in them
